### PR TITLE
hc32_series: add hc32f4a2

### DIFF
--- a/hc32f4a2/ChangeLog.md
+++ b/hc32f4a2/ChangeLog.md
@@ -1,0 +1,1410 @@
+# Update History
+------
+## V2.3.0  Nov 08, 2024
+#### documents
+#### drivers
+- ##### bsp/components
+  - **24cxx**
+    - Add null pointer check
+    - Add prefix to static global variable
+  - **gt9xx**
+    - Add null pointer check
+  - **nt35510**
+    - Add null pointer check
+    - Optimize function: NT35510_Init/ReadID
+    - Compliant LCD drive IC: NT35510(0x5510), ILI9341, ST7789V, SSD1963
+    - Add inline function.
+  - **rtl8201**
+    - Add rtl8201 component
+  - **tca9539**
+    - Add null pointer check
+  - **w25qxx**
+    - Add null pointer check
+  - **wm8731**
+    - Add null pointer check
+    - Add prefix to static global variable
+- ##### bsp/ev_hc32f4a2_lqfp176
+  - Modify for data overflow in function BSP_I2C_Init()
+  - Enable cache in API BSP_CLK_Init()
+  - MISRAC fix in API BSP_XTAL32_Init()
+  - FCM interface add instance
+  - Modify XTAL/XTAL32 pins definition
+  - Modify I2C peripheral clock
+  - Use EXMC_CLK port status feedback as the sample clock
+  - Optimize using DMA linked list transfer
+- ##### cmsis/Device
+  - Remove EVT_SRC_ETH_PPS_OUT_0/1
+  - Modify DBGC/DCU/DMA/QSPI/TMR4/TMR6/I2C/I2S/MAU registers
+  - Modify GPIO configuration value of QSPI
+- ##### hc32_ll_driver
+  - **generic**
+    - Modify version as Rev2.3.0
+    - Add __USED definition
+  - **interrupts_share**
+    - Add handler for USB
+    - Refine for USB interrupt
+  - **adc**
+    - Add declaration of API ADC_MxChCmd(), ADC_ConvDataAverageMxChCmd(), and add defgroup ADC_Mx_Channel
+    - Add declaration of API ADC_GetResolution()
+    - Fixed some comments
+    - Add API ADC_MxChCmd(),ADC_ConvDataAverageMxChCmd
+    - Add API ADC_GetResolution()
+    - Optimized access code for some registers to improve readability
+  - **aos**
+    - Optimize assert IS_AOS_TARGET
+  - **can**
+    - API CAN_DeInit() added return value
+    - Added macro group CAN_ID_Mask
+    - API optimized: CAN_WriteTxBuf()
+    - Replace constants with Macros
+  - **clk**
+    - Modify comment
+    - Refine API CLK_XtalStdInit and add API CLK_XtalStdCmd, CLK_SetXtalStdExceptionType
+    - Refine API CLK_XtalStdInit. and add API CLK_XtalStdCmd, CLK_SetXtalStdExceptionType
+    - Modify CLK_PLLXM_DIV_MAX as 25U
+    - Modify CLK_PLLXM_DIV_MIN as 1U
+    - Delete group definition for CLK_FREQ
+  - **cmp**
+    - Refine relation of CMP out detect flag functions and Unified Register Bit Names
+  - **crc**
+    - Add declaration of API CRC_GetResult() & CRC_SetInitValue()
+    - Modify interface of AccumulateData and Calculate functions
+    - Add API CRC_GetResult() & CRC_SetInitValue()
+    - Optimized APIs CRC_WriteData8/16/32
+  - **dac**
+    - Add align parametric in struct stc_dac_init_t
+    - All parameter assert add module name
+    - Add DAC data align configuration
+  - **dbgc**
+    - Delete redundancies API and Correct DBGC spell
+  - **dma**
+    - Modify API input param type:u16->u32
+    - Add structure stc_dma_rc_nonseq_init_t
+    - Add API DMA_ReconfigNonSeqStructInit() & DMA_ReconfigNonSeqInit()
+    - Add API DMA_MxChSWTrigger() and DMA_SWReconfig()
+    - Add API DMA_AHB_HProtBufCacheCmd()
+    - Add DMA Repeat size assert
+    - Use macros replace immediate data, modify IS_DMA_NON_SEQ_TRANS_CNT
+    - Optimize DMA_ClearErrStatus() & DMA_ClearTransCompleteStatus()
+    - Add assert IS_DMA_DATA_WIDTH_ADDR
+    - Add API DMA_MxChSWTrigger() & DMA_SWReconfig()
+  - **dmc**
+    - API EXMC_DMC_DeInit add return value
+    - Function EXMC_DMC_DeInit add return value
+  - **dvp**
+    - API DVP_DeInit add return value
+    - Modify DVP_ClearStatus for couping risk
+    - Function DVP_DeInit add return value
+  - **efm**
+    - Rename EFM_DataCacheResetCmd() as EFM_CacheRamReset() and modify comment
+    - Optimized macro group EFM_Remap_Size definitions
+    - Move EFM_CACHE_ALL from c file to head file
+    - Add prefix EFM to SECTOR_SIZE and macro EFM_PROTECT_LEVEL_ALL
+    - Add const before buffer pointer to cater top-level calls
+    - Optimize EFM_ClearStatus()
+    - Optimize condition judgment
+    - Bug Fixed # judge the EFM_FLAG_OPTEND whether set o not before clear EFM_FLAG_OPTEND
+    - Remap the sector number parameter of EFM_SingleSectorOperateCmd based on SWAP and OTP status
+  - **emb**
+    - Add macro EMB_FLAG_CLR_ALL
+    - Add EMB_EVT_ALL definition
+    - Modify assert IS_EMB_MONITOR_EVT
+    - Optimize EMB_ClearStatus function
+    - Rename macro-definition: IS_VALID_EMB_INT -> IS_EMB_INT
+  - **eth**
+    - Rename _OPERA_ to _OP_ and delete redundant definition
+    - Modify ETH_PPS_OUTPUT_FREQ_1HZ as ETH_PPS_OUTPUT_PULSE_1HZ
+    - Modify comment of defgroup ETH_PPS_Output_Frequency
+    - Extract the relevant code of PHY
+    - Add assert IS_ETH_MAC_SMI_CLK(), IS_ETH_PPS_CH_OUTPUT_FREQ(), IS_ETH_PPS_OUTPUT_MD_FREQ
+    - Optimize the process of ETH_Start() & ETH_Stop()
+    - Optimize ETH_MAC_SetInterface(), ETH_PTP_UpdateBasicAddend(), ETH_PTP_SysTimeInit(), ETH_PPS_Init()
+    - Fixed bug of ETH_PMT_EnterPowerDown() # modify && as || logic
+    - Modify ETH_PPS_SetPps0OutputFreq() as ETH_PPS_SetPpsOutputFreq()
+    - Add API ETH_MAC_SetMdcClock()
+    - Modify comment of API ETH_PPS_SetPpsOutputFreq()
+  - **fcm**
+    - Interface add instance
+    - Modify API FCM_ClearStatus(), Clear status by write instruction
+  - **fmac**
+    - All parameter assert add module name
+  - **gpio**
+    - Add assert for GPIO register lock status in API GPIO_AnalogCmd(), GPIO_ExtIntCmd()
+    - clear EFEN bit or NOCEN bit in GPIO_ExtIntCmd() before enable interrupt
+  - **hash**
+    - Modify API about CR register for couping risk
+    - Fixed HASH_HMAC_Calculate function
+  - **hrpwm**
+    - Modify macro definition group HRPWM_Global_Macros and unified the abbreviation of Calibrate
+    - unified the abbreviation of Calibrate
+  - **i2c**
+    - Adjust I2C_FLAG_ALL & I2C_FLAG_CLR_ALL & I2C_INT_ALL
+    - Add I2C_Flag_Clear def group
+    - Fix I2C_Deinit
+    - Rename related to SMBus Alert Response Address
+    - Modify I2C_Restart()
+    - Modify macro IS_I2C_INT_FLAG -> IS_I2C_INT
+    - Modify I2C_CR1_ENGC to I2C_CR1_GCEN
+    - Modify the I2C_BaudrateConfig func rounding off method
+    - Modify duty cycle for SCL
+    - Modify I2C_CCR_FREQ to I2C_CCR_CKDIV
+  - **i2s**
+    - Optimize I2S_DeInit()
+    - Removed I2S_RST_TYPE_CODEC
+    - Optimize calculate for I2SDIV and ODD in MCK enabled mode
+    - Delete needless set data in I2S_Init function
+  - **icg**
+    - Modify macro define: ICG_SWDT_LPM_CNT_CONTINUE -> ICG_SWDT_LPM_CNT_CONT
+    - Delete ICG2 function
+    - Modify comment of ICG_BOR_Voltage_Threshold
+    - Add __USED for optimize
+  - **interrupts**
+    - Modify INTC filter B macros correspond with RM
+    - Modify API NMI_ClearNmiStatus(),EXTINT_ClearExtIntStatus() Clear status by write instruction
+    - clear EFEN bit in EXTINT_Init()
+  - **mau**
+    - All parameter assert add module name
+  - **mpu**
+    - Add structure stc_mpu_unit_init_t, and declaration of MPU_UnitInit(), MPU_UnitStructInit()
+    - Refine def group MPU_Flag
+    - Add API MPU_UnitInit(), MPU_UnitStructInit()
+  - **nfc**
+    - Update API function parameter: EXMC_NFC_Read/EXMC_NFC_Write
+    - API EXMC_NFC_DeInit add return value
+    - Remove C Library function: memcpy
+    - Optimize EXMC_NFC_Read/EXMC_NFC_Write parameter
+    - Function EXMC_NFC_DeInit add return value
+    - Optimize function EXMC_NFC_ReadId
+  - **pwc**
+    - Refine API PWC_SLEEP_Enter()
+    - Add API PWC_PD_SetIoState & PWC_PD_SetMode and add return value to PWC_PD_Enter
+    - Remove redundant assert
+    - Modify API PWC_PD_Enter() #use assert to replace the unlock, and add return value
+    - Modify API PWC_STOP_Enter() #delete redundancies code
+    - Unified the operation mode for register
+    - Refine PWC_SLEEP_Enter()
+    - Add API PWC_PD_SetIoState() & PWC_PD_SetMode()
+    - Add assert in PWC_PD_Config()
+    - Modify LVD initialize process
+    - Remove macro PWC_LVD_EXT_INPUT_EN_REG & PWC_LVD_EXT_INPUT_EN_BIT & PWC_LVD_CMP_OUTPUT_EN_REG & PWC_LVD_CMP_OUTPUT_EN_BIT
+    - Modify PWC_LVD_ClearStatus & PWC_PD_ClearWakeupStatus for couping risk
+    - Couping Risks caused by modifying the status bits of the WKTM
+    - Modify macro name IS_PWC_WKT_COMPARISION_VALUE as IS_PWC_WKT_COMPARISON_VALUE
+    - Accessed CM_PWC->WKTC2 in 8-bit
+    - Add assert for PWC_STOP_Enter()
+  - **qspi**
+    - Delete judgement condition when switching to direct communication mode
+    - Modify QSPI->SR2 to QSPI->CLR
+  - **rmu**
+    - Modify IS_VALID_RMU_RST_FLAG -> IS_RMU_RST_FLAG
+  - **rtc**
+    - Modify RTC_EnterRwMode,RTC_ExitRwMode,RTC_ConfirmLPMCond,RTC_SetIntPeriod,RTC_AlarmCmd,RTC_IntCmd,RTC_ClearStatus for couping risk
+    - Optimized access code for some registers to improve readability
+  - **sdioc**
+    - Add parameter for SDMMC_CMD38_Erase
+  - **smc**
+    - Rename macro-define: EXMC_SMC_READ_BURST_CONTINUOUS -> EXMC_SMC_READ_BURST_INFINITE
+    - Rename macro-define: EXMC_SMC_WRITE_BURST_CONTINUOUS -> EXMC_SMC_WRITE_BURST_INFINITE
+    - Update macro: EXMC_SMC_READ_BURST_CONTINUOUS -> EXMC_SMC_READ_BURST_INFINITE
+    - Update macro: EXMC_SMC_WRITE_BURST_CONTINUOUS -> EXMC_SMC_WRITE_BURST_INFINITE
+  - **spi**
+    - Rename SPI_FLAG_OVERLOAD as SPI_FLAG_OVERRUN, SPI_FLAG_UNDERLOAD as SPI_FLAG_UNDERRUN
+    - Modify API API_xxxConfig() to SPI_Setxxx() and refine SPI_SetSSValidLevel, modify SPI_IRQ_ALL -> SPI_INT_ALL
+    - Modify some assert
+    - Rename some API SPI_xxxConfig as SPI_Setxxx
+    - Refine API SPI_Init()
+    - Add Send restriction in SPI_TxRx function
+    - Modify SPI_DeInit,SPI_ClearStatus for couping risk
+  - **sram**
+    - Refine def group SRAM_ECC_Mode, and refine def group SRAM_Err_Mode as SRAM_Exception_Type
+    - Add macro SRAM_ECC_SRAM_ALL and group SRAM_Check_SRAM
+    - Refine SRAM_SetEccMode, and refine SRAM_SetErrorMode() as SRAM_SetExceptionType
+    - Modify assert IS_SRAM_ECC_MD()
+  - **swdt**
+    - Modify macro define: SWDT_LPM_CNT_CONTINUE -> SWDT_LPM_CNT_CONT
+    - Modify API SWDT_ClearStatus() for couping risk
+  - **tmr0**
+    - Modify API of TMR0_DeInit()
+    - Modify TMR0_ClearStatus for couping risk
+  - **tmr2**
+    - API TMR2_DeInit() added return value
+    - Modify TMR2_DeInit()
+    - Modify TMR2_ClearStatus for couping risk
+  - **tmr4**
+    - Fix bug that the status flag of CCSR/OCSR for couping risk
+    - Refine TMR4_GetStatus()
+    - Fix misra warning, MODIFY_REG->MODIFY_RCSR_REG
+  - **tmr6**
+    - Modify for headfile update: CM_TMR6CR -> CM_TMR6_COMMON
+    - Modify API TMR6_ClearStatus() for couping risk
+  - **tmra**
+    - API TMRA_DeInit() added return value
+    - API TMRA_DeInit() refined
+    - Modify PCONR reg from RW_MEM16 to MODIFY_REG16 in TMRA_PWM_Init() function
+    - Modify TMRA_CountReloadCmd,TMRA_ClearStatus,TMRA_IntCmd for couping risk
+    - Optimized access code for some registers to improve readability
+  - **trng**
+    - Use MODIFY_REG32() to prevent reserved bit from being overwritten
+  - **usart**
+    - Add the declaration of API USART_GetFuncState()
+    - Add interfaces for getting USART configuration status
+    - Add API USART_GetFuncState()
+    - Add assert for the register bit can only be set when TE=0&RE=0
+    - Optimize condition judgment
+    - Add assert for pvBuf pointer alignment for data width 9bit
+  - **usb**
+    - Modify for macro define USB_MAX_TX_FIFOS
+    - Modify parameter type in function usb_FrameIntervalConfig():uint8_t -> uint32_t
+    - Modify API usb_wrpkt & usb_rdpkt for C-STAT
+    - Select default internal PHY for USBFS core
+  - **utility**
+    - Optimized the Delay functions as cache is enabled
+  - **wdt**
+    - Modify macro define: WDT_LPM_CNT_CONTINUE -> WDT_LPM_CNT_CONT
+    - Modify API WDT_ClearStatus() for couping risk
+#### midwares
+- ##### hc32/emulate_eeprom
+  - Add flash emulate eeprom midware
+- ##### hc32/iap
+  - Modify u8FrameData to 4-byte alignment
+  - Fix cppcheck warning
+- ##### hc32/iec60730_class_b_stl
+  - Add compiler macros pre-processor: GCC and AC6
+  - Use STL_RetargetPrintf() replace printf() of the C lib.
+  - Fix warning: MISRAC2012-Rule-8.4
+  - Assign m_pu32MarchRAM using the variable m_au32MarchRAM
+- ##### hc32/usb
+  - Support Microsoft OS descriptor
+  - Modify for macro define USB_MAX_TX_FIFOS
+  - Delete undesired EP status setting operation
+  - Add USB class WinUSB midware
+  - Modify for control write transfer for USB DMA mode
+  - Optimize the interface init function
+  - Modify for MISRA
+  - Optimize the interface struct
+  - Change the DataLength in the _CDCXfer struct from u16 to u32
+  - Change the length parameter in the usb_host_cdc_senddata() from u16 to u32
+  - Add a CDC Request state
+  - Optimize assignment operation
+  - Modify for channel distribute and free
+  - Modify usb_host_chx_in_isr() for BBERR flag
+  - Clear ACK flag when XFRC in usb_host_chx_in_isr() function
+  - Clear CHH flag when XFRC in usb_host_chx_in_isr() and usb_host_chx_out_isr() function
+  - Modify function usb_host_parsecfgdesc()
+#### projects
+- ##### ev_hc32f4a2_lqfp176/applications
+  - **functional_safety/iec60730_class_b**
+    - Add clock initialization
+    - Change STL_ADC_AWD_LOW_THRESHOLD_VOL value: 1.6F -> 1.5F
+    - FCM interface add instance
+    - Replace peripheral WDT with SWDT to avoid dependencies on the system clock
+  - **iap/iap_boot**
+    - Re-config SRAM read/write wait cycle
+    - Modify XTAL pins definition
+  - **iap/iap_ymodem_boot**
+    - Re-config SRAM read/write wait cycle
+    - Modify XTAL pins definition
+  - **usb/usb_dev_cdc**
+    - Optimize print information
+    - Support Microsoft OS descriptor
+  - **usb/usb_dev_cdc_msc**
+    - Re-config SRAM read/write wait cycle
+    - Optimize print information
+    - Support Microsoft OS descriptor
+    - Update for new SDIOC midwares
+  - **usb/usb_dev_hid_cdc**
+    - Modify timer0 clock division for asynchronous clock
+    - Optimize print information
+    - Support Microsoft OS descriptor
+  - **usb/usb_dev_hid_custom**
+    - Modify timer0 clock division for asynchronous clock
+    - Optimize print information
+    - Support Microsoft OS descriptor
+  - **usb/usb_dev_hid_msc**
+    - Re-config SRAM read/write wait cycle
+    - Optimize print information
+    - Support Microsoft OS descriptor
+    - Update for new SDIOC midwares
+  - **usb/usb_dev_mouse**
+    - Optimize print information
+    - Support Microsoft OS descriptor
+  - **usb/usb_dev_msc**
+    - Re-config SRAM read/write wait cycle
+    - Optimize print information
+    - Support Microsoft OS descriptor
+    - Update for new SDIOC midwares
+  - **usb/usb_host_cdc**
+    - Add BSP_KEY_Init() in the usb_bsp_init() function
+    - Optimize print information
+    - Remove unused code in host_user_userinput() function
+    - Redesign the CDC data tx and rx application demo
+    - Modify user state definition
+  - **usb/usb_host_mouse_kb**
+    - Optimize print information
+  - **usb/usb_host_msc**
+    - Optimize print information
+- ##### ev_hc32f4a2_lqfp176/examples
+  - **adc/adc_awd**
+    - Modify macro TMR0_CMP_VAL value
+  - **adc/adc_hard_trigger**
+    - Modify macro TMR0_CMP_VAL value
+  - **can/can_classical**
+    - Example optimized.
+  - **can/can_fd**
+    - Example optimized.
+  - **clk/clk_xtalstop_detect**
+    - Use CLK_XtalStdInit() to replace XtalStopDetctInit()
+    - Modify XTAL_STOP_IrqCallback
+  - **cmp/cmp_window**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+  - **crc/crc_hw_accumulate_check**
+    - Modify code due to CRC interface change
+  - **crc/crc_hw_encode_hw_check**
+    - Modify code due to CRC interface change
+  - **crc/crc_hw_encode_sw_check**
+    - Modify code due to CRC interface change,and
+    - Fix cppcheck warning
+  - **ctc/ctc_ctcref_trimming**
+    - Implement the weak function: CTC_Udf/Ovf_IrqHandler
+    - Optimize process
+  - **ctc/ctc_xtal32_trimming**
+    - Implement the weak function: CTC_Udf/Ovf_IrqHandler
+  - **ctc/ctc_xtal_trimming**
+    - Implement the weak function: CTC_Udf/Ovf_IrqHandler
+  - **dac/dac_base**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+  - **dac/dac_sync_mode**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+  - **dcu/dcu_compare**
+    - Add m_u8DoneFlag to indicate interrupt done
+  - **dcu/dcu_sawtooth_wave_mode**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+    - Add DAC_StructInit() before DAC_Init()
+  - **dcu/dcu_triangle_wave_mode**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+    - Add DAC_StructInit() before DAC_Init()
+    - Fix the enabled interrupt type
+  - **dmac/dmac_base**
+    - Optimize DMA2_Error_IrqCallback()
+    - Add DMA transform tigger by software
+  - **efm/efm_dbus**
+    - Optimaize code process
+  - **efm/efm_protect**
+    - Disable cache while chip erase & set read only after chip erase
+  - **emb/emb_cmp_brake_timer4**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+    - Add DAC_StructInit() before DAC_Init()
+  - **emb/emb_cmp_brake_timer6**
+    - Delete DAC_DataRegAlignConfig() due to align configure in DAC_Init()
+    - Add DAC_StructInit() before DAC_Init()
+  - **eth/eth_loopback**
+    - Strip PHY operation code into BSP file
+    - Add high driver for ETH output pin
+    - Delete interrupt codes of RMII interface
+  - **eth/eth_twoboards**
+    - Optimize the init process of ETH
+    - Add high driver for ETH output pin
+    - Strip PHY operation code into BSP file
+    - Re-config SRAM read/write wait cycle
+  - **exmc/exmc_nfc_nandflash_mt29f2g08ab**
+    - Fix bug: 4BitECC m_au8WriteDataHwEcc value error
+  - **fcm/fcm_freq_measure**
+    - FCM interface add instance
+  - **hash/hash_hmac**
+    - Delete interrupt mode
+  - **i2c/i2c_master_dma**
+    - Clear DMA transfer completed flag before DMA start
+  - **i2c/i2c_slave_dma**
+    - Clear DMA transfer completed flag before DMA start
+  - **i2c/i2c_slave_int**
+    - Add STOPF clearing to eei callback
+  - **i2s/i2s_play_audio**
+    - Remove the configuration of unused pin
+  - **i2s/i2s_record_and_play**
+    - Optimize using DMA linked list transfer
+  - **intc/intc_extint_key**
+    - Integrate global, group, share interrupt in one project
+  - **intc/intc_swint**
+    - Change the flashing LEDs from all to only blue for simple.
+  - **mau/mau_base**
+    - Optimize software calculate sqrt formula
+    - Use MRC and set PCLK4 for better random data
+  - **mpu/mpu_core_write_protect**
+    - Modify protect region from RTC to SRAM
+  - **rtc/rtc_calendar**
+    - Add XTAL32 clock source selection for RTC
+  - **rtc/rtc_calibration_output**
+    - Variable name changed: from u16CompenVal to i16CompenVal
+  - **rtc/rtc_intrusion_detect**
+    - Place BSP_XTAL32_Init function after PWC_VBAT_Reset function
+  - **sdioc/sdioc_mmc**
+    - Re-config SRAM read/write wait cycle
+  - **sdioc/sdioc_sd**
+    - Re-config SRAM read/write wait cycle
+  - **sdioc/sdioc_sdio**
+    - Re-config SRAM read/write wait cycle
+  - **timer0/timer0_basetimer**
+    - Modify timer0 clock division for asynchronous clock
+  - **timer0/timer0_capture**
+    - Change Timer0 interrupt priority to (DDL_IRQ_PRIO_DEFAULT - 1U)
+  - **timer6/timer6_cmp_deadtime**
+    - Modify transfer condition of general buffer
+  - **timer6/timer6_cmp_sawtooth_dual_buf**
+    - Modify compare register buffer initialization value
+  - **timer6/timer6_cmp_triangular_buf**
+    - Modify compare register buffer initialization value
+  - **timer6/timer6_sw_sync**
+    - Delete CHB output pin
+  - **timer6/timer6_valid_period**
+    - Modify compare register buffer initialization value
+  - **timera/timera_pwm**
+    - Set the initial value of the count register to 1 when using triangle wave mode to output PWM.
+  - **trng/trng_base**
+    - Set PCLK4 for better random data.
+  - **usart/usart_clocksync_dma**
+    - Fixed the return value type of ClockSync_Receive_DMA() and ClockSync_TransReceive_DMA()
+  - **usart/usart_uart_dma**
+    - Optimize function: USART_TxComplete_IrqCallback
+    - Add function: USART_StopTimeoutTimer
+#### utils
+------
+## V2.2.0  Sep 30, 2023
+#### documents
+#### drivers
+- ##### bsp/components
+  - **nt35510**
+    - Optimize function arguments
+- ##### bsp/ev_hc32f4a2_lqfp176
+  - Fix some typo: KYESCAN -> KEYSCAN
+  - Add API BSP_XTAL32_Init()
+  - Optimize function BSP_I2C_Init()
+  - Add include file named hc32_ll_fcm.h and add declaration of BSP_XTAL32_Init()
+  - Modify DMC timing for EXCLK frequency 60MHz -> 30MHz
+  - Modify SMC timing parameter: EXCLK 60MHz -> 30MHz
+  - Optimize comments
+  - Change Reset control pin from NMOS to CMOS output cause of "EV_F4A2_LQ176_Rev1.0"'s modification
+  - Rename local variables: stcTca9539Config -> m_stcTca9539Config
+  - Modify the IO properties of SPI
+  - Modify for MISRAC2012
+  - Modify SPI clock divide factor from DIV4 to DIV64
+  - Modify 'BSP_SPI_TIMEOUT' to HCLK_VALUE
+  - Rename local variables: stcWm8731Config -> m_stcWm8731Config
+- ##### cmsis/Device
+  - Modify headfile based on reference manual Rev1.3
+- ##### hc32_ll_driver
+  - **generic**
+    - Modify version as 2.2.0
+    - Modify typo
+    - Add __NO_OPTIMIZE configuration item
+    - Add attribute for __RAM_FUNC definition
+  - **interrupts_share**
+    - Modify typo
+    - IRQxxx_Handler add __DSB for Arm Errata 838869
+    - The BCSTR register of TimerA is split into BCSTRH and BCSTRL
+    - Modify for head file update: EIRQFR -> EIFR
+  - **adc**
+    - Modify typo
+    - API fixed: ADC_DeInit()
+  - **aes**
+    - Add API AES_DeInit()
+  - **aos**
+    - Modify for new head file
+  - **can**
+    - Added 3 APIs for local-reset
+    - Modify typo
+    - Added 3 APIs for local-reset.Refine local function CAN_ReadRxBuf(), CAN_WriteTxBuf()
+  - **clk**
+    - Modify typo
+    - Modify CLK_SetUSBClockSrc(), add delay after configure USB clock
+    - Modify API CLK_Xtal32Cmd(), CLK_MrcCmd() and CLK_LrcCmd(), use DDL_DelayUS() to replace CLK_Delay()
+  - **cmp**
+    - Modify typo
+    - Add assert for CIEN bit in GetCmpFuncStatusAndDisFunc function
+    - Remove redundant code in function CMP_WindowModeInit
+  - **crc**
+    - Reconstruct interface function relate to calculate CRC
+    - Modify return type of function CRC_DeInit
+    - Modify comment
+    - Delete and modify some of group/function relate to calculate CRC
+    - Optimize CRC_DeInit function
+    - Modify typo
+  - **ctc**
+    - Modify typo
+    - Modify the init assignment of i32Ret in CTC_DeInit()
+  - **dac**
+    - Refine definition of dac resolution
+    - Modify API DAC_DeInit
+    - Refine data validation
+    - Modify function:DAC_DeInit
+  - **dbgc**
+    - Add hc32_ll_dbgc driver
+  - **dcu**
+    - Modify typo
+    - Delete macro definition: DCU_INT_SAWTOOTH_WAVE_RELOAD
+    - Modify macro-definition according to RM:DCU_CTL_COMP_TRG->DCU_CTL_COMPTRG
+    - Modify API DCU_DeInit()
+    - Modify function DCU_IntCmd() for misra
+  - **dma**
+    - Add API DMA_SetDataWidth()
+    - Modify typo
+    - Modify blocksize assert, 1024U is valid
+    - Optimize set blocksize & repeat count process
+  - **dmc**
+    - Modify typo
+  - **dvp**
+    - Modify typo
+    - Add function: DVP_GetCaptureState
+  - **efm**
+    - Add FLASH security addr define
+    - Modify API EFM_OTP_Lock()
+    - Modify API EFM_Program()
+    - Modify assert IS_EFM_ADDR() range
+    - Modify typo
+    - Modify API EFM_WriteSecurityCode(), switch to read_only mode before exit
+    - Use FNWPRT_REG to replace CM_EFM->F0NWPRT0
+    - Remove address assert from EFM_ReadByte()
+    - Refine EFM_SequenceProgram() & EFM_ChipErase(), and put them in RAM
+  - **emb**
+    - Update EMB_CTL1_CMPEN0~3 to EMB_CTL1_CMPEN1~4
+    - Update EMB_INTEN_PORTINTEN to EMB_INTEN_PORTININTEN
+    - Function EMB_TMR4_Init don't call EMB_DeInit
+    - Function EMB_TMR6_Init don't call EMB_DeInit
+    - Function EMB_DeInit set register EMB_RLSSEL to reset value
+  - **eth**
+    - Modify typo
+    - Add ETH_MAC_SetInterface function
+    - Optimize ETH start and stop timing
+    - Modify the process of obtaining PHY status
+    - Modify the process of auto-negotiation disable
+    - Modify ETH_PTP_UpdateBasicAddend function
+    - Modify the clock division of SMIC
+    - Modify operation sequence of ETH_DeInit function
+  - **event_port**
+    - Modify typo
+    - Modify for new head file
+  - **fcg**
+    - Modify for head file update: PWC_FCG3_CMP1->PWC_FCG3_CMP12, PWC_FCG3_CMP2->PWC_FCG3_CMP34
+  - **fcm**
+    - Modify API FCM_DeInit()
+  - **fmac**
+    - Modify API FMAC_DeInit()
+  - **gpio**
+    - Rename GPIO_ExIntCmd() as GPIO_ExtIntCmd
+    - Modify GPIO_SetFunc()
+    - Optimize API: GPIO_Init(), GPIO_SetFunc(), GPIO_SubFuncCmd(), GPIO_InputMOSCmd(), GPIO_AnalogCmd(), GPIO_ExtIntCmd()
+  - **hash**
+    - Add HASH_DeInit function
+  - **hrpwm**
+    - Modify typo
+  - **i2c**
+    - Modify typo
+    - Move macro define I2C_SRC_CLK to head file
+    - Disable slave address function in I2C_Init()
+  - **i2s**
+    - Modify I2S_ClearStatus function
+  - **interrupts**
+    - IRQxxx_Handler add __DSB for Arm Errata 838869
+    - Modify micro define EIRQCFR_REG and EIRQFR_REG base RM
+    - Remove space line
+  - **keyscan**
+    - Add function KEYSCAN_DeInit
+  - **mau**
+    - Add API MAU_DeInit()
+  - **mpu**
+    - Modify typo
+    - Optimize MPU_ClearStatus function
+  - **nfc**
+    - Modify typo
+    - Add API function: EXMC_NFC_Read/EXMC_NFC_Write
+    - Typo: featrue -> feature; regsiter, Regster -> register
+    - Modify macro: EXMC_NFC_4BIT_ECCS -> EXMC_NFC_4BIT_ECC
+    - Change function attributes from local to global: EXMC_NFC_Read/EXMC_NFC_Write
+  - **ots**
+    - Modify typo
+    - Modify API OTS_DeInit()
+  - **pwc**
+    - Modify group PWC_Stop_Type
+    - Add function PWC_LVD_DeInit
+    - Modify the PWC_LVD_Detection_Voltage_Sel comment
+    - Modify typo
+    - Add api PWC_LVD_DeInit()
+    - Modify API PWC_STOP_Enter() & add assert IS_PWC_STOP_TYPE()
+  - **qspi**
+    - Modify return value type of QSPI_DeInit function
+    - Optimize QSPI_ClearStatus function
+  - **rmu**
+    - Use IS_RMU_UNLOCKED() to assert
+  - **rtc**
+    - Modify typo
+  - **sdioc**
+    - Modify typo
+    - Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+    - Rename function SDMMC_CMD1_SendOperatCond to SDMMC_CMD1_SendOperateCond
+    - Support CMD5/CMD52/CMD53
+    - Rename macro definition SDIOC_ACMD52_RW_DIRECT to SDIOC_CMD52_IO_RW_DIRECT
+    - Rename macro definition SDIOC_ACMD53_RW_EXTENDED to SDIOC_CMD53_IO_RW_EXTENDED
+    - Modify response type of MMC CMD3
+    - Optimize SDIOC_GetMode function
+  - **smc**
+    - API EXMC_SMC_DeInit add return value
+    - Function EXMC_SMC_DeInit add return value
+  - **spi**
+    - Add SPI_SetSckPolarity,SPI_SetSckPhase functions
+    - Add group SPI_SCK_Polarity_Define, SPI_SCK_Phase_Define
+    - Modify return type of fuction SPI_DeInit
+    - Modify SPI_GetStatus,SPI_TxRx,SPI_Tx function
+  - **sram**
+    - Modify typo
+    - API fixed: SRAM_ClearStatus()
+    - API fixed: SRAM_SetWaitCycle()
+  - **swdt**
+    - Optimize SWDT_ClearStatus function timeout
+  - **tmr0**
+    - Modify typo
+  - **tmr2**
+    - Modify typo
+  - **tmr4**
+    - Add the macros group @ref TMR4_OC_Output_Polarity
+    - Modify typo
+    - TMR4_OC_Buffer_Object group add macro-definition: TMR4_OC_BUF_NONE
+    - Modify API TMR4_DeInit
+    - Fix spell error about "response" that in function name
+    - Add function comments: macros group @ref TMR4_OC_Channel
+    - Modify function return value comments: TMR4_OC_GetPolarity
+    - Modify function parameter comments: TMR4_PWM_SetPolarity
+    - Modify function: TMR4_DeInit, TMR4_OC_DeInit, TMR4_PWM_DeInit, TMR4_EVT_DeInit
+    - Modify macro-definition: IS_TMR4_OC_BUF_OBJECT
+    - Fix magic number of function:  TMR4_OC_StructInit
+    - Modify fuction:TMR4_PWM_Init
+    - Modify comment
+  - **tmr6**
+    - Delete union in stc_tmr6_init_t structure
+    - Modify macro define for group TMR6_Emb_Ch_Define
+    - Add macro define for TMR6_Count_Dir_Status_Define
+    - Modify typo
+    - Modify API TMR6_GetCountDir()
+  - **tmra**
+    - Modify typo
+    - Update about split 16bit register TMRA_BCSTR into two 8bit registers TMRA_BCSTRH and TMRA_BCSTRL
+    - Delete union in stc_tmra_init_t structure
+    - Modify some of member type of struct stc_tmra_init_t and relate fuction about these member
+    - Modify macro-definition value for group TMRA_Interrupt_Type/TMRA_Status_Flag
+    - Rename marco definition IS_TMRA_CMPVAL_BUF_COND to IS_TMRA_BUF_TRANS_COND
+  - **trng**
+    - Add TRNG_Cmd,TRNG_DeInit functions
+    - API optimized for better random numbers: TRNG_GenerateRandom()
+    - API fixed: rewrite TRNG_GenerateRandom() to Support get multiple random data
+    - API optimized for better random numbers: TRNG_GenerateRandom(), TRNG_GetRandom()
+    - Add TRNG_Cmd,TRNG_DeInit functions and optimize TRNG_Start function
+    - Optimize the processing of discarded data and enable TRNG in TRNG_Init()
+  - **usart**
+    - Modify typo
+    - Change macro-definition: USART_DR_MPID -> USART_TDR_MPID
+    - Modify USART_SetTransType parameter: u32Type -> u16Type
+    - Modify USART_SC_ETU_CLK128/256 value
+    - Modify return type of function USART_DeInit
+    - Remove u32StopBit param from stc_usart_smartcard_init_t structure
+    - Add function note: USART_FuncCmd
+    - Round off baudrate fraction division
+    - Split register USART_DR to USART_RDR and USART_TDR
+    - Delete function: USART_GetUsartClockDiv
+    - Fix MISRAC2012 warning: USART_GetUsartClockFreq
+    - Code Refine
+    - Modify return type of function USART_DeInit()
+    - Modify USART_SmartCard_Init() for stc_usart_smartcard_init_t has modified(u32StopBit has removed)
+    - Fix bug: did not enable MP while USART_MultiProcessor_Init()
+    - Re-define IS_USART_SMARTCARD_UNIT
+    - API refined: USART_SetBaudrate()
+  - **usb**
+    - Modify typo
+    - Fix bug for function usb_clearepstall()
+  - **utility**
+    - Modify register USART DR to USART TDR
+    - Prohibit DDL_DelayMS and DDL_DelayUS functions from being optimized
+  - **wdt**
+    - Optimize WDT_ClearStatus function timeout
+#### midwares
+- ##### hc32/iec60730_class_b_stl
+  - Modify register USART DR to USART TDR
+- ##### hc32/usb
+  - Modify for variable alignment
+  - Typo: Initailizes -> Initializes
+  - Modify API usb_dev_resume()
+  - Modify function usb_susp_isr()
+  - Modify for doxygen
+  - Replace MAX_CHNUM by USB_MAX_CH_NUM
+  - Delete micro define MAX_CHNUM
+#### projects
+- ##### ev_hc32f4a2_lqfp176/applications
+  - **execute_inplace/qspi_xip**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **functional_safety/iec60730_class_b**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Change STL IO test input pin: PA0 -> PH7
+    - Initialize XTAL32 using BSP_XTAL32_Init
+    - Modify sw_count field of stc_tmra_init_t: u16xxx -> u8xxx
+  - **iap/iap_app**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Rename function CRC_CalculateData8 to CRC_CRC16_Calculate
+  - **iap/iap_boot**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Rename function CRC_CalculateData8 to CRC_CRC16_Calculate
+  - **iap/iap_ymodem_app**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **iap/iap_ymodem_boot**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **usb/usb_dev_cdc_msc**
+    - Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+    - Do not erase SD card before write operation
+  - **usb/usb_dev_hid_msc**
+    - Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+    - Do not erase SD card before write operation
+  - **usb/usb_dev_mouse**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **usb/usb_dev_msc**
+    - Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+    - Do not erase SD card before write operation
+  - **usb/usb_host_cdc**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **usb/usb_host_mouse_kb**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **usb/usb_host_msc**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+- ##### ev_hc32f4a2_lqfp176/examples
+  - **adc/adc_awd**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_base**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_channel_remap**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_dma**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_extended_channel**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_hard_trigger**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_pga**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **adc/adc_sample_hold**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **aes/aes_base**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **can/can_classical**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **can/can_fd**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Changed baudrate of data phase from 8Mbps to 5Mbps.
+  - **can/can_ttcan**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **clk/clk_switch_sysclk**
+    - Modify XTAL32 initialize process, use BSP_XTAL32_Init() to replace Xtal32Init()
+  - **crc/crc_hw_accumulate_check**
+    - Add crc_hw_accumulate_check example
+  - **crc/crc_hw_encode_hw_check**
+    - Modify for reconstructed API
+  - **crc/crc_hw_encode_sw_check**
+    - Modify for reconstructed API
+  - **ctc/ctc_xtal32_trimming**
+    - Initialize XTAL32 using BSP_XTAL32_Init
+  - **dac/dac_base**
+    - Define DAC_DATA_MAX by resolution
+  - **dac/dac_sync_mode**
+    - Define DAC_DATA_MAX by resolution
+  - **dcu/dcu_sawtooth_wave_mode**
+    - Sync driver: DCU reload interrupt is always valid
+  - **dmac/dmac_base**
+    - Add DMA2_Error_IrqCallback function
+  - **dvp/dvp_camera_display**
+    - Re-implement code
+  - **efm/efm_chip_erase**
+    - Add efm_chip_erase example
+  - **efm/efm_dbus**
+    - Add efm_dbus example
+  - **efm/efm_otp**
+    - Modify the process
+  - **efm/efm_sequence_program**
+    - Add Customize defintion
+    - Re-structure
+  - **efm/efm_swap**
+    - Use EFM_GetSwapStatus to judge
+  - **emb/emb_cmp_brake_timer4**
+    - Typo: hander -> handler
+    - Fix magic number
+    - Modify TMR4_PwmConfig: enable main output following PWM initialization
+  - **emb/emb_cmp_brake_timer6**
+    - Modify typo
+    - Fix magic number
+  - **emb/emb_osc_brake_timer4**
+    - Typo: hander -> handler
+    - Modify TMR4_PwmConfig: enable main output following PWM initialization
+  - **emb/emb_osc_brake_timer6**
+    - Modify typo
+  - **emb/emb_port_brake_timer4**
+    - Typo: hander -> handler
+    - Modify TMR4_PwmConfig: enable main output following PWM initialization
+  - **emb/emb_port_brake_timer6**
+    - Modify typo
+  - **emb/emb_pwm_brake_timer4**
+    - Typo: hander -> handler
+    - Modify TMR4_PwmConfig: enable main output following PWM initialization
+  - **emb/emb_pwm_brake_timer6**
+    - Modify typo
+  - **emb/emb_sw_brake_timer4**
+    - Modify TMR4_PwmConfig: enable main output following PWM initialization
+  - **emb/emb_sw_brake_timer6**
+    - Modify typo
+  - **eth/eth_loopback**
+    - Modify the process of obtaining PHY status
+    - Add MAC interface selection before ETH_DeInit function
+    - Disable auto negotiation in low_level_init function
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **eth/eth_twoboards**
+    - Add MAC interface selection before ETH_DeInit function
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **exmc/exmc_dmc_sdram_is42s16400j7tli**
+    - Modify EXCLK frequency: 60MHz -> 30MHz
+    - Fix typos
+    - Fix memory address printf value
+  - **exmc/exmc_sdram_sram**
+    - Modify EXCLK frequency: 60MHz -> 30MHz
+    - Fix typos
+    - Fix memory address printf value
+  - **exmc/exmc_smc_lcd_nt35510**
+    - Change EXCLK freqeuncy to 30MHz
+  - **exmc/exmc_smc_sram_is62wv51216**
+    - Modify EXCLK frequency: 60MHz -> 30MHz
+    - Fix typos and modify file brief
+    - Fix memory address printf value
+  - **hash/hash_base**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **hash/hash_hmac**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **hrpwm/hrpwm_output**
+    - Modify for Peripheral clock command process
+  - **i2c/i2c_master_dma**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Add definition I2C_ADDR_MD as address condition select
+    - Configure DMA interrupt disable in I2C_DMA_Initialize() function
+  - **i2c/i2c_master_int**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **i2c/i2c_master_polling**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Add definition I2C_ADDR_MD as address condition select
+  - **i2c/i2c_slave_dma**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Add definition I2C_ADDR_MD as address condition select
+    - Configure DMA interrupt disable in I2C_DMA_Initialize() function
+  - **i2c/i2c_slave_int**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Add definition I2C_ADDR_MD as address condition select
+  - **i2c/i2c_slave_polling**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+    - Add definition I2C_ADDR_MD as address condition select
+  - **icg/icg_wdt_interrupt_hw_startup**
+    - Add delay before WDT_GetStatus function
+  - **intc/intc_nmi_xtalstop**
+    - NMI_Handler add __DSB for Arm Errata 838869
+  - **mpu/mpu_core_write_protect**
+    - Fixed parameters error of Core_MPU_Region_Size
+    - MemManage_Handler add __DSB for Arm Errata 838869
+    - Modify trigger condition for RTC protection
+    - Optimize RTC init sequence
+  - **mpu/mpu_dma_write_protect**
+    - NMI_Handler add __DSB for Arm Errata 838869
+    - Remove key jitter
+  - **mpu/mpu_ip_read_protect**
+    - BusFault_Handler add __DSB for Arm Errata 838869
+    - Optimize RTC init sequence
+  - **ots/ots_base**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **ots/ots_scaling_experiment**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **pwc/pwc_lpc**
+    - Modify typo
+    - Clear wake up event flag in PdMode_Init() function
+  - **pwc/pwc_stop_wake**
+    - Support PWC_STOP_WFE
+  - **rtc/rtc_alarm**
+    - Optimize RTC init sequence
+    - Replace XTAL32_ClkInit to BSP_XTAL32_Init
+  - **rtc/rtc_calendar**
+    - Optimize RTC init sequence
+    - Modify the judgment condition for RTC operation status
+  - **rtc/rtc_calibration_output**
+    - Optimize RTC init sequence
+    - Replace XTAL32_ClkInit to BSP_XTAL32_Init
+  - **rtc/rtc_intrusion_detect**
+    - Optimize RTC init sequence
+    - Replace XTAL32_ClkInit to BSP_XTAL32_Init
+  - **rtc/rtc_low_power**
+    - Optimize RTC init sequence
+    - Delete XTAL32_ClkInit
+  - **sdioc/sdioc_mmc**
+    - Modify RCA value about EMMC device
+    - Rename function SDMMC_CMD1_SendOperatCond to SDMMC_CMD1_SendOperateCond
+    - Rename MMC_CARD_STAT_PAG to MMC_CARD_STAT_PGM
+  - **sdioc/sdioc_sd**
+    - Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+  - **sdioc/sdioc_sdio**
+    - Add sdioc_sdio example
+  - **spi/spi_dma**
+    - Modify the IO properties of SPI
+  - **spi/spi_int**
+    - Modify the IO properties of SPI
+    - Modify rx interrupt priority of SPI
+  - **spi/spi_polling**
+    - Modify the IO properties of SPI
+    - Replace the tx&rx function of SPI
+  - **sram/sram_error_check**
+    - NMI_Handler add __DSB for Arm Errata 838869
+  - **systick/systick_int**
+    - SysTick_Handler add __DSB for Arm Errata 838869
+  - **timer0/timer0_basetimer**
+    - Replace XTAL32_Config to BSP_XTAL32_Init
+  - **timer2/timer2_capture**
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+  - **timer2/timer2_clock_source**
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+  - **timer4/timer4_event_compare**
+    - Update TMR4 event: EVT_SRC_TMR4_1_SCMP_UH -> EVT_SRC_TMR4_1_SCMP0
+  - **timer4/timer4_event_delay**
+    - Update TMR4 event: EVT_SRC_TMR4_1_SCMP_UH -> EVT_SRC_TMR4_1_SCMP0
+  - **timer4/timer4_pwm_through**
+    - Modify the initial configuration to achieve 0% or 100% duty cycle
+  - **timer6/timer6_capture**
+    - Modify the PWM stop polarity as high
+  - **timer6/timer6_capture_dual_buf**
+    - Modify the PWM stop polarity as high
+  - **timer6/timer6_cmp_deadtime**
+    - Remove redundant code
+  - **timer6/timer6_cmp_sawtooth**
+    - Remove redundant code
+  - **timer6/timer6_cmp_sawtooth_dual_buf**
+    - Remove redundant code
+  - **timer6/timer6_cmp_triangular_buf**
+    - Remove redundant code
+  - **timer6/timer6_define_pwm_number**
+    - Modify for Peripheral clock command process
+  - **timer6/timer6_hw_code_cnt**
+    - Modify debug info
+  - **timer6/timer6_pulse_encoder_z_count**
+    - Add timer6_pulse_encoder_z_count example
+  - **timera/timera_base_timer**
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+  - **timera/timera_capture**
+    - Set XTAL as system clock source
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+    - Modify uart baudrate:19200->115200
+  - **timera/timera_cascade_count**
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+  - **timera/timera_compare_value_buffer**
+    - Set XTAL as system clock source
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+    - Modify uart baudrate:19200->115200
+  - **timera/timera_pulse_encoder_z_count**
+    - Add timera_pulse_encoder_z_count example
+  - **timera/timera_pwm**
+    - Refine code due to some of member type of struct stc_tmra_init_t is changed
+  - **trng/trng_base**
+    - Set XTAL as system clock source
+    - Modify printf baudrate
+  - **usart/usart_clocksync_dma**
+    - Add usart_clocksync_dma example
+  - **usart/usart_smartcard_atr**
+    - Remove u32StopBit from stcSmartCardInit structure
+  - **usart/usart_uart_dma**
+    - Split register USART_DR to USART_RDR and USART_TDR
+  - **usart/usart_uart_multiprocessor**
+    - Optimize the RX process
+  - **wdt/wdt_interrupt_sw_startup**
+    - Add delay before WDT_GetStatus function
+#### utils
+------
+## V2.1.0  Jan 15, 2023
+#### documents
+#### drivers
+- ##### bsp/components
+  - **gt9xx**
+    - Add gt9xx component
+  - **nt35510**
+    - Compliant LCD drive IC: NT35310
+- ##### bsp/ev_hc32f4a2_lqfp176
+  - Add configuration of XTAL IO as analog function
+  - Add XTAL/XTAL32 IO define
+  - Re-define macro: BSP_KEY_KEY10_WAKEUP
+  - Add gt9xx bsp
+  - Add timing comments
+  - Optimize timing parameters
+  - Optimize function arguments
+  - Update function arguments
+  - Add macro-define:LIN & smartcard
+  - Initialize CS state
+- ##### cmsis/Device
+  - Modify headfile register address and register name based on reference manual Rev1.13
+  - Delete the __low_level_init function of IAR and $Sub$$main function of MDK
+- ##### hc32_ll_driver
+  - **generic**
+    - Modify version as 2.1.0
+    - Implemented the definition of __NO_INIT for AC6 and ARM Compiler
+    - ARM Compiler suppress warning message: diag_1296
+  - **interrupts_share**
+    - Rename I2Cx_Error_IrqHandler as I2Cx_EE_IrqHandler
+    - Refine TMRA CMP DCU MAU share handler
+  - **adc**
+    - Modify macro group definition: ADC_Scan_Mode, ADC_Sync_Unit, ADC_Sync_Mode
+    - API fixed: ADC_DeInit()
+  - **aos**
+    - Modified parameters name of API AOS_CommonTriggerCmd() and AOS_SetTriggerEventSrc()
+    - Macro name modified: from IS_AOS_TRIG_SEL to IS_AOS_TARGET
+    - Modified parameters name and comments of AOS_CommonTriggerCmd() and AOS_SetTriggerEventSrc()
+  - **can**
+    - Deleted redundant comments
+    - Remove CAN_FLAG_RX_BUF_OVF from CAN_FLAG_CLR_ALL
+    - API fixed: CAN_FillTxFrame(), CAN_GetStatus(), CAN_ClearStatus()
+  - **clk**
+    - Refine stc_clock_freq_t
+    - Fixed bug# GetClockFreq() API xtal32 value
+    - Modified CLK_PLLN_DEFAULT value
+    - Optimize API CLK_SetCANClockSrc(), add assert IS_PWC_UNLOCKED()
+  - **cmp**
+    - Modify structure stc_cmp_window_init_t
+    - Modify macro define for API
+  - **crc**
+    - Add waiting time after write CRC data
+  - **dac**
+    - Modify function: DAC_AMPCmd
+    - Modify function: DAC_AMPCmd and add assert
+    - Synchronize register: EN->E,ADPSL->ADCSL,ALIGN->DPSEL
+  - **dcu**
+    - Modify macro group comments: DCU_Interrupt_Type
+    - Synchronize register: DCU_INTSEL -> DCU_INTEVTSEL
+    - Modify function comments: DCU_IntCmd
+  - **dma**
+    - Modify DMA_StructInit() default value
+    - Modify API DMA_DeInit and add LLP address assert
+  - **efm**
+    - Add Flash protect level define
+    - Code refine
+    - Use define to replace magic data
+    - Add API EFM_Protect_Enable & EFM_WriteSecurityCode
+    - Modify API EFM_Read & EFM_Program
+  - **emb**
+    - Modify structure comments:stc_emb_monitor_tmr_pwm_t
+    - Optimize function: EMB_TMR4_Init
+    - Optimize function: EMB_TMR6_Init
+  - **fcm**
+    - Modify parameter check for reference clock source
+  - **gpio**
+    - Add API GPIO_AnalogCmd() and GPIO_ExIntCmd()
+  - **i2c**
+    - Add API I2C_SlaveAddrCmd()
+    - Add API I2C_SlaveAddrCmd(), modify API I2C_SlaveAddrConfig()
+  - **icg**
+    - Delete ICG2 function
+  - **interrupts**
+    - Delete comment code
+    - Add macro-definition: EIRQFR_REG/NMIENR_REG/INTWKEN_REG
+  - **mpu**
+    - Update define base on new head file
+    - Modify IS_MPU_SP_START_ADDR & SP start address
+  - **ots**
+    - API fixed: OTS_CalculateTemp()
+  - **pwc**
+    - Refine API PWC_STOP_Enter()
+    - Modify API PWC_HighSpeedToLowSpeed() base umRev1.13
+    - Optimize API PWC_STOP_ClockSelect() & comment
+  - **qspi**
+    - Modify the conditions for entering direct communication mode
+  - **smc**
+    - Modify EXMC_SMC_StructInit, EXMC_SMC_Init, EXMC_SMC_GetChipConfig
+    - Delete function comments: EXMC_SMC_Chipx
+  - **spi**
+    - Add frame level processing for API SPI_TxRx(),SPI_Tx()
+  - **sram**
+    - Deleted redundant comments
+  - **tmr2**
+    - Deleted redundant comments
+  - **tmr4**
+    - Update API parameter u16IntType to u32IntType
+    - Modify macro-define: TMR4_OCSR_MASK
+    - Re-name parameter u16IntType to u32IntType
+    - Add RCSR register data type
+  - **tmr6**
+    - Modify structure stc_tmr6_deadtime_config_t
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+    - Modify macro define for group TMR6_Emb_Ch_Define
+    - Modify macro define for group TMR6_hardware_xxx_condition_Define
+    - Modify macro define for group TMR6_HW_Count_xx_Cond_Define
+    - Modify macro define for group TMR6_Valid_Period_Count_Cond_Define
+    - Modify API TMR6_SetFilterClockDiv()
+    - Define variable in the beginning of the function
+  - **tmra**
+    - Comments optimization
+  - **trng**
+    - API fixed: TRNG_Init()
+  - **usart**
+    - Optimize UART DIV_Fraction calculation time
+    - Fix bug: expressions may cause overflow when calculate UART DIV_Fraction
+  - **usb**
+    - Add USB core ID select function
+    - Delete comment
+    - Add USB DMA function
+  - **utility**
+    - Support re-target printf for IAR EW version 9 or later
+#### midwares
+- ##### hc32/iec60730_class_b_stl
+  - Optimize macros definitions
+  - Modify USART_SR_TXE to USART_SR_TC in STL_ConsoleOutputChar()
+  - Fix warning: MISRAC2012-Rule-18.4
+  - Fix bug: Reading CC Build CRC32 value is error in release project
+- ##### hc32/usb
+  - Add USB core ID select function
+  - Modify for MISRAC
+  - Delete comment
+  - Fix bug for USB endpoint GET_STATUS request
+  - Modify for variable alignment
+  - Add bot xfer error processing
+  - Remove msc bot reset operation
+  - Optimize for device insert detection
+  - Remove the judgment of ErrCnt when xfer error
+#### projects
+- ##### ev_hc32f4a2_lqfp176/applications
+  - **functional_safety/iec60730_class_b**
+    - Add VBAT initialization
+    - Add configuration of XTAL32 IO as analog function
+  - **iap/iap_boot**
+    - Add configuration of XTAL IO as analog function
+  - **iap/iap_ymodem_boot**
+    - Add configuration of XTAL IO as analog function
+    - Add print strings for download and upload completion
+  - **usb/usb_dev_cdc**
+    - Modify for MISRAC
+    - Add USB core ID select function
+    - Modify DEV_MANUFACTURER_STRING
+  - **usb/usb_dev_cdc_msc**
+    - Modify for MISRAC
+    - Add USB core ID select function
+    - Using micro SD card as memory and support USB HS
+    - Add usb_dev_cdc_msc application
+    - Modify the error of CSD parameter calculation
+    - Modify DEV_MANUFACTURER_STRING
+    - Modify Vendor Identification
+  - **usb/usb_dev_hid_cdc**
+    - Modify for MISRAC
+    - Add USB core ID select function
+    - Modify DEV_MANUFACTURER_STRING
+  - **usb/usb_dev_hid_custom**
+    - Add USB core ID select function
+    - Modify DEV_MANUFACTURER_STRING
+  - **usb/usb_dev_hid_msc**
+    - Add USB core ID select function
+    - Using micro SD card as memory and support USB HS
+    - Add usb_dev_hid_msc application
+    - Modify the error of CSD parameter calculation
+    - Modify DEV_MANUFACTURER_STRING
+    - Modify Vendor Identification
+  - **usb/usb_dev_mouse**
+    - Add USB core ID select function
+    - Modify DEV_MANUFACTURER_STRING
+  - **usb/usb_dev_msc**
+    - Add USB core ID select function
+    - Using micro SD card as memory and support USB HS
+    - Add usb_dev_msc application
+    - Modify the error of CSD parameter calculation
+    - Modify DEV_MANUFACTURER_STRING
+    - Modify Vendor Identification
+  - **usb/usb_host_cdc**
+    - Add USB core ID select function
+  - **usb/usb_host_mouse_kb**
+    - Add USB core ID select function
+  - **usb/usb_host_msc**
+    - Add USB core ID select function
+    - Support LFN print
+    - Fix bug for device disconnect detect
+- ##### ev_hc32f4a2_lqfp176/examples
+  - **adc/adc_awd**
+    - Comment fixed
+  - **adc/adc_base**
+    - Add configuration of XTAL IO as analog function
+    - Add configuration usage of sampling time
+  - **can/can_classical**
+    - CAN_IrqCallback() fixed
+  - **can/can_fd**
+    - CAN_IrqCallback() fixed
+  - **can/can_ttcan**
+    - CAN_IrqCallback() fixed
+  - **clk/clk_switch_sysclk**
+    - Add configuration of XTAL and XTAL32 IO as analog function
+  - **clk/clk_xtalstop_detect**
+    - Add configuration of XTAL IO as analog function
+  - **cmp/cmp_normal_blankwindow**
+    - Modify for driver update
+  - **cmp/cmp_normal_int**
+    - Modify for driver update
+  - **cmp/cmp_window**
+    - Modify for driver update
+  - **ctc/ctc_ctcref_trimming**
+    - Add configuration of XTAL IO as analog function
+  - **ctc/ctc_xtal32_trimming**
+    - Add configuration of XTAL and XTAL32 IO as analog function
+  - **ctc/ctc_xtal_trimming**
+    - Add configuration of XTAL IO as analog function
+  - **dac/dac_base**
+    - Simplify the dac base example
+  - **dac/dac_sync_mode**
+    - Add dac_sync_mode example
+  - **efm/efm_protect**
+    - Add efm_protect example
+  - **emb/emb_cmp_brake_timer4**
+    - Sync CMP and DAC driver
+  - **emb/emb_cmp_brake_timer6**
+    - Sync CMP and DAC driver
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **emb/emb_osc_brake_timer4**
+    - Add configuration of XTAL IO as analog function
+  - **emb/emb_osc_brake_timer6**
+    - Add configuration of XTAL IO as analog function
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **emb/emb_port_brake_timer6**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **emb/emb_pwm_brake_timer6**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **emb/emb_sw_brake_timer6**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **eth/eth_loopback**
+    - Delect RX_ER Pin in RMII mode
+  - **eth/eth_twoboards**
+    - Add configuration of XTAL IO as analog function
+  - **exmc/exmc_dmc_sdram_is42s16400j7tli**
+    - Initialize buffer with random data
+  - **exmc/exmc_nfc_nandflash_mt29f2g08ab**
+    - Initialize buffer with random data
+  - **exmc/exmc_sdram_sram**
+    - Add exmc_sdram_sram example
+  - **exmc/exmc_smc_lcd_nt35510**
+    - Add exmc_smc_lcd_nt35510 example
+  - **exmc/exmc_smc_sram_is62wv51216**
+    - Initialize buffer with random data
+  - **fcm/fcm_freq_measure**
+    - Add configuration of XTAL and XTAL32 IO as analog function
+    - Modify print process after clear flag in IRQ handle
+    - Modify reference clock for SWDTLRC
+  - **hrpwm/hrpwm_output**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **i2c/i2c_master_dma**
+    - Add i2c_master_dma example
+  - **i2c/i2c_master_int**
+    - Modify LED blink time
+  - **i2c/i2c_master_polling**
+    - Modify LED blink time
+  - **i2c/i2c_slave_dma**
+    - Add i2c_slave_dma example
+  - **i2c/i2c_slave_int**
+    - Modify LED blink time
+  - **i2c/i2c_slave_polling**
+    - Modify LED blink time
+  - **icg/icg_swdt_interrupt_hw_startup**
+    - Exchange LED color
+  - **icg/icg_wdt_interrupt_hw_startup**
+    - Exchange LED color
+  - **intc/intc_nmi_xtalstop**
+    - Add configuration of XTAL IO as analog function
+  - **ots/ots_base**
+    - Print log fixed
+  - **pwc/pwc_lpc**
+    - Code refine
+  - **pwc/pwc_lvd**
+    - Add filter configure to LVD initialize
+  - **pwc/pwc_stop_wake**
+    - Code refine
+  - **rtc/rtc_alarm**
+    - Add configuration of XTAL32 IO as analog function
+  - **rtc/rtc_calibration_output**
+    - Add configuration of XTAL32 IO as analog function
+  - **rtc/rtc_intrusion_detect**
+    - Add configuration of XTAL32 IO as analog function
+  - **rtc/rtc_low_power**
+    - Add configuration of XTAL32 IO as analog function
+  - **sdioc/sdioc_mmc**
+    - Add configuration of XTAL IO as analog function
+    - Add the function to get extended CSD register
+  - **sdioc/sdioc_sd**
+    - Add configuration of XTAL IO as analog function
+    - Modify the error of CSD parameter calculation
+  - **swdt/swdt_interrupt_sw_startup**
+    - Exchange LED color
+  - **timer0/timer0_basetimer**
+    - Add configuration of XTAL32 IO as analog function
+  - **timer2/timer2_capture**
+    - Macro definition fixed
+  - **timer4/timer4_counter_sawtooth**
+    - Fix MISRA warning: MISRAC2012-Rule-10.3
+  - **timer6/timer6_capture**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+    - Modify macro define for group TMR6_hardware_xxx_condition_Define
+  - **timer6/timer6_capture_dual_buf**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+    - Modify macro define for group TMR6_hardware_xxx_condition_Define
+  - **timer6/timer6_cmp_deadtime**
+    - Modify structure stc_tmr6_deadtime_config_t
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timer6/timer6_cmp_sawtooth**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timer6/timer6_cmp_sawtooth_dual_buf**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timer6/timer6_cmp_triangular_buf**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timer6/timer6_define_pwm_number**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timer6/timer6_hw_code_cnt**
+    - Modify macro define for group TMR6_HW_Count_xx_Cond_Define
+  - **timer6/timer6_hw_sta_stp_clr**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+    - Modify macro define for group TMR6_hardware_xxx_condition_Define
+  - **timer6/timer6_sw_sync**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+    - Code refine for peripheral clock command
+  - **timer6/timer6_valid_period**
+    - Modify structure stc_timer6_init_t to stc_tmr6_init_t
+  - **timera/timera_base_timer**
+    - Comments fixed
+  - **timera/timera_capture**
+    - TMRA_IrqCallback(): comment fixed, print log fixed
+  - **timera/timera_pwm**
+    - Comment fixed
+  - **usart/usart_clocksync_int**
+    - Read USART_DR.RDR when USART overrun error occur
+  - **usart/usart_smartcard_atr**
+    - Add delay time for smartcard cold reset
+    - Read USART_DR.RDR when USART overrun error occur.
+  - **usart/usart_uart_dma**
+    - Delete the redundant code
+    - Read USART_DR.RDR when USART overrun error occur.
+    - Update UART timeout function calculating formula for Timer0 CMP value
+  - **usart/usart_uart_halfduplex_int**
+    - Read USART_DR.RDR when USART overrun error occur
+  - **usart/usart_uart_int**
+    - Read USART_DR.RDR when USART overrun error occur
+  - **usart/usart_uart_multiprocessor**
+    - Read USART_DR.RDR when USART overrun error occur
+  - **usart/usart_uart_polling**
+    - Read USART_DR.RDR when USART overrun error occur
+  - **wdt/wdt_interrupt_sw_startup**
+    - Exchange LED color
+#### utils
+------
+## V2.0.0  Mar 31, 2022
+- Initial release.

--- a/hc32f4a2/LICENSE
+++ b/hc32f4a2/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022-2025, Xiaohua Semiconductor Co., Ltd. ("XHSC")
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/hc32f4a2/SConscript
+++ b/hc32f4a2/SConscript
@@ -64,7 +64,7 @@ if GetDepend(['RT_USING_WDT']):
 if GetDepend(['RT_USING_SDIO']):
     src += ['src/hc32_ll_sdioc.c']
 
-if GetDepend(['RT_USING_HWTIMER']):
+if GetDepend(['BSP_USING_CLOCK_TIMER']):
     src += ['src/hc32_ll_tmr2.c']
     src += ['src/hc32_ll_tmr4.c']
     src += ['src/hc32_ll_tmr6.c']

--- a/hc32f4a2/SConscript
+++ b/hc32f4a2/SConscript
@@ -64,9 +64,6 @@ if GetDepend(['RT_USING_WDT']):
 if GetDepend(['RT_USING_SDIO']):
     src += ['src/hc32_ll_sdioc.c']
 
-if GetDepend(['RT_USING_ON_CHIP_FLASH']):
-    src += ['src/hc32_ll_efm.c']
-
 if GetDepend(['RT_USING_HWTIMER']):
     src += ['src/hc32_ll_tmr2.c']
     src += ['src/hc32_ll_tmr4.c']

--- a/hc32f4a2/SConscript
+++ b/hc32f4a2/SConscript
@@ -1,0 +1,112 @@
+import rtconfig
+from building import *
+
+# get current directory
+cwd = GetCurrentDir()
+
+# The set of source files associated with this SConscript file.
+
+src = Split('''
+src/hc32_ll.c
+src/hc32_ll_aos.c
+src/hc32_ll_clk.c
+src/hc32_ll_dma.c
+src/hc32_ll_efm.c
+src/hc32_ll_fcg.c
+src/hc32_ll_gpio.c
+src/hc32_ll_icg.c
+src/hc32_ll_interrupts.c
+src/hc32_ll_pwc.c
+src/hc32_ll_rmu.c
+src/hc32_ll_sram.c
+src/hc32_ll_utility.c
+src/hc32f4a2_ll_interrupts_share.c
+''')
+
+if GetDepend(['BSP_USING_NAND']):
+    src += ['src/hc32_ll_nfc.c']
+
+if GetDepend(['BSP_USING_SDRAM']):
+    src += ['src/hc32_ll_dmc.c']
+
+if GetDepend(['RT_USING_SERIAL']):
+    src += ['src/hc32_ll_usart.c']
+    src += ['src/hc32_ll_tmr0.c']
+
+if GetDepend(['RT_USING_I2C']):
+    src += ['src/hc32_ll_i2c.c']
+
+if GetDepend(['RT_USING_SPI']):
+    src += ['src/hc32_ll_spi.c']
+
+if GetDepend(['RT_USING_QSPI']):
+    src += ['src/hc32_ll_qspi.c']
+
+if GetDepend(['RT_USING_CAN']):
+    src += ['src/hc32_ll_can.c']
+
+if GetDepend(['BSP_USING_ETH']):
+    src += ['src/hc32_ll_eth.c']
+
+if GetDepend(['RT_USING_ADC']):
+    src += ['src/hc32_ll_adc.c']
+
+if GetDepend(['RT_USING_DAC']):
+    src += ['src/hc32_ll_dac.c']
+
+if GetDepend(['RT_USING_RTC']):
+    src += ['src/hc32_ll_rtc.c']
+
+if GetDepend(['RT_USING_WDT']):
+    src += ['src/hc32_ll_swdt.c']
+    src += ['src/hc32_ll_wdt.c']
+
+if GetDepend(['RT_USING_SDIO']):
+    src += ['src/hc32_ll_sdioc.c']
+
+if GetDepend(['RT_USING_ON_CHIP_FLASH']):
+    src += ['src/hc32_ll_efm.c']
+
+if GetDepend(['RT_USING_HWTIMER']):
+    src += ['src/hc32_ll_tmr2.c']
+    src += ['src/hc32_ll_tmr4.c']
+    src += ['src/hc32_ll_tmr6.c']
+    src += ['src/hc32_ll_tmra.c']
+
+if GetDepend(['RT_USING_PULSE_ENCODER']):
+    src += ['src/hc32_ll_tmr6.c']
+    src += ['src/hc32_ll_tmra.c']
+
+if GetDepend(['RT_USING_PWM']):
+    src += ['src/hc32_ll_tmr4.c']
+    src += ['src/hc32_ll_tmr6.c']
+    src += ['src/hc32_ll_tmra.c']
+
+if GetDepend(['RT_USING_INPUT_CAPTURE']):
+    src += ['src/hc32_ll_tmr6.c']
+
+if GetDepend(['RT_HWCRYPTO_USING_RNG']):
+    src += ['src/hc32_ll_trng.c']
+
+if GetDepend(['RT_HWCRYPTO_USING_CRC']):
+    src += ['src/hc32_ll_crc.c']
+
+if GetDepend(['RT_HWCRYPTO_USING_AES']):
+    src += ['src/hc32_ll_aes.c']
+
+if GetDepend(['RT_HWCRYPTO_USING_SHA2']):
+    src += ['src/hc32_ll_hash.c']
+
+if GetDepend(['BSP_USING_USBD']) or GetDepend(['BSP_USING_USBH']):
+    src += ['src/hc32_ll_usb.c']
+
+if GetDepend(['BSP_RTC_USING_XTAL32']) or GetDepend(['RT_USING_PM']):
+    src += ['src/hc32_ll_fcm.c']
+
+path = [cwd + '/inc']
+
+CPPDEFINES = ['USE_DDL_DRIVER']
+
+group = DefineGroup('HC32F4A2-LL', src, depend = ['SOC_HC32F4A2SI'], CPPPATH = path, CPPDEFINES = CPPDEFINES)
+
+Return('group')

--- a/hc32f4a2/inc/hc32_ll.h
+++ b/hc32f4a2/inc/hc32_ll.h
@@ -1,0 +1,362 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll.h
+ * @brief This file contains HC32 Series Device Driver Library file call
+ *        management.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Modify version as 2.1.0
+   2023-09-30       CDT             Modify version as 2.2.0
+   2024-11-08       CDT             Modify version as Rev2.3.0
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_H__
+#define __HC32_LL_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_Global
+ * @{
+ */
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup LL_Global_Macros LL Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup Peripheral_Register_WP_Global_Macros Peripheral Register Write Protection Global Macros
+ * @{
+ */
+#define LL_PERIPH_EFM           (1UL << 0U)
+#define LL_PERIPH_FCG           (1UL << 1U)
+#define LL_PERIPH_GPIO          (1UL << 2U)
+#define LL_PERIPH_INTC          (1UL << 3U)
+#define LL_PERIPH_LVD           (1UL << 4U)
+#define LL_PERIPH_MPU           (1UL << 5U)
+#define LL_PERIPH_PWC_CLK_RMU   (1UL << 6U)
+#define LL_PERIPH_SRAM          (1UL << 7U)
+#define LL_PERIPH_ALL           (LL_PERIPH_EFM | LL_PERIPH_FCG | LL_PERIPH_GPIO | LL_PERIPH_INTC  | \
+                                 LL_PERIPH_LVD | LL_PERIPH_MPU | LL_PERIPH_SRAM | LL_PERIPH_PWC_CLK_RMU)
+/**
+ * @}
+ */
+
+/* Defined use Device Driver Library */
+#if !defined (USE_DDL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the Device Driver Library.
+ * In this case, the application code will be based on direct access to
+ * peripherals registers.
+ */
+/* #define USE_DDL_DRIVER */
+#endif /* USE_DDL_DRIVER */
+
+/**
+* @defgroup HC32_Series_DDL_Release_Version HC32 Series DDL Release Version
+* @{
+*/
+#define HC32_DDL_REV_MAIN               0x02U  /*!< [31:24] main version  */
+#define HC32_DDL_REV_SUB1               0x03U  /*!< [23:16] sub1 version  */
+#define HC32_DDL_REV_SUB2               0x00U  /*!< [15:8]  sub2 version  */
+#define HC32_DDL_REV_PATCH              0x00U  /*!< [7:0]   patch version */
+#define HC32_DDL_REV                    ((HC32_DDL_REV_MAIN << 24) | (HC32_DDL_REV_SUB1 << 16) | \
+                                         (HC32_DDL_REV_SUB2 << 8 ) | (HC32_DDL_REV_PATCH))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* Use Device Driver Library */
+#if defined (USE_DDL_DRIVER)
+
+/**
+ * @brief Include peripheral module's header file
+ */
+#if (LL_ADC_ENABLE == DDL_ON)
+#include "hc32_ll_adc.h"
+#endif /* LL_ADC_ENABLE */
+
+#if (LL_AES_ENABLE == DDL_ON)
+#include "hc32_ll_aes.h"
+#endif /* LL_AES_ENABLE */
+
+#if (LL_AOS_ENABLE == DDL_ON)
+#include "hc32_ll_aos.h"
+#endif /* LL_AOS_ENABLE */
+
+#if (LL_CAN_ENABLE == DDL_ON)
+#include "hc32_ll_can.h"
+#endif /* LL_CAN_ENABLE */
+
+#if (LL_CLK_ENABLE == DDL_ON)
+#include "hc32_ll_clk.h"
+#endif /* LL_CLK_ENABLE */
+
+#if (LL_CMP_ENABLE == DDL_ON)
+#include "hc32_ll_cmp.h"
+#endif /* LL_CMP_ENABLE */
+
+#if (LL_CRC_ENABLE == DDL_ON)
+#include "hc32_ll_crc.h"
+#endif /* LL_CRC_ENABLE */
+
+#if (LL_CTC_ENABLE == DDL_ON)
+#include "hc32_ll_ctc.h"
+#endif /* LL_CTC_ENABLE */
+
+#if (LL_DAC_ENABLE == DDL_ON)
+#include "hc32_ll_dac.h"
+#endif /* LL_DAC_ENABLE */
+
+#if (LL_DBGC_ENABLE == DDL_ON)
+#include "hc32_ll_dbgc.h"
+#endif /* LL_DBGC_ENABLE */
+
+#if (LL_DCU_ENABLE == DDL_ON)
+#include "hc32_ll_dcu.h"
+#endif /* LL_DCU_ENABLE */
+
+#if (LL_DMA_ENABLE == DDL_ON)
+#include "hc32_ll_dma.h"
+#endif /* LL_DMA_ENABLE */
+
+#if (LL_DMC_ENABLE == DDL_ON)
+#include "hc32_ll_dmc.h"
+#endif /* LL_DMC_ENABLE */
+
+#if (LL_DVP_ENABLE == DDL_ON)
+#include "hc32_ll_dvp.h"
+#endif /* LL_DVP_ENABLE */
+
+#if (LL_EFM_ENABLE == DDL_ON)
+#include "hc32_ll_efm.h"
+#endif /* LL_EFM_ENABLE */
+
+#if (LL_EMB_ENABLE == DDL_ON)
+#include "hc32_ll_emb.h"
+#endif /* LL_EMB_ENABLE */
+
+#if (LL_ETH_ENABLE == DDL_ON)
+#include "hc32_ll_eth.h"
+#endif /* LL_ETH_ENABLE */
+
+#if (LL_EVENT_PORT_ENABLE == DDL_ON)
+#include "hc32_ll_event_port.h"
+#endif /* LL_EVENT_PORT_ENABLE */
+
+#if (LL_FCG_ENABLE == DDL_ON)
+#include "hc32_ll_fcg.h"
+#endif /* LL_FCG_ENABLE */
+
+#if (LL_FCM_ENABLE == DDL_ON)
+#include "hc32_ll_fcm.h"
+#endif /* LL_FCM_ENABLE */
+
+#if (LL_FMAC_ENABLE == DDL_ON)
+#include "hc32_ll_fmac.h"
+#endif /* LL_FMAC_ENABLE */
+
+#if (LL_GPIO_ENABLE == DDL_ON)
+#include "hc32_ll_gpio.h"
+#endif /* LL_GPIO_ENABLE */
+
+#if (LL_HASH_ENABLE == DDL_ON)
+#include "hc32_ll_hash.h"
+#endif /* LL_HASH_ENABLE */
+
+#if (LL_HRPWM_ENABLE == DDL_ON)
+#include "hc32_ll_hrpwm.h"
+#endif /* LL_HRPWM_ENABLE */
+
+#if (LL_I2C_ENABLE == DDL_ON)
+#include "hc32_ll_i2c.h"
+#endif /* LL_I2C_ENABLE */
+
+#if (LL_I2S_ENABLE == DDL_ON)
+#include "hc32_ll_i2s.h"
+#endif /* LL_I2S_ENABLE */
+
+#if (LL_ICG_ENABLE == DDL_ON)
+#include "hc32_ll_icg.h"
+#endif /* LL_ICG_ENABLE */
+
+#if (LL_INTERRUPTS_ENABLE == DDL_ON)
+#include "hc32_ll_interrupts.h"
+#endif /* LL_INTERRUPTS_ENABLE */
+
+#if (LL_INTERRUPTS_SHARE_ENABLE == DDL_ON)
+#include "hc32f4a2_ll_interrupts_share.h"
+#endif /* LL_INTERRUPTS_ENABLE */
+
+#if (LL_KEYSCAN_ENABLE == DDL_ON)
+#include "hc32_ll_keyscan.h"
+#endif /* LL_KEYSCAN_ENABLE */
+
+#if (LL_MAU_ENABLE == DDL_ON)
+#include "hc32_ll_mau.h"
+#endif /* LL_MAU_ENABLE */
+
+#if (LL_MPU_ENABLE == DDL_ON)
+#include "hc32_ll_mpu.h"
+#endif /* LL_MPU_ENABLE */
+
+#if (LL_NFC_ENABLE == DDL_ON)
+#include "hc32_ll_nfc.h"
+#endif /* LL_NFC_ENABLE */
+
+#if (LL_OTS_ENABLE == DDL_ON)
+#include "hc32_ll_ots.h"
+#endif /* LL_OTS_ENABLE */
+
+#if (LL_PWC_ENABLE == DDL_ON)
+#include "hc32_ll_pwc.h"
+#endif /* LL_PWC_ENABLE */
+
+#if (LL_QSPI_ENABLE == DDL_ON)
+#include "hc32_ll_qspi.h"
+#endif /* LL_QSPI_ENABLE */
+
+#if (LL_RMU_ENABLE == DDL_ON)
+#include "hc32_ll_rmu.h"
+#endif /* LL_RMU_ENABLE */
+
+#if (LL_RTC_ENABLE == DDL_ON)
+#include "hc32_ll_rtc.h"
+#endif /* LL_RTC_ENABLE */
+
+#if (LL_SDIOC_ENABLE == DDL_ON)
+#include "hc32_ll_sdioc.h"
+#endif /* LL_SDIOC_ENABLE */
+
+#if (LL_SMC_ENABLE == DDL_ON)
+#include "hc32_ll_smc.h"
+#endif /* LL_SMC_ENABLE */
+
+#if (LL_SPI_ENABLE == DDL_ON)
+#include "hc32_ll_spi.h"
+#endif /* LL_SPI_ENABLE */
+
+#if (LL_SRAM_ENABLE == DDL_ON)
+#include "hc32_ll_sram.h"
+#endif /* LL_SRAM_ENABLE */
+
+#if (LL_SWDT_ENABLE == DDL_ON)
+#include "hc32_ll_swdt.h"
+#endif /* LL_SWDT_ENABLE */
+
+#if (LL_TMR0_ENABLE == DDL_ON)
+#include "hc32_ll_tmr0.h"
+#endif /* LL_TMR0_ENABLE */
+
+#if (LL_TMR2_ENABLE == DDL_ON)
+#include "hc32_ll_tmr2.h"
+#endif /* LL_TMR2_ENABLE */
+
+#if (LL_TMR4_ENABLE == DDL_ON)
+#include "hc32_ll_tmr4.h"
+#endif /* LL_TMR4_ENABLE */
+
+#if (LL_TMR6_ENABLE == DDL_ON)
+#include "hc32_ll_tmr6.h"
+#endif /* LL_TMR6_ENABLE */
+
+#if (LL_TMRA_ENABLE == DDL_ON)
+#include "hc32_ll_tmra.h"
+#endif /* LL_TMRA_ENABLE */
+
+#if (LL_TRNG_ENABLE == DDL_ON)
+#include "hc32_ll_trng.h"
+#endif /* LL_TRNG_ENABLE */
+
+#if (LL_USART_ENABLE == DDL_ON)
+#include "hc32_ll_usart.h"
+#endif /* LL_USART_ENABLE */
+
+#if (LL_UTILITY_ENABLE == DDL_ON)
+#include "hc32_ll_utility.h"
+#endif /* LL_UTILITY_ENABLE */
+
+#if (LL_USB_ENABLE == DDL_ON)
+#include "hc32_ll_usb.h"
+#endif /* LL_USB_ENABLE */
+
+#if (LL_WDT_ENABLE == DDL_ON)
+#include "hc32_ll_wdt.h"
+#endif /* LL_WDT_ENABLE */
+
+#endif /* USE_DDL_DRIVER */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup LL_Global_Functions
+ * @{
+ */
+void LL_PERIPH_WE(uint32_t u32Peripheral);
+void LL_PERIPH_WP(uint32_t u32Peripheral);
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_DDL_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_adc.h
+++ b/hc32f4a2/inc/hc32_ll_adc.h
@@ -1,0 +1,550 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_adc.h
+ * @brief This file contains all the functions prototypes of the ADC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Modify macro group definition: ADC_Scan_Mode, ADC_Sync_Unit, ADC_Sync_Mode
+   2023-06-30       CDT             Modify typo
+                                    API fixed: ADC_DeInit()
+   2023-12-15       CDT             Add declaration of API ADC_MxChCmd(), ADC_ConvDataAverageMxChCmd(), and add defgroup ADC_Mx_Channel
+                                    Add declaration of API ADC_GetResolution()
+   2024-06-30       CDT             Fixed some comments
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_ADC_H__
+#define __HC32_LL_ADC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_ADC
+ * @{
+ */
+
+#if (LL_ADC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup ADC_Global_Types ADC Global Types
+ * @{
+ */
+/**
+ * @brief Structure definition of analog watchdog(AWD) configuration.
+ */
+typedef struct {
+    uint16_t u16WatchdogMode;           /*!< Specifies the ADC analog watchdog mode.
+                                             This parameter can be a value of @ref ADC_AWD_Mode */
+    uint16_t u16LowThreshold;           /*!< Specifies the ADC analog watchdog Low threshold value. */
+    uint16_t u16HighThreshold;          /*!< Specifies the ADC analog watchdog High threshold value. */
+} stc_adc_awd_config_t;
+
+/**
+ * @brief Structure definition of ADC initialization.
+ */
+typedef struct {
+    uint16_t u16ScanMode;               /*!< Specifies the ADC scan convert mode.
+                                             This parameter can be a value of @ref ADC_Scan_Mode */
+    uint16_t u16Resolution;             /*!< Specifies the ADC resolution.
+                                             This parameter can be a value of @ref ADC_Resolution */
+    uint16_t u16DataAlign;              /*!< Specifies ADC data alignment.
+                                             This parameter can be a value of @ref ADC_Data_Align */
+} stc_adc_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ADC_Global_Macros ADC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup ADC_Sequence ADC Sequence
+ * @{
+ */
+#define ADC_SEQ_A                       (0U)                /*!< ADC sequence A. */
+#define ADC_SEQ_B                       (1U)                /*!< ADC sequence B. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Channel ADC Channel
+ * @{
+ */
+#define ADC_CH0                         (0U)        /*!< Default input pin: PA0 for ADC1, ADC2 and ADC3. */
+#define ADC_CH1                         (1U)        /*!< Default input pin: PA1 for ADC1, ADC2 and ADC3. */
+#define ADC_CH2                         (2U)        /*!< Default input pin: PA2 for ADC1, ADC2 and ADC3. */
+#define ADC_CH3                         (3U)        /*!< Default input pin: PA3 for ADC1, ADC2 and ADC3. */
+#define ADC_CH4                         (4U)        /*!< Default input pin: PA4 for ADC1 and ADC2, PF6 for ADC3. */
+#define ADC_CH5                         (5U)        /*!< Default input pin: PA5 for ADC1 and ADC2, PF7 for ADC3. */
+#define ADC_CH6                         (6U)        /*!< Default input pin: PA6 for ADC1 and ADC2, PF8 for ADC3. */
+#define ADC_CH7                         (7U)        /*!< Default input pin: PA7 for ADC1 and ADC2, PF9 for ADC3. */
+#define ADC_CH8                         (8U)        /*!< Default input pin: PB0 for ADC1 and ADC2, PF10 for ADC3. */
+#define ADC_CH9                         (9U)        /*!< Default input pin: PB1 for ADC1 and ADC2, PF3 for ADC3. */
+#define ADC_CH10                        (10U)       /*!< Default input pin: PC0 for ADC1, ADC2 and ADC3. */
+#define ADC_CH11                        (11U)       /*!< Default input pin: PC1 for ADC1, ADC2 and ADC3. */
+#define ADC_CH12                        (12U)       /*!< Default input pin: PC2 for ADC1, ADC2 and ADC3. */
+#define ADC_CH13                        (13U)       /*!< Default input pin: PC3 for ADC1, ADC2 and ADC3. */
+#define ADC_CH14                        (14U)       /*!< Default input pin: PC4 for ADC1 and ADC2, PF4 for ADC3. */
+#define ADC_CH15                        (15U)       /*!< Default input pin: PC5 for ADC1 and ADC2, PF5 for ADC3. */
+#define ADC_CH16                        (16U)       /*!< Default input pin: PH2 for ADC3. NOT support ADC1 and ADC2. */
+#define ADC_CH17                        (17U)       /*!< Default input pin: PH3 for ADC3. NOT support ADC1 and ADC2. */
+#define ADC_CH18                        (18U)       /*!< Default input pin: PH4 for ADC3. NOT support ADC1 and ADC2. */
+#define ADC_CH19                        (19U)       /*!< Default input pin: PH5 for ADC3. NOT support ADC1 and ADC2. */
+
+#define ADC_EXT_CH                      (ADC_CH15)  /*!< ADC1, ADC2 and ADC3: analog input source can be external analog pin,
+                                                         or internal reference voltage, or VBAT/2. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Mx_Channel ADC Channel
+ * @{
+ */
+#define ADC_MX_CH0                      (1U << 0U)          /*!< ADC channel 0 position  */
+#define ADC_MX_CH1                      (1U << 1U)          /*!< ADC channel 1 position  */
+#define ADC_MX_CH2                      (1U << 2U)          /*!< ADC channel 2 position  */
+#define ADC_MX_CH3                      (1U << 3U)          /*!< ADC channel 3 position  */
+#define ADC_MX_CH4                      (1U << 4U)          /*!< ADC channel 4 position  */
+#define ADC_MX_CH5                      (1U << 5U)          /*!< ADC channel 5 position  */
+#define ADC_MX_CH6                      (1U << 6U)          /*!< ADC channel 6 position  */
+#define ADC_MX_CH7                      (1U << 7U)          /*!< ADC channel 7 position  */
+#define ADC_MX_CH8                      (1U << 8U)          /*!< ADC channel 8 position  */
+#define ADC_MX_CH9                      (1U << 9U)          /*!< ADC channel 9 position  */
+#define ADC_MX_CH10                     (1U << 10U)         /*!< ADC channel 10 position */
+#define ADC_MX_CH11                     (1U << 11U)         /*!< ADC channel 11 position */
+#define ADC_MX_CH12                     (1U << 12U)         /*!< ADC channel 12 position */
+#define ADC_MX_CH13                     (1U << 13U)         /*!< ADC channel 13 position */
+#define ADC_MX_CH14                     (1U << 14U)         /*!< ADC channel 14 position */
+#define ADC_MX_CH15                     (1U << 15U)         /*!< ADC channel 15 position */
+#define ADC_MX_CH16                     (1U << 16U)         /*!< ADC channel 16 position */
+#define ADC_MX_CH17                     (1U << 17U)         /*!< ADC channel 17 position */
+#define ADC_MX_CH18                     (1U << 18U)         /*!< ADC channel 18 position */
+#define ADC_MX_CH19                     (1U << 19U)         /*!< ADC channel 19 position */
+
+#define ADC1_MX_CH_ALL                  (0xFFFFUL)          /*!< ADC1 Channel mask position */
+#define ADC2_MX_CH_ALL                  (0xFFFFUL)          /*!< ADC2 Channel mask position */
+#define ADC3_MX_CH_ALL                  (0xFFFFFUL)         /*!< ADC3 Channel mask position */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Scan_Mode ADC Scan Convert Mode
+ * @{
+ */
+#define ADC_MD_SEQA_SINGLESHOT              (0x0U)                      /*!< Sequence A single shot. Sequence B is disabled. */
+#define ADC_MD_SEQA_CONT                    (0x1U << ADC_CR0_MS_POS)    /*!< Sequence A continuous. Sequence B is disabled. */
+#define ADC_MD_SEQA_SEQB_SINGLESHOT         (0x2U << ADC_CR0_MS_POS)    /*!< Sequence A and B both single shot. */
+#define ADC_MD_SEQA_CONT_SEQB_SINGLESHOT    (0x3U << ADC_CR0_MS_POS)    /*!< Sequence A continuous and sequence B single shot. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Resolution ADC Resolution
+ * @{
+ */
+#define ADC_RESOLUTION_12BIT            (0x0U)              /*!< Resolution is 12 bit. */
+#define ADC_RESOLUTION_10BIT            (ADC_CR0_ACCSEL_0)  /*!< Resolution is 10 bit. */
+#define ADC_RESOLUTION_8BIT             (ADC_CR0_ACCSEL_1)  /*!< Resolution is 8 bit. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Data_Align ADC Data Align
+ * @{
+ */
+#define ADC_DATAALIGN_RIGHT             (0x0U)              /*!< Right alignment of converted data. */
+#define ADC_DATAALIGN_LEFT              (ADC_CR0_DFMT)      /*!< Left alignment of converted data. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Average_Count ADC Average Count
+ * @{
+ */
+#define ADC_AVG_CNT2                    (0x0U)                      /*!< 2 consecutive average conversions. */
+#define ADC_AVG_CNT4                    (0x1U << ADC_CR0_AVCNT_POS) /*!< 4 consecutive average conversions. */
+#define ADC_AVG_CNT8                    (0x2U << ADC_CR0_AVCNT_POS) /*!< 8 consecutive average conversions. */
+#define ADC_AVG_CNT16                   (0x3U << ADC_CR0_AVCNT_POS) /*!< 16 consecutive average conversions. */
+#define ADC_AVG_CNT32                   (0x4U << ADC_CR0_AVCNT_POS) /*!< 32 consecutive average conversions. */
+#define ADC_AVG_CNT64                   (0x5U << ADC_CR0_AVCNT_POS) /*!< 64 consecutive average conversions. */
+#define ADC_AVG_CNT128                  (0x6U << ADC_CR0_AVCNT_POS) /*!< 128 consecutive average conversions. */
+#define ADC_AVG_CNT256                  (0x7U << ADC_CR0_AVCNT_POS) /*!< 256 consecutive average conversions. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_SeqA_Resume_Mode ADC Sequence A Resume Mode
+ * @brief After interrupted by sequence B, sequence A continues to scan from the interrupt channel or the first channel.
+ * @{
+ */
+#define ADC_SEQA_RESUME_SCAN_CONT       (0U)                /*!< Scanning will continue from the interrupted channel. */
+#define ADC_SEQA_RESUME_SCAN_RESTART    (ADC_CR1_RSCHSEL)   /*!< Scanning will start from the first channel. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Hard_Trigger_Sel ADC Hard Trigger Selection
+ * @{
+ */
+#define ADC_HARDTRIG_ADTRG_PIN          (0x0U)                      /*!< Selects the following edge of pin ADTRG as the trigger of ADC sequence. */
+#define ADC_HARDTRIG_EVT0               (ADC_TRGSR_TRGSELA_0)       /*!< Selects an internal event as the trigger of ADC sequence.
+                                                                         This event is specified by register ADCx_TRGSEL0(x=(null), 1, 2, 3). */
+#define ADC_HARDTRIG_EVT1               (ADC_TRGSR_TRGSELA_1)       /*!< Selects an internal event as the trigger of ADC sequence.
+                                                                         This event is specified by register ADCx_TRGSEL1(x=(null), 1, 2, 3). */
+#define ADC_HARDTRIG_EVT0_EVT1          (ADC_TRGSR_TRGSELA)         /*!< Selects two internal events as the trigger of ADC sequence.
+                                                                         The two events are specified by register ADCx_TRGSEL0 and register ADCx_TRGSEL1. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Int_Type ADC Interrupt Type
+ * @{
+ */
+#define ADC_INT_EOCA                    (ADC_ICR_EOCAIEN)           /*!< Interrupt of the end of conversion of sequence A. */
+#define ADC_INT_EOCB                    (ADC_ICR_EOCBIEN)           /*!< Interrupt of the end of conversion of sequence B. */
+#define ADC_INT_ALL                     (ADC_INT_EOCA | ADC_INT_EOCB)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Ext_Ch_Analog_Src ADC Extended Channel Analog Source
+ * @{
+ */
+#define ADC_EXTCH_EXTERN_ANALOG_PIN     (0x0U)                      /*!< The analog source of extended channel is external analog input pin. */
+#define ADC_EXTCH_INTERN_ANALOG_SRC     (ADC_EXCHSELR_EXCHSEL)      /*!< The analog source of extended channel is internal analog signal. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Status_Flag ADC Status Flag
+ * @{
+ */
+#define ADC_FLAG_EOCA                   (ADC_ISR_EOCAF)             /*!< Status flag of the end of conversion of sequence A. */
+#define ADC_FLAG_EOCB                   (ADC_ISR_EOCBF)             /*!< Status flag of the end of conversion of sequence B. */
+#define ADC_FLAG_NESTED                 (ADC_ISR_SASTPDF)           /*!< Status flag of sequence A was interrupted by sequence B. */
+#define ADC_FLAG_ALL                    (ADC_FLAG_EOCA | ADC_FLAG_EOCB | ADC_FLAG_NESTED)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Sync_Unit ADC Synchronous Unit
+ * @{
+ */
+#define ADC_SYNC_ADC1_ADC2              (0U)                                /*!< ADC1 and ADC2 work synchronously. */
+#define ADC_SYNC_ADC1_ADC2_ADC3         (0x1U << ADC_SYNCCR_SYNCMD_POS)     /*!< ADC1, ADC2 and ADC3 work synchronously. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Sync_Mode ADC Synchronous Mode
+ * @{
+ */
+#define ADC_SYNC_SINGLE_DELAY_TRIG      (0U)                            /*!< Single shot delayed trigger mode.
+                                                                             When the trigger condition occurs, ADC1 starts first, then ADC2, last ADC3(if has).
+                                                                             All ADCs scan once. */
+#define ADC_SYNC_SINGLE_PARALLEL_TRIG   (0x2U << ADC_SYNCCR_SYNCMD_POS) /*!< Single shot parallel trigger mode.
+                                                                             When the trigger condition occurs, all ADCs start at the same time.
+                                                                             All ADCs scan once. */
+#define ADC_SYNC_CYCLIC_DELAY_TRIG      (0x4U << ADC_SYNCCR_SYNCMD_POS) /*!< Cyclic delayed trigger mode.
+                                                                             When the trigger condition occurs, ADC1 starts first, then ADC2, last ADC3(if has).
+                                                                             All ADCs scan cyclically(keep scanning till you stop them). */
+#define ADC_SYNC_CYCLIC_PARALLEL_TRIG   (0x6U << ADC_SYNCCR_SYNCMD_POS) /*!< Single shot parallel trigger mode.
+                                                                             When the trigger condition occurs, all ADCs start at the same time.
+                                                                             All ADCs scan cyclically(keep scanning till you stop them). */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_Unit ADC Analog Watchdog Unit
+ * @{
+ */
+#define ADC_AWD0                        (0U)    /*!< ADC analog watchdog 0. */
+#define ADC_AWD1                        (1U)    /*!< ADC analog watchdog 1. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_Int_Type ADC AWD Interrupt Type
+ * @{
+ */
+#define ADC_AWD_INT_AWD0                (ADC_AWDCR_AWD0IEN)     /*!< Interrupt of AWD0. */
+#define ADC_AWD_INT_AWD1                (ADC_AWDCR_AWD1IEN)     /*!< Interrupt of AWD1. */
+#define ADC_AWD_INT_ALL                 (ADC_AWD_INT_AWD0 | ADC_AWD_INT_AWD1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_Mode ADC Analog Watchdog Mode
+ * @{
+ */
+#define ADC_AWD_MD_CMP_OUT              (0x0U)  /*!< ADCValue > HighThreshold or ADCValue < LowThreshold */
+#define ADC_AWD_MD_CMP_IN               (0x1U)  /*!< LowThreshold < ADCValue < HighThreshold */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_Comb_Mode ADC AWD(Analog Watchdog) Combination Mode
+ * @note If combination mode is valid(ADC_AWD_COMB_OR/ADC_AWD_COMB_AND/ADC_AWD_COMB_XOR) and
+ *       the Channels selected by the AWD0 and AWD1 are different, make sure that the channel
+ *       of AWD1 is converted after the channel conversion of AWD0 ends.
+ * @{
+ */
+#define ADC_AWD_COMB_INVD               (0U)                /*!< Combination mode is invalid. */
+#define ADC_AWD_COMB_OR                 (ADC_AWDCR_AWDCM_0) /*!< The status of AWD0 is set or the status of AWD1 is set, the status of combination mode is set. */
+#define ADC_AWD_COMB_AND                (ADC_AWDCR_AWDCM_1) /*!< The status of AWD0 is set and the status of AWD1 is set, the status of combination mode is set. */
+#define ADC_AWD_COMB_XOR                (ADC_AWDCR_AWDCM)   /*!< Only one of the status of AWD0 and AWD1 is set, the status of combination mode is set. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_Status_Flag ADC AWD Status Flag
+ * @{
+ */
+#define ADC_AWD_FLAG_AWD0               (ADC_AWDSR_AWD0F)   /*!< Flag of AWD0. */
+#define ADC_AWD_FLAG_AWD1               (ADC_AWDSR_AWD1F)   /*!< Flag of AWD1. */
+#define ADC_AWD_FLAG_COMB               (ADC_AWDSR_AWDCMF)  /*!< Flag of combination of mode. */
+#define ADC_AWD_FLAG_ALL                (ADC_AWD_FLAG_AWD0 | ADC_AWD_FLAG_AWD1 | ADC_AWD_FLAG_COMB)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_PGA_Unit ADC PGA Unit
+ * @{
+ */
+#define ADC_PGA1                        (0U)    /*!< PGA1, belongs to ADC1. Input pin is ADC123_IN0. */
+#define ADC_PGA2                        (1U)    /*!< PGA2, belongs to ADC1. Input pin is ADC123_IN1. */
+#define ADC_PGA3                        (2U)    /*!< PGA3, belongs to ADC1. Input pin is ADC123_IN2. */
+#define ADC_PGA4                        (3U)    /*!< PGA4, belongs to ADC2. Input pin is ADC12_IN6. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_PGA_Gain ADC PGA Gain Factor
+ * @{
+ */
+#define ADC_PGA_GAIN_2                  (0x0U)  /*!< PGA gain factor is 2. */
+#define ADC_PGA_GAIN_2P133              (0x1U)  /*!< PGA gain factor is 2.133. */
+#define ADC_PGA_GAIN_2P286              (0x2U)  /*!< PGA gain factor is 2.286. */
+#define ADC_PGA_GAIN_2P667              (0x3U)  /*!< PGA gain factor is 2.667. */
+#define ADC_PGA_GAIN_2P909              (0x4U)  /*!< PGA gain factor is 2.909. */
+#define ADC_PGA_GAIN_3P2                (0x5U)  /*!< PGA gain factor is 3.2. */
+#define ADC_PGA_GAIN_3P556              (0x6U)  /*!< PGA gain factor is 2.556. */
+#define ADC_PGA_GAIN_4                  (0x7U)  /*!< PGA gain factor is 4. */
+#define ADC_PGA_GAIN_4P571              (0x8U)  /*!< PGA gain factor is 4.571. */
+#define ADC_PGA_GAIN_5P333              (0x9U)  /*!< PGA gain factor is 5.333. */
+#define ADC_PGA_GAIN_6P4                (0xAU)  /*!< PGA gain factor is 6.4. */
+#define ADC_PGA_GAIN_8                  (0xBU)  /*!< PGA gain factor is 8. */
+#define ADC_PGA_GAIN_10P667             (0xCU)  /*!< PGA gain factor is 10.667. */
+#define ADC_PGA_GAIN_16                 (0xDU)  /*!< PGA gain factor is 16. */
+#define ADC_PGA_GAIN_32                 (0xEU)  /*!< PGA gain factor is 32. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_PGA_VSS ADC PGA VSS
+ * @{
+ */
+#define ADC_PGA_VSS_PGAVSS              (0U)    /*!< Use pin PGAx_VSS as the reference GND of PGAx. */
+#define ADC_PGA_VSS_AVSS                (1U)    /*!< Use AVSS as the reference GND of PGAx. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Remap_Pin ADC Remap Pin
+ * @{
+ */
+#define ADC12_PIN_PA0                   (0U)    /*!< ADC123_IN0(PA0): default channel is ADC_CH0 of ADC1 and ADC2 */
+#define ADC12_PIN_PA1                   (1U)    /*!< ADC123_IN1(PA1): default channel is ADC_CH1 of ADC1 and ADC2 */
+#define ADC12_PIN_PA2                   (2U)    /*!< ADC123_IN2(PA2): default channel is ADC_CH2 of ADC1 and ADC2 */
+#define ADC12_PIN_PA3                   (3U)    /*!< ADC123_IN3(PA3): default channel is ADC_CH3 of ADC1 and ADC2 */
+#define ADC12_PIN_PA4                   (4U)    /*!< ADC12_IN4(PA4): default channel is ADC_CH4 of ADC1 and ADC2 */
+#define ADC12_PIN_PA5                   (5U)    /*!< ADC12_IN5(PA5): default channel is ADC_CH5 of ADC1 and ADC2 */
+#define ADC12_PIN_PA6                   (6U)    /*!< ADC12_IN6(PA6): default channel is ADC_CH6 of ADC1 and ADC2 */
+#define ADC12_PIN_PA7                   (7U)    /*!< ADC12_IN7(PA7): default channel is ADC_CH7 of ADC1 and ADC2 */
+#define ADC12_PIN_PB0                   (8U)    /*!< ADC12_IN8(PB0): default channel is ADC_CH8 of ADC1 and ADC2 */
+#define ADC12_PIN_PB1                   (9U)    /*!< ADC12_IN9(PB1): default channel is ADC_CH9 of ADC1 and ADC2 */
+#define ADC12_PIN_PC0                   (10U)   /*!< ADC123_IN10(PC0): default channel is ADC_CH10 of ADC1 and ADC2 */
+#define ADC12_PIN_PC1                   (11U)   /*!< ADC123_IN11(PC1): default channel is ADC_CH11 of ADC1 and ADC2 */
+#define ADC12_PIN_PC2                   (12U)   /*!< ADC123_IN12(PC2): default channel is ADC_CH12 of ADC1 and ADC2 */
+#define ADC12_PIN_PC3                   (13U)   /*!< ADC123_IN13(PC3): default channel is ADC_CH13 of ADC1 and ADC2 */
+#define ADC12_PIN_PC4                   (14U)   /*!< ADC12_IN14(PC4): default channel is ADC_CH14 of ADC1 and ADC2 */
+#define ADC12_PIN_PC5                   (15U)   /*!< ADC12_IN15(PC5): default channel is ADC_CH15 of ADC1 and ADC2 */
+
+#define ADC3_PIN_PA0                    (0U)    /*!< ADC123_IN0(PA0): default channel is ADC_CH0 of ADC3 */
+#define ADC3_PIN_PA1                    (1U)    /*!< ADC123_IN1(PA1): default channel is ADC_CH1 of ADC3 */
+#define ADC3_PIN_PA2                    (2U)    /*!< ADC123_IN2(PA2): default channel is ADC_CH2 of ADC3 */
+#define ADC3_PIN_PA3                    (3U)    /*!< ADC123_IN3(PA3): default channel is ADC_CH3 of ADC3 */
+#define ADC3_PIN_PF6                    (4U)    /*!< ADC3_IN4(PF6): default channel is ADC_CH4 of ADC3 */
+#define ADC3_PIN_PF7                    (5U)    /*!< ADC3_IN5(PF7): default channel is ADC_CH5 of ADC3 */
+#define ADC3_PIN_PF8                    (6U)    /*!< ADC3_IN6(PF8): default channel is ADC_CH6 of ADC3 */
+#define ADC3_PIN_PF9                    (7U)    /*!< ADC3_IN7(PF9): default channel is ADC_CH7 of ADC3 */
+#define ADC3_PIN_PF10                   (8U)    /*!< ADC3_IN8(PF10): default channel is ADC_CH8 of ADC3 */
+#define ADC3_PIN_PF3                    (9U)    /*!< ADC3_IN9(PF3): default channel is ADC_CH9 of ADC3 */
+#define ADC3_PIN_PC0                    (10U)   /*!< ADC123_IN10(PC0): default channel is ADC_CH10 of ADC3 */
+#define ADC3_PIN_PC1                    (11U)   /*!< ADC123_IN11(PC1): default channel is ADC_CH11 of ADC3 */
+#define ADC3_PIN_PC2                    (12U)   /*!< ADC123_IN12(PC2): default channel is ADC_CH12 of ADC3 */
+#define ADC3_PIN_PC3                    (13U)   /*!< ADC123_IN13(PC3): default channel is ADC_CH13 of ADC3 */
+#define ADC3_PIN_PF4                    (14U)   /*!< ADC3_IN14(PF4): default channel is ADC_CH14 of ADC3 */
+#define ADC3_PIN_PF5                    (15U)   /*!< ADC3_IN15(PF5): default channel is ADC_CH15 of ADC3 */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup ADC_Global_Functions
+ * @{
+ */
+/*******************************************************************************
+  Basic features
+ ******************************************************************************/
+int32_t ADC_Init(CM_ADC_TypeDef *ADCx, const stc_adc_init_t *pstcAdcInit);
+int32_t ADC_DeInit(CM_ADC_TypeDef *ADCx);
+int32_t ADC_StructInit(stc_adc_init_t *pstcAdcInit);
+void ADC_ChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint8_t u8Ch, en_functional_state_t enNewState);
+void ADC_MxChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint32_t u32MxCh, en_functional_state_t enNewState);
+void ADC_SetSampleTime(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, uint8_t u8SampleTime);
+
+/* Conversion data average calculation function. */
+void ADC_ConvDataAverageConfig(CM_ADC_TypeDef *ADCx, uint16_t u16AverageCount);
+void ADC_ConvDataAverageChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, en_functional_state_t enNewState);
+void ADC_ConvDataAverageMxChCmd(CM_ADC_TypeDef *ADCx, uint32_t u32MxCh, en_functional_state_t enNewState);
+/* Extended channel. */
+void ADC_SetExtChSrc(CM_ADC_TypeDef *ADCx, uint8_t u8ExtChSrc);
+
+void ADC_TriggerConfig(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint16_t u16TriggerSel);
+void ADC_TriggerCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, en_functional_state_t enNewState);
+void ADC_IntCmd(CM_ADC_TypeDef *ADCx, uint8_t u8IntType, en_functional_state_t enNewState);
+int32_t ADC_Start(CM_ADC_TypeDef *ADCx);
+void ADC_Stop(CM_ADC_TypeDef *ADCx);
+uint16_t ADC_GetValue(const CM_ADC_TypeDef *ADCx, uint8_t u8Ch);
+uint16_t ADC_GetResolution(const CM_ADC_TypeDef *ADCx);
+en_flag_status_t ADC_GetStatus(const CM_ADC_TypeDef *ADCx, uint8_t u8Flag);
+void ADC_ClearStatus(CM_ADC_TypeDef *ADCx, uint8_t u8Flag);
+/*******************************************************************************
+  Advanced features
+ ******************************************************************************/
+/* Channel remap. */
+void ADC_ChRemap(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, uint8_t u8AdcPin);
+uint8_t ADC_GetChPin(const CM_ADC_TypeDef *ADCx, uint8_t u8Ch);
+void ADC_ResetChMapping(CM_ADC_TypeDef *ADCx);
+
+/* Sync mode. */
+void ADC_SyncModeConfig(uint16_t u16SyncUnit, uint16_t u16SyncMode, uint8_t u8TriggerDelay);
+void ADC_SyncModeCmd(en_functional_state_t enNewState);
+
+/* Analog watchdog */
+int32_t ADC_AWD_Config(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint8_t u8Ch, const stc_adc_awd_config_t *pstcAwd);
+/* Combination mode. */
+void ADC_AWD_SetCombMode(CM_ADC_TypeDef *ADCx, uint16_t u16CombMode);
+void ADC_AWD_SetMode(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint16_t u16WatchdogMode);
+uint16_t ADC_AWD_GetMode(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit);
+void ADC_AWD_SetThreshold(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint16_t u16LowThreshold, uint16_t u16HighThreshold);
+void ADC_AWD_SelectCh(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint8_t u8Ch);
+void ADC_AWD_Cmd(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, en_functional_state_t enNewState);
+void ADC_AWD_IntCmd(CM_ADC_TypeDef *ADCx, uint16_t u16IntType, en_functional_state_t enNewState);
+en_flag_status_t ADC_AWD_GetStatus(const CM_ADC_TypeDef *ADCx, uint32_t u32Flag);
+void ADC_AWD_ClearStatus(CM_ADC_TypeDef *ADCx, uint32_t u32Flag);
+
+/* Sample hold */
+void ADC_SH_SetSampleTime(CM_ADC_TypeDef *ADCx, uint8_t u8SampleTime);
+void ADC_SH_ChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, en_functional_state_t enNewState);
+
+/* PGA */
+void ADC_PGA_Config(CM_ADC_TypeDef *ADCx, uint8_t u8PgaUnit, uint8_t u8Gain, uint8_t u8PgaVss);
+void ADC_PGA_Cmd(CM_ADC_TypeDef *ADCx, uint8_t u8PgaUnit, en_functional_state_t enNewState);
+
+void ADC_DataRegAutoClearCmd(CM_ADC_TypeDef *ADCx, en_functional_state_t enNewState);
+void ADC_SetSeqAResumeMode(CM_ADC_TypeDef *ADCx, uint16_t u16SeqAResumeMode);
+/**
+ * @}
+ */
+
+#endif /* LL_ADC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_ADC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_aes.h
+++ b/hc32f4a2/inc/hc32_ll_aes.h
@@ -1,0 +1,118 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_aes.h
+ * @brief This file contains all the functions prototypes of the AES driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add API AES_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_AES_H__
+#define __HC32_LL_AES_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_AES
+ * @{
+ */
+
+#if (LL_AES_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup AES_Global_Macros AES Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup AES_Key_Size AES Key Size
+ * @{
+ */
+#define AES_KEY_SIZE_16BYTE                 (16U)
+#define AES_KEY_SIZE_24BYTE                 (24U)
+#define AES_KEY_SIZE_32BYTE                 (32U)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup AES_Global_Functions
+ * @{
+ */
+int32_t AES_Encrypt(const uint8_t *pu8Plaintext, uint32_t u32PlaintextSize,
+                    const uint8_t *pu8Key, uint8_t u8KeySize,
+                    uint8_t *pu8Ciphertext);
+
+int32_t AES_Decrypt(const uint8_t *pu8Ciphertext, uint32_t u32CiphertextSize,
+                    const uint8_t *pu8Key, uint8_t u8KeySize,
+                    uint8_t *pu8Plaintext);
+
+int32_t AES_DeInit(void);
+/**
+ * @}
+ */
+
+#endif /* LL_AES_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_AES_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_aos.h
+++ b/hc32f4a2/inc/hc32_ll_aos.h
@@ -1,0 +1,188 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_aos.h
+ * @brief This file contains all the functions prototypes of the AOS driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Modified parameters name of API AOS_CommonTriggerCmd() and AOS_SetTriggerEventSrc()
+   2023-09-30       CDT             Modify for new head file
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_AOS_H__
+#define __HC32_LL_AOS_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_AOS
+ * @{
+ */
+
+#if (LL_AOS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup AOS_Global_Macros AOS Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup AOS_Target_Select AOS Target Select
+ * @{
+ */
+#define AOS_DCU1                (uint32_t)(&CM_AOS->DCU_TRGSEL1)
+#define AOS_DCU2                (uint32_t)(&CM_AOS->DCU_TRGSEL2)
+#define AOS_DCU3                (uint32_t)(&CM_AOS->DCU_TRGSEL3)
+#define AOS_DCU4                (uint32_t)(&CM_AOS->DCU_TRGSEL4)
+#define AOS_DMA1_0              (uint32_t)(&CM_AOS->DMA1_TRGSEL0)
+#define AOS_DMA1_1              (uint32_t)(&CM_AOS->DMA1_TRGSEL1)
+#define AOS_DMA1_2              (uint32_t)(&CM_AOS->DMA1_TRGSEL2)
+#define AOS_DMA1_3              (uint32_t)(&CM_AOS->DMA1_TRGSEL3)
+#define AOS_DMA1_4              (uint32_t)(&CM_AOS->DMA1_TRGSEL4)
+#define AOS_DMA1_5              (uint32_t)(&CM_AOS->DMA1_TRGSEL5)
+#define AOS_DMA1_6              (uint32_t)(&CM_AOS->DMA1_TRGSEL6)
+#define AOS_DMA1_7              (uint32_t)(&CM_AOS->DMA1_TRGSEL7)
+#define AOS_DMA2_0              (uint32_t)(&CM_AOS->DMA2_TRGSEL0)
+#define AOS_DMA2_1              (uint32_t)(&CM_AOS->DMA2_TRGSEL1)
+#define AOS_DMA2_2              (uint32_t)(&CM_AOS->DMA2_TRGSEL2)
+#define AOS_DMA2_3              (uint32_t)(&CM_AOS->DMA2_TRGSEL3)
+#define AOS_DMA2_4              (uint32_t)(&CM_AOS->DMA2_TRGSEL4)
+#define AOS_DMA2_5              (uint32_t)(&CM_AOS->DMA2_TRGSEL5)
+#define AOS_DMA2_6              (uint32_t)(&CM_AOS->DMA2_TRGSEL6)
+#define AOS_DMA2_7              (uint32_t)(&CM_AOS->DMA2_TRGSEL7)
+#define AOS_DMA_RC              (uint32_t)(&CM_AOS->DMA_RC_TRGSEL)
+#define AOS_TMR6_0              (uint32_t)(&CM_AOS->TMR6_TRGSEL0)
+#define AOS_TMR6_1              (uint32_t)(&CM_AOS->TMR6_TRGSEL1)
+#define AOS_TMR6_2              (uint32_t)(&CM_AOS->TMR6_TRGSEL2)
+#define AOS_TMR6_3              (uint32_t)(&CM_AOS->TMR6_TRGSEL3)
+#define AOS_EVTPORT12           (uint32_t)(&CM_AOS->PEVNT_TRGSEL12)
+#define AOS_EVTPORT34           (uint32_t)(&CM_AOS->PEVNT_TRGSEL34)
+#define AOS_TMR0                (uint32_t)(&CM_AOS->TMR0_TRGSEL)
+#define AOS_TMR2                (uint32_t)(&CM_AOS->TMR2_TRGSEL)
+#define AOS_HASH_A              (uint32_t)(&CM_AOS->HASH_TRGSELA)
+#define AOS_HASH_B              (uint32_t)(&CM_AOS->HASH_TRGSELB)
+#define AOS_TMRA_0              (uint32_t)(&CM_AOS->TMRA_TRGSEL0)
+#define AOS_TMRA_1              (uint32_t)(&CM_AOS->TMRA_TRGSEL1)
+#define AOS_TMRA_2              (uint32_t)(&CM_AOS->TMRA_TRGSEL2)
+#define AOS_TMRA_3              (uint32_t)(&CM_AOS->TMRA_TRGSEL3)
+#define AOS_OTS                 (uint32_t)(&CM_AOS->OTS_TRGSEL)
+#define AOS_ADC1_0              (uint32_t)(&CM_AOS->ADC1_TRGSEL0)
+#define AOS_ADC1_1              (uint32_t)(&CM_AOS->ADC1_TRGSEL1)
+#define AOS_ADC2_0              (uint32_t)(&CM_AOS->ADC2_TRGSEL0)
+#define AOS_ADC2_1              (uint32_t)(&CM_AOS->ADC2_TRGSEL1)
+#define AOS_ADC3_0              (uint32_t)(&CM_AOS->ADC3_TRGSEL0)
+#define AOS_ADC3_1              (uint32_t)(&CM_AOS->ADC3_TRGSEL1)
+#define AOS_COMM_1              (uint32_t)(&CM_AOS->COMTRG1)
+#define AOS_COMM_2              (uint32_t)(&CM_AOS->COMTRG2)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup AOS_Common_Trigger_ID AOS Common Trigger ID
+ * @{
+ */
+#define AOS_COMM_TRIG1          (1UL << 30U)
+#define AOS_COMM_TRIG2          (1UL << 31U)
+#define AOS_COMM_TRIG_MASK      (AOS_COMM_TRIG1 | AOS_COMM_TRIG2)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup AOS_Trigger_Select_Mask AOS Trigger Select Mask
+ * @{
+ */
+#define AOS_TRIG_SEL_MASK       (0x1FFUL)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup AOS_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  AOS software trigger.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void AOS_SW_Trigger(void)
+{
+    WRITE_REG32(bCM_AOS->INTSFTTRG_b.STRG, SET);
+}
+
+void AOS_CommonTriggerCmd(uint32_t u32Target, uint32_t u32CommonTrigger, en_functional_state_t enNewState);
+void AOS_SetTriggerEventSrc(uint32_t u32Target, en_event_src_t enSource);
+/**
+ * @}
+ */
+
+#endif /* LL_AOS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_AOS_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_can.h
+++ b/hc32f4a2/inc/hc32_ll_can.h
@@ -1,0 +1,734 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_can.h
+ * @brief This file contains all the functions prototypes of the CAN driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Deleted redundant comments
+                                    Remove CAN_FLAG_RX_BUF_OVF from CAN_FLAG_CLR_ALL
+   2023-06-30       CDT             Added 3 APIs for local-reset
+                                    Modify typo
+   2024-06-30       CDT             API CAN_DeInit() added return value
+                                    Added macro group CAN_ID_Mask
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_CAN_H__
+#define __HC32_LL_CAN_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_CAN
+ * @{
+ */
+#if (LL_CAN_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup CAN_Global_Types CAN Global Types
+ * @{
+ */
+/**
+ * @brief CAN bit time configuration structure.
+ * @note 1. TQ = u32Prescaler / CANClock.
+ * @note 2. Bit time = (u32TimeSeg2 + u32TimeSeg2) x TQ.
+ * @note 3. Baudrate = CANClock/(u32Prescaler*(u32TimeSeg1 + u32TimeSeg2))
+ * @note 4. See user manual of the target MCU and ISO11898-1 for more details.
+ */
+typedef struct {
+    uint32_t u32Prescaler;                  /*!< Specifies the prescaler of CAN clock, [1, 256]. */
+    uint32_t u32TimeSeg1;                   /*!< Specifies the number of time quanta in Bit Segment 1.
+                                                 u32TimeSeg1 Contains synchronization segment,
+                                                 propagation time segment and phase buffer segment 1. */
+    uint32_t u32TimeSeg2;                   /*!< Specifies the number of time quanta in Bit Segment 2.
+                                                 Phase buffer segment 2. */
+    uint32_t u32SJW;                        /*!< Synchronization Jump Width.
+                                                 Specifies the maximum number of time quanta the CAN hardware
+                                                 is allowed to lengthen or shorten a bit to perform resynchronization. */
+} stc_can_bit_time_config_t;
+
+/**
+ * @brief CAN acceptance filter configuration structure.
+ */
+typedef struct {
+    uint32_t u32ID;                         /*!< Specifies the identifier(ID). 11 bits standard ID or 29 bits extended ID, depending on IDE. */
+    uint32_t u32IDMask;                     /*!< Specifies the identifier(ID) mask. The mask bits of ID will be ignored by the acceptance filter. */
+    uint32_t u32IDType;                     /*!< Specifies the identifier(ID) type. This parameter can be a value of @ref CAN_ID_Type */
+} stc_can_filter_config_t;
+
+/**
+ * @brief CAN-FD configuration structure.
+ */
+typedef struct {
+    stc_can_bit_time_config_t stcBitCfg;    /*!< Bit time configuration of flexible data-rate bit. */
+    uint8_t u8Mode;                         /*!< CAN-FD mode, Bosch CAN-FD or ISO 11898-1:2015 CAN-FD.
+                                                 This parameter can be a value of @ref CAN_FD_Mode */
+    uint8_t u8TDC;                          /*!< Enable or disable Transmitter Delay Compensation.
+                                                 This parameter can be a value of @ref CAN_FD_TDC_En */
+    uint8_t u8SSPOffset;                    /*!< Specifies Secondary Sample Point offset.
+                                                 The transmitter delay plus u8SSPOffset defines the time of the secondary sample point for TDC.
+                                                 u8SSPOffset is given as a number of TQ. Range is [0, 127] */
+} stc_canfd_config_t;
+
+/**
+ * @brief TTCAN configuration structure.
+ */
+typedef struct {
+    uint32_t u32RefMsgID;                   /*!< Reference message identifier. */
+    uint32_t u32RefMsgIDE;                  /*!< Reference message identifier extension bit.
+                                                 '1' to set the ID which is specified by parameter 'u32RefMsgID' as an extended ID while
+                                                 '0' to set it as a standard ID. */
+    uint8_t u8NTUPrescaler;                 /*!< Prescaler of NTU(network time unit). The source is the bit time which is defined by SBT.
+                                                 This parameter can be a value of @ref TTCAN_NTU_Prescaler */
+    uint8_t u8TxBufMode;                    /*!< TTCAN Transmit Buffer Mode.
+                                                 This parameter can be a value of @ref TTCAN_Tx_Buf_Mode */
+    uint16_t u16TriggerType;                /*!< Trigger type of TTCAN.
+                                                 This parameter can be a value of @ref TTCAN_Trigger_Type */
+    uint16_t u16TxEnableWindow;             /*!< Tx_Enable window. Time period within which the transmission of a message may be started. Range is [1, 16] */
+    uint16_t u16TxTriggerTime;              /*!< Specifies for the referred message the time window of the matrix cycle at which it is to be transmitted. Range is [0, 65535] */
+    uint16_t u16WatchTriggerTime;           /*!< Time mark used to check whether the time since the last valid reference message has been too long. Range is [0, 65535] */
+} stc_can_ttc_config_t;
+
+/**
+ * @brief CAN initialization structure.
+ */
+typedef struct {
+    stc_can_bit_time_config_t stcBitCfg;    /*!< Bit time configuration of classical CAN bit. @ref stc_can_bit_time_config_t */
+    stc_can_filter_config_t *pstcFilter;    /*!< Pointer to a @ref stc_can_filter_config_t structure that
+                                                 contains the configuration informations for the acceptance filters. */
+    uint16_t u16FilterSelect;               /*!< Selects acceptance filters.
+                                                 This parameter can be values of @ref CAN_Acceptance_Filter */
+    uint8_t u8WorkMode;                     /*!< Specifies the work mode of CAN.
+                                                 This parameter can be a value of @ref CAN_Work_Mode */
+    uint8_t u8PTBSingleShotTx;              /*!< Enable or disable single shot transmission of PTB.
+                                                 This parameter can be a value of @ref PTB_SingleShot_Tx_En */
+    uint8_t u8STBSingleShotTx;              /*!< Enable or disable single shot transmission of STB.
+                                                 This parameter can be a value of @ref STB_SingleShot_Tx_En */
+    uint8_t u8STBPrioMode;                  /*!< Enable or disable the priority decision mode of STB.
+                                                 This parameter can be a value of @ref CAN_STB_Prio_Mode_En
+                                                 NOTE: A frame in the PTB has always the highest priority regardless of the ID. */
+    uint8_t u8RxWarnLimit;                  /*!< Specifies receive buffer almost full warning limit. Rang is [1, 8].
+                                                 Each CAN unit has 8 receive buffers. When the number of received frames reaches
+                                                 the value specified by u8RxWarnLimit, register bit RTIF.RAFIF is set and the interrupt occurred
+                                                 if it was enabled. */
+    uint8_t u8ErrorWarnLimit;               /*!< Specifies programmable error warning limit. Range is [0, 15].
+                                                 Error warning limit = (u8ErrorWarnLimit + 1) * 8. */
+    uint8_t u8RxAllFrame;                   /*!< Enable or disable receive all frames(includes frames with error).
+                                                 This parameter can be a value of @ref CAN_Rx_All_En */
+    uint8_t u8RxOvfMode;                    /*!< Receive buffer overflow mode. In case of a full receive buffer when a new frame is received.
+                                                 This parameter can be a value of @ref CAN_Rx_Ovf_Mode */
+    uint8_t u8SelfAck;                      /*!< Enable or disable self-acknowledge.
+                                                 This parameter can be a value of @ref CAN_Self_ACK_En */
+    stc_canfd_config_t *pstcCanFd;          /*!< Pointer to a CAN-FD configuration structure. @ref stc_canfd_config_t
+                                                 Set it to NULL if not needed CAN-FD. */
+
+    stc_can_ttc_config_t *pstcCanTtc;       /*!< Pointer to a TTCAN configuration structure. @ref stc_can_ttc_config_t
+                                                 Set it to NULL if not needed TTCAN. */
+} stc_can_init_t;
+
+/**
+ * @brief CAN error information structure.
+ */
+typedef struct {
+    uint8_t u8ArbitrLostPos;                /*!< Bit position in the frame where the arbitration has been lost.  */
+    uint8_t u8ErrorType;                    /*!< CAN error type. This parameter can be a value of @ref CAN_Err_Type */
+    uint8_t u8RxErrorCount;                 /*!< Receive error count. */
+    uint8_t u8TxErrorCount;                 /*!< Transmit error count. */
+} stc_can_error_info_t;
+
+/**
+ * @brief CAN TX frame data structure.
+ */
+typedef struct {
+    uint32_t u32ID;                         /*!< 11 bits standard ID or 29 bits extended ID, depending on IDE. */
+    union {
+        uint32_t u32Ctrl;
+        struct {
+            uint32_t DLC: 4;                /*!< Data length code. Length of the data segment of data frame.
+                                                 It should be zero while the frame is remote frame.
+                                                 This parameter can be a value of @ref CAN_Data_Length_Code */
+            uint32_t BRS: 1;                /*!< Bit rate switch. */
+            uint32_t FDF: 1;                /*!< CAN FD frame. */
+            uint32_t RTR: 1;                /*!< Remote transmission request bit.
+                                                 It is used to distinguish between data frames and remote frames. */
+            uint32_t IDE: 1;                /*!< Identifier extension flag.
+                                                 It is used to distinguish between standard format and extended format.
+                                                 This parameter can be a 1 or 0. */
+            uint32_t RSVD: 24;              /*!< Reserved bits. */
+        };
+    };
+    uint8_t au8Data[64U];                   /*!< TX data payload. */
+} stc_can_tx_frame_t;
+
+/**
+ * @brief CAN RX frame data structure.
+ */
+typedef struct {
+    uint32_t u32ID;                         /*!< 11 bits standard ID or 29 bits extended ID, depending on IDE. */
+    union {
+        uint32_t u32Ctrl;
+        struct {
+            uint32_t DLC: 4;                /*!< Data length code. Length of the data segment of data frame.
+                                                 It should be zero while the frame is remote frame.
+                                                 This parameter can be a value of @ref CAN_Data_Length_Code */
+            uint32_t BRS: 1;                /*!< Bit rate switch. */
+            uint32_t FDF: 1;                /*!< CAN FD frame. */
+            uint32_t RTR: 1;                /*!< Remote transmission request bit.
+                                                 It is used to distinguish between data frames and remote frames. */
+            uint32_t IDE: 1;                /*!< Identifier extension flag.
+                                                 It is used to distinguish between standard format and extended format.
+                                                 This parameter can be 1 or 0. */
+            uint32_t RSVD: 4;               /*!< Reserved bits. */
+            uint32_t TX: 1;                 /*!< This bit is set to 1 when receiving self-transmitted data in loopback mode. */
+            uint32_t ERRT: 3;               /*!< Error type. */
+            uint32_t CYCLE_TIME: 16;        /*!< Cycle time of time-triggered communication(TTC). */
+        };
+    };
+    uint8_t au8Data[64U];                   /*!< RX data payload. */
+} stc_can_rx_frame_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CAN_Global_Macros CAN Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup CAN_Work_Mode CAN Work Mode
+ * @{
+ */
+#define CAN_WORK_MD_NORMAL              (0U)                    /*!< Normal work mode. */
+#define CAN_WORK_MD_SILENT              (1U)                    /*!< Silent work mode. Prohibit data transmission. */
+#define CAN_WORK_MD_ILB                 (2U)                    /*!< Internal loop back mode, just for self-test while developing. */
+#define CAN_WORK_MD_ELB                 (3U)                    /*!< External loop back mode, just for self-test while developing. */
+#define CAN_WORK_MD_ELB_SILENT          (4U)                    /*!< External loop back silent mode, just for self-test while developing.
+                                                                     It is forbidden to respond to received frames and error frames,
+                                                                     but data can be transmitted. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Tx_Buf_Type CAN Transmit Buffer Type
+ * @{
+ */
+#define CAN_TX_BUF_PTB                  (0U)                    /*!< Primary transmit buffer. */
+#define CAN_TX_BUF_STB                  (1U)                    /*!< Secondary transmit buffer. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Data_Length_Code CAN Data Length Code
+ * @{
+ */
+#define CAN_DLC0                        (0x0U)                  /*!< CAN2.0 and CAN FD: the size of data field is 0 bytes. */
+#define CAN_DLC1                        (0x1U)                  /*!< CAN2.0 and CAN FD: the size of data field is 1 bytes. */
+#define CAN_DLC2                        (0x2U)                  /*!< CAN2.0 and CAN FD: the size of data field is 2 bytes. */
+#define CAN_DLC3                        (0x3U)                  /*!< CAN2.0 and CAN FD: the size of data field is 3 bytes. */
+#define CAN_DLC4                        (0x4U)                  /*!< CAN2.0 and CAN FD: the size of data field is 4 bytes. */
+#define CAN_DLC5                        (0x5U)                  /*!< CAN2.0 and CAN FD: the size of data field is 5 bytes. */
+#define CAN_DLC6                        (0x6U)                  /*!< CAN2.0 and CAN FD: the size of data field is 6 bytes. */
+#define CAN_DLC7                        (0x7U)                  /*!< CAN2.0 and CAN FD: the size of data field is 7 bytes. */
+#define CAN_DLC8                        (0x8U)                  /*!< CAN2.0 and CAN FD: the size of data field is 8 bytes. */
+#define CAN_DLC12                       (0x9U)                  /*!< CAN FD: the size of data field is 12 bytes. */
+#define CAN_DLC16                       (0xAU)                  /*!< CAN FD: the size of data field is 16 bytes. */
+#define CAN_DLC20                       (0xBU)                  /*!< CAN FD: the size of data field is 20 bytes. */
+#define CAN_DLC24                       (0xCU)                  /*!< CAN FD: the size of data field is 24 bytes. */
+#define CAN_DLC32                       (0xDU)                  /*!< CAN FD: the size of data field is 32 bytes. */
+#define CAN_DLC48                       (0xEU)                  /*!< CAN FD: the size of data field is 48 bytes. */
+#define CAN_DLC64                       (0xFU)                  /*!< CAN FD: the size of data field is 64 bytes. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PTB_SingleShot_Tx_En PTB Single Shot Transmission Function Control
+ * @{
+ */
+#define CAN_PTB_SINGLESHOT_TX_DISABLE   (0x0U)                  /*!< Primary transmit buffer auto retransmit. */
+#define CAN_PTB_SINGLESHOT_TX_ENABLE    (CAN_CFG_STAT_TPSS)     /*!< Primary transmit buffer single short transmit. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup STB_SingleShot_Tx_En STB Single Shot Transmission Function Control
+ * @{
+ */
+#define CAN_STB_SINGLESHOT_TX_DISABLE   (0x0U)                  /*!< Secondary transmit buffer auto retransmit. */
+#define CAN_STB_SINGLESHOT_TX_ENABLE    (CAN_CFG_STAT_TSSS)     /*!< Secondary transmit buffer single short transmit. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Tx_Request CAN Transmission Request
+ * @{
+ */
+#define CAN_TX_REQ_STB_ONE              (CAN_TCMD_TSONE)        /*!< Transmit one STB frame. */
+#define CAN_TX_REQ_STB_ALL              (CAN_TCMD_TSALL)        /*!< Transmit all STB frames. */
+#define CAN_TX_REQ_PTB                  (CAN_TCMD_TPE)          /*!< Transmit PTB frame. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_STB_Prio_Mode_En CAN STB Priority Mode Function Control
+ * @note A frame in the PTB has always the highest priority regardless of the ID.
+ * @{
+ */
+#define CAN_STB_PRIO_MD_DISABLE         (0x0U)                  /*!< The frame first in will first be transmitted. */
+#define CAN_STB_PRIO_MD_ENABLE          (CAN_TCTRL_TSMODE)      /*!< The frame with lower ID will first be transmitted. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Tx_Buf_Status CAN Transmit Buffer Status
+ * @{
+ */
+#define CAN_TX_BUF_EMPTY                (0x0U)                  /*!< TTCAN is disabled(TTEN == 0): STB is empty.
+                                                                     TTCAN is disabled(TTEN == 1) and transmit buffer is specified by TBPTR and TTPTR(TTTBM == 1):
+                                                                     PTB and STB are both empty. */
+#define CAN_TX_BUF_NOT_MORE_THAN_HALF   (0x1U)                  /*!< TTEN == 0: STB is less than or equal to half full;
+                                                                     TTEN == 1 && TTTBM == 1: PTB and STB are neither empty. */
+#define CAN_TX_BUF_MORE_THAN_HALF       (0x2U)                  /*!< TTEN == 0: STB is more than half full;
+                                                                     TTEN == 1 && TTTBM == 1: reserved value. */
+#define CAN_TX_BUF_FULL                 (0x3U)                  /*!< TTEN == 0: STB is full;
+                                                                     TTEN == 1 && TTTBM == 1: PTB and STB are both full. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Rx_Buf_Status CAN Receive Buffer Status
+ * @{
+ */
+#define CAN_RX_BUF_EMPTY                (0x0U)                  /*!< Receive buffer is empty. */
+#define CAN_RX_BUF_NOT_WARN             (0x1U)                  /*!< Receive buffer is not empty, but is less than almost full warning limit. */
+#define CAN_RX_BUF_WARN                 (0x2U)                  /*!< Receive buffer is not full and not overflow, but is more than or equal to almost full warning limit. */
+#define CAN_RX_BUF_FULL                 (0x3U)                  /*!< Receive buffer is full. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Rx_All_En CAN Receive All Frames
+ * @{
+ */
+#define CAN_RX_ALL_FRAME_DISABLE        (0x0U)                  /*!< Only receives correct frames. */
+#define CAN_RX_ALL_FRAME_ENABLE         (CAN_RCTRL_RBALL)       /*!< Receives all frames, including frames with error. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Rx_Ovf_Mode CAN Receive Buffer Overflow Mode
+ * @{
+ */
+#define CAN_RX_OVF_SAVE_NEW             (0x0U)                  /*!< Saves the newly received data and the oldest frame will be overwritten. */
+#define CAN_RX_OVF_DISCARD_NEW          (CAN_RCTRL_ROM)         /*!< Discard the newly received data. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Self_ACK_En CAN Self-ACK Function Control
+ * @{
+ */
+#define CAN_SELF_ACK_DISABLE            (0x0U)                  /*!< Disable self-acknowledge. */
+#define CAN_SELF_ACK_ENABLE             (CAN_RCTRL_SACK)        /*!< Enable self-acknowledge. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Interrupt_Type CAN Interrupt Type
+ * @{
+ */
+#define CAN_INT_ERR_INT                 (1UL << 1U)             /*!< Register bit RTIE.EIE. The interrupt RTIF.EIF will be set if enabled by RTIE.EIE under the following conditions:
+                                                                     The border of the error warning limit has been crossed in either direction by RECNT or TECNT or
+                                                                     the BUSOFF bit has been changed in either direction. */
+#define CAN_INT_STB_TX                  (1UL << 2U)             /*!< Register bit RTIE.TSIE. STB was transmitted. */
+#define CAN_INT_PTB_TX                  (1UL << 3U)             /*!< Register bit RTIE.TPIE. PTB was transmitted. */
+#define CAN_INT_RX_BUF_WARN             (1UL << 4U)             /*!< Register bit RTIE.RAFIE. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value. */
+#define CAN_INT_RX_BUF_FULL             (1UL << 5U)             /*!< Register bit RTIE.RFIE. The FIFO of receive buffer is full. */
+#define CAN_INT_RX_OVERRUN              (1UL << 6U)             /*!< Register bit RTIE.ROIE. Receive buffers are full and there is a further message to be stored. */
+#define CAN_INT_RX                      (1UL << 7U)             /*!< Register bit RTIE.RIE. Received a valid data frame or remote frame. */
+#define CAN_INT_BUS_ERR                 (1UL << 9U)             /*!< Register bit ERRINT.BEIE. Each of the error defined by EALCAP.KOER can cause bus-error interrupt. */
+#define CAN_INT_ARBITR_LOST             (1UL << 11U)            /*!< Register bit ERRINT.ALIE. Arbitration lost. */
+#define CAN_INT_ERR_PASSIVE             (1UL << 13U)            /*!< Register bit ERRINT.EPIE. A change from error-passive to error-active or error-active to error-passive has occurred. */
+
+#define CAN_INT_ALL                     (CAN_INT_ERR_INT     | \
+                                         CAN_INT_STB_TX      | \
+                                         CAN_INT_PTB_TX      | \
+                                         CAN_INT_RX_BUF_WARN | \
+                                         CAN_INT_RX_BUF_FULL | \
+                                         CAN_INT_RX_OVERRUN  | \
+                                         CAN_INT_RX          | \
+                                         CAN_INT_BUS_ERR     | \
+                                         CAN_INT_ARBITR_LOST | \
+                                         CAN_INT_ERR_PASSIVE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Status_Flag CAN Status Flag
+ * @{
+ */
+#define CAN_FLAG_BUS_OFF                (1UL << 0U)             /*!< Register bit CFG_STAT.BUSOFF. CAN bus off. */
+#define CAN_FLAG_TX_GOING               (1UL << 1U)             /*!< Register bit CFG_STAT.TACTIVE. CAN bus is transmitting. */
+#define CAN_FLAG_RX_GOING               (1UL << 2U)             /*!< Register bit CFG_STAT.RACTIVE. CAN bus is receiving. */
+#define CAN_FLAG_RX_BUF_OVF             (1UL << 5U)             /*!< Register bit RCTRL.ROV. Receive buffer is full and there is a further bit to be stored. At least one frame will be lost. */
+#define CAN_FLAG_TX_BUF_FULL            (1UL << 8U)             /*!< Register bit RTIE.TSFF. Transmit buffers are all full.
+                                                                     TTCFG.TTEN == 0 or TCTRL.TTTEM == 0: ALL STB slots are filled.
+                                                                     TTCFG.TTEN == 1 and TCTRL.TTTEM == 1: Transmit buffer that pointed by TBSLOT.TBPTR is filled.*/
+#define CAN_FLAG_TX_ABORTED             (1UL << 16U)            /*!< Register bit RTIF.AIF. Transmit messages requested via TCMD.TPA and TCMD.TSA were successfully canceled. */
+#define CAN_FLAG_ERR_INT                (1UL << 17U)            /*!< Register bit RTIF.EIF. The interrupt RTIF.EIF will be set if enabled by RTIE.EIE under the following conditions:
+                                                                     The border of the error warning limit has been crossed in either direction by RECNT or TECNT or
+                                                                     the BUSOFF bit has been changed in either direction. */
+#define CAN_FLAG_STB_TX                 (1UL << 18U)            /*!< Register bit RTIF.TSIF. STB was transmitted. */
+#define CAN_FLAG_PTB_TX                 (1UL << 19U)            /*!< Register bit RTIF.TPIF. PTB was transmitted. */
+#define CAN_FLAG_RX_BUF_WARN            (1UL << 20U)            /*!< Register bit RTIF.RAFIF. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value. */
+#define CAN_FLAG_RX_BUF_FULL            (1UL << 21U)            /*!< Register bit RTIF.RFIF. The FIFO of receive buffer is full. */
+#define CAN_FLAG_RX_OVERRUN             (1UL << 22U)            /*!< Register bit RTIF.ROIF. Receive buffers are all full and there is a further message to be stored. */
+#define CAN_FLAG_RX                     (1UL << 23U)            /*!< Register bit RTIF.RIF. Received a valid data frame or remote frame. */
+#define CAN_FLAG_BUS_ERR                (1UL << 24U)            /*!< Register bit ERRINT.BEIF. Each of the error defined by EALCAP.KOER can make this flag set. */
+#define CAN_FLAG_ARBITR_LOST            (1UL << 26U)            /*!< Register bit ERRINT.ALIF. Arbitration lost. */
+#define CAN_FLAG_ERR_PASSIVE            (1UL << 28U)            /*!< Register bit ERRINT.EPIF. A change from error-passive to error-active or error-active to error-passive has occurred. */
+#define CAN_FLAG_ERR_PASSIVE_NODE       (1UL << 30U)            /*!< Register bit ERRINT.EPASS. The node is an error-passive node. */
+#define CAN_FLAG_TEC_REC_WARN           (1UL << 31U)            /*!< Register bit ERRINT.EWARN. REC or TEC is greater than or equal to the LIMIT.EWL setting value. */
+
+#define CAN_FLAG_ALL                    (CAN_FLAG_BUS_OFF          | \
+                                         CAN_FLAG_TX_GOING         | \
+                                         CAN_FLAG_RX_GOING         | \
+                                         CAN_FLAG_RX_BUF_OVF       | \
+                                         CAN_FLAG_TX_BUF_FULL      | \
+                                         CAN_FLAG_TX_ABORTED       | \
+                                         CAN_FLAG_ERR_INT          | \
+                                         CAN_FLAG_STB_TX           | \
+                                         CAN_FLAG_PTB_TX           | \
+                                         CAN_FLAG_RX_BUF_WARN      | \
+                                         CAN_FLAG_RX_BUF_FULL      | \
+                                         CAN_FLAG_RX_OVERRUN       | \
+                                         CAN_FLAG_RX               | \
+                                         CAN_FLAG_BUS_ERR          | \
+                                         CAN_FLAG_ARBITR_LOST      | \
+                                         CAN_FLAG_ERR_PASSIVE      | \
+                                         CAN_FLAG_ERR_PASSIVE_NODE | \
+                                         CAN_FLAG_TEC_REC_WARN)
+
+#define CAN_FLAG_CLR_ALL                (CAN_FLAG_TX_ABORTED       | \
+                                         CAN_FLAG_ERR_INT          | \
+                                         CAN_FLAG_STB_TX           | \
+                                         CAN_FLAG_PTB_TX           | \
+                                         CAN_FLAG_RX_BUF_WARN      | \
+                                         CAN_FLAG_RX_BUF_FULL      | \
+                                         CAN_FLAG_RX_OVERRUN       | \
+                                         CAN_FLAG_RX               | \
+                                         CAN_FLAG_BUS_ERR          | \
+                                         CAN_FLAG_ARBITR_LOST      | \
+                                         CAN_FLAG_ERR_PASSIVE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_ID_Type CAN Identifier Type
+ * @{
+ */
+#define CAN_ID_STD_EXT                  (0x0U)                  /*!< Acceptance filter accept frames with both standard ID and extended ID. */
+#define CAN_ID_STD                      (CAN_ACF_AIDEE)         /*!< Acceptance filter accept frames with only standard ID. */
+#define CAN_ID_EXT                      (CAN_ACF_AIDEE | \
+                                         CAN_ACF_AIDE)          /*!< Acceptance filter accept frames with only extended ID. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_ID_Mask CAN ID Mask
+ * @{
+ */
+#define CAN_STD_ID_MASK                (0x7FFUL)                /*!< Standard ID mask */
+#define CAN_EXT_ID_MASK                (0x1FFFFFFFUL)           /*!< Extended ID mask */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Err_Type CAN Error Type
+ * @{
+ */
+#define CAN_ERR_NONE                    (0U)                    /*!< No error. */
+#define CAN_ERR_BIT                     (0x1U)                  /*!< Error is bit error. */
+#define CAN_ERR_FORM                    (0x2U)                  /*!< Error is form error. */
+#define CAN_ERR_STUFF                   (0x3U)                  /*!< Error is stuff error. */
+#define CAN_ERR_ACK                     (0x4U)                  /*!< Error is ACK error. */
+#define CAN_ERR_CRC                     (0x5U)                  /*!< Error is CRC error. */
+#define CAN_ERR_OTHER                   (0x6U)                  /*!< Error is other error.
+                                                                     Dominant bits after own error flag, received active Error Flag too long,
+                                                                     dominant bit during Passive-Error-Flag after ACK error. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Acceptance_Filter CAN Acceptance Filter
+ * @{
+ */
+#define CAN_FILTER1                     (CAN_ACFEN_AE_1)        /*!< Acceptance filter 1 select bit. */
+#define CAN_FILTER2                     (CAN_ACFEN_AE_2)        /*!< Acceptance filter 2 select bit. */
+#define CAN_FILTER3                     (CAN_ACFEN_AE_3)        /*!< Acceptance filter 3 select bit. */
+#define CAN_FILTER4                     (CAN_ACFEN_AE_4)        /*!< Acceptance filter 4 select bit. */
+#define CAN_FILTER5                     (CAN_ACFEN_AE_5)        /*!< Acceptance filter 5 select bit. */
+#define CAN_FILTER6                     (CAN_ACFEN_AE_6)        /*!< Acceptance filter 6 select bit. */
+#define CAN_FILTER7                     (CAN_ACFEN_AE_7)        /*!< Acceptance filter 7 select bit. */
+#define CAN_FILTER8                     (CAN_ACFEN_AE_8)        /*!< Acceptance filter 8 select bit. */
+#define CAN_FILTER9                     (CAN_ACFEN_AE_9)        /*!< Acceptance filter 9 select bit. */
+#define CAN_FILTER10                    (CAN_ACFEN_AE_10)       /*!< Acceptance filter 10 select bit. */
+#define CAN_FILTER11                    (CAN_ACFEN_AE_11)       /*!< Acceptance filter 11 select bit. */
+#define CAN_FILTER12                    (CAN_ACFEN_AE_12)       /*!< Acceptance filter 12 select bit. */
+#define CAN_FILTER13                    (CAN_ACFEN_AE_13)       /*!< Acceptance filter 13 select bit. */
+#define CAN_FILTER14                    (CAN_ACFEN_AE_14)       /*!< Acceptance filter 14 select bit. */
+#define CAN_FILTER15                    (CAN_ACFEN_AE_15)       /*!< Acceptance filter 15 select bit. */
+#define CAN_FILTER16                    (CAN_ACFEN_AE_16)       /*!< Acceptance filter 16 select bit. */
+#define CAN_FILTER_ALL                  (0xFFFFU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_FD_Mode CAN-FD Mode
+ * @{
+ */
+#define CAN_FD_MD_BOSCH                 (0x0U)                  /*!< Bosch CAN FD (non-ISO) mode. */
+#define CAN_FD_MD_ISO                   (CAN_TCTRL_FD_ISO)      /*!< ISO CAN FD mode (ISO 11898-1:2015). */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_FD_TDC_En CAN-FD TDC Function Control
+ * @{
+ */
+#define CAN_FD_TDC_DISABLE              (0x0U)                  /*!< Disable transmitter delay compensation. */
+#define CAN_FD_TDC_ENABLE               (CAN_TDC_TDCEN)         /*!< Enable transmitter delay compensation. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Tx_Buf_Mode TTCAN Transmit Buffer Mode
+ * @{
+ */
+#define CAN_TTC_TX_BUF_MD_CAN           (0x0U)                  /*!< Normal CAN mode. TTCAN transmit buffer depends on the priority mode of STB which is defined by @ref CAN_STB_Prio_Mode_En */
+#define CAN_TTC_TX_BUF_MD_TTCAN         (CAN_TCTRL_TTTBM)       /*!< Full TTCAN mode. TTCAN transmit buffer is pointed by TBSLOT.TBPTR(for data filling) and
+                                                                     TRG_CFG.TTPTR(for data transmission). */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Tx_Buf_Sel TTCAN Transmit Buffer Selection
+ * @{
+ */
+#define CAN_TTC_TX_BUF_PTB              (0x0U)                  /*!< Point to PTB. */
+#define CAN_TTC_TX_BUF_STB1             (0x1U)                  /*!< Point to STB slot 1. */
+#define CAN_TTC_TX_BUF_STB2             (0x2U)                  /*!< Point to STB slot 2. */
+#define CAN_TTC_TX_BUF_STB3             (0x3U)                  /*!< Point to STB slot 3. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Tx_Buf_Mark_State TTCAN Transmit Buffer Mark State
+ * @{
+ */
+#define CAN_TTC_TX_BUF_MARK_EMPTY       (CAN_TBSLOT_TBE)        /*!< Marks the transmit buffer selected by TBSLOT.TBPTR as "empty".
+                                                                     TBE is automatically reset to 0 as soon as the slot is marked as empty and TSFF=0.
+                                                                     If a transmission from this slot is active, then TBE stays set as long as either the
+                                                                     transmission completes or after a transmission error or arbitration loss the transmission
+                                                                     is not active any more. If both TBF and TBE are set, then TBE wins. */
+#define CAN_TTC_TX_BUF_MARK_FILLED      (CAN_TBSLOT_TBF)        /*!< Marks the transmit buffer selected by TBSLOT.TBPTR as "filled".
+                                                                     TBF is automatically reset to 0 as soon as the slot is marked as filled and RTIE.TSFF=1.
+                                                                     If both TBF and TBE are set, then TBE wins. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Interrupt_Type TTCAN Interrupt Type
+ * @{
+ */
+#define CAN_TTC_INT_TIME_TRIG           (CAN_TTCFG_TTIE)        /*!< Time trigger interrupt. */
+#define CAN_TTC_INT_WATCH_TRIG          (CAN_TTCFG_WTIE)        /*!< Watch trigger interrupt. */
+#define CAN_TTC_INT_ALL                 (CAN_TTC_INT_TIME_TRIG | \
+                                         CAN_TTC_INT_WATCH_TRIG)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Status_Flag TTCAN Status Flag
+ * @{
+ */
+#define CAN_TTC_FLAG_TIME_TRIG          (CAN_TTCFG_TTIF)        /*!< Time trigger interrupt flag. */
+#define CAN_TTC_FLAG_TRIG_ERR           (CAN_TTCFG_TEIF)        /*!< Trigger error interrupt flag. */
+#define CAN_TTC_FLAG_WATCH_TRIG         (CAN_TTCFG_WTIF)        /*!< Watch trigger interrupt flag. */
+
+#define CAN_TTC_FLAG_ALL                (CAN_TTC_FLAG_TIME_TRIG | \
+                                         CAN_TTC_FLAG_TRIG_ERR  | \
+                                         CAN_TTC_FLAG_WATCH_TRIG)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_NTU_Prescaler TTCAN Network Time Unit Prescaler
+ * @{
+ */
+#define CAN_TTC_NTU_PRESCALER1          (0x0U)                  /*!< NTU is SBT bit time * 1. */
+#define CAN_TTC_NTU_PRESCALER2          (CAN_TTCFG_T_PRESC_0)   /*!< NTU is SBT bit time * 2. */
+#define CAN_TTC_NTU_PRESCALER4          (CAN_TTCFG_T_PRESC_1)   /*!< NTU is SBT bit time * 4. */
+#define CAN_TTC_NTU_PRESCALER8          (CAN_TTCFG_T_PRESC)     /*!< NTU is SBT bit time * 8. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TTCAN_Trigger_Type TTCAN Trigger Type
+ * @note Except for the immediate trigger, all triggers set TTIF if TTIE is enabled.
+ * @{
+ */
+#define CAN_TTC_TRIG_IMMED_TRIG         (0x0U)                  /*!< Immediate trigger for immediate transmission. */
+#define CAN_TTC_TRIG_TIME_TRIG          (CAN_TRG_CFG_TTYPE_0)   /*!< Time trigger for receive triggers. */
+#define CAN_TTC_TRIG_SINGLESHOT_TX_TRIG (CAN_TRG_CFG_TTYPE_1)   /*!< Single shot transmit trigger for exclusive time windows. */
+#define CAN_TTC_TRIG_TX_START_TRIG      (CAN_TRG_CFG_TTYPE_1 | \
+                                         CAN_TRG_CFG_TTYPE_0)   /*!< Transmit start trigger for merged arbitrating time windows. */
+#define CAN_TTC_TRIG_TX_STOP_TRIG       (CAN_TRG_CFG_TTYPE_2)   /*!< Transmit stop trigger for merged arbitrating time windows. */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup CAN_Global_Functions
+ * @{
+ */
+/* Classical CAN */
+int32_t CAN_Init(CM_CAN_TypeDef *CANx, const stc_can_init_t *pstcCanInit);
+int32_t CAN_StructInit(stc_can_init_t *pstcCanInit);
+int32_t CAN_DeInit(CM_CAN_TypeDef *CANx);
+void CAN_IntCmd(CM_CAN_TypeDef *CANx, uint32_t u32IntType, en_functional_state_t enNewState);
+int32_t CAN_FillTxFrame(CM_CAN_TypeDef *CANx, uint8_t u8TxBufType, const stc_can_tx_frame_t *pstcTx);
+void CAN_StartTx(CM_CAN_TypeDef *CANx, uint8_t u8TxRequest);
+void CAN_AbortTx(CM_CAN_TypeDef *CANx, uint8_t u8TxBufType);
+int32_t CAN_GetRxFrame(CM_CAN_TypeDef *CANx, stc_can_rx_frame_t *pstcRx);
+
+void CAN_EnterLocalReset(CM_CAN_TypeDef *CANx);
+void CAN_ExitLocalReset(CM_CAN_TypeDef *CANx);
+en_flag_status_t CAN_GetLocalResetStatus(CM_CAN_TypeDef *CANx);
+
+en_flag_status_t CAN_GetStatus(const CM_CAN_TypeDef *CANx, uint32_t u32Flag);
+void CAN_ClearStatus(CM_CAN_TypeDef *CANx, uint32_t u32Flag);
+uint32_t CAN_GetStatusValue(const CM_CAN_TypeDef *CANx);
+int32_t CAN_GetErrorInfo(const CM_CAN_TypeDef *CANx, stc_can_error_info_t *pstcErr);
+uint8_t CAN_GetTxBufStatus(const CM_CAN_TypeDef *CANx);
+uint8_t CAN_GetRxBufStatus(const CM_CAN_TypeDef *CANx);
+void CAN_FilterCmd(CM_CAN_TypeDef *CANx, uint16_t u16FilterSelect, en_functional_state_t enNewState);
+void CAN_SetRxWarnLimit(CM_CAN_TypeDef *CANx, uint8_t u8RxWarnLimit);
+void CAN_SetErrorWarnLimit(CM_CAN_TypeDef *CANx, uint8_t u8ErrorWarnLimit);
+
+int32_t CAN_FD_StructInit(stc_canfd_config_t *pstcCanFd);
+void CAN_FD_Cmd(const CM_CAN_TypeDef *CANx, en_functional_state_t enNewState);
+
+/* TTCAN */
+int32_t CAN_TTC_StructInit(stc_can_ttc_config_t *pstcCanTtc);
+int32_t CAN_TTC_Config(CM_CAN_TypeDef *CANx, const stc_can_ttc_config_t *pstcCanTtc);
+void CAN_TTC_IntCmd(CM_CAN_TypeDef *CANx, uint8_t u8IntType, en_functional_state_t enNewState);
+void CAN_TTC_Cmd(CM_CAN_TypeDef *CANx, en_functional_state_t enNewState);
+
+en_flag_status_t CAN_TTC_GetStatus(const CM_CAN_TypeDef *CANx, uint8_t u8Flag);
+void CAN_TTC_ClearStatus(CM_CAN_TypeDef *CANx, uint8_t u8Flag);
+uint8_t CAN_TTC_GetStatusValue(const CM_CAN_TypeDef *CANx);
+
+void CAN_TTC_SetTriggerType(CM_CAN_TypeDef *CANx, uint16_t u16TriggerType);
+void CAN_TTC_SetTxEnableWindow(CM_CAN_TypeDef *CANx, uint16_t u16TxEnableWindow);
+void CAN_TTC_SetTxTriggerTime(CM_CAN_TypeDef *CANx, uint16_t u16TxTriggerTime);
+void CAN_TTC_SetWatchTriggerTime(CM_CAN_TypeDef *CANx, uint16_t u16WatchTriggerTime);
+
+int32_t CAN_TTC_FillTxFrame(CM_CAN_TypeDef *CANx, uint8_t u8CANTTCTxBuf, const stc_can_tx_frame_t *pstcTx);
+
+int32_t CAN_TTC_GetConfig(const CM_CAN_TypeDef *CANx, stc_can_ttc_config_t *pstcCanTtc);
+
+/**
+ * @}
+ */
+
+#endif /* LL_CAN_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_CAN_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_clk.h
+++ b/hc32f4a2/inc/hc32_ll_clk.h
@@ -1,0 +1,744 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_clk.h
+ * @brief This file contains all the functions prototypes of the CLK driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Refine stc_clock_freq_t
+   2023-12-15       CDT             Modify comment
+                                    Refine API CLK_XtalStdInit and add API CLK_XtalStdCmd, CLK_SetXtalStdExceptionType
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_CLK_H__
+#define __HC32_LL_CLK_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_CLK
+ * @{
+ */
+
+#if (LL_CLK_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup CLK_Global_Types CLK Global Types
+ * @{
+ */
+/**
+ * @brief  CLK XTAL configuration structure definition
+ */
+typedef struct {
+    uint8_t u8State;            /*!< The new state of the XTAL.
+                                     This parameter can be a value of @ref CLK_XTAL_State                   */
+    uint8_t u8Drv;              /*!< The XTAL drive ability.
+                                     This parameter can be a value of @ref CLK_XTAL_Driver                  */
+    uint8_t u8Mode;             /*!< The XTAL mode selection osc or exclk.
+                                     This parameter can be a value of @ref CLK_XTAL_Mode_Selection          */
+    uint8_t u8StableTime;       /*!< The XTAL stable time selection.
+                                     This parameter can be a value of @ref CLK_XTAL_Stable_Time_Selection   */
+} stc_clock_xtal_init_t;
+
+/**
+ * @brief  CLK XTAL fault detect configuration structure definition
+ */
+typedef struct {
+    uint8_t u8State;            /*!< Specifies the new state of XTALSTD.
+                                     This parameter can be a value of @ref CLK_XTALSTD_State                */
+    uint8_t u8ExceptionType;    /*!< Specifies the XTALSTD exception type.
+                                     This parameter can be a value of @ref CLK_XTALSTD_Exception_type       */
+} stc_clock_xtalstd_init_t;
+
+/**
+ * @brief  CLK XTAL32 configuration structure definition
+ */
+typedef struct {
+    uint8_t u8State;            /*!< The new state of the XTAL32 divide.
+                                     This parameter can be a value of @ref CLK_XTAL32_State                 */
+    uint8_t u8Drv;              /*!< The Xtal32 drive ability setting,
+                                     This parameter can be a value of @ref CLK_XTAL32_Drive                 */
+    uint8_t u8Filter;           /*!< Xtal32 noise filter setting,
+                                     This parameter can be a value of@ref CLK_XTAL32_Filter_Selection       */
+} stc_clock_xtal32_init_t;
+
+/**
+ * @brief  CLK clock frequency configuration structure definition
+ */
+typedef struct {
+    union {
+        uint32_t SCFGR;     /*!< clock frequency config register  */
+        struct {
+            uint32_t PCLK0S     : 3;    /*!< PCLK0      */
+            uint32_t resvd0     : 1;    /*!< reserved   */
+            uint32_t PCLK1S     : 3;    /*!< PCLK1      */
+            uint32_t resvd1     : 1;    /*!< reserved   */
+            uint32_t PCLK2S     : 3;    /*!< PCLK2      */
+            uint32_t resvd2     : 1;    /*!< reserved   */
+            uint32_t PCLK3S     : 3;    /*!< PCLK3      */
+            uint32_t resvd3     : 1;    /*!< reserved   */
+            uint32_t PCLK4S     : 3;    /*!< PCLK4      */
+            uint32_t resvd4     : 1;    /*!< reserved   */
+            uint32_t EXCKS      : 3;    /*!< EXCLK      */
+            uint32_t resvd5     : 1;    /*!< reserved   */
+            uint32_t HCLKS      : 3;    /*!< HCLK       */
+            uint32_t resvd6     : 5;    /*!< reserved   */
+        } SCFGR_f;
+    };
+} stc_clock_scale_t;
+
+/**
+ * @brief  CLK PLL configuration structure definition
+ * @note   PLL for PLLH
+ */
+typedef struct {
+    uint8_t u8PLLState;         /*!< PLL new state, @ref CLK_PLL_State for details */
+    union {
+        uint32_t PLLCFGR;       /*!< PLL config register */
+        struct {
+            uint32_t PLLM   : 2; /*!< PLL M divide */
+            uint32_t resvd0 : 5; /*!< reserved */
+            uint32_t PLLSRC : 1; /*!< PLL/PLLA source clock select */
+            uint32_t PLLN   : 8; /*! PLLH N multi */
+            uint32_t resvd1 : 4; /*! reserved */
+            uint32_t PLLR   : 4; /*!< PLL R divide  */
+            uint32_t PLLQ   : 4; /*!< PLL Q divide  */
+            uint32_t PLLP   : 4; /*!< PLL P divide  */
+        } PLLCFGR_f;
+    };
+} stc_clock_pll_init_t;
+
+/**
+ * @brief  CLK PLLx configuration structure definition
+ *         PLLx for PLLA
+ */
+typedef struct {
+    uint8_t u8PLLState;          /*!< PLLx new state, @ref CLK_PLLx_State for details */
+    union {
+        uint32_t PLLCFGR;        /*!< PLLx config register */
+        struct {
+            uint32_t PLLM   : 5; /*!< PLLx M divide */
+            uint32_t resvd0 : 3; /*!< reserved */
+            uint32_t PLLN   : 9; /*!< PLLx N multi- */
+            uint32_t resvd1 : 3; /*!< reserved */
+            uint32_t PLLR   : 4; /*!< PLLx R divide */
+            uint32_t PLLQ   : 4; /*!< PLLx Q divide */
+            uint32_t PLLP   : 4; /*!< PLLx P divide */
+        } PLLCFGR_f;
+    };
+} stc_clock_pllx_init_t;
+
+/**
+ * @brief  CLK bus frequency structure definition
+ */
+typedef struct {
+    uint32_t u32SysclkFreq;        /*!< System clock frequency. */
+    uint32_t u32HclkFreq;          /*!< Hclk frequency.         */
+    uint32_t u32Pclk0Freq;         /*!< Pclk0 frequency.        */
+    uint32_t u32Pclk1Freq;         /*!< Pclk1 frequency.        */
+    uint32_t u32Pclk2Freq;         /*!< Pclk2 frequency.        */
+    uint32_t u32Pclk3Freq;         /*!< Pclk3 frequency.        */
+    uint32_t u32Pclk4Freq;         /*!< Pclk4 frequency.        */
+    uint32_t u32ExclkFreq;         /*!< Exclk frequency.        */
+} stc_clock_freq_t;
+
+/**
+ * @brief  CLK PLL clock frequency structure definition
+ */
+typedef struct {
+    uint32_t u32PllVcin;               /*!< PLL vcin clock frequency.      */
+    uint32_t u32PllVco;                /*!< PLL vco clock frequency.       */
+    uint32_t u32PllP;                  /*!< PLLp clock frequency.          */
+    uint32_t u32PllQ;                  /*!< PLLq clock frequency.          */
+    uint32_t u32PllR;                  /*!< PLLr clock frequency.          */
+    uint32_t u32PllxVcin;              /*!< pllx vcin clock frequency.     */
+    uint32_t u32PllxVco;               /*!< pllx vco clock frequency.      */
+    uint32_t u32PllxP;                 /*!< pllxp clock frequency.         */
+    uint32_t u32PllxQ;                 /*!< pllxq clock frequency.         */
+    uint32_t u32PllxR;                 /*!< pllxr clock frequency.         */
+} stc_pll_clock_freq_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CLK_Global_Macros CLK Global Macros
+ * @{
+ */
+/**
+ * @defgroup CLK_PLLx_State CLK PLLx State
+ *         PLLx for PLLA
+ * @{
+ */
+#define CLK_PLLX_OFF                    (0x01U)
+#define CLK_PLLX_ON                     (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PLL_State PLL state on or off
+ * @{
+ */
+#define CLK_PLL_OFF                     (0x01U)
+#define CLK_PLL_ON                      (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PLL_Source_Clock PLL source clock selection
+ * @{
+ */
+#define CLK_PLL_SRC_XTAL                (0x00UL)
+#define CLK_PLL_SRC_HRC                 (0x01UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL_State XTAL function config
+ * @{
+ */
+#define CLK_XTAL_OFF                    (CMU_XTALCR_XTALSTP)
+#define CLK_XTAL_ON                     (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL_Driver XTAL drive ability
+ * @note
+ * @verbatim
+ *            High      |       Mid       |       Low       |      ULow     |
+ *          [20~25]     |     [16~20)     |     (8~16)      |     [4~8]     |
+ * @endverbatim
+ * @{
+ */
+#define CLK_XTAL_DRV_HIGH               (0x00U << CMU_XTALCFGR_XTALDRV_POS)
+#define CLK_XTAL_DRV_MID                (0x01U << CMU_XTALCFGR_XTALDRV_POS)
+#define CLK_XTAL_DRV_LOW                (0x02U << CMU_XTALCFGR_XTALDRV_POS)
+#define CLK_XTAL_DRV_ULOW               (0x03U << CMU_XTALCFGR_XTALDRV_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL_Mode_Selection XTAL mode selection osc or exclk
+ * @{
+ */
+#define CLK_XTAL_MD_OSC                 (0x00U)
+#define CLK_XTAL_MD_EXCLK               (CMU_XTALCFGR_XTALMS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL_Stable_Time_Selection XTAL stable time selection
+ * @note  a cycle of stable counter = a cycle of LRC divide by 8
+ * @{
+ */
+#define CLK_XTAL_STB_133US              (0x01U)       /*!< 35 stable count cycle, approx. 133us */
+#define CLK_XTAL_STB_255US              (0x02U)       /*!< 67 stable count cycle, approx. 255us */
+#define CLK_XTAL_STB_499US              (0x03U)       /*!< 131 stable count cycle, approx. 499us */
+#define CLK_XTAL_STB_988US              (0x04U)       /*!< 259 stable count cycle, approx. 988us */
+#define CLK_XTAL_STB_2MS                (0x05U)       /*!< 547 stable count cycle, approx. 2ms  */
+#define CLK_XTAL_STB_4MS                (0x06U)       /*!< 1059 stable count cycle, approx. 4ms */
+#define CLK_XTAL_STB_8MS                (0x07U)       /*!< 2147 stable count cycle, approx. 8ms */
+#define CLK_XTAL_STB_16MS               (0x08U)       /*!< 4291 stable count cycle, approx. 16ms */
+#define CLK_XTAL_STB_31MS               (0x09U)       /*!< 8163 stable count cycle, approx. 32ms */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTALSTD_State XTAL error detection on or off
+ * @{
+ */
+#define CLK_XTALSTD_OFF                 (0x00U)
+#define CLK_XTALSTD_ON                  (CMU_XTALSTDCR_XTALSTDE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTALSTD_Exception_type XTALSTD exception type
+ * @{
+ */
+#define CLK_XTALSTD_EXP_TYPE_NONE       (0x00U)
+#define CLK_XTALSTD_EXP_TYPE_RST        (CMU_XTALSTDCR_XTALSTDRIS | CMU_XTALSTDCR_XTALSTDRE)
+#define CLK_XTALSTD_EXP_TYPE_INT        (CMU_XTALSTDCR_XTALSTDIE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL32_State XTAL32 state on or off
+ * @{
+ */
+#define CLK_XTAL32_OFF                  (CMU_XTAL32CR_XTAL32STP)
+#define CLK_XTAL32_ON                   (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL32_Drive XTAL32 drive ability
+ * @{
+ */
+#define CLK_XTAL32_DRV_MID              (0x00U)
+#define CLK_XTAL32_DRV_HIGH             (0x01U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_XTAL32_Filter_Selection XTAL32 filtering selection.
+ * @{
+ */
+#define CLK_XTAL32_FILTER_ALL_MD        (0x00U)   /*!< Valid in run,stop,power down mode.     */
+#define CLK_XTAL32_FILTER_RUN_MD        (0x01U)   /*!< Valid in run mode.                     */
+#define CLK_XTAL32_FILTER_OFF           (0x03U)   /*!< Invalid in run,stop,power down mode.   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_HRC_Config HRC Config
+ * @{
+ */
+#define CLK_HRC_OFF                     (CMU_HRCCR_HRCSTP)
+#define CLK_HRC_ON                      (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_STB_Flag CLK Stable Flags
+ * @{
+ */
+#define CLK_STB_FLAG_HRC                (CMU_OSCSTBSR_HRCSTBF)
+#define CLK_STB_FLAG_XTAL               (CMU_OSCSTBSR_XTALSTBF)
+#define CLK_STB_FLAG_PLL                (CMU_OSCSTBSR_PLLHSTBF)
+#define CLK_STB_FLAG_PLLX               (CMU_OSCSTBSR_PLLASTBF)
+#define CLK_STB_FLAG_MASK               (CMU_OSCSTBSR_HRCSTBF | CMU_OSCSTBSR_XTALSTBF | \
+                                        CMU_OSCSTBSR_PLLASTBF | CMU_OSCSTBSR_PLLHSTBF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_System_Clock_Source System Clock Source
+ * @{
+ */
+#define CLK_SYSCLK_SRC_HRC              (0x00U)
+#define CLK_SYSCLK_SRC_MRC              (0x01U)
+#define CLK_SYSCLK_SRC_LRC              (0x02U)
+#define CLK_SYSCLK_SRC_XTAL             (0x03U)
+#define CLK_SYSCLK_SRC_XTAL32           (0x04U)
+#define CLK_SYSCLK_SRC_PLL              (0x05U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_Bus_Clock_Sel Clock Bus Clock Category Selection
+ * @{
+ */
+#define CLK_BUS_PCLK0                   (CMU_SCFGR_PCLK0S)
+#define CLK_BUS_PCLK1                   (CMU_SCFGR_PCLK1S)
+#define CLK_BUS_PCLK2                   (CMU_SCFGR_PCLK2S)
+#define CLK_BUS_PCLK3                   (CMU_SCFGR_PCLK3S)
+#define CLK_BUS_PCLK4                   (CMU_SCFGR_PCLK4S)
+#define CLK_BUS_EXCLK                   (CMU_SCFGR_EXCKS)
+#define CLK_BUS_HCLK                    (CMU_SCFGR_HCLKS)
+#define CLK_BUS_CLK_ALL                 (CLK_BUS_PCLK0 | CLK_BUS_PCLK1 | CLK_BUS_PCLK2 | CLK_BUS_PCLK3 | \
+                                         CLK_BUS_PCLK4 | CLK_BUS_EXCLK | CLK_BUS_HCLK)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_Clock_Divider Clock Divider
+ * @{
+ */
+
+/**
+ * @defgroup CLK_System_Clock_Divider System Clock Divider
+ * @{
+ */
+#define CLK_SYSCLK_DIV1                 (0x00U)
+#define CLK_SYSCLK_DIV2                 (0x01U)
+#define CLK_SYSCLK_DIV4                 (0x02U)
+#define CLK_SYSCLK_DIV8                 (0x03U)
+#define CLK_SYSCLK_DIV16                (0x04U)
+#define CLK_SYSCLK_DIV32                (0x05U)
+#define CLK_SYSCLK_DIV64                (0x06U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_HCLK_Divider CLK HCLK Divider
+ * @{
+ */
+#define CLK_HCLK_DIV1                   (CLK_SYSCLK_DIV1  << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV2                   (CLK_SYSCLK_DIV2  << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV4                   (CLK_SYSCLK_DIV4  << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV8                   (CLK_SYSCLK_DIV8  << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV16                  (CLK_SYSCLK_DIV16 << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV32                  (CLK_SYSCLK_DIV32 << CMU_SCFGR_HCLKS_POS)
+#define CLK_HCLK_DIV64                  (CLK_SYSCLK_DIV64 << CMU_SCFGR_HCLKS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PCLK1_Divider CLK PCLK1 Divider
+ * @{
+ */
+#define CLK_PCLK1_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_PCLK1S_POS)
+#define CLK_PCLK1_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_PCLK1S_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PCLK4_Divider CLK PCLK4 Divider
+ * @{
+ */
+#define CLK_PCLK4_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_PCLK4S_POS)
+#define CLK_PCLK4_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_PCLK4S_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PCLK3_Divider CLK PCLK3 Divider
+ * @{
+ */
+#define CLK_PCLK3_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_PCLK3S_POS)
+#define CLK_PCLK3_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_PCLK3S_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_EXCLK_Divider CLK EXCLK Divider
+ * @{
+ */
+#define CLK_EXCLK_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_EXCKS_POS)
+#define CLK_EXCLK_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_EXCKS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PCLK2_Divider CLK PCLK2 Divider
+ * @{
+ */
+#define CLK_PCLK2_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_PCLK2S_POS)
+#define CLK_PCLK2_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_PCLK2S_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PCLK0_Divider CLK PCLK0 Divider
+ * @{
+ */
+#define CLK_PCLK0_DIV1                  (CLK_SYSCLK_DIV1  << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV2                  (CLK_SYSCLK_DIV2  << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV4                  (CLK_SYSCLK_DIV4  << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV8                  (CLK_SYSCLK_DIV8  << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV16                 (CLK_SYSCLK_DIV16 << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV32                 (CLK_SYSCLK_DIV32 << CMU_SCFGR_PCLK0S_POS)
+#define CLK_PCLK0_DIV64                 (CLK_SYSCLK_DIV64 << CMU_SCFGR_PCLK0S_POS)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_USBCLK_Sel CLK USB Clock Selection
+ * @{
+ */
+#define CLK_USBCLK_SYSCLK_DIV2          (0x01U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV3          (0x02U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV4          (0x03U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV5          (0x04U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV6          (0x05U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV7          (0x06U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_SYSCLK_DIV8          (0x07U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_PLLQ                 (0x08U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_PLLR                 (0x09U << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_PLLXP                (0x0AU << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_PLLXQ                (0x0BU << CMU_USBCKCFGR_USBCKS_POS)
+#define CLK_USBCLK_PLLXR                (0x0CU << CMU_USBCKCFGR_USBCKS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_CANCLK_Sel CLK CAN Clock Selection
+ * @{
+ */
+#define CLK_CANCLK_SYSCLK_DIV2          (0x01U)
+#define CLK_CANCLK_SYSCLK_DIV3          (0x02U)
+#define CLK_CANCLK_SYSCLK_DIV4          (0x03U)
+#define CLK_CANCLK_SYSCLK_DIV5          (0x04U)
+#define CLK_CANCLK_SYSCLK_DIV6          (0x05U)
+#define CLK_CANCLK_SYSCLK_DIV7          (0x06U)
+#define CLK_CANCLK_SYSCLK_DIV8          (0x07U)
+#define CLK_CANCLK_PLLQ                 (0x08U)
+#define CLK_CANCLK_PLLR                 (0x09U)
+#define CLK_CANCLK_PLLXP                (0x0AU)
+#define CLK_CANCLK_PLLXQ                (0x0BU)
+#define CLK_CANCLK_PLLXR                (0x0CU)
+#define CLK_CANCLK_XTAL                 (0x0DU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_CAN_Sel CLK CAN Channel Selection
+ * @{
+ */
+#define CLK_CAN1                        (0x01U)
+#define CLK_CAN2                        (0x02U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_PERIPH_Sel CLK Peripheral Clock Selection
+ * @note    ADC,I2S,DAC,TRNG
+ * @{
+ */
+/*  PCLK2 is used for ADC clock, PCLK1 is used for I2S clock, PCLK4 is used for DAC/TRNG clock */
+#define CLK_PERIPHCLK_PCLK              (0x0000U)
+#define CLK_PERIPHCLK_PLLQ              (0x0008U)
+#define CLK_PERIPHCLK_PLLR              (0x0009U)
+#define CLK_PERIPHCLK_PLLXP             (0x000AU)
+#define CLK_PERIPHCLK_PLLXQ             (0x000BU)
+#define CLK_PERIPHCLK_PLLXR             (0x000CU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_I2S_Sel CLK I2S Channel Selection
+ * @{
+ */
+#define CLK_I2S1                        (0x00U)
+#define CLK_I2S2                        (0x01U)
+#define CLK_I2S3                        (0x02U)
+#define CLK_I2S4                        (0x03U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_TPIU_Divider TPIU clock divider
+ * @{
+ */
+#define CLK_TPIUCLK_DIV1                (0x00U)
+#define CLK_TPIUCLK_DIV2                (0x01U)
+#define CLK_TPIUCLK_DIV4                (0x02U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_MCO_Channel_Sel CLK MCO Channel Select
+ * @{
+ */
+#define CLK_MCO1                        (0x00U)
+#define CLK_MCO2                        (0x01U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_MCO_Clock_Source CLK MCO Clock Source
+ * @{
+ */
+#define CLK_MCO_SRC_HRC                 (0x00U)
+#define CLK_MCO_SRC_MRC                 (0x01U)
+#define CLK_MCO_SRC_LRC                 (0x02U)
+#define CLK_MCO_SRC_XTAL                (0x03U)
+#define CLK_MCO_SRC_XTAL32              (0x04U)
+#define CLK_MCO_SRC_PLLP                (0x06U)
+#define CLK_MCO_SRC_PLLXP               (0x07U)
+#define CLK_MCO_SRC_PLLQ                (0x08U)
+#define CLK_MCO_SRC_PLLXQ               (0x09U)
+#define CLK_MCO_SRC_PLLXR               (0x0AU)
+#define CLK_MCO_SRC_HCLK                (0x0BU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_MCO_Clock_Prescaler CLK MCO Clock Prescaler
+ * @{
+ */
+#define CLK_MCO_DIV1                    (0x00U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV2                    (0x01U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV4                    (0x02U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV8                    (0x03U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV16                   (0x04U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV32                   (0x05U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV64                   (0x06U << CMU_MCOCFGR_MCODIV_POS)
+#define CLK_MCO_DIV128                  (0x07U << CMU_MCOCFGR_MCODIV_POS)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup CLK_Global_Functions
+ * @{
+ */
+int32_t CLK_HrcCmd(en_functional_state_t enNewState);
+int32_t CLK_MrcCmd(en_functional_state_t enNewState);
+int32_t CLK_LrcCmd(en_functional_state_t enNewState);
+
+void CLK_HrcTrim(int8_t i8TrimVal);
+void CLK_MrcTrim(int8_t i8TrimVal);
+void CLK_LrcTrim(int8_t i8TrimVal);
+void CLK_RtcLrcTrim(int8_t i8TrimVal);
+
+int32_t CLK_XtalStructInit(stc_clock_xtal_init_t *pstcXtalInit);
+int32_t CLK_XtalInit(const stc_clock_xtal_init_t *pstcXtalInit);
+int32_t CLK_XtalCmd(en_functional_state_t enNewState);
+
+void CLK_XtalStdCmd(en_functional_state_t enNewState);
+int32_t CLK_XtalStdInit(uint8_t u8State, uint8_t u8ExceptionType);
+int32_t CLK_SetXtalStdExceptionType(uint8_t u8ExceptionType);
+void CLK_ClearXtalStdStatus(void);
+en_flag_status_t CLK_GetXtalStdStatus(void);
+
+int32_t CLK_Xtal32StructInit(stc_clock_xtal32_init_t *pstcXtal32Init);
+int32_t CLK_Xtal32Init(const stc_clock_xtal32_init_t *pstcXtal32Init);
+int32_t CLK_Xtal32Cmd(en_functional_state_t enNewState);
+void CLK_Xtal32InputCmd(en_functional_state_t enNewState);
+
+void CLK_SetPLLSrc(uint32_t u32PllSrc);
+int32_t CLK_PLLStructInit(stc_clock_pll_init_t *pstcPLLInit);
+int32_t CLK_PLLInit(const stc_clock_pll_init_t *pstcPLLInit);
+int32_t CLK_PLLCmd(en_functional_state_t enNewState);
+int32_t CLK_GetPLLClockFreq(stc_pll_clock_freq_t *pstcPllClkFreq);
+int32_t CLK_PLLxStructInit(stc_clock_pllx_init_t *pstcPLLxInit);
+int32_t CLK_PLLxInit(const stc_clock_pllx_init_t *pstcPLLxInit);
+int32_t CLK_PLLxCmd(en_functional_state_t enNewState);
+
+void CLK_MCOConfig(uint8_t u8Ch, uint8_t u8Src, uint8_t u8Div);
+void CLK_MCOCmd(uint8_t u8Ch, en_functional_state_t enNewState);
+
+en_flag_status_t CLK_GetStableStatus(uint8_t u8Flag);
+void CLK_SetSysClockSrc(uint8_t u8Src);
+void CLK_SetClockDiv(uint32_t u32Clock, uint32_t u32Div);
+int32_t CLK_GetClockFreq(stc_clock_freq_t *pstcClockFreq);
+uint32_t CLK_GetBusClockFreq(uint32_t u32Clock);
+
+void CLK_SetPeriClockSrc(uint16_t u16Src);
+void CLK_SetUSBClockSrc(uint8_t u8Src);
+void CLK_SetI2SClockSrc(uint8_t u8Unit, uint8_t u8Src);
+void CLK_SetCANClockSrc(uint8_t u8Unit, uint8_t u8Src);
+
+void CLK_TpiuClockCmd(en_functional_state_t enNewState);
+void CLK_SetTpiuClockDiv(uint8_t u8Div);
+/**
+ * @}
+ */
+
+#endif /* LL_CLK_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_CLK_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_cmp.h
+++ b/hc32f4a2/inc/hc32_ll_cmp.h
@@ -1,0 +1,379 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_cmp.h
+ * @brief This file contains all the functions prototypes of the CMP driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify structure stc_cmp_window_init_t
+                                    Modify macro define for API
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_CMP_H__
+#define __HC32_LL_CMP_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_CMP
+ * @{
+ */
+
+#if (LL_CMP_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup CMP_Global_Types CMP Global Types
+ * @{
+ */
+
+/**
+ * @brief CMP normal mode configuration structure
+ */
+typedef struct {
+    uint16_t u16PositiveInput;      /*!< Positive(compare voltage) input @ref CMP_Positive_Input_Select */
+    uint16_t u16NegativeInput;      /*!< Negative(Reference voltage) input @ref CMP_Negative_Input_Select */
+    uint16_t u16OutPolarity;        /*!< Output polarity select, @ref CMP_Out_Polarity_Select */
+    uint16_t u16OutDetectEdge;      /*!< Output detect edge, @ref CMP_Out_Detect_Edge_Select */
+    uint16_t u16OutFilter;          /*!< Output Filter, @ref CMP_Out_Filter */
+} stc_cmp_init_t;
+
+/**
+ * @brief CMP window mode configuration structure
+ */
+typedef struct {
+    /* Window mode Positive(compare voltage) input:
+       CMP2_INP3 valid for u16PositiveInput of CMP_WIN_CMP12
+       CMP4_INP3 valid for u16PositiveInput of CMP_WIN_CMP34 */
+    uint16_t u16WinVolLow;          /*!< CMP reference low voltage for window mode @ref CMP_Window_Low_Select */
+    uint16_t u16WinVolHigh;         /*!< CMP reference high voltage for window mode @ref CMP_Window_High_Select */
+    uint16_t u16OutPolarity;        /*!< Output polarity select, @ref CMP_Out_Polarity_Select */
+    uint16_t u16OutDetectEdge;      /*!< Output detect edge, @ref CMP_Out_Detect_Edge_Select */
+    uint16_t u16OutFilter;          /*!< Output Filter, @ref CMP_Out_Filter */
+} stc_cmp_window_init_t;
+
+/**
+ * @brief CMP blank window function configuration structure
+ */
+typedef struct {
+    uint16_t u16Src;                /*!< blank window source select,
+                                         can be any combination of @ref CMP_BlankWindow_Src */
+    uint8_t u8ValidLevel;           /*!< Blank window valid level @ref CMP_BlankWindow_Valid_Level */
+    uint8_t u8OutLevel;             /*!< CMP output level when blank window valid @ref CMP_BlankWindow_output_Level */
+} stc_cmp_blankwindow_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup CMP_Global_Macros CMP Global Macros
+ * @{
+ */
+
+#define VISR_OFFSET                 (8U)
+
+/**
+ * @defgroup CMP_Window_Mode_Unit CMP Window Mode Unit
+ * @{
+ */
+#define CMP_WIN_CMP12               (0x01U)
+#define CMP_WIN_CMP34               (0x02U)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Positive_Input_Select CMP Positive(Compare) Voltage Input
+ * @{
+ */
+#define CMP_POSITIVE_NONE           (0x0U)
+/* Select positive input for CMP1 */
+#define CMP1_POSITIVE_PGA1_BP       (CMP_PMSR_CVSL_0)                                       /*!< Select PGA1_BP */
+#define CMP1_POSITIVE_PGA1          ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_0 << VISR_OFFSET))  /*!< Select PGA1 */
+#define CMP1_POSITIVE_PGA2          ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_1 << VISR_OFFSET))  /*!< Select PGA2 */
+#define CMP1_POSITIVE_CMP1_INP2     ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_2 << VISR_OFFSET))  /*!< Select CMP1_INP2 */
+#define CMP1_POSITIVE_CMP1_INP3     ((CMP_PMSR_CVSL_2) | (CMP_VISR_P3SL_0 << VISR_OFFSET))  /*!< Select CMP1_INP3 */
+#define CMP1_POSITIVE_CMP2_INP3     ((CMP_PMSR_CVSL_2) | (CMP_VISR_P3SL_1 << VISR_OFFSET))  /*!< Select CMP2_INP3 */
+#define CMP1_POSITIVE_CMP1_INP4     (CMP_PMSR_CVSL_3)                                       /*!< Select CMP1_INP4 */
+/* Select positive input for CMP2 */
+#define CMP2_POSITIVE_PGA2_BP       (CMP_PMSR_CVSL_0)   /*!< Select PGA2_BP */
+#define CMP2_POSITIVE_PGA2          (CMP_PMSR_CVSL_1)   /*!< Select PGA2 */
+#define CMP2_POSITIVE_CMP2_INP3     (CMP_PMSR_CVSL_2)   /*!< Select CMP2_INP3 */
+#define CMP2_POSITIVE_CMP2_INP4     (CMP_PMSR_CVSL_3)   /*!< Select CMP2_INP4 */
+/* Select positive input for CMP3 */
+#define CMP3_POSITIVE_PGA3_BP       (CMP_PMSR_CVSL_0)                                       /*!< Select PGA3_BP */
+#define CMP3_POSITIVE_PGA3          ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_0 << VISR_OFFSET))  /*!< Select PGA3 */
+#define CMP3_POSITIVE_PGA4          ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_1 << VISR_OFFSET))  /*!< Select PGA4_BP */
+#define CMP3_POSITIVE_CMP3_INP2     ((CMP_PMSR_CVSL_1) | (CMP_VISR_P2SL_2 << VISR_OFFSET))  /*!< Select CMP3_INP2 */
+#define CMP3_POSITIVE_CMP3_INP3     ((CMP_PMSR_CVSL_2) | (CMP_VISR_P2SL_0 << VISR_OFFSET))  /*!< Select CMP3_INP3 */
+#define CMP3_POSITIVE_CMP4_INP3     ((CMP_PMSR_CVSL_2) | (CMP_VISR_P2SL_1 << VISR_OFFSET))  /*!< Select CMP4_INP3 */
+#define CMP3_POSITIVE_CMP3_INP4     (CMP_PMSR_CVSL_3)                                       /*!< Select CMP3_INP4 */
+/* Select positive input for CMP4 */
+#define CMP4_POSITIVE_PGA4_BP       (CMP_PMSR_CVSL_0)   /*!< Select PGA4_BP */
+#define CMP4_POSITIVE_PGA4          (CMP_PMSR_CVSL_1)   /*!< Select PGA4 */
+#define CMP4_POSITIVE_CMP4_INP3     (CMP_PMSR_CVSL_2)   /*!< Select CMP4_INP3 */
+#define CMP4_POSITIVE_CMP4_INP4     (CMP_PMSR_CVSL_3)   /*!< Select CMP4_INP4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Negative_Input_Select CMP Negative(Reference) Voltage Input
+ * @{
+ */
+#define CMP_NEGATIVE_NONE           (0x0U)
+/* Negative input select table
+        CMP1            CMP2            CMP3            CMP4
+--------------------------------------------------------------------
+INM1    DAC1_OUT1       DAC1_OUT1       DAC2_OUT1       DAC2_OUT1
+INM2    DAC1_OUT2       DAC1_OUT2       DAC2_OUT2       DAC2_OUT2
+INM3    CMP123_INM3     CMP123_INM3     CMP123_INM3     CMP4_INM3
+INM4    CMP1_INM4       CMP2_INM4       CMP3_INM4       CMP4_INM4
+*/
+#define CMP_NEGATIVE_INM1           (CMP_PMSR_RVSL_0)
+#define CMP_NEGATIVE_INM2           (CMP_PMSR_RVSL_1)
+#define CMP_NEGATIVE_INM3           (CMP_PMSR_RVSL_2)
+#define CMP_NEGATIVE_INM4           (CMP_PMSR_RVSL_3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Window_Low_Select CMP Window Mode Window Low Voltage
+ * @{
+ */
+#define CMP_WIN_LOW_NONE            (0x0U)
+/* Window mode low voltage select table
+        WIN_CMP12       WIN_CMP34
+------------------------------------
+INM1    DAC1_OUT1       DAC2_OUT1
+INM2    DAC1_OUT2       DAC2_OUT2
+INM3    CMP123_INM3     CMP123_INM3
+INM4    CMP1_INM4       CMP3_INM4
+*/
+#define CMP_WIN_LOW_INM1            (CMP_PMSR_RVSL_0)
+#define CMP_WIN_LOW_INM2            (CMP_PMSR_RVSL_1)
+#define CMP_WIN_LOW_INM3            (CMP_PMSR_RVSL_2)
+#define CMP_WIN_LOW_INM4            (CMP_PMSR_RVSL_3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Window_High_Select CMP Window Mode Window High Voltage
+ * @{
+ */
+#define CMP_WIN_HIGH_NONE           (0x0U)
+/* Window mode high voltage select table
+        WIN_CMP12       WIN_CMP34
+-------------------------------------------------------
+INM1    DAC1_OUT1       DAC2_OUT1
+INM2    DAC1_OUT2       DAC2_OUT2
+INM3    CMP123_INM3     CMP4_INM3
+INM4    CMP2_INM4       CMP4_INM4
+*/
+#define CMP_WIN_HIGH_INM1           (CMP_PMSR_RVSL_0)
+#define CMP_WIN_HIGH_INM2           (CMP_PMSR_RVSL_1)
+#define CMP_WIN_HIGH_INM3           (CMP_PMSR_RVSL_2)
+#define CMP_WIN_HIGH_INM4           (CMP_PMSR_RVSL_3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Out_Polarity_Select CMP Output Polarity
+ * @{
+ */
+#define CMP_OUT_INVT_OFF            (0x0U)                    /*!< CMP output don't reverse */
+#define CMP_OUT_INVT_ON             (CMP_OCR_COPS)            /*!< CMP output level reverse */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Out_Detect_Edge_Select CMP Output Detect Edge
+ * @{
+ */
+#define CMP_DETECT_EDGS_NONE        (0U)                       /*!< Do not detect edge */
+#define CMP_DETECT_EDGS_RISING      (1U << CMP_FIR_EDGS_POS)   /*!< Detect rising edge */
+#define CMP_DETECT_EDGS_FALLING     (2U << CMP_FIR_EDGS_POS)   /*!< Detect falling edge */
+#define CMP_DETECT_EDGS_BOTH        (3U << CMP_FIR_EDGS_POS)   /*!< Detect rising and falling edges */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Out_Filter CMP Output Filter Configuration
+ * @{
+ */
+#define CMP_OUT_FILTER_NONE         (0U)                       /*!< Do not filter */
+#define CMP_OUT_FILTER_CLK          (1U << CMP_FIR_FCKS_POS)
+#define CMP_OUT_FILTER_CLK_DIV8     (2U << CMP_FIR_FCKS_POS)
+#define CMP_OUT_FILTER_CLK_DIV32    (3U << CMP_FIR_FCKS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_BlankWindow_Src CMP Output blank window Function Control Signal
+ * @{
+ */
+/* Blank window PWM source select table
+        CMP1            CMP2            CMP3            CMP4
+------------------------------------------------------------------------
+SRC1    TMRA_1_PWM1     TMRA_3_PWM1     TMRA_1_PWM1     TMRA_2_PWM1
+SRC2    TMRA_1_PWM2     TMRA_3_PWM2     TMRA_1_PWM2     TMRA_2_PWM2
+SRC3    TMRA_1_PWM3     TMRA_3_PWM3     TMRA_1_PWM3     TMRA_2_PWM3
+SRC4    TMRA_2_PWM1     TMRA_4_PWM1     TMRA_3_PWM1     TMRA_4_PWM1
+SRC5    TMRA_2_PWM2     TMRA_4_PWM2     TMRA_3_PWM2     TMRA_4_PWM2
+SRC6    TMRA_2_PWM3     TMRA_4_PWM3     TMRA_3_PWM3     TMRA_4_PWM3
+SRC7    TMR6_1_PWMA     TMR6_5_PWMA     TMR6_1_PWMB     TMR6_5_PWMB
+SRC8    TMR6_2_PWMA     TMR6_6_PWMA     TMR6_2_PWMB     TMR6_6_PWMB
+SRC9    TMR6_3_PWMA     TMR6_7_PWMA     TMR6_3_PWMB     TMR6_7_PWMB
+SRC10   TMR6_4_PWMA     TMR6_8_PWMA     TMR6_4_PWMB     TMR6_8_PWMB
+SRC11   TMR4_1_OUH      TMR4_2_OUH      TMR4_3_OUH      TMR4_3_OUH
+SRC12   TMR4_1_OUL      TMR4_2_OUL      TMR4_3_OUL      TMR4_3_OUL
+SRC13   TMR4_1_OVH      TMR4_2_OVH      TMR4_3_OVH      TMR4_3_OVH
+SRC14   TMR4_1_OVL      TMR4_2_OVL      TMR4_3_OVL      TMR4_3_OVL
+SRC15   TMR4_1_OWH      TMR4_2_OWH      TMR4_3_OWH      TMR4_3_OWH
+SRC16   TMR4_1_OWL      TMR4_2_OWL      TMR4_3_OWL      TMR4_3_OWL
+*/
+#define CMP_BLANKWIN_SRC1           (CMP_TWSR_CTWS0)
+#define CMP_BLANKWIN_SRC2           (CMP_TWSR_CTWS1)
+#define CMP_BLANKWIN_SRC3           (CMP_TWSR_CTWS2)
+#define CMP_BLANKWIN_SRC4           (CMP_TWSR_CTWS3)
+#define CMP_BLANKWIN_SRC5           (CMP_TWSR_CTWS4)
+#define CMP_BLANKWIN_SRC6           (CMP_TWSR_CTWS5)
+#define CMP_BLANKWIN_SRC7           (CMP_TWSR_CTWS6)
+#define CMP_BLANKWIN_SRC8           (CMP_TWSR_CTWS7)
+#define CMP_BLANKWIN_SRC9           (CMP_TWSR_CTWS8)
+#define CMP_BLANKWIN_SRC10          (CMP_TWSR_CTWS9)
+#define CMP_BLANKWIN_SRC11          (CMP_TWSR_CTWS10)
+#define CMP_BLANKWIN_SRC12          (CMP_TWSR_CTWS11)
+#define CMP_BLANKWIN_SRC13          (CMP_TWSR_CTWS12)
+#define CMP_BLANKWIN_SRC14          (CMP_TWSR_CTWS13)
+#define CMP_BLANKWIN_SRC15          (CMP_TWSR_CTWS14)
+#define CMP_BLANKWIN_SRC16          (CMP_TWSR_CTWS15)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_BlankWindow_Valid_Level CMP Blank Window Valid Level
+ * @{
+ */
+#define CMP_BLANKWIN_VALID_LVL_LOW  (0U)                   /*!< Blank window valid level is low */
+#define CMP_BLANKWIN_VALID_LVL_HIGH (1U)                   /*!< Blank window valid level is high */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_BlankWindow_output_Level CMP Output Level When Blank Windows Valid
+ * @{
+ */
+#define CMP_BLANKWIN_OUTPUT_LVL_LOW     (0U)                   /*!< Output low when blank windows valid */
+#define CMP_BLANKWIN_OUTPUT_LVL_HIGH    (CMP_OCR_TWOL)         /*!< Output high when blank windows valid */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup CMP_Global_Functions
+ * @{
+ */
+
+int32_t CMP_StructInit(stc_cmp_init_t *pstcCmpInit);
+int32_t CMP_NormalModeInit(CM_CMP_TypeDef *CMPx, const stc_cmp_init_t *pstcCmpInit);
+void CMP_DeInit(CM_CMP_TypeDef *CMPx);
+
+void CMP_FuncCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState);
+void CMP_IntCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState);
+void CMP_CompareOutCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState);
+void CMP_PinVcoutCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState);
+en_flag_status_t CMP_GetStatus(const CM_CMP_TypeDef *CMPx);
+void CMP_SetOutDetectEdge(CM_CMP_TypeDef *CMPx, uint8_t u8CmpEdges);
+void CMP_SetOutFilter(CM_CMP_TypeDef *CMPx, uint8_t u8CmpFilter);
+void CMP_SetOutPolarity(CM_CMP_TypeDef *CMPx, uint16_t u16CmpPolarity);
+void CMP_SetPositiveInput(CM_CMP_TypeDef *CMPx, uint16_t  u16PositiveInput);
+void CMP_SetNegativeInput(CM_CMP_TypeDef *CMPx, uint16_t u16NegativeInput);
+
+int32_t CMP_WindowModeInit(uint8_t u8WinCMPx, const stc_cmp_window_init_t *pstcCmpWindowInit);
+int32_t CMP_WindowStructInit(stc_cmp_window_init_t *pstcCmpWindowInit);
+
+void CMP_BlankWindowSrcDisable(CM_CMP_TypeDef *CMPx, uint16_t u16BlankWindowSrc);
+int32_t CMP_BlankWindowConfig(CM_CMP_TypeDef *CMPx, const stc_cmp_blankwindow_t *pstcBlankWindowConfig);
+int32_t CMP_BlankWindowStructInit(stc_cmp_blankwindow_t *pstcBlankWindowConfig);
+void CMP_BlankWindowCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_CMP_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_CMP_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_crc.h
+++ b/hc32f4a2/inc/hc32_ll_crc.h
@@ -1,0 +1,172 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_crc.h
+ * @brief This file contains all the functions prototypes of the CRC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Reconstruct interface function relate to calculate CRC
+                                    Modify return type of function CRC_DeInit
+   2023-09-30       CDT             Modify comment
+                                    Delete and modify some of group/function relate to calculate CRC
+   2024-06-30       CDT             Add declaration of API CRC_GetResult() & CRC_SetInitValue()
+   2024-11-08       CDT             Modify interface of AccumulateData and Calculate functions
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_CRC_H__
+#define __HC32_LL_CRC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_CRC
+ * @{
+ */
+
+#if (LL_CRC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup CRC_Global_Types CRC Global Types
+ * @{
+ */
+
+/**
+ * @brief CRC initialization structure definition
+ */
+typedef struct {
+    uint32_t u32Protocol;   /*!< Specifies CRC Protocol.
+                                 This parameter can be a value of @ref CRC_Protocol_Control_Bit */
+    uint32_t u32InitValue;  /*!< Specifies initial CRC value.
+                                 This parameter can be CRC_INIT_VALUE_DEFAULT @ref CRC_Init_Value_Default */
+} stc_crc_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CRC_Global_Macros CRC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup CRC_Protocol_Control_Bit CRC Protocol Control Bit
+ * @{
+ */
+#define CRC_CRC16                   (0x0UL)
+#define CRC_CRC32                   (CRC_CR_CR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_DATA_Bit_Width CRC Data Bit Width
+ * @{
+ */
+#define CRC_DATA_WIDTH_8BIT         (1U)
+#define CRC_DATA_WIDTH_16BIT        (2U)
+#define CRC_DATA_WIDTH_32BIT        (4U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_Init_Value_Default CRC Default Computation Initialization Value
+ * @{
+ */
+#define CRC_INIT_VALUE_DEFAULT      (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup CRC_Global_Functions
+ * @{
+ */
+int32_t CRC_StructInit(stc_crc_init_t *pstcCrcInit);
+int32_t CRC_Init(const stc_crc_init_t *pstcCrcInit);
+int32_t CRC_DeInit(void);
+
+uint32_t CRC_GetResult(void);
+void CRC_SetInitValue(uint32_t u32Value);
+
+en_flag_status_t CRC_GetResultStatus(void);
+
+int32_t CRC_CRC16_AccumulateData(uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t *pu16Out);
+int32_t CRC_CRC16_Calculate(uint16_t u16InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t *pu16Out);
+en_flag_status_t CRC_CRC16_CheckData(uint16_t u16InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t u16ExpectValue);
+en_flag_status_t CRC_CRC16_GetCheckResult(uint16_t u16ExpectValue);
+
+int32_t CRC_CRC32_AccumulateData(uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t *pu32Out);
+int32_t CRC_CRC32_Calculate(uint32_t u32InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t *pu32Out);
+en_flag_status_t CRC_CRC32_CheckData(uint32_t u32InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t u32ExpectValue);
+en_flag_status_t CRC_CRC32_GetCheckResult(uint32_t u32ExpectValue);
+
+/**
+ * @}
+ */
+
+#endif /* LL_CRC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_CRC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_ctc.h
+++ b/hc32f4a2/inc/hc32_ll_ctc.h
@@ -1,0 +1,198 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_ctc.h
+ * @brief This file contains all the functions prototypes of the Clock Trimming
+ *        Controller(CTC) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_CTC_H__
+#define __HC32_LL_CTC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_CTC
+ * @{
+ */
+
+#if (LL_CTC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup CTC_Global_Types CTC Global Types
+ * @{
+ */
+
+/**
+ * @brief CTC continuous trim initialization structure definition
+ */
+typedef struct {
+    uint32_t  u32RefClockFreq;      /*!< Reference clock frequency
+                                         This parameter should refer user manual recommended values */
+    uint32_t  u32RefClockSrc;       /*!< Reference clock source selection
+                                         This parameter can be a value of @ref CTC_Continuous_Trim_Reference_Clock_Source */
+    uint32_t  u32RefClockDiv;       /*!< Reference clock division
+                                         This parameter can be a value of @ref CTC_Reference_Clock_Division */
+    float32_t f32TolerantErrRate;   /*!< CTC tolerance deviation
+                                         This parameter can be a value between Min_Data=0.0 and Max_Data=1.0(100%) */
+    uint8_t   u8TrimValue;          /*!< CTC TRMVAL value
+                                         This parameter can be a value between Min_Data=0 and Max_Data=0x3F */
+} stc_ctc_ct_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CTC_Global_Macros CTC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup CTC_Continuous_Trim_Reference_Clock_Source CTC Continuous Trim Reference Clock Source
+ * @{
+ */
+#define CTC_REF_CLK_SRC_CTCREF          (0UL)               /*!< Clock source: CTCREF */
+#define CTC_REF_CLK_SRC_XTAL            (CTC_CR1_REFCKS)    /*!< Clock source: XTAL */
+#define CTC_REF_CLK_SRC_XTAL32          (CTC_CR1_REFCKS_1)  /*!< Clock source: XTAL32 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CTC_Flag CTC Flag
+ * @{
+ */
+#define CTC_FLAG_TRIM_OK                (CTC_STR_TRIMOK)    /*!< Trimming OK flag */
+#define CTC_FLAG_TRIM_OVF               (CTC_STR_TRMOVF)    /*!< Trimming overflow flag */
+#define CTC_FLAG_TRIM_UDF               (CTC_STR_TRMUDF)    /*!< Trimming underflow flag */
+#define CTC_FLAG_BUSY                   (CTC_STR_CTCBSY)    /*!< CTC busy flag */
+#define CTC_FLAG_ALL                    (CTC_FLAG_TRIM_OVF | CTC_FLAG_TRIM_UDF | \
+                                         CTC_FLAG_TRIM_OK  | CTC_FLAG_BUSY)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CTC_Reference_Clock_Division CTC Reference Clock Division
+ * @{
+ */
+#define CTC_REF_CLK_DIV8                (0UL)   /*!< REFCLK/8 */
+#define CTC_REF_CLK_DIV32               (1UL)   /*!< REFCLK/32 */
+#define CTC_REF_CLK_DIV128              (2UL)   /*!< REFCLK/128 */
+#define CTC_REF_CLK_DIV256              (3UL)   /*!< REFCLK/256 */
+#define CTC_REF_CLK_DIV512              (4UL)   /*!< REFCLK/512 */
+#define CTC_REF_CLK_DIV1024             (5UL)   /*!< REFCLK/1024 */
+#define CTC_REF_CLK_DIV2048             (6UL)   /*!< REFCLK/2048 */
+#define CTC_REF_CLK_DIV4096             (7UL)   /*!< REFCLK/4096 */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup CTC_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Start CTC trimming.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void CTC_Start(void)
+{
+    SET_REG32_BIT(CM_CTC->CR1, CTC_CR1_CTCEN);
+}
+
+/**
+ * @brief  Stop CTC trimming.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void CTC_Stop(void)
+{
+    CLR_REG32_BIT(CM_CTC->CR1, CTC_CR1_CTCEN);
+}
+
+int32_t CTC_CT_StructInit(stc_ctc_ct_init_t *pstcCtcInit);
+int32_t CTC_CT_Init(const stc_ctc_ct_init_t *pstcCtcInit);
+
+int32_t CTC_DeInit(void);
+void CTC_IntCmd(en_functional_state_t enNewState);
+en_flag_status_t CTC_GetStatus(uint32_t u32Flag);
+void CTC_SetTrimValue(uint8_t u8TrimValue);
+uint8_t CTC_GetTrimValue(void);
+void CTC_SetReloadValue(uint16_t u16ReloadValue);
+uint16_t CTC_GetReloadValue(void);
+void CTC_SetOffsetValue(uint8_t u8OffsetValue);
+uint8_t CTC_GetOffsetValue(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_CTC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_CTC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dac.h
+++ b/hc32f4a2/inc/hc32_ll_dac.h
@@ -1,0 +1,196 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dac.h
+ * @brief This file contains all the functions prototypes of the DAC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify function: DAC_AMPCmd
+   2023-06-30       CDT             Refine definition of dac resolution
+   2023-09-30       CDT             Modify API DAC_DeInit
+   2024-11-08       CDT             Add align parametric in struct stc_dac_init_t
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DAC_H__
+#define __HC32_LL_DAC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DAC
+ * @{
+ */
+
+#if (LL_DAC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup DAC_Global_Types DAC Global Types
+ * @{
+ */
+
+/**
+ * @brief Structure definition of DAC initialization.
+ */
+typedef struct {
+    uint16_t u16Src;                 /*!< Data source to be converted
+                                     This parameter can be a value of @ref DAC_DATA_SRC */
+    uint16_t u16Align;               /*!< Specify the data alignment
+                                     This parameter can be a value of @ref DAC_DATAREG_ALIGN_PATTERN */
+    en_functional_state_t enOutput;  /*!< Enable or disable analog output
+                                     This parameter can be a value of @ref en_functional_state_t */
+} stc_dac_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup DAC_Global_Macros DAC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup DAC_CH DAC channel
+ * @{
+ */
+#define DAC_CH1                           (0U)
+#define DAC_CH2                           (1U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DAC_DATA_SRC DAC data source
+ * @{
+ */
+#define DAC_DATA_SRC_DATAREG               (0U)
+#define DAC_DATA_SRC_DCU                   (DAC_DACR_EXTDSL1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DAC_DATAREG_ALIGN_PATTERN DAC data register alignment pattern
+ * @{
+ */
+#define DAC_DATA_ALIGN_LEFT                (DAC_DACR_DPSEL)
+#define DAC_DATA_ALIGN_RIGHT               (0U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DAC_RESOLUTION DAC resolution
+ * @{
+ */
+#define DAC_RESOLUTION_12BIT                 (12U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DAC_ADP_SELECT DAC ADCx priority select
+ * @{
+ */
+#define DAC_ADP_SEL_ADC1                    (DAC_DAADPCR_ADCSL1)
+#define DAC_ADP_SEL_ADC2                    (DAC_DAADPCR_ADCSL2)
+#define DAC_ADP_SEL_ADC3                    (DAC_DAADPCR_ADCSL3)
+#define DAC_ADP_SEL_ALL                     (DAC_DAADPCR_ADCSL1 | DAC_DAADPCR_ADCSL2 | DAC_DAADPCR_ADCSL3)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup DAC_Global_Functions
+ * @{
+ */
+
+int32_t DAC_StructInit(stc_dac_init_t *pstcDacInit);
+int32_t DAC_Init(CM_DAC_TypeDef *DACx, uint16_t u16Ch, const stc_dac_init_t *pstcDacInit);
+int32_t DAC_DeInit(CM_DAC_TypeDef *DACx);
+
+void DAC_SetDataSrc(CM_DAC_TypeDef *DACx, uint16_t u16Ch, uint16_t u16Src);
+void DAC_DataRegAlignConfig(CM_DAC_TypeDef *DACx, uint16_t u16Align);
+void DAC_OutputCmd(CM_DAC_TypeDef *DACx, uint16_t u16Ch, en_functional_state_t enNewState);
+void DAC_AMPCmd(CM_DAC_TypeDef *DACx, uint16_t u16Ch, en_functional_state_t enNewState);
+void DAC_ADCPrioCmd(CM_DAC_TypeDef *DACx, en_functional_state_t enNewState);
+void DAC_ADCPrioConfig(CM_DAC_TypeDef *DACx, uint16_t u16ADCxPrio, en_functional_state_t enNewState);
+
+int32_t DAC_Start(CM_DAC_TypeDef *DACx, uint16_t u16Ch);
+int32_t DAC_Stop(CM_DAC_TypeDef *DACx, uint16_t u16Ch);
+void DAC_StartDualCh(CM_DAC_TypeDef *DACx);
+void DAC_StopDualCh(CM_DAC_TypeDef *DACx);
+
+void DAC_SetChData(CM_DAC_TypeDef *DACx, uint16_t u16Ch, uint16_t u16Data);
+void DAC_SetDualChData(CM_DAC_TypeDef *DACx, uint16_t u16Data1, uint16_t u16Data2);
+int32_t DAC_GetChConvertState(const CM_DAC_TypeDef *DACx, uint16_t u16Ch);
+
+/**
+ * @}
+ */
+
+#endif /* LL_DAC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DAC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dbgc.h
+++ b/hc32f4a2/inc/hc32_ll_dbgc.h
@@ -1,0 +1,163 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dbgc.h
+ * @brief This file contains all the functions prototypes of the DBGC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2023-09-30       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DBGC_H__
+#define __HC32_LL_DBGC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DBGC
+ * @{
+ */
+
+#if (LL_DBGC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DBGC_Global_Macros DBGC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup DBGC_Periph_Sel DBGC Periph Selection
+ * @{
+ */
+#define DBGC_PERIPH_SWDT                    (DBGC_MCUSTPCTL_SWDTSTP)
+#define DBGC_PERIPH_WDT                     (DBGC_MCUSTPCTL_WDTSTP)
+#define DBGC_PERIPH_RTC                     (DBGC_MCUSTPCTL_RTCSTP)
+#define DBGC_PERIPH_TMR0_1                  (DBGC_MCUSTPCTL_M06STP)
+#define DBGC_PERIPH_TMR0_2                  (DBGC_MCUSTPCTL_M07STP)
+#define DBGC_PERIPH_TMR2_1                  (DBGC_MCUSTPCTL_M08STP)
+#define DBGC_PERIPH_TMR2_2                  (DBGC_MCUSTPCTL_M09STP)
+#define DBGC_PERIPH_TMR2_3                  (DBGC_MCUSTPCTL_M10STP)
+#define DBGC_PERIPH_TMR2_4                  (DBGC_MCUSTPCTL_M11STP)
+#define DBGC_PERIPH_TMR4_1                  (DBGC_MCUSTPCTL_M12STP)
+#define DBGC_PERIPH_TMR4_2                  (DBGC_MCUSTPCTL_M13STP)
+#define DBGC_PERIPH_TMR4_3                  (DBGC_MCUSTPCTL_M14STP)
+#define DBGC_PERIPH_TMR6_1                  (DBGC_MCUSTPCTL_M15STP)
+#define DBGC_PERIPH_TMR6_2                  (DBGC_MCUSTPCTL_M16STP)
+#define DBGC_PERIPH_TMR6_3                  (DBGC_MCUSTPCTL_M17STP)
+#define DBGC_PERIPH_TMR6_4                  (DBGC_MCUSTPCTL_M18STP)
+#define DBGC_PERIPH_TMR6_5                  (DBGC_MCUSTPCTL_M19STP)
+#define DBGC_PERIPH_TMR6_6                  (DBGC_MCUSTPCTL_M20STP)
+#define DBGC_PERIPH_TMR6_7                  (DBGC_MCUSTPCTL_M21STP)
+#define DBGC_PERIPH_TMR6_8                  (DBGC_MCUSTPCTL_M22STP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DBGC_Periph2_Sel DBGC Periph2 Selection
+ * @{
+ */
+#define DBGC_PERIPH_TMRA_1                  (DBGC_MCUSTPCTL2_M32STP)
+#define DBGC_PERIPH_TMRA_2                  (DBGC_MCUSTPCTL2_M33STP)
+#define DBGC_PERIPH_TMRA_3                  (DBGC_MCUSTPCTL2_M34STP)
+#define DBGC_PERIPH_TMRA_4                  (DBGC_MCUSTPCTL2_M35STP)
+#define DBGC_PERIPH_TMRA_5                  (DBGC_MCUSTPCTL2_M36STP)
+#define DBGC_PERIPH_TMRA_6                  (DBGC_MCUSTPCTL2_M37STP)
+#define DBGC_PERIPH_TMRA_7                  (DBGC_MCUSTPCTL2_M38STP)
+#define DBGC_PERIPH_TMRA_8                  (DBGC_MCUSTPCTL2_M39STP)
+#define DBGC_PERIPH_TMRA_9                  (DBGC_MCUSTPCTL2_M40STP)
+#define DBGC_PERIPH_TMRA_10                 (DBGC_MCUSTPCTL2_M41STP)
+#define DBGC_PERIPH_TMRA_11                 (DBGC_MCUSTPCTL2_M42STP)
+#define DBGC_PERIPH_TMRA_12                 (DBGC_MCUSTPCTL2_M43STP)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DBGC_Trace_Mode DBGC trace mode
+ * @{
+ */
+#define DBGC_TRACE_ASYNC                    (0UL)
+#define DBGC_TRACE_SYNC_1BIT                (DBGC_MCUTRACECTL_TRACEMODE_0)
+#define DBGC_TRACE_SYNC_2BIT                (DBGC_MCUTRACECTL_TRACEMODE_1)
+#define DBGC_TRACE_SYNC_4BIT                (DBGC_MCUTRACECTL_TRACEMODE)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup DBGC_Global_Functions
+ * @{
+ */
+void DBGC_PeriphCmd(uint32_t u32Periph, en_functional_state_t enNewState);
+void DBGC_Periph2Cmd(uint32_t u32Periph, en_functional_state_t enNewState);
+void DBGC_TraceIoCmd(en_functional_state_t enNewState);
+void DBGC_TraceModeConfig(uint32_t u32TraceMode);
+/**
+ * @}
+ */
+
+#endif /* LL_DBGC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DBGC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dcu.h
+++ b/hc32f4a2/inc/hc32_ll_dcu.h
@@ -1,0 +1,302 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dcu.h
+ * @brief This file contains all the functions prototypes of the DCU(Data
+ *        Computing Unit) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify macro group comments: DCU_Interrupt_Type
+   2023-06-30       CDT             Modify typo
+                                    Delete macro definition: DCU_INT_SAWTOOTH_WAVE_RELOAD
+                                    Modify macro-definition according to RM:DCU_CTL_COMP_TRG->DCU_CTL_COMPTRG
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DCU_H__
+#define __HC32_LL_DCU_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DCU
+ * @{
+ */
+
+#if (LL_DCU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup DCU_Global_Types DCU Global Types
+ * @{
+ */
+
+/**
+ * @brief DCU initialization structure definition
+ */
+typedef struct {
+    uint32_t u32Mode;         /*!< Specifies DCU operation.
+                                   This parameter can be a value of @ref DCU_Mode */
+    uint32_t u32DataWidth;    /*!< Specifies DCU data width.
+                                   This parameter can be a value of @ref DCU_Data_Width */
+} stc_dcu_init_t;
+
+/**
+ * @brief DCU wave output configure structure definition
+ */
+typedef struct {
+    uint32_t u32LowerLimit;   /*!< Defines the wave lower limit of the wave amplitude.
+                                   This parameter can be a value between Min_Data = 0 and Max_Data = 0xFFF */
+    uint32_t u32UpperLimit;   /*!< Defines the upper limit of the wave amplitude.
+                                   This parameter can be a value between Min_Data = 0 and Max_Data = 0xFFF */
+    uint32_t u32Step;         /*!< Defines the increasing/decreasing step.
+                                   This parameter can be a value between Min_Data = 0 and Max_Data = 0xFFF */
+} stc_dcu_wave_config_t;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DCU_Global_Macros DCU Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup DCU_Data_Width DCU Data Width
+ * @{
+ */
+#define DCU_DATA_WIDTH_8BIT                 (0UL)                   /*!< DCU data width: 8 bit */
+#define DCU_DATA_WIDTH_16BIT                (DCU_CTL_DATASIZE_0)    /*!< DCU data width: 16 bit */
+#define DCU_DATA_WIDTH_32BIT                (DCU_CTL_DATASIZE_1)    /*!< DCU data width: 32 bit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Compare_Trigger_Condition DCU Compare Trigger Condition
+ * @{
+ */
+#define DCU_CMP_TRIG_DATA0                  (0UL)               /*!< DCU compare triggered by DATA0 */
+#define DCU_CMP_TRIG_DATA0_DATA1_DATA2      (DCU_CTL_COMPTRG)   /*!< DCU compare triggered by DATA0 or DATA1 or DATA2 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Mode DCU Mode
+ * @{
+ */
+#define DCU_MD_INVD                         (0UL)   /*!< DCU invalid */
+#define DCU_MD_ADD                          (1UL)   /*!< DCU add operation */
+#define DCU_MD_SUB                          (2UL)   /*!< DCU sub operation */
+#define DCU_MD_HW_ADD                       (3UL)   /*!< DCU hardware trigger add */
+#define DCU_MD_HW_SUB                       (4UL)   /*!< DCU hardware trigger sub */
+#define DCU_MD_CMP                          (5UL)   /*!< DCU compare */
+#define DCU_MD_TRIANGLE_WAVE                (8UL)   /*!< DCU triangle wave output mode */
+#define DCU_MD_SAWTOOTH_WAVE_INC            (9UL)   /*!< DCU increasing sawtooth wave output mode */
+#define DCU_MD_SAWTOOTH_WAVE_DEC            (10UL)  /*!< DCU decreasing sawtooth wave output mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Flag DCU Flag
+ * @{
+ */
+#define DCU_FLAG_CARRY                      (DCU_FLAG_FLAG_OP)  /*!< DCU addition overflow or subtraction underflow flag */
+#define DCU_FLAG_DATA0_LT_DATA2             (DCU_FLAG_FLAG_LS2) /*!< DCU DATA0 < DATA2 flag */
+#define DCU_FLAG_DATA0_EQ_DATA2             (DCU_FLAG_FLAG_EQ2) /*!< DCU DATA0 = DATA2 flag */
+#define DCU_FLAG_DATA0_GT_DATA2             (DCU_FLAG_FLAG_GT2) /*!< DCU DATA0 > DATA2 flag */
+#define DCU_FLAG_DATA0_LT_DATA1             (DCU_FLAG_FLAG_LS1) /*!< DCU DATA0 < DATA1 flag */
+#define DCU_FLAG_DATA0_EQ_DATA1             (DCU_FLAG_FLAG_EQ1) /*!< DCU DATA0 = DATA1 flag */
+#define DCU_FLAG_DATA0_GT_DATA1             (DCU_FLAG_FLAG_GT1) /*!< DCU DATA0 > DATA1 flag */
+#define DCU_FLAG_SAWTOOTH_WAVE_RELOAD       (DCU_FLAG_FLAG_RLD) /*!< DCU sawtooth wave mode reload interrupt */
+#define DCU_FLAG_TRIANGLE_WAVE_BOTTOM       (DCU_FLAG_FLAG_BTM) /*!< DCU triangle wave mode bottom interrupt */
+#define DCU_FLAG_TRIANGLE_WAVE_TOP          (DCU_FLAG_FLAG_TOP) /*!< DCU triangle wave mode top interrupt */
+
+#define DCU_FLAG_ALL                        (0x00000E7FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Category DCU Category
+ * @{
+ */
+#define DCU_CATEGORY_OP                     (0UL)   /*!< DCU operation result(overflow/underflow) */
+#define DCU_CATEGORY_CMP_WIN                (1UL)   /*!< DCU comparison(window) */
+#define DCU_CATEGORY_CMP_NON_WIN            (2UL)   /*!< DCU comparison(non-window) */
+#define DCU_CATEGORY_WAVE                   (3UL)   /*!< DCU wave mode(sawtooth/triangle wave) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Interrupt_Type DCU Interrupt Type
+ * @{
+ */
+/**
+ * @defgroup DCU_Compare_Interrupt DCU Compare(Non-window) Interrupt
+ * @note Interrupt type DCU_Compare_Interrupt is valid when only select DCU_CATEGORY_CMP_NON_WIN
+ * @{
+ */
+#define DCU_INT_CMP_DATA0_LT_DATA2          (DCU_INTEVTSEL_SEL_LS2)   /*!< DCU DATA0 < DATA2 interrupt */
+#define DCU_INT_CMP_DATA0_EQ_DATA2          (DCU_INTEVTSEL_SEL_EQ2)   /*!< DCU DATA0 = DATA2 interrupt */
+#define DCU_INT_CMP_DATA0_GT_DATA2          (DCU_INTEVTSEL_SEL_GT2)   /*!< DCU DATA0 > DATA2 interrupt */
+#define DCU_INT_CMP_DATA0_LT_DATA1          (DCU_INTEVTSEL_SEL_LS1)   /*!< DCU DATA0 < DATA1 interrupt */
+#define DCU_INT_CMP_DATA0_EQ_DATA1          (DCU_INTEVTSEL_SEL_EQ1)   /*!< DCU DATA0 = DATA1 interrupt */
+#define DCU_INT_CMP_DATA0_GT_DATA1          (DCU_INTEVTSEL_SEL_GT1)   /*!< DCU DATA0 > DATA1 interrupt */
+#define DCU_INT_CMP_NON_WIN_ALL             (DCU_INT_CMP_DATA0_LT_DATA2 |  \
+                                             DCU_INT_CMP_DATA0_EQ_DATA2 |  \
+                                             DCU_INT_CMP_DATA0_GT_DATA2 |  \
+                                             DCU_INT_CMP_DATA0_LT_DATA1 |  \
+                                             DCU_INT_CMP_DATA0_EQ_DATA1 |  \
+                                             DCU_INT_CMP_DATA0_GT_DATA1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Window_Compare_Interrupt DCU Window Compare Interrupt
+ * @note Interrupt type DCU_Window_Compare_Interrupt is valid when only select DCU_CATEGORY_CMP_WIN
+ * @{
+ */
+#define DCU_INT_CMP_WIN_INSIDE              (DCU_INTEVTSEL_SEL_WIN_0)  /*!< DCU comparison(DATA2 <= DATA0 <= DATA1) interrupt */
+#define DCU_INT_CMP_WIN_OUTSIDE             (DCU_INTEVTSEL_SEL_WIN_1)  /*!< DCU comparison(DATA0 < DATA2 & DATA0 > DATA1) interrupt */
+#define DCU_INT_CMP_WIN_ALL                 (DCU_INT_CMP_WIN_INSIDE | DCU_INT_CMP_WIN_OUTSIDE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Operation_Interrupt DCU Operation Interrupt
+ * @note DCU_Window_Compare_Interrupt selection is valid when only select DCU_CATEGORY_OP
+ * @{
+ */
+#define DCU_INT_OP_CARRY                    (DCU_INTEVTSEL_SEL_OP) /*!< DCU addition overflow or subtraction underflow interrupt */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Wave_Mode_Interrupt DCU Wave Mode Interrupt
+ * @note Interrupt type DCU_Wave_Mode_Interrupt is valid when only select DCU_CATEGORY_WAVE
+ * @{
+ */
+#define DCU_INT_TRIANGLE_WAVE_TOP           (DCU_INTEVTSEL_SEL_TOP) /*!< DCU triangle wave mode top interrupt */
+#define DCU_INT_TRIANGLE_WAVE_BOTTOM        (DCU_INTEVTSEL_SEL_BTM) /*!< DCU triangle wave mode bottom interrupt */
+#define DCU_INT_WAVE_MD_ALL                 (DCU_INT_TRIANGLE_WAVE_TOP    | \
+                                             DCU_INT_TRIANGLE_WAVE_BOTTOM)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Data_Register_Index DCU Data Register Index
+ * @{
+ */
+#define DCU_DATA0_IDX                       (0UL)   /*!< DCU DATA0 */
+#define DCU_DATA1_IDX                       (1UL)   /*!< DCU DATA1 */
+#define DCU_DATA2_IDX                       (2UL)   /*!< DCU DATA2 */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup DCU_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration functions */
+int32_t DCU_Init(CM_DCU_TypeDef *DCUx, const stc_dcu_init_t *pstcDcuInit);
+int32_t DCU_StructInit(stc_dcu_init_t *pstcDcuInit);
+int32_t DCU_DeInit(CM_DCU_TypeDef *DCUx);
+
+int32_t DCU_WaveConfig(CM_DCU_TypeDef *DCUx, const stc_dcu_wave_config_t *pstcWaveConfig);
+
+void DCU_SetMode(CM_DCU_TypeDef *DCUx, uint32_t u32Mode);
+void DCU_SetDataWidth(CM_DCU_TypeDef *DCUx, uint32_t u32DataWidth);
+void DCU_SetCompareCond(CM_DCU_TypeDef *DCUx, uint32_t u32Cond);
+
+/* Interrupt and flag management functions */
+en_flag_status_t DCU_GetStatus(const CM_DCU_TypeDef *DCUx, uint32_t u32Flag);
+void DCU_ClearStatus(CM_DCU_TypeDef *DCUx, uint32_t u32Flag);
+void DCU_GlobalIntCmd(CM_DCU_TypeDef *DCUx, en_functional_state_t enNewState);
+void DCU_IntCmd(CM_DCU_TypeDef *DCUx, uint32_t u32IntCategory, uint32_t u32IntType, en_functional_state_t enNewState);
+
+/* Read and write functions */
+uint8_t DCU_ReadData8(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex);
+void DCU_WriteData8(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint8_t u8Data);
+uint16_t DCU_ReadData16(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex);
+void DCU_WriteData16(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint16_t u16Data);
+uint32_t DCU_ReadData32(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex);
+void DCU_WriteData32(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint32_t u32Data);
+
+/**
+ * @}
+ */
+
+#endif /* LL_DCU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DCU_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_def.h
+++ b/hc32f4a2/inc/hc32_ll_def.h
@@ -1,0 +1,400 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_def.h
+ * @brief This file contains LL common definitions: enumeration, macros and
+  *       structures definitions.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Implemented the definition of __NO_INIT for AC6 and ARM Compiler
+                                    ARM Compiler suppress warning message: diag_1296
+   2023-06-30       CDT             Modify typo
+                                    Add __NO_OPTIMIZE configuration item
+   2023-09-30       CDT             Add attribute for __RAM_FUNC definition
+   2024-08-31       CDT             Add __USED definition
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DEF_H__
+#define __HC32_LL_DEF_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup LL_Common LL Common
+ * @{
+ */
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup LL_Common_Global_Types LL Common Global Types
+ * @{
+ */
+
+/**
+ * @brief Single precision floating point number (4 byte)
+ */
+typedef float float32_t;
+
+/**
+ * @brief Double precision floating point number (8 byte)
+ */
+typedef double float64_t;
+
+/**
+ * @brief Function pointer type to void/void function
+ */
+typedef void (*func_ptr_t)(void);
+
+/**
+ * @brief Functional state
+ */
+typedef enum {
+    DISABLE = 0U,
+    ENABLE  = 1U,
+} en_functional_state_t;
+
+/**
+ * @brief Flag status
+ */
+typedef enum {
+    RESET = 0U,
+    SET   = 1U,
+} en_flag_status_t, en_int_status_t;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup LL_Common_Global_Macros LL Common Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup Compiler_Macros Compiler Macros
+ * @{
+ */
+#ifndef __UNUSED
+#define __UNUSED                        __attribute__((unused))
+#endif /* __UNUSED */
+
+#ifndef __USED
+#define __USED                        __attribute__((used))
+#endif /* __USED */
+
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#ifndef __WEAKDEF
+#define __WEAKDEF                   __attribute__((weak))
+#endif /* __WEAKDEF */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN               __attribute__((aligned(4)))
+#endif /* __ALIGN_BEGIN */
+#ifndef __NOINLINE
+#define __NOINLINE                  __attribute__((noinline))
+#endif /* __NOINLINE */
+/* RAM functions are defined using the toolchain options.
+Functions that are executed in RAM should reside in a separate source module.
+Using the 'Options for File' dialog you can simply change the 'Code / Const'
+area of a module to a memory space in physical RAM. */
+#ifndef __RAM_FUNC
+#define __RAM_FUNC                  __attribute__((section("RAMCODE")))
+#endif /* __RAM_FUNC */
+#ifndef __NO_INIT
+#define __NO_INIT                   __attribute__((section(".bss.noinit")))
+#endif /* __NO_INIT */
+#ifndef __NO_OPTIMIZE
+#define __NO_OPTIMIZE               __attribute__((optnone))
+#endif /* __NO_OPTIMIZE */
+#elif defined (__GNUC__) && !defined (__CC_ARM) /*!< GNU Compiler */
+#ifndef __WEAKDEF
+#define __WEAKDEF                   __attribute__((weak))
+#endif /* __WEAKDEF */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN               __attribute__((aligned (4)))
+#endif /* __ALIGN_BEGIN */
+#ifndef __NOINLINE
+#define __NOINLINE                  __attribute__((noinline))
+#endif /* __NOINLINE */
+#ifndef __RAM_FUNC
+#define __RAM_FUNC                  __attribute__((long_call, section(".ramfunc")))
+/* Usage: __RAM_FUNC void foo(void) */
+#endif /* __RAM_FUNC */
+#ifndef __NO_INIT
+#define __NO_INIT                   __attribute__((section(".noinit")))
+#endif /* __NO_INIT */
+#ifndef __NO_OPTIMIZE
+#define __NO_OPTIMIZE               __attribute__((optimize("O0")))
+#endif /* __NO_OPTIMIZE */
+#elif defined (__ICCARM__)              /*!< IAR Compiler */
+#ifndef __WEAKDEF
+#define __WEAKDEF                   __weak
+#endif /* __WEAKDEF */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN               _Pragma("data_alignment=4")
+#endif /* __ALIGN_BEGIN */
+#ifndef __NOINLINE
+#define __NOINLINE                  _Pragma("optimize = no_inline")
+#endif /* __NOINLINE */
+#ifndef __RAM_FUNC
+#define __RAM_FUNC                  __ramfunc
+#endif /* __RAM_FUNC */
+#ifndef __NO_INIT
+#define __NO_INIT                   __no_init
+#endif /* __NO_INIT */
+#ifndef __NO_OPTIMIZE
+#define __NO_OPTIMIZE               _Pragma("optimize=none")
+#endif /* __NO_OPTIMIZE */
+#elif defined (__CC_ARM)                /*!< ARM Compiler */
+#ifndef __WEAKDEF
+#define __WEAKDEF                   __attribute__((weak))
+#endif /* __WEAKDEF */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN               __align(4)
+#endif /* __ALIGN_BEGIN */
+#ifndef __NOINLINE
+#define __NOINLINE                  __attribute__((noinline))
+#endif /* __NOINLINE */
+#ifndef __NO_INIT
+#define __NO_INIT                   __attribute__((section(".bss.noinit"), zero_init))
+#endif /* __NO_INIT */
+#ifndef __NO_OPTIMIZE
+#define __NO_OPTIMIZE
+#endif /* __NO_OPTIMIZE */
+/* RAM functions are defined using the toolchain options.
+Functions that are executed in RAM should reside in a separate source module.
+Using the 'Options for File' dialog you can simply change the 'Code / Const'
+area of a module to a memory space in physical RAM. */
+#ifndef __RAM_FUNC
+#define __RAM_FUNC                  __attribute__((section("RAMCODE")))
+#endif /* __RAM_FUNC */
+/* Suppress warning message: extended constant initializer used */
+#pragma diag_suppress 1296
+#else
+#error  "unsupported compiler!!"
+#endif
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Extend_Macros Extend Macros
+ * @{
+ */
+/* Decimal to BCD */
+#define DEC2BCD(x)                      ((((x) / 10U) << 4U) + ((x) % 10U))
+
+/* BCD to decimal */
+#define BCD2DEC(x)                      ((((x) >> 4U) * 10U) + ((x) & 0x0FU))
+
+/* Returns the dimension of an array */
+#define ARRAY_SZ(x)                     ((sizeof(x)) / (sizeof((x)[0])))
+
+/* Returns the minimum value out of two values */
+#define LL_MIN(x, y)                    ((x) < (y) ? (x) : (y))
+
+/* Returns the maximum value out of two values */
+#define LL_MAX(x, y)                    ((x) > (y) ? (x) : (y))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Check_Parameters_Validity Check Parameters Validity
+ * @{
+ */
+
+/* Check Functional State */
+#define IS_FUNCTIONAL_STATE(state)      (((state) == DISABLE) || ((state) == ENABLE))
+
+/**
+ * @defgroup Check_Address_Align_Validity Check Address Align Validity
+ * @{
+ */
+#define IS_ADDR_ALIGN(addr, align)      (0UL == (((uint32_t)(addr)) & (((uint32_t)(align)) - 1UL)))
+#define IS_ADDR_ALIGN_HALFWORD(addr)    (0UL == (((uint32_t)(addr)) & 0x1UL))
+#define IS_ADDR_ALIGN_WORD(addr)        (0UL == (((uint32_t)(addr)) & 0x3UL))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Peripheral_Bit_Band Peripheral Bit Band
+ * @{
+ */
+#define __PERIPH_BIT_BAND_BASE          (0x42000000UL)
+#define __PERIPH_BASE                   (0x40000000UL)
+#define __REG_OFS(regAddr)              ((regAddr) - __PERIPH_BASE)
+#define __BIT_BAND_ADDR(regAddr, pos)   ((__REG_OFS(regAddr) << 5U) + ((uint32_t)(pos) << 2U) + __PERIPH_BIT_BAND_BASE)
+#define PERIPH_BIT_BAND(regAddr, pos)   (*(__IO uint32_t *)__BIT_BAND_ADDR((regAddr), (pos)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Generic_Error_Codes Generic Error Codes
+ * @{
+ */
+#define LL_OK                           (0)   /*!< No error */
+#define LL_ERR                          (-1)  /*!< Non-specific error code */
+#define LL_ERR_UNINIT                   (-2)  /*!< Module (or part of it) was not initialized properly */
+#define LL_ERR_INVD_PARAM               (-3)  /*!< Provided parameter is not valid */
+#define LL_ERR_INVD_MD                  (-4)  /*!< Operation not allowed in current mode */
+#define LL_ERR_NOT_RDY                  (-5)  /*!< A requested final state is not reached */
+#define LL_ERR_BUSY                     (-6)  /*!< A conflicting or requested operation is still in progress */
+#define LL_ERR_ADDR_ALIGN               (-7)  /*!< Address alignment does not match */
+#define LL_ERR_TIMEOUT                  (-8)  /*!< Time Out error occurred (e.g. I2C arbitration lost, Flash time-out, etc.) */
+#define LL_ERR_BUF_EMPTY                (-9)  /*!< Circular buffer can not be read because the buffer is empty */
+#define LL_ERR_BUF_FULL                 (-10) /*!< Circular buffer can not be written because the buffer is full */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Chip_Module_Switch Chip Module Switch
+ * @{
+ */
+#define DDL_ON                          (1U)
+#define DDL_OFF                         (0U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Bit_Mask_Macros Bit Mask Macros
+ * @{
+ */
+#define BIT_MASK_00                     (1UL << 0U)
+#define BIT_MASK_01                     (1UL << 1U)
+#define BIT_MASK_02                     (1UL << 2U)
+#define BIT_MASK_03                     (1UL << 3U)
+#define BIT_MASK_04                     (1UL << 4U)
+#define BIT_MASK_05                     (1UL << 5U)
+#define BIT_MASK_06                     (1UL << 6U)
+#define BIT_MASK_07                     (1UL << 7U)
+#define BIT_MASK_08                     (1UL << 8U)
+#define BIT_MASK_09                     (1UL << 9U)
+#define BIT_MASK_10                     (1UL << 10U)
+#define BIT_MASK_11                     (1UL << 11U)
+#define BIT_MASK_12                     (1UL << 12U)
+#define BIT_MASK_13                     (1UL << 13U)
+#define BIT_MASK_14                     (1UL << 14U)
+#define BIT_MASK_15                     (1UL << 15U)
+#define BIT_MASK_16                     (1UL << 16U)
+#define BIT_MASK_17                     (1UL << 17U)
+#define BIT_MASK_18                     (1UL << 18U)
+#define BIT_MASK_19                     (1UL << 19U)
+#define BIT_MASK_20                     (1UL << 20U)
+#define BIT_MASK_21                     (1UL << 21U)
+#define BIT_MASK_22                     (1UL << 22U)
+#define BIT_MASK_23                     (1UL << 23U)
+#define BIT_MASK_24                     (1UL << 24U)
+#define BIT_MASK_25                     (1UL << 25U)
+#define BIT_MASK_26                     (1UL << 26U)
+#define BIT_MASK_27                     (1UL << 27U)
+#define BIT_MASK_28                     (1UL << 28U)
+#define BIT_MASK_29                     (1UL << 29U)
+#define BIT_MASK_30                     (1UL << 30U)
+#define BIT_MASK_31                     (1UL << 31U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Register_Macros Register Macros
+ * @{
+ */
+#define RW_MEM8(addr)                   (*(volatile uint8_t *)(addr))
+#define RW_MEM16(addr)                  (*(volatile uint16_t *)(addr))
+#define RW_MEM32(addr)                  (*(volatile uint32_t *)(addr))
+
+#define SET_REG_BIT(REG, BIT)           ((REG) |= (BIT))
+#define SET_REG8_BIT(REG, BIT)          ((REG) |= ((uint8_t)(BIT)))
+#define SET_REG16_BIT(REG, BIT)         ((REG) |= ((uint16_t)(BIT)))
+#define SET_REG32_BIT(REG, BIT)         ((REG) |= ((uint32_t)(BIT)))
+
+#define CLR_REG_BIT(REG, BIT)           ((REG) &= (~(BIT)))
+#define CLR_REG8_BIT(REG, BIT)          ((REG) &= ((uint8_t)(~((uint8_t)(BIT)))))
+#define CLR_REG16_BIT(REG, BIT)         ((REG) &= ((uint16_t)(~((uint16_t)(BIT)))))
+#define CLR_REG32_BIT(REG, BIT)         ((REG) &= ((uint32_t)(~((uint32_t)(BIT)))))
+
+#define READ_REG_BIT(REG, BIT)          ((REG) & (BIT))
+#define READ_REG8_BIT(REG, BIT)         ((REG) & ((uint8_t)(BIT)))
+#define READ_REG16_BIT(REG, BIT)        ((REG) & ((uint16_t)(BIT)))
+#define READ_REG32_BIT(REG, BIT)        ((REG) & ((uint32_t)(BIT)))
+
+#define CLR_REG(REG)                    ((REG) = (0U))
+#define CLR_REG8(REG)                   ((REG) = ((uint8_t)(0U)))
+#define CLR_REG16(REG)                  ((REG) = ((uint16_t)(0U)))
+#define CLR_REG32(REG)                  ((REG) = ((uint32_t)(0UL)))
+
+#define WRITE_REG(REG, VAL)             ((REG) = (VAL))
+#define WRITE_REG8(REG, VAL)            ((REG) = ((uint8_t)(VAL)))
+#define WRITE_REG16(REG, VAL)           ((REG) = ((uint16_t)(VAL)))
+#define WRITE_REG32(REG, VAL)           ((REG) = ((uint32_t)(VAL)))
+
+#define READ_REG(REG)                   (REG)
+#define READ_REG8(REG)                  (REG)
+#define READ_REG16(REG)                 (REG)
+#define READ_REG32(REG)                 (REG)
+
+#define MODIFY_REG(REGS, CLRMASK, SETMASK)    (WRITE_REG((REGS), (((READ_REG(REGS)) & (~(CLRMASK))) | ((SETMASK) & (CLRMASK)))))
+#define MODIFY_REG8(REGS, CLRMASK, SETMASK)   (WRITE_REG8((REGS), (((READ_REG8((REGS))) & ((uint8_t)(~((uint8_t)(CLRMASK))))) | ((uint8_t)(SETMASK) & (uint8_t)(CLRMASK)))))
+#define MODIFY_REG16(REGS, CLRMASK, SETMASK)  (WRITE_REG16((REGS), (((READ_REG16((REGS))) & ((uint16_t)(~((uint16_t)(CLRMASK))))) | ((uint16_t)(SETMASK) & (uint16_t)(CLRMASK)))))
+#define MODIFY_REG32(REGS, CLRMASK, SETMASK)  (WRITE_REG32((REGS), (((READ_REG32((REGS))) & ((uint32_t)(~((uint32_t)(CLRMASK))))) | ((uint32_t)(SETMASK) & (uint32_t)(CLRMASK)))))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global function prototypes (definition in C source)
+ ******************************************************************************/
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DEF_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dma.h
+++ b/hc32f4a2/inc/hc32_ll_dma.h
@@ -1,0 +1,612 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dma.h
+ * @brief This file contains all the functions prototypes of the DMA driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add API DMA_SetDataWidth()
+   2023-12-15       CDT             Modify API input param type:u16->u32
+                                    Add structure stc_dma_rc_nonseq_init_t
+                                    Add API DMA_ReconfigNonSeqStructInit() & DMA_ReconfigNonSeqInit()
+   2024-11-08       CDT             Add API DMA_MxChSWTrigger() and DMA_SWReconfig()
+                                    Add API DMA_AHB_HProtBufCacheCmd()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DMA_H__
+#define __HC32_LL_DMA_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DMA
+ * @{
+ */
+
+#if (LL_DMA_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup DMA_Global_Types DMA Global Types
+ * @{
+ */
+
+/**
+ * @brief  DMA basic configuration
+ */
+typedef struct {
+    uint32_t u32IntEn;          /*!< Specifies the DMA interrupt function.
+                                    This parameter can be a value of @ref DMA_Int_Config                */
+    uint32_t u32SrcAddr;        /*!< Specifies the DMA source address.                                  */
+    uint32_t u32DestAddr;       /*!< Specifies the DMA destination address.                             */
+    uint32_t u32DataWidth;      /*!< Specifies the DMA transfer data width.
+                                    This parameter can be a value of @ref DMA_DataWidth_Sel             */
+    uint32_t u32BlockSize;      /*!< Specifies the DMA block size.                                      */
+    uint32_t u32TransCount;     /*!< Specifies the DMA transfer count.                                  */
+    uint32_t u32SrcAddrInc;     /*!< Specifies the source address increment mode.
+                                    This parameter can be a value of @ref DMA_SrcAddr_Incremented_Mode  */
+    uint32_t u32DestAddrInc;    /*!< Specifies the destination address increment mode.
+                                    This parameter can be a value of @ref DMA_DesAddr_Incremented_Mode  */
+} stc_dma_init_t;
+
+/**
+ * @brief  DMA repeat mode configuration
+ */
+typedef struct {
+    uint32_t u32Mode;       /*!< Specifies the DMA source repeat function.
+                                This parameter can be a value of @ref DMA_Repeat_Config */
+    uint32_t u32SrcCount;   /*!< Specifies the DMA source repeat size. */
+    uint32_t u32DestCount;  /*!< Specifies the DMA destination repeat size. */
+} stc_dma_repeat_init_t;
+
+/**
+ * @brief  DMA non-sequence mode configuration
+ */
+typedef struct {
+    uint32_t u32Mode;        /*!< Specifies the DMA source non-sequence function.
+                                        This parameter can be a value of @ref DMA_NonSeq_Config */
+    uint32_t u32SrcCount;     /*!< Specifies the DMA source non-sequence function count. */
+    uint32_t u32SrcOffset;    /*!< Specifies the DMA source non-sequence function offset. */
+    uint32_t u32DestCount;    /*!< Specifies the DMA destination non-sequence function count. */
+    uint32_t u32DestOffset;   /*!< Specifies the DMA destination non-sequence function offset. */
+} stc_dma_nonseq_init_t;
+
+/**
+ * @brief  DMA Link List Pointer (LLP) mode configuration
+ */
+typedef struct {
+    uint32_t u32State;      /*!< Specifies the DMA LLP function.
+                                This parameter can be a value of @ref DMA_Llp_En */
+    uint32_t u32Mode;       /*!< Specifies the DMA LLP auto or wait REQ.
+                                This parameter can be a value of @ref DMA_Llp_Mode */
+    uint32_t u32Addr;       /*!< Specifies the DMA list pointer address for LLP function. */
+} stc_dma_llp_init_t;
+
+/**
+ * @brief  DMA re-config function configuration
+ */
+typedef struct {
+    uint32_t u32CountMode;          /*!< Specifies the DMA reconfig function count mode.
+                                      This parameter can be a value of @ref DMA_Reconfig_Count_Sel */
+    uint32_t u32DestAddrMode;       /*!< Specifies the DMA reconfig function destination address mode.
+                                        This parameter can be a value of @ref DMA_Reconfig_DestAddr_Sel */
+    uint32_t u32SrcAddrMode;        /*!< Specifies the DMA reconfig function source address mode.
+                                        This parameter can be a value of @ref DMA_Reconfig_SrcAddr_Sel */
+} stc_dma_reconfig_init_t;
+
+/**
+ * @brief  DMA re-config non-sequence mode configuration
+ */
+typedef struct {
+    uint32_t u32Mode;           /*!< Specifies the DMA source non-sequence function.
+                                    This parameter can be a value of @ref DMA_NonSeq_Config         */
+    uint32_t u32SrcCount;       /*!< Specifies the DMA source non-sequence function count.          */
+    uint32_t u32SrcDist;        /*!< Specifies the DMA source non-sequence function distance.       */
+    uint32_t u32DestCount;      /*!< Specifies the DMA destination non-sequence function count.     */
+    uint32_t u32DestDist;       /*!< Specifies the DMA destination non-sequence function distance.  */
+} stc_dma_rc_nonseq_init_t;
+
+/**
+ * @brief  Dma LLP(linked list pointer) descriptor structure definition
+ */
+typedef struct {
+    uint32_t SARx;              /*!< LLP source address */
+    uint32_t DARx;              /*!< LLP destination address */
+    uint32_t DTCTLx;            /*!< LLP transfer count and block size */
+    uint32_t RPTx;              /*!< LLP source & destination repeat size */
+    uint32_t SNSEQCTLx;         /*!< LLP source non-seq count and offset */
+    uint32_t DNSEQCTLx;         /*!< LLP destination non-seq count and offset */
+    uint32_t LLPx;              /*!< LLP next list pointer */
+    uint32_t CHCTLx;            /*!< LLP channel control */
+} stc_dma_llp_descriptor_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DMA_Global_Macros DMA Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup DMA_Channel_selection DMA Channel Position selection
+ * @{
+ */
+#define DMA_CH0                         (0x00U)        /*!< DMA Channel 0 */
+#define DMA_CH1                         (0x01U)        /*!< DMA Channel 1 */
+#define DMA_CH2                         (0x02U)        /*!< DMA Channel 2 */
+#define DMA_CH3                         (0x03U)        /*!< DMA Channel 3 */
+#define DMA_CH4                         (0x04U)        /*!< DMA Channel 4 */
+#define DMA_CH5                         (0x05U)        /*!< DMA Channel 5 */
+#define DMA_CH6                         (0x06U)        /*!< DMA Channel 6 */
+#define DMA_CH7                         (0x07U)        /*!< DMA Channel 7 */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Mx_Channel_selection DMA Multiplex Channel selection
+ * @{
+ */
+#define DMA_MX_CH0                      (0x01U)        /*!< DMA Channel 0 position */
+#define DMA_MX_CH1                      (0x02U)        /*!< DMA Channel 1 position */
+#define DMA_MX_CH2                      (0x04U)        /*!< DMA Channel 2 position */
+#define DMA_MX_CH3                      (0x08U)        /*!< DMA Channel 3 position */
+#define DMA_MX_CH4                      (0x10U)        /*!< DMA Channel 4 position */
+#define DMA_MX_CH5                      (0x20U)        /*!< DMA Channel 5 position */
+#define DMA_MX_CH6                      (0x40U)        /*!< DMA Channel 6 position */
+#define DMA_MX_CH7                      (0x80U)        /*!< DMA Channel 7 position */
+#define DMA_MX_CH_ALL                   (DMA_CHEN_CHEN) /*!< DMA Channel mask position */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Flag_Request_Err_Sel  DMA request error flag selection
+ * @{
+ */
+#define DMA_FLAG_REQ_ERR_CH0            (DMA_INTSTAT0_REQERR_0) /*!< DMA request error flag CH.0 */
+#define DMA_FLAG_REQ_ERR_CH1            (DMA_INTSTAT0_REQERR_1) /*!< DMA request error flag CH.1 */
+#define DMA_FLAG_REQ_ERR_CH2            (DMA_INTSTAT0_REQERR_2) /*!< DMA request error flag CH.2 */
+#define DMA_FLAG_REQ_ERR_CH3            (DMA_INTSTAT0_REQERR_3) /*!< DMA request error flag CH.3 */
+#define DMA_FLAG_REQ_ERR_CH4            (DMA_INTSTAT0_REQERR_4) /*!< DMA request error flag CH.4 */
+#define DMA_FLAG_REQ_ERR_CH5            (DMA_INTSTAT0_REQERR_5) /*!< DMA request error flag CH.5 */
+#define DMA_FLAG_REQ_ERR_CH6            (DMA_INTSTAT0_REQERR_6) /*!< DMA request error flag CH.6 */
+#define DMA_FLAG_REQ_ERR_CH7            (DMA_INTSTAT0_REQERR_7) /*!< DMA request error flag CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Flag_Trans_Err_Sel  DMA transfer error flag selection
+ * @{
+ */
+#define DMA_FLAG_TRANS_ERR_CH0          (DMA_INTSTAT0_TRNERR_0) /*!< DMA transfer error flag CH.0 */
+#define DMA_FLAG_TRANS_ERR_CH1          (DMA_INTSTAT0_TRNERR_1) /*!< DMA transfer error flag CH.1 */
+#define DMA_FLAG_TRANS_ERR_CH2          (DMA_INTSTAT0_TRNERR_2) /*!< DMA transfer error flag CH.2 */
+#define DMA_FLAG_TRANS_ERR_CH3          (DMA_INTSTAT0_TRNERR_3) /*!< DMA transfer error flag CH.3 */
+#define DMA_FLAG_TRANS_ERR_CH4          (DMA_INTSTAT0_TRNERR_4) /*!< DMA transfer error flag CH.4 */
+#define DMA_FLAG_TRANS_ERR_CH5          (DMA_INTSTAT0_TRNERR_5) /*!< DMA transfer error flag CH.5 */
+#define DMA_FLAG_TRANS_ERR_CH6          (DMA_INTSTAT0_TRNERR_6) /*!< DMA transfer error flag CH.6 */
+#define DMA_FLAG_TRANS_ERR_CH7          (DMA_INTSTAT0_TRNERR_7) /*!< DMA transfer error flag CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Flag_Btc_Sel  DMA block transfer completed flag selection
+ * @{
+ */
+#define DMA_FLAG_BTC_CH0                (DMA_INTSTAT1_BTC_0)    /*!< DMA block transfer completed flag CH.0 */
+#define DMA_FLAG_BTC_CH1                (DMA_INTSTAT1_BTC_1)    /*!< DMA block transfer completed flag CH.1 */
+#define DMA_FLAG_BTC_CH2                (DMA_INTSTAT1_BTC_2)    /*!< DMA block transfer completed flag CH.2 */
+#define DMA_FLAG_BTC_CH3                (DMA_INTSTAT1_BTC_3)    /*!< DMA block transfer completed flag CH.3 */
+#define DMA_FLAG_BTC_CH4                (DMA_INTSTAT1_BTC_4)    /*!< DMA block transfer completed flag CH.4 */
+#define DMA_FLAG_BTC_CH5                (DMA_INTSTAT1_BTC_5)    /*!< DMA block transfer completed flag CH.5 */
+#define DMA_FLAG_BTC_CH6                (DMA_INTSTAT1_BTC_6)    /*!< DMA block transfer completed flag CH.6 */
+#define DMA_FLAG_BTC_CH7                (DMA_INTSTAT1_BTC_7)    /*!< DMA block transfer completed flag CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Flag_Tc_Sel  DMA transfer completed flag selection
+ * @{
+ */
+#define DMA_FLAG_TC_CH0                 (DMA_INTSTAT1_TC_0)     /*!< DMA transfer completed flag CH.0 */
+#define DMA_FLAG_TC_CH1                 (DMA_INTSTAT1_TC_1)     /*!< DMA transfer completed flag CH.1 */
+#define DMA_FLAG_TC_CH2                 (DMA_INTSTAT1_TC_2)     /*!< DMA transfer completed flag CH.2 */
+#define DMA_FLAG_TC_CH3                 (DMA_INTSTAT1_TC_3)     /*!< DMA transfer completed flag CH.3 */
+#define DMA_FLAG_TC_CH4                 (DMA_INTSTAT1_TC_4)     /*!< DMA transfer completed flag CH.4 */
+#define DMA_FLAG_TC_CH5                 (DMA_INTSTAT1_TC_5)     /*!< DMA transfer completed flag CH.5 */
+#define DMA_FLAG_TC_CH6                 (DMA_INTSTAT1_TC_6)     /*!< DMA transfer completed flag CH.6 */
+#define DMA_FLAG_TC_CH7                 (DMA_INTSTAT1_TC_7)     /*!< DMA transfer completed flag CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Int_Request_Err_Sel  DMA request error interrupt selection
+ * @{
+ */
+#define DMA_INT_REQ_ERR_CH0             (DMA_INTMASK0_MSKREQERR_0) /*!< DMA request error interrupt CH.0 */
+#define DMA_INT_REQ_ERR_CH1             (DMA_INTMASK0_MSKREQERR_1) /*!< DMA request error interrupt CH.1 */
+#define DMA_INT_REQ_ERR_CH2             (DMA_INTMASK0_MSKREQERR_2) /*!< DMA request error interrupt CH.2 */
+#define DMA_INT_REQ_ERR_CH3             (DMA_INTMASK0_MSKREQERR_3) /*!< DMA request error interrupt CH.3 */
+#define DMA_INT_REQ_ERR_CH4             (DMA_INTMASK0_MSKREQERR_4) /*!< DMA request error interrupt CH.4 */
+#define DMA_INT_REQ_ERR_CH5             (DMA_INTMASK0_MSKREQERR_5) /*!< DMA request error interrupt CH.5 */
+#define DMA_INT_REQ_ERR_CH6             (DMA_INTMASK0_MSKREQERR_6) /*!< DMA request error interrupt CH.6 */
+#define DMA_INT_REQ_ERR_CH7             (DMA_INTMASK0_MSKREQERR_7) /*!< DMA request error interrupt CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Int_Trans_Err_Sel  DMA transfer error interrupt selection
+ * @{
+ */
+#define DMA_INT_TRANS_ERR_CH0           (DMA_INTMASK0_MSKTRNERR_0) /*!< DMA transfer error interrupt CH.0 */
+#define DMA_INT_TRANS_ERR_CH1           (DMA_INTMASK0_MSKTRNERR_1) /*!< DMA transfer error interrupt CH.1 */
+#define DMA_INT_TRANS_ERR_CH2           (DMA_INTMASK0_MSKTRNERR_2) /*!< DMA transfer error interrupt CH.2 */
+#define DMA_INT_TRANS_ERR_CH3           (DMA_INTMASK0_MSKTRNERR_3) /*!< DMA transfer error interrupt CH.3 */
+#define DMA_INT_TRANS_ERR_CH4           (DMA_INTMASK0_MSKTRNERR_4) /*!< DMA transfer error interrupt CH.4 */
+#define DMA_INT_TRANS_ERR_CH5           (DMA_INTMASK0_MSKTRNERR_5) /*!< DMA transfer error interrupt CH.5 */
+#define DMA_INT_TRANS_ERR_CH6           (DMA_INTMASK0_MSKTRNERR_6) /*!< DMA transfer error interrupt CH.6 */
+#define DMA_INT_TRANS_ERR_CH7           (DMA_INTMASK0_MSKTRNERR_7) /*!< DMA transfer error interrupt CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Int_Btc_Sel  DMA block transfer completed interrupt selection
+ * @{
+ */
+#define DMA_INT_BTC_CH0                 (DMA_INTMASK1_MSKBTC_0)    /*!< DMA block transfer completed interrupt CH.0 */
+#define DMA_INT_BTC_CH1                 (DMA_INTMASK1_MSKBTC_1)    /*!< DMA block transfer completed interrupt CH.1 */
+#define DMA_INT_BTC_CH2                 (DMA_INTMASK1_MSKBTC_2)    /*!< DMA block transfer completed interrupt CH.2 */
+#define DMA_INT_BTC_CH3                 (DMA_INTMASK1_MSKBTC_3)    /*!< DMA block transfer completed interrupt CH.3 */
+#define DMA_INT_BTC_CH4                 (DMA_INTMASK1_MSKBTC_4)    /*!< DMA block transfer completed interrupt CH.4 */
+#define DMA_INT_BTC_CH5                 (DMA_INTMASK1_MSKBTC_5)    /*!< DMA block transfer completed interrupt CH.5 */
+#define DMA_INT_BTC_CH6                 (DMA_INTMASK1_MSKBTC_6)    /*!< DMA block transfer completed interrupt CH.6 */
+#define DMA_INT_BTC_CH7                 (DMA_INTMASK1_MSKBTC_7)    /*!< DMA block transfer completed interrupt CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Int_Tc_Sel  DMA transfer completed interrupt selection
+ * @{
+ */
+#define DMA_INT_TC_CH0                  (DMA_INTMASK1_MSKTC_0)     /*!< DMA transfer completed interrupt CH.0 */
+#define DMA_INT_TC_CH1                  (DMA_INTMASK1_MSKTC_1)     /*!< DMA transfer completed interrupt CH.1 */
+#define DMA_INT_TC_CH2                  (DMA_INTMASK1_MSKTC_2)     /*!< DMA transfer completed interrupt CH.2 */
+#define DMA_INT_TC_CH3                  (DMA_INTMASK1_MSKTC_3)     /*!< DMA transfer completed interrupt CH.3 */
+#define DMA_INT_TC_CH4                  (DMA_INTMASK1_MSKTC_4)     /*!< DMA transfer completed interrupt CH.4 */
+#define DMA_INT_TC_CH5                  (DMA_INTMASK1_MSKTC_5)     /*!< DMA transfer completed interrupt CH.5 */
+#define DMA_INT_TC_CH6                  (DMA_INTMASK1_MSKTC_6)     /*!< DMA transfer completed interrupt CH.6 */
+#define DMA_INT_TC_CH7                  (DMA_INTMASK1_MSKTC_7)     /*!< DMA transfer completed interrupt CH.7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_FlagMsk_Sel DMA flag mask selection
+ * @{
+ */
+#define DMA_FLAG_ERR_MASK               (DMA_INTSTAT0_TRNERR | DMA_INTSTAT0_REQERR)   /*!< DMA error flag mask */
+#define DMA_FLAG_TRANS_MASK             (DMA_INTSTAT1_TC | DMA_INTSTAT1_BTC)          /*!< DMA transfer flag mask */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_IntMsk_Sel DMA interrupt mask selection
+ * @{
+ */
+#define DMA_INT_ERR_MASK                (DMA_INTMASK0_MSKREQERR | DMA_INTMASK0_MSKTRNERR)   /*!< DMA error interrupt mask */
+#define DMA_INT_TRANS_MASK              (DMA_INTMASK1_MSKTC | DMA_INTMASK1_MSKBTC)          /*!< DMA transfer interrupt mask */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Req_Status_Sel DMA request status
+ * @{
+ */
+#define DMA_STAT_REQ_RECONFIG           (DMA_REQSTAT_RCFGREQ)                       /*!< DMA request from reconfig */
+#define DMA_STAT_REQ_CH0                (DMA_REQSTAT_CHREQ_0)                       /*!< DMA request from CH.0 */
+#define DMA_STAT_REQ_CH1                (DMA_REQSTAT_CHREQ_1)                       /*!< DMA request from CH.1 */
+#define DMA_STAT_REQ_CH2                (DMA_REQSTAT_CHREQ_2)                       /*!< DMA request from CH.2 */
+#define DMA_STAT_REQ_CH3                (DMA_REQSTAT_CHREQ_3)                       /*!< DMA request from CH.3 */
+#define DMA_STAT_REQ_CH4                (DMA_REQSTAT_CHREQ_4)                       /*!< DMA request from CH.4 */
+#define DMA_STAT_REQ_CH5                (DMA_REQSTAT_CHREQ_5)                       /*!< DMA request from CH.5 */
+#define DMA_STAT_REQ_CH6                (DMA_REQSTAT_CHREQ_6)                       /*!< DMA request from CH.6 */
+#define DMA_STAT_REQ_CH7                (DMA_REQSTAT_CHREQ_7)                       /*!< DMA request from CH.7 */
+
+#define DMA_STAT_REQ_MASK               (DMA_REQSTAT_CHREQ | DMA_REQSTAT_RCFGREQ)   /*!< DMA request mask */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Trans_Status_Sel DMA transfer status
+ * @{
+ */
+#define DMA_STAT_TRANS_CH0              (DMA_CHSTAT_CHACT_0)    /*!< DMA transfer status of CH.0 */
+#define DMA_STAT_TRANS_CH1              (DMA_CHSTAT_CHACT_1)    /*!< DMA transfer status of CH.1 */
+#define DMA_STAT_TRANS_CH2              (DMA_CHSTAT_CHACT_2)    /*!< DMA transfer status of CH.2 */
+#define DMA_STAT_TRANS_CH3              (DMA_CHSTAT_CHACT_3)    /*!< DMA transfer status of CH.3 */
+#define DMA_STAT_TRANS_CH4              (DMA_CHSTAT_CHACT_4)    /*!< DMA transfer status of CH.4 */
+#define DMA_STAT_TRANS_CH5              (DMA_CHSTAT_CHACT_5)    /*!< DMA transfer status of CH.5 */
+#define DMA_STAT_TRANS_CH6              (DMA_CHSTAT_CHACT_6)    /*!< DMA transfer status of CH.6 */
+#define DMA_STAT_TRANS_CH7              (DMA_CHSTAT_CHACT_7)    /*!< DMA transfer status of CH.7 */
+#define DMA_STAT_TRANS_DMA              (DMA_CHSTAT_DMAACT)     /*!< DMA transfer status of the DMA */
+#define DMA_STAT_TRANS_RECONFIG         (DMA_CHSTAT_RCFGACT)    /*!< DMA reconfig status */
+
+#define DMA_STAT_TRANS_MASK             (DMA_CHSTAT_DMAACT | DMA_CHSTAT_CHACT | DMA_CHSTAT_RCFGACT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_DataWidth_Sel DMA transfer data width
+ * @{
+ */
+#define DMA_DATAWIDTH_8BIT              (0x00000000UL)          /*!< DMA transfer data width 8bit  */
+#define DMA_DATAWIDTH_16BIT             (DMA_CHCTL_HSIZE_0)     /*!< DMA transfer data width 16bit */
+#define DMA_DATAWIDTH_32BIT             (DMA_CHCTL_HSIZE_1)     /*!< DMA transfer data width 32bit */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Llp_En DMA LLP(linked list pointer) enable or disable
+ * @{
+ */
+#define DMA_LLP_DISABLE                 (0x00000000UL)          /*!< DMA linked list pointer disable    */
+#define DMA_LLP_ENABLE                  (DMA_CHCTL_LLPEN)       /*!< DMA linked list pointer enable     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Llp_Mode DMA linked list pointer mode while transferring complete
+ * @{
+ */
+#define DMA_LLP_WAIT                    (0x00000000UL)          /*!< DMA Llp wait next request while transferring complete */
+#define DMA_LLP_RUN                     (DMA_CHCTL_LLPRUN)      /*!< DMA Llp run right now while transferring complete     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_SrcAddr_Incremented_Mode DMA source address increment mode
+ * @{
+ */
+#define DMA_SRC_ADDR_FIX                (0x00000000UL)          /*!< DMA source address fix             */
+#define DMA_SRC_ADDR_INC                (DMA_CHCTL_SINC_0)      /*!< DMA source address increment       */
+#define DMA_SRC_ADDR_DEC                (DMA_CHCTL_SINC_1)      /*!< DMA source address decrement       */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_DesAddr_Incremented_Mode DMA destination address increment mode
+ * @{
+ */
+#define DMA_DEST_ADDR_FIX               (0x00000000UL)          /*!< DMA destination address fix        */
+#define DMA_DEST_ADDR_INC               (DMA_CHCTL_DINC_0)      /*!< DMA destination address increment  */
+#define DMA_DEST_ADDR_DEC               (DMA_CHCTL_DINC_1)      /*!< DMA destination address decrement  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Int_Config DMA interrupt function config
+ * @{
+ */
+#define DMA_INT_ENABLE                  (DMA_CHCTL_IE)          /*!< DMA interrupt enable */
+#define DMA_INT_DISABLE                 (0x00000000UL)          /*!< DMA interrupt disable */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Repeat_Config DMA repeat mode function config
+ * @{
+ */
+#define DMA_RPT_NONE                    (0x00000000UL)                                  /*!< DMA repeat disable */
+#define DMA_RPT_SRC                     (DMA_CHCTL_SRPTEN)                              /*!< DMA source repeat enable */
+#define DMA_RPT_DEST                    (DMA_CHCTL_DRPTEN)                              /*!< DMA destination repeat enable */
+#define DMA_RPT_BOTH                    (DMA_CHCTL_SRPTEN | DMA_CHCTL_DRPTEN)           /*!< DMA source & destination repeat enable */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_NonSeq_Config DMA non-sequence mode function config
+ * @{
+ */
+#define DMA_NON_SEQ_NONE                (0x00000000UL)                                  /*!< DMA non-sequence disable */
+#define DMA_NON_SEQ_SRC                 (DMA_CHCTL_SNSEQEN)                             /*!< DMA source non-sequence enable */
+#define DMA_NON_SEQ_DEST                (DMA_CHCTL_DNSEQEN)                             /*!< DMA destination non-sequence enable */
+#define DMA_NON_SEQ_BOTH                (DMA_CHCTL_SNSEQEN | DMA_CHCTL_DNSEQEN)         /*!< DMA source & destination non-sequence enable */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Reconfig_Count_Sel DMA reconfig count mode selection
+ * @{
+ */
+#define DMA_RC_CNT_KEEP                 (0x00000000UL)          /*!< Keep the original counting method */
+#define DMA_RC_CNT_SRC                  (DMA_RCFGCTL_CNTMD_0)   /*!< Use source address counting method */
+#define DMA_RC_CNT_DEST                 (DMA_RCFGCTL_CNTMD_1)   /*!< Use destination address counting method */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Reconfig_DestAddr_Sel DMA reconfig destination address mode selection
+ * @{
+ */
+#define DMA_RC_DEST_ADDR_KEEP           (0x00000000UL)          /*!< Destination address Keep the original mode */
+#define DMA_RC_DEST_ADDR_NS             (DMA_RCFGCTL_DARMD_0)   /*!< Destination address non-sequence */
+#define DMA_RC_DEST_ADDR_RPT            (DMA_RCFGCTL_DARMD_1)   /*!< Destination address repeat */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DMA_Reconfig_SrcAddr_Sel DMA reconfig source address mode selection
+ * @{
+ */
+#define DMA_RC_SRC_ADDR_KEEP            (0x00000000UL)          /*!< Source address Keep the original mode */
+#define DMA_RC_SRC_ADDR_NS              (DMA_RCFGCTL_SARMD_0)   /*!< Source address non-sequence */
+#define DMA_RC_SRC_ADDR_RPT             (DMA_RCFGCTL_SARMD_1)   /*!< Source address repeat */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup DMA_Global_Functions
+ * @{
+ */
+void DMA_Cmd(CM_DMA_TypeDef *DMAx, en_functional_state_t enNewState);
+
+void DMA_ErrIntCmd(CM_DMA_TypeDef *DMAx, uint32_t u32ErrInt, en_functional_state_t enNewState);
+en_flag_status_t DMA_GetErrStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Flag);
+void DMA_ClearErrStatus(CM_DMA_TypeDef *DMAx, uint32_t u32Flag);
+
+void DMA_TransCompleteIntCmd(CM_DMA_TypeDef *DMAx, uint32_t u32TransCompleteInt, en_functional_state_t enNewState);
+en_flag_status_t DMA_GetTransCompleteStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Flag);
+void DMA_ClearTransCompleteStatus(CM_DMA_TypeDef *DMAx, uint32_t u32Flag);
+
+void DMA_MxChCmd(CM_DMA_TypeDef *DMAx, uint8_t u8MxCh, en_functional_state_t enNewState);
+int32_t DMA_ChCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState);
+
+en_flag_status_t DMA_GetRequestStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Status);
+en_flag_status_t DMA_GetTransStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Status);
+
+int32_t DMA_SetSrcAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr);
+int32_t DMA_SetDestAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr);
+int32_t DMA_SetTransCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint16_t u16Count);
+int32_t DMA_SetBlockSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint16_t u16Size);
+int32_t DMA_SetDataWidth(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32DataWidth);
+
+int32_t DMA_SetSrcRepeatSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Size);
+int32_t DMA_SetDestRepeatSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Size);
+int32_t DMA_SetNonSeqSrcCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Count);
+int32_t DMA_SetNonSeqDestCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Count);
+int32_t DMA_SetNonSeqSrcOffset(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Offset);
+int32_t DMA_SetNonSeqDestOffset(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Offset);
+
+void DMA_SetLlpAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr);
+
+int32_t DMA_StructInit(stc_dma_init_t *pstcDmaInit);
+int32_t DMA_Init(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_init_t *pstcDmaInit);
+void DMA_DeInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+
+int32_t DMA_RepeatStructInit(stc_dma_repeat_init_t *pstcDmaRepeatInit);
+int32_t DMA_RepeatInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_repeat_init_t *pstcDmaRepeatInit);
+
+int32_t DMA_NonSeqStructInit(stc_dma_nonseq_init_t *pstcDmaNonSeqInit);
+int32_t DMA_NonSeqInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_nonseq_init_t *pstcDmaNonSeqInit);
+
+int32_t DMA_LlpStructInit(stc_dma_llp_init_t *pstcDmaLlpInit);
+int32_t DMA_LlpInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_llp_init_t *pstcDmaLlpInit);
+
+void DMA_LlpCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState);
+
+int32_t DMA_ReconfigStructInit(stc_dma_reconfig_init_t *pstcDmaRCInit);
+int32_t DMA_ReconfigInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_reconfig_init_t *pstcDmaRCInit);
+void DMA_ReconfigCmd(CM_DMA_TypeDef *DMAx, en_functional_state_t enNewState);
+void DMA_ReconfigLlpCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState);
+int32_t DMA_ReconfigNonSeqStructInit(stc_dma_rc_nonseq_init_t *pstcDmaRcNonSeqInit);
+int32_t DMA_ReconfigNonSeqInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_rc_nonseq_init_t *pstcDmaRcNonSeqInit);
+
+uint32_t DMA_GetSrcAddr(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetDestAddr(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetTransCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetBlockSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetSrcRepeatSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetDestRepeatSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetNonSeqSrcCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetNonSeqDestCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetNonSeqSrcOffset(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+uint32_t DMA_GetNonSeqDestOffset(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch);
+void DMA_AHB_HProtBufCacheCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState);
+
+void DMA_MxChSWTrigger(CM_DMA_TypeDef *DMAx, uint8_t u8MxCh);
+void DMA_SWReconfig(CM_DMA_TypeDef *DMAx);
+/**
+ * @}
+ */
+
+#endif /* LL_DMA_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DMA_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dmc.h
+++ b/hc32f4a2/inc/hc32_ll_dmc.h
@@ -1,0 +1,417 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dmc.h
+ * @brief This file contains all the functions prototypes of the EXMC_DMC
+ *        (External Memory Controller: Dynamic Memory Controller) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-08-31       CDT             API EXMC_DMC_DeInit add return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DMC_H__
+#define __HC32_LL_DMC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EXMC
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DMC
+ * @{
+ */
+
+#if (LL_DMC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_DMC_Global_Types EXMC_DMC Global Types
+ * @{
+ */
+
+/**
+ * @brief  EXMC_DMC Chip Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32AddrMask;           /*!< Defines the address mask.
+                                         This parameter can be a value of @ref EXMC_DMC_Mask_Address. */
+    uint32_t u32AddrMatch;          /*!< Defines the address match.
+                                         This parameter can be a value between Min_Data = 0x80 and Max_Data = 0x87 */
+    uint32_t u32AddrDecodeMode;     /*!< Defines the address decode mode.
+                                         This parameter can be a value of @ref EXMC_DMC_Address_Decode_Mode. */
+} stc_exmc_dmc_chip_config_t;
+
+/**
+ * @brief  EXMC_DMC Initialization Structure definition
+ */
+typedef struct {
+    uint32_t u32SampleClock;        /*!< DMC sample clock.
+                                         This parameter can be a value of @ref EXMC_DMC_Sample_Clock. */
+    uint32_t u32MemoryWidth;        /*!< DMC memory width.
+                                         This parameter can be a value of @ref EXMC_DMC_Memory_Width. */
+    uint32_t u32RefreshPeriod;      /*!< DMC memory refresh period.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x7FFF */
+    uint32_t u32ColumnBitsNumber;   /*!< Defines the number of bits of column address.
+                                         This parameter can be a value of @ref EXMC_DMC_Column_Bits_Number. */
+    uint32_t u32RowBitsNumber;      /*!< Defines the number of bits of row address.
+                                         This parameter can be a value of @ref EXMC_DMC_Row_Bits_Number. */
+    uint32_t u32AutoPrechargePin;   /*!< Defines the auto-precharge pin.
+                                         This parameter can be a value of @ref EXMC_DMC_Auto_Precharge_Pin. */
+    uint32_t u32MemClockSel;        /*!< Defines the memory clock selection.
+                                         This parameter can be a value of @ref EXMC_DMC_Clock_Selection */
+    uint32_t u32CkeOutputSel;       /*!< Defines the CKE output selection.
+                                         This parameter can be a value of @ref EXMC_DMC_CKE_Output_Selection */
+    uint32_t u32CkeDisablePeriod;   /*!< Defines the CKE disable period.
+                                         This parameter can be a value between Min_Data = 0x00 and Max_Data = 0x3F */
+    uint32_t u32MemBurst;           /*!< Defines the number of data accesses.
+                                         This parameter can be a value of @ref EXMC_DMC_Memory_Burst. */
+    uint32_t u32AutoRefreshChips;   /*!< Defines the refresh command generation for the number of memory chips.
+                                         This parameter can be a value of @ref EXMC_DMC_Auto_Refresh_Chips. */
+    struct {
+        uint8_t u8CASL;             /*!< Defines the CAS latency in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8DQSS;             /*!< Defines the DQSS in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 3 */
+        uint8_t u8MRD;              /*!< Defines the mode register command time in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x7F */
+        uint8_t u8RAS;              /*!< Defines the RAS in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F */
+        uint8_t u8RC;               /*!< Defines the RC in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F */
+        uint8_t u8RCD_B;            /*!< Defines the RCD base value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8RCD_P;            /*!< Defines the RCD append value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8RFC_B;            /*!< Defines the RFC base value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x1F */
+        uint8_t u8RFC_P;            /*!< Defines the RFC append value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x1F */
+        uint8_t u8RP_B;             /*!< Defines the RP base value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8RP_P;             /*!< Defines the RP append value in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8RRD;              /*!< Defines the RRD in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F */
+        uint8_t u8WR;               /*!< Defines the WR in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8WTR;              /*!< Defines the WTR in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+        uint8_t u8XP;               /*!< Defines the XP in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+        uint8_t u8XSR;              /*!< Defines the XSR in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+        uint8_t u8ESR;              /*!< Defines the ESR in memory clock cycles.
+                                         This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    } stcTimingConfig;
+} stc_exmc_dmc_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_DMC_Global_Macros EXMC_DMC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_DMC_Memory_Width EXMC_DMC Memory Width
+ * @{
+ */
+#define EXMC_DMC_MEMORY_WIDTH_16BIT         (0UL)
+#define EXMC_DMC_MEMORY_WIDTH_32BIT         (DMC_BACR_DMCMW_0)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Chip EXMC_DMC Chip
+ * @{
+ */
+#define EXMC_DMC_CHIP0                      (0UL)     /*!< Chip 0 */
+#define EXMC_DMC_CHIP1                      (1UL)     /*!< Chip 1 */
+#define EXMC_DMC_CHIP2                      (2UL)     /*!< Chip 2 */
+#define EXMC_DMC_CHIP3                      (3UL)     /*!< Chip 3 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Bank EXMC_DMC Bank
+ * @{
+ */
+#define EXMC_DMC_BANK0                      (0UL)     /*!< Bank 0 */
+#define EXMC_DMC_BANK1                      (1UL)     /*!< Bank 1 */
+#define EXMC_DMC_BANK2                      (2UL)     /*!< Bank 2 */
+#define EXMC_DMC_BANK3                      (3UL)     /*!< Bank 3 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Current_Status EXMC_DMC Current Status
+ * @{
+ */
+#define EXMC_DMC_CURR_STATUS_CONFIG         (0UL)
+#define EXMC_DMC_CURR_STATUS_RDY            (DMC_STSR_STATUS_0)
+#define EXMC_DMC_CURR_STATUS_PAUSED         (DMC_STSR_STATUS_1)
+#define EXMC_DMC_CURR_STATUS_LOWPOWER       (DMC_STSR_STATUS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Control_State EXMC_DMC Control State
+ * @{
+ */
+#define EXMC_DMC_CTRL_STATE_GO              (0UL)
+#define EXMC_DMC_CTRL_STATE_SLEEP           (1UL)
+#define EXMC_DMC_CTRL_STATE_WAKEUP          (2UL)
+#define EXMC_DMC_CTRL_STATE_PAUSE           (3UL)
+#define EXMC_DMC_CTRL_STATE_CONFIG          (4UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Command EXMC_DMC Command
+ * @{
+ */
+#define EXMC_DMC_CMD_PRECHARGE_ALL          (0UL)               /*!< Precharge all */
+#define EXMC_DMC_CMD_AUTO_REFRESH           (DMC_CMDR_CMD_0)    /*!< Auto refresh */
+#define EXMC_DMC_CMD_MDREG_CONFIG           (DMC_CMDR_CMD_1)    /*!< Set memory device mode register */
+#define EXMC_DMC_CMD_NOP                    (DMC_CMDR_CMD)      /*!< NOP */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Address_Decode_Mode EXMC_DMC Address Decode Mode
+ * @{
+ */
+#define EXMC_DMC_CS_DECODE_ROWBANKCOL       (0UL)           /*!< Row -> Bank -> Column */
+#define EXMC_DMC_CS_DECODE_BANKROWCOL       (DMC_CSCR_BRC)  /*!< Bank -> Row -> Column */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Column_Bits_Number EXMC_DMC Column Bits Number
+ * @{
+ */
+#define EXMC_DMC_COLUMN_BITS_NUM8           (0UL)
+#define EXMC_DMC_COLUMN_BITS_NUM9           (1UL << DMC_CPCR_COLBS_POS)
+#define EXMC_DMC_COLUMN_BITS_NUM10          (2UL << DMC_CPCR_COLBS_POS)
+#define EXMC_DMC_COLUMN_BITS_NUM11          (3UL << DMC_CPCR_COLBS_POS)
+#define EXMC_DMC_COLUMN_BITS_NUM12          (4UL << DMC_CPCR_COLBS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Row_Bits_Number EXMC_DMC Row Bits Number
+ * @{
+ */
+#define EXMC_DMC_ROW_BITS_NUM11             (0UL)
+#define EXMC_DMC_ROW_BITS_NUM12             (1UL << DMC_CPCR_ROWBS_POS)
+#define EXMC_DMC_ROW_BITS_NUM13             (2UL << DMC_CPCR_ROWBS_POS)
+#define EXMC_DMC_ROW_BITS_NUM14             (3UL << DMC_CPCR_ROWBS_POS)
+#define EXMC_DMC_ROW_BITS_NUM15             (4UL << DMC_CPCR_ROWBS_POS)
+#define EXMC_DMC_ROW_BITS_NUM16             (5UL << DMC_CPCR_ROWBS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Auto_Precharge_Pin EXMC_DMC Auto Pre-charge Pin
+ * @{
+ */
+#define EXMC_DMC_AUTO_PRECHARGE_A8          (DMC_CPCR_APBS)
+#define EXMC_DMC_AUTO_PRECHARGE_A10         (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_CKE_Output_Selection EXMC_DMC CKE Output Selection
+ * @{
+ */
+#define EXMC_DMC_CKE_OUTPUT_ENABLE          (0UL)
+#define EXMC_DMC_CKE_OUTPUT_DISABLE         (DMC_CPCR_CKEDIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Clock_Selection EXMC_DMC Clock Selection
+ * @{
+ */
+#define EXMC_DMC_CLK_NORMAL_OUTPUT          (0UL)
+#define EXMC_DMC_CLK_NOP_STOP_OUTPUT        (DMC_CPCR_CKSTOP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Memory_Burst EXMC_DMC Memory Burst
+ * @{
+ */
+#define EXMC_DMC_BURST_1BEAT                (0UL)
+#define EXMC_DMC_BURST_2BEAT                (1UL << DMC_CPCR_BURST_POS)
+#define EXMC_DMC_BURST_4BEAT                (2UL << DMC_CPCR_BURST_POS)
+#define EXMC_DMC_BURST_8BEAT                (3UL << DMC_CPCR_BURST_POS)
+#define EXMC_DMC_BURST_16BEAT               (4UL << DMC_CPCR_BURST_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Auto_Refresh_Chips EXMC_DMC Auto Refresh
+ * @{
+ */
+#define EXMC_DMC_AUTO_REFRESH_1CHIP         (0UL)
+#define EXMC_DMC_AUTO_REFRESH_2CHIPS        (DMC_CPCR_ACTCP_0)
+#define EXMC_DMC_AUTO_REFRESH_3CHIPS        (DMC_CPCR_ACTCP_1)
+#define EXMC_DMC_AUTO_REFRESH_4CHIPS        (DMC_CPCR_ACTCP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Mask_Address EXMC_DMC Mask Address
+ * @{
+ */
+#define EXMC_DMC_ADDR_MASK_16MB             (0xFFUL)
+#define EXMC_DMC_ADDR_MASK_32MB             (0xFEUL)
+#define EXMC_DMC_ADDR_MASK_64MB             (0xFCUL)
+#define EXMC_DMC_ADDR_MASK_128MB            (0xF8UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Address_Space EXMC_DMC Address Space
+ * @{
+ */
+#define EXMC_DMC_ADDR_MIN                   (0x80000000UL)
+#define EXMC_DMC_ADDR_MAX                   (0x87FFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Sample_Clock EXMC_DMC Sample Clock
+ * @{
+ */
+#define EXMC_DMC_SAMPLE_CLK_INTERNCLK       (0UL)
+#define EXMC_DMC_SAMPLE_CLK_INTERNCLK_INVT  (DMC_BACR_CKSEL_0)
+#define EXMC_DMC_SAMPLE_CLK_EXTCLK          (DMC_BACR_CKSEL_1)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EXMC_DMC_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Get DMC status.
+ * @param  None
+ * @retval Returned value can be one of the macros group @ref EXMC_DMC_Current_Status
+ *           - EXMC_DMC_CURR_STATUS_CONFIG:   Configure status
+ *           - EXMC_DMC_CURR_STATUS_RDY:      Ready status
+ *           - EXMC_DMC_CURR_STATUS_PAUSED:   Pause status
+ *           - EXMC_DMC_CURR_STATUS_LOWPOWER: Sleep for low power status
+ */
+__STATIC_INLINE uint32_t EXMC_DMC_GetStatus(void)
+{
+    return READ_REG32_BIT(CM_DMC->STSR, DMC_STSR_STATUS);
+}
+
+/* Initialization and configuration EXMC_DMC functions */
+int32_t EXMC_DMC_StructInit(stc_exmc_dmc_init_t *pstcDmcInit);
+int32_t EXMC_DMC_Init(const stc_exmc_dmc_init_t *pstcDmcInit);
+int32_t EXMC_DMC_DeInit(void);
+
+void EXMC_DMC_Cmd(en_functional_state_t enNewState);
+void EXMC_DMC_SetState(uint32_t u32State);
+
+int32_t EXMC_DMC_ChipConfig(uint32_t u32Chip, const stc_exmc_dmc_chip_config_t *pstcChipConfig);
+uint32_t EXMC_DMC_GetChipStartAddr(uint32_t u32Chip);
+uint32_t EXMC_DMC_GetChipEndAddr(uint32_t u32Chip);
+void EXMC_DMC_SetCommand(uint32_t u32Chip, uint32_t u32Bank, uint32_t u32Cmd, uint32_t u32Addr);
+
+/**
+ * @}
+ */
+
+#endif /* LL_DMC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DMC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_dvp.h
+++ b/hc32f4a2/inc/hc32_ll_dvp.h
@@ -1,0 +1,300 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dvp.h
+ * @brief This file contains all the functions prototypes of the DVP(Digital
+ *        Video Processor) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Add function: DVP_GetCaptureState
+   2024-08-31       CDT             API DVP_DeInit add return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_DVP_H__
+#define __HC32_LL_DVP_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_DVP
+ * @{
+ */
+
+#if (LL_DVP_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup DVP_Global_Types DVP Global Types
+ * @{
+ */
+
+/**
+ * @brief  DVP Initialization Structure definition
+ */
+typedef struct {
+    uint32_t u32SyncMode;           /*!< The DVP sync mode.
+                                         This parameter can be a value of @ref DVP_Sync_Mode. */
+    uint32_t u32DataWidth;          /*!< The DVP data interface width.
+                                         This parameter can be a value of @ref DVP_Data_Width. */
+    uint32_t u32CaptureMode;        /*!< The DVP capture mode.
+                                         This parameter can be a value of @ref DVP_Capture_Mode. */
+    uint32_t u32CaptureFreq;        /*!< The DVP capture frequency.
+                                         This parameter can be a value of @ref DVP_Capture_Frequency. */
+    uint32_t u32PIXCLKPolarity;     /*!< The DVP_PIXCLK Polarity.
+                                         This parameter can be a value of @ref DVP_PIXCLK_Polarity. */
+    uint32_t u32HSYNCPolarity;      /*!< The DVP_HSYNC Polarity.
+                                         This parameter can be a value of @ref DVP_HSYNC_Polarity. */
+    uint32_t u32VSYNCPolarity;      /*!< The DVP_VSYNC Polarity.
+                                         This parameter can be a value of @ref DVP_VSYNC_Polarity. */
+} stc_dvp_init_t;
+
+/**
+ * @brief  DVP Crop Window Configure definition
+ */
+typedef struct {
+    uint16_t u16RowStartLine;       /*!< The DVP window row start line.
+                                         This parameter can be a value between 0x00 and 0x3FFF */
+    uint16_t u16ColumnStartLine;    /*!< The DVP window column start line.
+                                         This parameter can be a value between 0x00 and 0x3FFF */
+    uint16_t u16RowLineSize;        /*!< The DVP window row line size.
+                                         This parameter can be a value between 0x04 and 0x3FFF */
+    uint16_t u16ColumnLineSize;     /*!< The DVP window column line size.
+                                         This parameter can be a value between 0x00 and 0x3FFF */
+} stc_dvp_crop_window_config_t;
+
+/**
+ * @brief  DVP Software Sync Code definition
+ */
+typedef struct {
+    uint8_t u8FrameStartSyncCode;   /*!< The sync code of the frame start delimiter.
+                                         This parameter can be a value between 0x00 and 0xFF */
+    uint8_t u8LineStartSyncCode;    /*!< The sync code of the line start delimiter.
+                                         This parameter can be a value between 0x00 and 0xFF */
+    uint8_t u8LineEndSyncCode;      /*!< The sync code of the line end delimiter.
+                                         This parameter can be a value between 0x00 and 0xFF */
+    uint8_t u8FrameEndSyncCode;     /*!< The sync code of the frame end delimiter.
+                                         This parameter can be a value between 0x00 and 0xFF */
+} stc_dvp_sw_sync_code_t;
+
+/**
+ * @brief  DVP Software Mask Code definition
+ */
+typedef struct {
+    uint8_t u8FrameStartMaskCode;   /*!< The mask code of the frame start delimiter.
+                                         This parameter can be a value between between 0x00 and 0xFF */
+    uint8_t u8LineStartMaskCode;    /*!< The mask code of the line start delimiter.
+                                         This parameter can be a value between between 0x00 and 0xFF */
+    uint8_t u8LineEndMaskCode;      /*!< The mask code of the line end delimiter.
+                                         This parameter can be a value between between 0x00 and 0xFF */
+    uint8_t u8FrameEndMaskCode;     /*!< The mask code of the frame end delimiter.
+                                         This parameter can be a value between between 0x00 and 0xFF */
+} stc_dvp_sw_mask_code_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DVP_Global_Macros DVP Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup DVP_Capture_Mode DVP Capture Mode
+ * @{
+ */
+#define DVP_CAPT_MD_CONT_FRAME          (0UL)
+#define DVP_CAPT_MD_SINGLE_FRAME        (DVP_CTR_CAPMD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_Sync_Mode DVP Sync Mode
+ * @{
+ */
+#define DVP_SYNC_MD_HW                  (0UL)               /*!< Hardware sync */
+#define DVP_SYNC_MD_SW                  (DVP_CTR_SWSYNC)    /*!< Software sync */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_PIXCLK_Polarity DVP PIXCLK Polarity
+ * @{
+ */
+#define DVP_PIXCLK_FALLING              (0UL)               /*!< DVP_PIXCLK active on Falling edge */
+#define DVP_PIXCLK_RISING               (DVP_CTR_PIXCKSEL)  /*!< DVP_PIXCLK active on Rising edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_HSYNC_Polarity DVP HSYNC Polarity
+ * @{
+ */
+#define DVP_HSYNC_LOW                   (0UL)               /*!< DVP_HSYNC active Low */
+#define DVP_HSYNC_HIGH                  (DVP_CTR_HSYNCSEL)  /*!< DVP_HSYNC active High */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_VSYNC_Polarity DVP VSYNC Polarity
+ * @{
+ */
+#define DVP_VSYNC_LOW                   (0UL)               /*!< DVP_VSYNC active Low */
+#define DVP_VSYNC_HIGH                  (DVP_CTR_VSYNCSEL)  /*!< DVP_VSYNC active High */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_Capture_Frequency DVP Capture Frequency
+ * @{
+ */
+#define DVP_CAPT_FREQ_ALL_FRAME         (0UL)               /*!< All frames are captured */
+#define DVP_CAPT_FREQ_ONT_TIME_2FRAME   (DVP_CTR_CAPFRC_0)  /*!< One frame per 2 frames captured */
+#define DVP_CAPT_FREQ_ONT_TIME_4FRAME   (DVP_CTR_CAPFRC_1)  /*!< One frame per 4 frames captured */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_Data_Width DVP Data Width
+ * @{
+ */
+#define DVP_DATA_WIDTH_8BIT             (0UL)               /*!< DVP captures 8-bit data on every DVP_PIXCLK clock */
+#define DVP_DATA_WIDTH_10BIT            (DVP_CTR_BITSEL_0)  /*!< DVP captures 10-bit data on every DVP_PIXCLK clock */
+#define DVP_DATA_WIDTH_12BIT            (DVP_CTR_BITSEL_1)  /*!< DVP captures 12-bit data on every DVP_PIXCLK clock */
+#define DVP_DATA_WIDTH_14BIT            (DVP_CTR_BITSEL)    /*!< DVP captures 14-bit data on every DVP_PIXCLK clock */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_Flag DVP Flag
+ * @{
+ */
+#define DVP_FLAG_FRAME_START            (DVP_STR_FSF)     /*!< Frame start flag */
+#define DVP_FLAG_LINE_START             (DVP_STR_LSF)     /*!< Line start flag */
+#define DVP_FLAG_LINE_END               (DVP_STR_LEF)     /*!< Line end flag */
+#define DVP_FLAG_FRAME_END              (DVP_STR_FEF)     /*!< Frame end flag */
+#define DVP_FLAG_FIFO_OVF               (DVP_STR_FIFOERF) /*!< FIFO overflow error flag */
+#define DVP_FLAG_SYNC_ERR               (DVP_STR_SQUERF)  /*!< Sync error flag */
+#define DVP_FLAG_ALL                    (DVP_FLAG_SYNC_ERR   |                 \
+                                         DVP_FLAG_FIFO_OVF   |                 \
+                                         DVP_FLAG_LINE_END   |                 \
+                                         DVP_FLAG_LINE_START |                 \
+                                         DVP_FLAG_FRAME_END  |                 \
+                                         DVP_FLAG_FRAME_START)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DVP_Interrupt DVP Interrupt
+ * @{
+ */
+#define DVP_INT_FRAME_START             (DVP_IER_FSIEN)     /*!< Frame start interrupt */
+#define DVP_INT_LINE_START              (DVP_IER_LSIEN)     /*!< Line start interrupt */
+#define DVP_INT_LINE_END                (DVP_IER_LEIEN)     /*!< Line end interrupt */
+#define DVP_INT_FRAME_END               (DVP_IER_FEIEN)     /*!< Frame end interrupt */
+#define DVP_INT_FIFO_OVF                (DVP_IER_FIFOERIEN) /*!< FIFO overflow error interrupt */
+#define DVP_INT_SYNC_ERR                (DVP_IER_SQUERIEN)  /*!< Sync error interrupt */
+#define DVP_INT_ALL                     (DVP_INT_SYNC_ERR   |                  \
+                                         DVP_INT_FIFO_OVF   |                  \
+                                         DVP_INT_LINE_END   |                  \
+                                         DVP_INT_LINE_START |                  \
+                                         DVP_INT_FRAME_END  |                  \
+                                         DVP_INT_FRAME_START)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup DVP_Global_Functions
+ * @{
+ */
+int32_t DVP_StructInit(stc_dvp_init_t *pstcDvpInit);
+int32_t DVP_Init(const stc_dvp_init_t *pstcDvpInit);
+int32_t DVP_DeInit(void);
+
+void DVP_Cmd(en_functional_state_t enNewState);
+void DVP_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+void DVP_CropCmd(en_functional_state_t enNewState);
+void DVP_JPEGCmd(en_functional_state_t enNewState);
+void DVP_CaptureCmd(en_functional_state_t enNewState);
+en_functional_state_t DVP_GetCaptureState(void);
+en_flag_status_t DVP_GetStatus(uint32_t u32Flag);
+void DVP_ClearStatus(uint32_t u32Flag);
+int32_t DVP_SetSWSyncCode(const stc_dvp_sw_sync_code_t *pstcSyncCode);
+int32_t DVP_SetSWMaskCode(const stc_dvp_sw_mask_code_t *pstcMaskCode);
+int32_t DVP_CropWindowConfig(const stc_dvp_crop_window_config_t *pstcConfig);
+/**
+ * @}
+ */
+
+#endif /* LL_DVP_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_DVP_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_efm.h
+++ b/hc32f4a2/inc/hc32_ll_efm.h
@@ -1,0 +1,735 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_efm.h
+ * @brief This file contains all the functions prototypes of the EFM driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Add Flash protect level define
+   2023-01-15       CDT             Code refine
+   2023-09-30       CDT             Add FLASH security addr define
+   2023-12-15       CDT             Rename EFM_DataCacheResetCmd() as EFM_CacheRamReset() and modify comment
+                                    Optimized macro group EFM_Remap_Size definitions
+   2024-06-30       CDT             Move EFM_CACHE_ALL from c file to head file
+                                    Add prefix EFM to SECTOR_SIZE and macro EFM_PROTECT_LEVEL_ALL
+   2024-10-17       CDT             Add const before buffer pointer to cater top-level calls
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_EFM_H__
+#define __HC32_LL_EFM_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EFM
+ * @{
+ */
+
+#if (LL_EFM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EFM_Global_Types EFM Global Types
+ * @{
+ */
+/**
+ * @brief EFM unique ID definition
+ */
+typedef struct {
+    uint32_t            u32UniqueID0;      /*!< unique ID 0.       */
+    uint32_t            u32UniqueID1;      /*!< unique ID 1.       */
+    uint32_t            u32UniqueID2;      /*!< unique ID 2.       */
+} stc_efm_unique_id_t;
+
+typedef struct {
+    uint32_t u32State;
+    uint32_t u32Addr;
+    uint32_t u32Size;
+} stc_efm_remap_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EFM_Global_Macros EFM Global Macros
+ * @{
+ */
+/**
+ * @defgroup EFM_Address EFM Address Area
+ * @{
+ */
+#define EFM_START_ADDR                  (0x00000000UL)    /*!< Flash start address */
+
+#define EFM_END_ADDR                    (0x001FFFFFUL)    /*!< Flash end address */
+#define EFM_FLASH_1_START_ADDR          (0x00100000UL)
+#define EFM_OTP_START_ADDR1             (0x00000000UL)    /*!< OTP start address */
+#define EFM_OTP_END_ADDR1               (0x0001FFFFUL)
+#define EFM_OTP_START_ADDR              (0x03000000UL)
+#define EFM_OTP_END_ADDR                (0x030017FFUL)    /*!< OTP end address */
+#define EFM_OTP_LOCK_ADDR_START         (0x03001800UL)    /*!< OTP lock address */
+#define EFM_OTP_LOCK_ADDR_END           (0x03001AD7UL)    /*!< OTP lock address */
+#define EFM_OTP_ENABLE_ADDR             (0x03001AD8UL)    /*!< OTP Enable address */
+#define EFM_SECURITY_START_ADDR         (0x03004000UL)    /*!< Flash security start address */
+#define EFM_SECURITY_END_ADDR           (0x0300400BUL)    /*!< Flash security end address */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Chip_Sel EFM Chip Selection
+ * @{
+ */
+#define EFM_CHIP0                       (EFM_FSTP_F0STP)
+#define EFM_CHIP1                       (EFM_FSTP_F1STP)
+#define EFM_CHIP_ALL                    (EFM_FSTP_F0STP | EFM_FSTP_F1STP)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Bus_Status EFM Bus Status
+ * @{
+ */
+#define EFM_BUS_HOLD                    (0x0UL)     /*!< Bus busy while flash program or erase */
+#define EFM_BUS_RELEASE                 (0x1UL)     /*!< Bus release while flash program or erase */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Wait_Cycle EFM Wait Cycle
+ * @{
+ */
+
+#define EFM_WAIT_CYCLE0                 (0U << EFM_FRMC_FLWT_POS)      /*!< Don't insert read wait cycle */
+#define EFM_WAIT_CYCLE1                 (1U << EFM_FRMC_FLWT_POS)      /*!< Insert 1 read wait cycle     */
+
+#define EFM_WAIT_CYCLE2                 (2U << EFM_FRMC_FLWT_POS)      /*!< Insert 2 read wait cycles    */
+#define EFM_WAIT_CYCLE3                 (3U << EFM_FRMC_FLWT_POS)      /*!< Insert 3 read wait cycles    */
+#define EFM_WAIT_CYCLE4                 (4U << EFM_FRMC_FLWT_POS)      /*!< Insert 4 read wait cycles    */
+#define EFM_WAIT_CYCLE5                 (5U << EFM_FRMC_FLWT_POS)      /*!< Insert 5 read wait cycles    */
+#define EFM_WAIT_CYCLE6                 (6U << EFM_FRMC_FLWT_POS)      /*!< Insert 6 read wait cycles    */
+#define EFM_WAIT_CYCLE7                 (7U << EFM_FRMC_FLWT_POS)      /*!< Insert 7 read wait cycles    */
+#define EFM_WAIT_CYCLE8                 (8U << EFM_FRMC_FLWT_POS)      /*!< Insert 8 read wait cycles    */
+#define EFM_WAIT_CYCLE9                 (9U << EFM_FRMC_FLWT_POS)      /*!< Insert 9 read wait cycles    */
+#define EFM_WAIT_CYCLE10                (10U << EFM_FRMC_FLWT_POS)     /*!< Insert 10 read wait cycles   */
+#define EFM_WAIT_CYCLE11                (11U << EFM_FRMC_FLWT_POS)     /*!< Insert 11 read wait cycles   */
+#define EFM_WAIT_CYCLE12                (12U << EFM_FRMC_FLWT_POS)     /*!< Insert 12 read wait cycles   */
+#define EFM_WAIT_CYCLE13                (13U << EFM_FRMC_FLWT_POS)     /*!< Insert 13 read wait cycles   */
+#define EFM_WAIT_CYCLE14                (14U << EFM_FRMC_FLWT_POS)     /*!< Insert 14 read wait cycles   */
+#define EFM_WAIT_CYCLE15                (15U << EFM_FRMC_FLWT_POS)     /*!< Insert 15 read wait cycles   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Swap_Address EFM Swap Address
+ * @{
+ */
+#define EFM_SWAP_ADDR                   (0x03002000UL)
+#define EFM_SWAP_DATA                   (0x005A5A5AUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_WriteLock_Sel EFM Write Protect Lock Selection
+ * @{
+ */
+#define EFM_WRLOCK0                     (EFM_WLOCK_WLOCK_0)     /*!< F0NWPRT0 controlled sector lock   */
+#define EFM_WRLOCK1                     (EFM_WLOCK_WLOCK_1)     /*!< F0NWPRT1 controlled sector lock   */
+#define EFM_WRLOCK2                     (EFM_WLOCK_WLOCK_2)     /*!< F0NWPRT2 controlled sector lock   */
+#define EFM_WRLOCK3                     (EFM_WLOCK_WLOCK_3)     /*!< F0NWPRT3 controlled sector lock   */
+#define EFM_WRLOCK4                     (EFM_WLOCK_WLOCK_4)     /*!< F1NWPRT0 controlled sector lock   */
+#define EFM_WRLOCK5                     (EFM_WLOCK_WLOCK_5)     /*!< F1NWPRT1 controlled sector lock   */
+#define EFM_WRLOCK6                     (EFM_WLOCK_WLOCK_6)     /*!< F1NWPRT2 controlled sector lock   */
+#define EFM_WRLOCK7                     (EFM_WLOCK_WLOCK_7)     /*!< F1NWPRT3 controlled sector lock   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_OperateMode_Sel EFM Operate Mode Selection
+ * @{
+ */
+#define EFM_MD_READONLY                 (0x0UL << EFM_FWMC_PEMOD_POS)   /*!< Read only mode               */
+#define EFM_MD_PGM_SINGLE               (0x1UL << EFM_FWMC_PEMOD_POS)   /*!< Program single mode          */
+#define EFM_MD_PGM_READBACK             (0x2UL << EFM_FWMC_PEMOD_POS)   /*!< Program and read back mode   */
+#define EFM_MD_PGM_SEQ                  (0x3UL << EFM_FWMC_PEMOD_POS)   /*!< Program sequence mode        */
+#define EFM_MD_ERASE_SECTOR             (0x4UL << EFM_FWMC_PEMOD_POS)   /*!< Sector erase mode            */
+
+#define EFM_MD_ERASE_ONE_CHIP           (0x5UL << EFM_FWMC_PEMOD_POS)   /*!< A flash Chip erase mode      */
+#define EFM_MD_ERASE_ALL_CHIP           (0x6UL << EFM_FWMC_PEMOD_POS)   /*!< All chip erase mode    */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Flag_Sel  EFM Flag Selection
+ * @{
+ */
+#define EFM_FLAG_OTPWERR                (EFM_FSR_OTPWERR0)      /*!< EFM Flash0 otp Programming/erase error flag.       */
+#define EFM_FLAG_PEPRTERR               (EFM_FSR_PRTWERR0)      /*!< EFM Flash0 write protect address error flag.       */
+#define EFM_FLAG_PGSZERR                (EFM_FSR_PGSZERR0)      /*!< EFM Flash0 programming size error flag.            */
+#define EFM_FLAG_PGMISMTCH              (EFM_FSR_MISMTCH0)      /*!< EFM Flash0 programming missing match error flag.   */
+#define EFM_FLAG_OPTEND                 (EFM_FSR_OPTEND0)       /*!< EFM Flash0 end of operation flag.                  */
+#define EFM_FLAG_COLERR                 (EFM_FSR_COLERR0)       /*!< EFM Flash0 read collide error flag.                */
+#define EFM_FLAG_RDY                    (EFM_FSR_RDY0)          /*!< EFM Flash0 ready flag.                             */
+#define EFM_FLAG_PEPRTERR1              (EFM_FSR_PRTWERR1)      /*!< EFM Flash1 write protect address error flag.       */
+#define EFM_FLAG_PGSZERR1               (EFM_FSR_PGSZERR1)      /*!< EFM Flash1 programming size error flag.            */
+#define EFM_FLAG_PGMISMTCH1             (EFM_FSR_MISMTCH1)      /*!< EFM Flash1 programming missing match error flag.   */
+#define EFM_FLAG_OPTEND1                (EFM_FSR_OPTEND1)       /*!< EFM Flash1 end of operation flag.                  */
+#define EFM_FLAG_COLERR1                (EFM_FSR_COLERR1)       /*!< EFM Flash1 read collide error flag.                */
+#define EFM_FLAG_RDY1                   (EFM_FSR_RDY1)          /*!< EFM Flash1 ready flag.                             */
+
+#define EFM_FLAG_ALL                (EFM_FLAG_OTPWERR | EFM_FLAG_PEPRTERR | EFM_FLAG_PGSZERR   | EFM_FLAG_PGMISMTCH  | \
+                                     EFM_FLAG_OPTEND  | EFM_FLAG_COLERR   | EFM_FLAG_PEPRTERR1 | EFM_FLAG_PGSZERR1   | \
+                                     EFM_FLAG_OPTEND1 | EFM_FLAG_COLERR1  | EFM_FLAG_RDY       | EFM_FLAG_PGMISMTCH1 | \
+                                     EFM_FLAG_RDY1)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Interrupt_Sel EFM Interrupt Selection
+ * @{
+ */
+#define EFM_INT_PEERR                   (EFM_FITE_PEERRITE)     /*!< Program/erase error Interrupt source    */
+#define EFM_INT_OPTEND                  (EFM_FITE_OPTENDITE)    /*!< End of EFM operation Interrupt source   */
+#define EFM_INT_COLERR                  (EFM_FITE_COLERRITE)    /*!< Read collide error Interrupt source     */
+
+#define EFM_INT_ALL                     (EFM_FITE_PEERRITE | EFM_FITE_OPTENDITE | EFM_FITE_COLERRITE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Cache_Mask EFM Cache Bit Mask
+ * @{
+ */
+#define EFM_CACHE_ALL                   (EFM_FRMC_CRST | EFM_FRMC_PREFETE | EFM_FRMC_DCACHE | EFM_FRMC_ICACHE)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Keys EFM Keys
+ * @{
+ */
+#define EFM_REG_UNLOCK_KEY1             (0x0123UL)
+#define EFM_REG_UNLOCK_KEY2             (0x3210UL)
+#define EFM_REG_LOCK_KEY                (0x0000UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Sector_Size EFM Sector Size
+ * @{
+ */
+#define EFM_SECTOR_SIZE                 (0x2000UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Sector_Address EFM Sector Address
+ * @{
+ */
+#define EFM_SECTOR_ADDR(x)          (uint32_t)(EFM_SECTOR_SIZE * (x))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_OTP_Base_Address EFM Otp Base Address
+ * @{
+ */
+#define EFM_OTP_BASE1_ADDR          (0x00000000UL)
+#define EFM_OTP_BASE1_SIZE          (0x2000UL)
+#define EFM_OTP_BASE1_OFFSET        (0UL)
+#define EFM_OTP_BASE2_ADDR          (0x03000000UL)
+#define EFM_OTP_BASE2_SIZE          (0x800UL)
+#define EFM_OTP_BASE2_OFFSET        (16UL)
+#define EFM_OTP_BASE3_ADDR          (0x03001000UL)
+#define EFM_OTP_BASE3_SIZE          (0x100UL)
+#define EFM_OTP_BASE3_OFFSET        (18UL)
+#define EFM_OTP_BASE4_ADDR          (0x03001400UL)
+#define EFM_OTP_BASE4_SIZE          (0x10UL)
+#define EFM_OTP_BASE4_OFFSET        (22UL)
+#define EFM_OTP_BASE5_ADDR          (0x03001600UL)
+#define EFM_OTP_BASE5_SIZE          (0x04UL)
+#define EFM_OTP_BASE5_OFFSET        (54UL)
+#define EFM_OTP_LOCK_ADDR           (0x03001800UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_OTP_Address EFM Otp Address
+ * @{
+ */
+#define EFM_OTP_BLOCK0              (EFM_OTP_BASE1_ADDR + ((0UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK1              (EFM_OTP_BASE1_ADDR + ((1UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK2              (EFM_OTP_BASE1_ADDR + ((2UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK3              (EFM_OTP_BASE1_ADDR + ((3UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK4              (EFM_OTP_BASE1_ADDR + ((4UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK5              (EFM_OTP_BASE1_ADDR + ((5UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK6              (EFM_OTP_BASE1_ADDR + ((6UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK7              (EFM_OTP_BASE1_ADDR + ((7UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK8              (EFM_OTP_BASE1_ADDR + ((8UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK9              (EFM_OTP_BASE1_ADDR + ((9UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK10             (EFM_OTP_BASE1_ADDR + ((10UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK11             (EFM_OTP_BASE1_ADDR + ((11UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK12             (EFM_OTP_BASE1_ADDR + ((12UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK13             (EFM_OTP_BASE1_ADDR + ((13UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+#define EFM_OTP_BLOCK14             (EFM_OTP_BASE1_ADDR + ((14UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+
+#define EFM_OTP_BLOCK15             (EFM_OTP_BASE1_ADDR + ((15UL - EFM_OTP_BASE1_OFFSET) * EFM_OTP_BASE1_SIZE))
+
+#define EFM_OTP_BLOCK16             (EFM_OTP_BASE2_ADDR + ((16UL - EFM_OTP_BASE2_OFFSET) * EFM_OTP_BASE2_SIZE))
+#define EFM_OTP_BLOCK17             (EFM_OTP_BASE2_ADDR + ((17UL - EFM_OTP_BASE2_OFFSET) * EFM_OTP_BASE2_SIZE))
+
+#define EFM_OTP_BLOCK18             (EFM_OTP_BASE3_ADDR + ((18UL - EFM_OTP_BASE3_OFFSET) * EFM_OTP_BASE3_SIZE))
+#define EFM_OTP_BLOCK19             (EFM_OTP_BASE3_ADDR + ((19UL - EFM_OTP_BASE3_OFFSET) * EFM_OTP_BASE3_SIZE))
+#define EFM_OTP_BLOCK20             (EFM_OTP_BASE3_ADDR + ((20UL - EFM_OTP_BASE3_OFFSET) * EFM_OTP_BASE3_SIZE))
+#define EFM_OTP_BLOCK21             (EFM_OTP_BASE3_ADDR + ((21UL - EFM_OTP_BASE3_OFFSET) * EFM_OTP_BASE3_SIZE))
+
+#define EFM_OTP_BLOCK22             (EFM_OTP_BASE4_ADDR + ((22UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK23             (EFM_OTP_BASE4_ADDR + ((23UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK24             (EFM_OTP_BASE4_ADDR + ((24UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK25             (EFM_OTP_BASE4_ADDR + ((25UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK26             (EFM_OTP_BASE4_ADDR + ((26UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK27             (EFM_OTP_BASE4_ADDR + ((27UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK28             (EFM_OTP_BASE4_ADDR + ((28UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK29             (EFM_OTP_BASE4_ADDR + ((29UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK30             (EFM_OTP_BASE4_ADDR + ((30UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK31             (EFM_OTP_BASE4_ADDR + ((31UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK32             (EFM_OTP_BASE4_ADDR + ((32UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK33             (EFM_OTP_BASE4_ADDR + ((33UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK34             (EFM_OTP_BASE4_ADDR + ((34UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK35             (EFM_OTP_BASE4_ADDR + ((35UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK36             (EFM_OTP_BASE4_ADDR + ((36UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK37             (EFM_OTP_BASE4_ADDR + ((37UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK38             (EFM_OTP_BASE4_ADDR + ((38UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK39             (EFM_OTP_BASE4_ADDR + ((39UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK40             (EFM_OTP_BASE4_ADDR + ((40UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK41             (EFM_OTP_BASE4_ADDR + ((41UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK42             (EFM_OTP_BASE4_ADDR + ((42UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK43             (EFM_OTP_BASE4_ADDR + ((43UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK44             (EFM_OTP_BASE4_ADDR + ((44UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK45             (EFM_OTP_BASE4_ADDR + ((45UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK46             (EFM_OTP_BASE4_ADDR + ((46UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK47             (EFM_OTP_BASE4_ADDR + ((47UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK48             (EFM_OTP_BASE4_ADDR + ((48UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK49             (EFM_OTP_BASE4_ADDR + ((49UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK50             (EFM_OTP_BASE4_ADDR + ((50UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK51             (EFM_OTP_BASE4_ADDR + ((51UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK52             (EFM_OTP_BASE4_ADDR + ((52UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+#define EFM_OTP_BLOCK53             (EFM_OTP_BASE4_ADDR + ((53UL - EFM_OTP_BASE4_OFFSET) * EFM_OTP_BASE4_SIZE))
+
+#define EFM_OTP_BLOCK54             (EFM_OTP_BASE5_ADDR + ((54UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK55             (EFM_OTP_BASE5_ADDR + ((55UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK56             (EFM_OTP_BASE5_ADDR + ((56UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK57             (EFM_OTP_BASE5_ADDR + ((57UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK58             (EFM_OTP_BASE5_ADDR + ((58UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK59             (EFM_OTP_BASE5_ADDR + ((59UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK60             (EFM_OTP_BASE5_ADDR + ((60UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK61             (EFM_OTP_BASE5_ADDR + ((61UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK62             (EFM_OTP_BASE5_ADDR + ((62UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK63             (EFM_OTP_BASE5_ADDR + ((63UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK64             (EFM_OTP_BASE5_ADDR + ((64UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK65             (EFM_OTP_BASE5_ADDR + ((65UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK66             (EFM_OTP_BASE5_ADDR + ((66UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK67             (EFM_OTP_BASE5_ADDR + ((67UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK68             (EFM_OTP_BASE5_ADDR + ((68UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK69             (EFM_OTP_BASE5_ADDR + ((69UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK70             (EFM_OTP_BASE5_ADDR + ((70UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK71             (EFM_OTP_BASE5_ADDR + ((71UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK72             (EFM_OTP_BASE5_ADDR + ((72UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK73             (EFM_OTP_BASE5_ADDR + ((73UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK74             (EFM_OTP_BASE5_ADDR + ((74UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK75             (EFM_OTP_BASE5_ADDR + ((75UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK76             (EFM_OTP_BASE5_ADDR + ((76UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK77             (EFM_OTP_BASE5_ADDR + ((77UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK78             (EFM_OTP_BASE5_ADDR + ((78UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK79             (EFM_OTP_BASE5_ADDR + ((79UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK80             (EFM_OTP_BASE5_ADDR + ((80UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK81             (EFM_OTP_BASE5_ADDR + ((81UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK82             (EFM_OTP_BASE5_ADDR + ((82UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK83             (EFM_OTP_BASE5_ADDR + ((83UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK84             (EFM_OTP_BASE5_ADDR + ((84UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK85             (EFM_OTP_BASE5_ADDR + ((85UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK86             (EFM_OTP_BASE5_ADDR + ((86UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK87             (EFM_OTP_BASE5_ADDR + ((87UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK88             (EFM_OTP_BASE5_ADDR + ((88UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK89             (EFM_OTP_BASE5_ADDR + ((89UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK90             (EFM_OTP_BASE5_ADDR + ((90UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK91             (EFM_OTP_BASE5_ADDR + ((91UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK92             (EFM_OTP_BASE5_ADDR + ((92UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK93             (EFM_OTP_BASE5_ADDR + ((93UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK94             (EFM_OTP_BASE5_ADDR + ((94UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK95             (EFM_OTP_BASE5_ADDR + ((95UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK96             (EFM_OTP_BASE5_ADDR + ((96UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK97             (EFM_OTP_BASE5_ADDR + ((97UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK98             (EFM_OTP_BASE5_ADDR + ((98UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK99             (EFM_OTP_BASE5_ADDR + ((99UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK100            (EFM_OTP_BASE5_ADDR + ((100UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK101            (EFM_OTP_BASE5_ADDR + ((101UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK102            (EFM_OTP_BASE5_ADDR + ((102UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK103            (EFM_OTP_BASE5_ADDR + ((103UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK104            (EFM_OTP_BASE5_ADDR + ((104UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK105            (EFM_OTP_BASE5_ADDR + ((105UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK106            (EFM_OTP_BASE5_ADDR + ((106UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK107            (EFM_OTP_BASE5_ADDR + ((107UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK108            (EFM_OTP_BASE5_ADDR + ((108UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK109            (EFM_OTP_BASE5_ADDR + ((109UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK110            (EFM_OTP_BASE5_ADDR + ((110UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK111            (EFM_OTP_BASE5_ADDR + ((111UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK112            (EFM_OTP_BASE5_ADDR + ((112UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK113            (EFM_OTP_BASE5_ADDR + ((113UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK114            (EFM_OTP_BASE5_ADDR + ((114UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK115            (EFM_OTP_BASE5_ADDR + ((115UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK116            (EFM_OTP_BASE5_ADDR + ((116UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK117            (EFM_OTP_BASE5_ADDR + ((117UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK118            (EFM_OTP_BASE5_ADDR + ((118UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK119            (EFM_OTP_BASE5_ADDR + ((119UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK120            (EFM_OTP_BASE5_ADDR + ((120UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK121            (EFM_OTP_BASE5_ADDR + ((121UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK122            (EFM_OTP_BASE5_ADDR + ((122UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK123            (EFM_OTP_BASE5_ADDR + ((123UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK124            (EFM_OTP_BASE5_ADDR + ((124UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK125            (EFM_OTP_BASE5_ADDR + ((125UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK126            (EFM_OTP_BASE5_ADDR + ((126UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK127            (EFM_OTP_BASE5_ADDR + ((127UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK128            (EFM_OTP_BASE5_ADDR + ((128UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK129            (EFM_OTP_BASE5_ADDR + ((129UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK130            (EFM_OTP_BASE5_ADDR + ((130UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK131            (EFM_OTP_BASE5_ADDR + ((131UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK132            (EFM_OTP_BASE5_ADDR + ((132UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK133            (EFM_OTP_BASE5_ADDR + ((133UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK134            (EFM_OTP_BASE5_ADDR + ((134UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK135            (EFM_OTP_BASE5_ADDR + ((135UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK136            (EFM_OTP_BASE5_ADDR + ((136UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK137            (EFM_OTP_BASE5_ADDR + ((137UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK138            (EFM_OTP_BASE5_ADDR + ((138UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK139            (EFM_OTP_BASE5_ADDR + ((139UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK140            (EFM_OTP_BASE5_ADDR + ((140UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK141            (EFM_OTP_BASE5_ADDR + ((141UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK142            (EFM_OTP_BASE5_ADDR + ((142UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK143            (EFM_OTP_BASE5_ADDR + ((143UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK144            (EFM_OTP_BASE5_ADDR + ((144UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK145            (EFM_OTP_BASE5_ADDR + ((145UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK146            (EFM_OTP_BASE5_ADDR + ((146UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK147            (EFM_OTP_BASE5_ADDR + ((147UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK148            (EFM_OTP_BASE5_ADDR + ((148UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK149            (EFM_OTP_BASE5_ADDR + ((149UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK150            (EFM_OTP_BASE5_ADDR + ((150UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK151            (EFM_OTP_BASE5_ADDR + ((151UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK152            (EFM_OTP_BASE5_ADDR + ((152UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK153            (EFM_OTP_BASE5_ADDR + ((153UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK154            (EFM_OTP_BASE5_ADDR + ((154UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK155            (EFM_OTP_BASE5_ADDR + ((155UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK156            (EFM_OTP_BASE5_ADDR + ((156UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK157            (EFM_OTP_BASE5_ADDR + ((157UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK158            (EFM_OTP_BASE5_ADDR + ((158UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK159            (EFM_OTP_BASE5_ADDR + ((159UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK160            (EFM_OTP_BASE5_ADDR + ((160UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK161            (EFM_OTP_BASE5_ADDR + ((161UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK162            (EFM_OTP_BASE5_ADDR + ((162UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK163            (EFM_OTP_BASE5_ADDR + ((163UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK164            (EFM_OTP_BASE5_ADDR + ((164UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK165            (EFM_OTP_BASE5_ADDR + ((165UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK166            (EFM_OTP_BASE5_ADDR + ((166UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK167            (EFM_OTP_BASE5_ADDR + ((167UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK168            (EFM_OTP_BASE5_ADDR + ((168UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK169            (EFM_OTP_BASE5_ADDR + ((169UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK170            (EFM_OTP_BASE5_ADDR + ((170UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK171            (EFM_OTP_BASE5_ADDR + ((171UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK172            (EFM_OTP_BASE5_ADDR + ((172UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK173            (EFM_OTP_BASE5_ADDR + ((173UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK174            (EFM_OTP_BASE5_ADDR + ((174UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK175            (EFM_OTP_BASE5_ADDR + ((175UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK176            (EFM_OTP_BASE5_ADDR + ((176UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK177            (EFM_OTP_BASE5_ADDR + ((177UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK178            (EFM_OTP_BASE5_ADDR + ((178UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK179            (EFM_OTP_BASE5_ADDR + ((179UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK180            (EFM_OTP_BASE5_ADDR + ((180UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+#define EFM_OTP_BLOCK181            (EFM_OTP_BASE5_ADDR + ((181UL - EFM_OTP_BASE5_OFFSET) * EFM_OTP_BASE5_SIZE))
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_OTP_Lock_Address EFM Otp Lock_address
+ *          x at range of 0~181
+ * @{
+ */
+#define EFM_OTP_BLOCK_LOCKADDR(x)    (EFM_OTP_LOCK_ADDR + 0x04UL * (x))   /*!< OTP block x  lock address */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_Reg_Write_Protection Write Protection Keys For EFM Remap Registers
+ * @{
+ */
+#define EFM_REMAP_REG_LOCK_KEY      (0x0000UL)
+#define EFM_REMAP_REG_UNLOCK_KEY1   (0x0123UL)
+#define EFM_REMAP_REG_UNLOCK_KEY2   (0x3210UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_State EFM remap function state
+ * @{
+ */
+#define EFM_REMAP_OFF               (0UL)
+#define EFM_REMAP_ON                (EFM_MMF_REMCR_EN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_Size EFM remap size definition
+ * @note refer to chip user manual for details size spec.
+ * @{
+ */
+#define EFM_REMAP_4K                (12UL)
+#define EFM_REMAP_8K                (13UL)
+#define EFM_REMAP_16K               (14UL)
+#define EFM_REMAP_32K               (15UL)
+#define EFM_REMAP_64K               (16UL)
+#define EFM_REMAP_128K              (17UL)
+#define EFM_REMAP_256K              (18UL)
+#define EFM_REMAP_512K              (19UL)
+#define EFM_REMAP_SIZE_MAX          EFM_REMAP_512K
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_Index EFM remap index
+ * @{
+ */
+#define EFM_REMAP_IDX0              (0U)
+#define EFM_REMAP_IDX1              (1U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_BaseAddr EFM remap base address
+ * @{
+ */
+#define EFM_REMAP_BASE_ADDR0        (0x2000000UL)
+#define EFM_REMAP_BASE_ADDR1        (0x2080000UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Remap_Region EFM remap ROM/RAM region
+ * @{
+ */
+#define EFM_REMAP_ROM_END_ADDR      EFM_END_ADDR
+
+#define EFM_REMAP_RAM_START_ADDR    (0x1FFE0000UL)
+#define EFM_REMAP_RAM_END_ADDR      (0x1FFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Protect_Level EFM protect level
+ * @{
+ */
+#define EFM_PROTECT_LEVEL1          (1UL << 0UL)
+#define EFM_PROTECT_LEVEL2          (1UL << 1UL)
+#define EFM_PROTECT_LEVEL3          (1UL << 2UL)
+#define EFM_PROTECT_LEVEL_ALL       (EFM_PROTECT_LEVEL1 | EFM_PROTECT_LEVEL2 | EFM_PROTECT_LEVEL3)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_MCU_Status EFM protect level
+ * @{
+ */
+#define EFM_MCU_PROTECT1_FREE       (0U)
+#define EFM_MCU_PROTECT1_LOCK       (1U)
+#define EFM_MCU_PROTECT1_UNLOCK     (2U)
+#define EFM_MCU_PROTECT2_LOCK       (4U)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EFM_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  EFM Protect Unlock.
+ * @param  None
+ * @retval None
+ */
+
+__STATIC_INLINE void EFM_REG_Unlock(void)
+{
+    WRITE_REG32(CM_EFM->FAPRT, EFM_REG_UNLOCK_KEY1);
+    WRITE_REG32(CM_EFM->FAPRT, EFM_REG_UNLOCK_KEY2);
+}
+
+/**
+ * @brief  EFM Protect Lock.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EFM_REG_Lock(void)
+{
+    WRITE_REG32(CM_EFM->FAPRT, EFM_REG_LOCK_KEY);
+}
+
+/**
+ * @brief  EFM remap Unlock.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EFM_REMAP_Unlock(void)
+{
+    WRITE_REG32(CM_EFM->MMF_REMPRT, EFM_REMAP_REG_UNLOCK_KEY1);
+    WRITE_REG32(CM_EFM->MMF_REMPRT, EFM_REMAP_REG_UNLOCK_KEY2);
+}
+
+/**
+ * @brief  EFM remap Lock.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EFM_REMAP_Lock(void)
+{
+    WRITE_REG32(CM_EFM->MMF_REMPRT, EFM_REMAP_REG_LOCK_KEY);
+}
+
+void EFM_Cmd(uint32_t u32Flash, en_functional_state_t enNewState);
+void EFM_FWMC_Cmd(en_functional_state_t enNewState);
+void EFM_SetBusStatus(uint32_t u32Status);
+void EFM_IntCmd(uint32_t u32EfmInt, en_functional_state_t enNewState);
+void EFM_ClearStatus(uint32_t u32Flag);
+int32_t EFM_SetWaitCycle(uint32_t u32WaitCycle);
+int32_t EFM_SetOperateMode(uint32_t u32Mode);
+int32_t EFM_ReadByte(uint32_t u32Addr, uint8_t *pu8ReadBuf, uint32_t u32ByteLen);
+int32_t EFM_Program(uint32_t u32Addr, const uint8_t *pu8Buf, uint32_t u32Len);
+int32_t EFM_SequenceProgram(uint32_t u32Addr, const  uint8_t *pu8Buf, uint32_t u32Len);
+int32_t EFM_ProgramWord(uint32_t u32Addr, uint32_t u32Data);
+int32_t EFM_ProgramWordReadBack(uint32_t u32Addr, uint32_t u32Data);
+int32_t EFM_ChipErase(uint8_t u8Chip);
+
+int32_t EFM_SectorErase(uint32_t u32Addr);
+
+en_flag_status_t EFM_GetAnyStatus(uint32_t u32Flag);
+en_flag_status_t EFM_GetStatus(uint32_t u32Flag);
+void EFM_GetUID(stc_efm_unique_id_t *pstcUID);
+
+void EFM_CacheRamReset(en_functional_state_t enNewState);
+void EFM_PrefetchCmd(en_functional_state_t enNewState);
+void EFM_DCacheCmd(en_functional_state_t enNewState);
+void EFM_ICacheCmd(en_functional_state_t enNewState);
+void EFM_LowVoltageReadCmd(en_functional_state_t enNewState);
+int32_t EFM_SwapCmd(en_functional_state_t enNewState);
+en_flag_status_t EFM_GetSwapStatus(void);
+int32_t EFM_OTP_Lock(uint32_t u32Addr);
+
+int32_t EFM_REMAP_StructInit(stc_efm_remap_init_t *pstcEfmRemapInit);
+int32_t EFM_REMAP_Init(uint8_t u8RemapIdx, stc_efm_remap_init_t *pstcEfmRemapInit);
+void EFM_REMAP_DeInit(void);
+void EFM_REMAP_Cmd(uint8_t u8RemapIdx, en_functional_state_t enNewState);
+void EFM_REMAP_SetAddr(uint8_t u8RemapIdx, uint32_t u32Addr);
+void EFM_REMAP_SetSize(uint8_t u8RemapIdx, uint32_t u32Size);
+
+uint32_t EFM_GetCID(void);
+void EFM_OTP_WP_Unlock(void);
+void EFM_OTP_WP_Lock(void);
+int32_t EFM_OTP_Enable(void);
+void EFM_SectorProtectRegLock(uint32_t u32RegLock);
+void EFM_SingleSectorOperateCmd(uint8_t u8SectorNum, en_functional_state_t enNewState);
+void EFM_SequenceSectorOperateCmd(uint32_t u32StartSectorNum, uint16_t u16Count, en_functional_state_t enNewState);
+
+void EFM_Protect_Enable(uint8_t u8Level);
+int32_t EFM_WriteSecurityCode(const uint8_t *pu8Buf, uint32_t u32Len);
+
+/**
+ * @}
+ */
+
+#endif /* LL_EFM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_EFM_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_emb.h
+++ b/hc32f4a2/inc/hc32_ll_emb.h
@@ -1,0 +1,513 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_emb.h
+ * @brief This file contains all the functions prototypes of the EMB
+ *        (Emergency Brake) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify structure comments:stc_emb_monitor_tmr_pwm_t
+   2023-09-30       CDT             Update EMB_CTL1_CMPEN0~3 to EMB_CTL1_CMPEN1~4
+                                    Update EMB_INTEN_PORTINTEN to EMB_INTEN_PORTININTEN
+   2023-12-15       CDT             Add macro EMB_FLAG_CLR_ALL
+   2024-06-30       CDT             Add EMB_EVT_ALL definition
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_EMB_H__
+#define __HC32_LL_EMB_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EMB
+ * @{
+ */
+
+#if (LL_EMB_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EMB_Global_Types EMB Global Types
+ * @{
+ */
+
+/**
+ * @brief EMB monitor OSC failure configuration
+ */
+typedef struct {
+    uint32_t u32OscState;           /*!< Enable or disable EMB detect OSC failure function
+                                         This parameter can be a value of @ref EMB_OSC_Selection */
+} stc_emb_monitor_osc_t;
+
+/**
+ * @brief EMB monitor EMB port configuration
+ */
+typedef struct {
+    uint32_t u32PortState;          /*!< Enable or disable EMB detect port in control function
+                                         This parameter can be a value of @ref EMB_Port_Selection */
+    uint32_t u32PortLevel;          /*!< EMB detect port level
+                                         This parameter can be a value of @ref EMB_Detect_Port_Level */
+    uint32_t u32PortFilterDiv;      /*!< EMB port filter division
+                                         This parameter can be a value of @ref EMB_Port_Filter_Clock_Division */
+    uint32_t u32PortFilterState;    /*!< Enable or disable EMB detect port filter in control function
+                                         This parameter can be a value of @ref EMB_Port_Filter_Selection */
+} stc_emb_monitor_port_config_t;
+
+/**
+ * @brief EMB monitor PWM configuration
+ */
+typedef struct {
+    uint32_t u32PwmState;   /*!< Enable or disable EMB detect timer same phase function
+                                 This parameter can be a value of @ref EMB_Detect_PWM state. */
+    uint32_t u32PwmLevel;   /*!< Detect timer polarity level
+                                 This parameter can be a value of @ref EMB_Detect_PWM level */
+} stc_emb_monitor_tmr_pwm_t;
+
+/**
+ * @brief EMB monitor port in configuration
+ */
+typedef struct {
+    stc_emb_monitor_port_config_t stcPort1; /*!< EMB detect EMB port in function
+                                                 This parameter details refer @ref stc_emb_monitor_port_config_t structure */
+    stc_emb_monitor_port_config_t stcPort2; /*!< EMB detect EMB port in function
+                                                 This parameter details refer @ref stc_emb_monitor_port_config_t structure */
+    stc_emb_monitor_port_config_t stcPort3; /*!< EMB detect EMB port in function
+                                                 This parameter details refer @ref stc_emb_monitor_port_config_t structure */
+    stc_emb_monitor_port_config_t stcPort4; /*!< EMB detect EMB port in function
+                                                 This parameter details refer @ref stc_emb_monitor_port_config_t structure */
+} stc_emb_monitor_port_t;
+
+/**
+ * @brief EMB monitor CMP configuration
+ */
+typedef struct {
+    uint32_t u32Cmp1State;                  /*!< Enable or disable EMB detect CMP1 result function
+                                                 This parameter can be a value of @ref EMB_CMP_Selection */
+    uint32_t u32Cmp2State;                  /*!< Enable or disable EMB detect CMP2 result function
+                                                 This parameter can be a value of @ref EMB_CMP_Selection */
+    uint32_t u32Cmp3State;                  /*!< Enable or disable EMB detect CMP3 result function
+                                                 This parameter can be a value of @ref EMB_CMP_Selection */
+    uint32_t u32Cmp4State;                  /*!< Enable or disable EMB detect CMP4 result function
+                                                 This parameter can be a value of @ref EMB_CMP_Selection */
+} stc_emb_monitor_cmp_t;
+
+/**
+ * @brief EMB monitor TMR4 configuration
+ */
+typedef struct {
+    stc_emb_monitor_tmr_pwm_t stcTmr4PwmU;  /*!< EMB detect TMR4 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr4PwmV;  /*!< EMB detect TMR4 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr4PwmW;  /*!< EMB detect TMR4 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+} stc_emb_monitor_tmr4_t;
+
+/**
+ * @brief EMB control TMR4 initialization configuration
+ */
+typedef struct {
+    stc_emb_monitor_cmp_t   stcCmp;     /*!< EMB detect CMP function
+                                             This parameter details refer @ref stc_emb_monitor_cmp_t structure */
+    stc_emb_monitor_osc_t   stcOsc;     /*!< EMB detect OSC function
+                                             This parameter details refer @ref stc_emb_monitor_osc_t structure */
+    stc_emb_monitor_port_t  stcPort;    /*!< EMB detect EMB port function
+                                             This parameter details refer @ref stc_emb_monitor_port_t structure */
+    stc_emb_monitor_tmr4_t  stcTmr4;    /*!< EMB detect TMR4 function
+                                             This parameter details refer @ref stc_emb_monitor_tmr4_t structure */
+} stc_emb_tmr4_init_t;
+
+/**
+ * @brief EMB monitor TMR6 configuration
+ */
+typedef struct {
+    stc_emb_monitor_tmr_pwm_t stcTmr6_1;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_2;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_3;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_4;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_5;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_6;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_7;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+    stc_emb_monitor_tmr_pwm_t stcTmr6_8;    /*!< EMB detect TMR6 function
+                                                 This parameter details refer @ref stc_emb_monitor_tmr_pwm_t structure */
+} stc_emb_monitor_tmr6_t;
+
+/**
+ * @brief EMB control TMR6 initialization configuration
+ */
+typedef struct {
+    stc_emb_monitor_cmp_t   stcCmp;     /*!< EMB detect CMP function
+                                             This parameter details refer @ref stc_emb_monitor_cmp_t structure */
+    stc_emb_monitor_osc_t   stcOsc;     /*!< EMB detect OSC function
+                                             This parameter details refer @ref stc_emb_monitor_osc_t structure */
+    stc_emb_monitor_port_t  stcPort;    /*!< EMB detect EMB port function
+                                             This parameter details refer @ref stc_emb_monitor_port_t structure */
+    stc_emb_monitor_tmr6_t  stcTmr6;    /*!< EMB detect TMR6 function
+                                             This parameter details refer @ref stc_emb_monitor_tmr6_t structure */
+} stc_emb_tmr6_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EMB_Global_Macros EMB Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup EMB_CMP_Selection EMB CMP Selection
+ * @{
+ */
+#define EMB_CMP1_DISABLE                    (0UL)
+#define EMB_CMP2_DISABLE                    (0UL)
+#define EMB_CMP3_DISABLE                    (0UL)
+#define EMB_CMP4_DISABLE                    (0UL)
+
+#define EMB_CMP1_ENABLE                     (EMB_CTL1_CMPEN1)
+#define EMB_CMP2_ENABLE                     (EMB_CTL1_CMPEN2)
+#define EMB_CMP3_ENABLE                     (EMB_CTL1_CMPEN3)
+#define EMB_CMP4_ENABLE                     (EMB_CTL1_CMPEN4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_OSC_Selection EMB OSC Selection
+ * @{
+ */
+#define EMB_OSC_DISABLE                     (0UL)
+#define EMB_OSC_ENABLE                      (EMB_CTL1_OSCSTPEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Detect_PWM EMB Detect PWM
+ * @{
+ */
+/**
+ * @defgroup EMB_TMR4_PWM_Selection EMB TMR4 PWM Selection
+ * @{
+ */
+#define EMB_TMR4_PWM_W_DISABLE              (0UL)
+#define EMB_TMR4_PWM_V_DISABLE              (0UL)
+#define EMB_TMR4_PWM_U_DISABLE              (0UL)
+
+#define EMB_TMR4_PWM_W_ENABLE               (EMB_CTL1_PWMSEN0)
+#define EMB_TMR4_PWM_V_ENABLE               (EMB_CTL1_PWMSEN1)
+#define EMB_TMR4_PWM_U_ENABLE               (EMB_CTL1_PWMSEN2)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Detect_TMR4_PWM_Level EMB Detect TMR4 PWM Level
+ * @{
+ */
+#define EMB_DETECT_TMR4_PWM_W_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR4_PWM_V_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR4_PWM_U_BOTH_LOW      (0UL)
+
+#define EMB_DETECT_TMR4_PWM_W_BOTH_HIGH     (EMB_CTL2_PWMLV0)
+#define EMB_DETECT_TMR4_PWM_V_BOTH_HIGH     (EMB_CTL2_PWMLV1)
+#define EMB_DETECT_TMR4_PWM_U_BOTH_HIGH     (EMB_CTL2_PWMLV2)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_TMR6_PWM_Selection EMB TMR6 PWM Selection
+ * @{
+ */
+#define EMB_TMR6_1_PWM_DISABLE              (0UL)
+#define EMB_TMR6_2_PWM_DISABLE              (0UL)
+#define EMB_TMR6_3_PWM_DISABLE              (0UL)
+#define EMB_TMR6_4_PWM_DISABLE              (0UL)
+#define EMB_TMR6_5_PWM_DISABLE              (0UL)
+#define EMB_TMR6_6_PWM_DISABLE              (0UL)
+#define EMB_TMR6_7_PWM_DISABLE              (0UL)
+#define EMB_TMR6_8_PWM_DISABLE              (0UL)
+
+#define EMB_TMR6_1_PWM_ENABLE               (EMB_CTL1_PWMSEN0)
+#define EMB_TMR6_2_PWM_ENABLE               (EMB_CTL1_PWMSEN1)
+#define EMB_TMR6_3_PWM_ENABLE               (EMB_CTL1_PWMSEN2)
+#define EMB_TMR6_4_PWM_ENABLE               (EMB_CTL1_PWMSEN3)
+#define EMB_TMR6_5_PWM_ENABLE               (EMB_CTL1_PWMSEN4)
+#define EMB_TMR6_6_PWM_ENABLE               (EMB_CTL1_PWMSEN5)
+#define EMB_TMR6_7_PWM_ENABLE               (EMB_CTL1_PWMSEN6)
+#define EMB_TMR6_8_PWM_ENABLE               (EMB_CTL1_PWMSEN7)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Detect_TMR6_PWM_Level EMB Detect TMR6 PWM Level
+ * @{
+ */
+#define EMB_DETECT_TMR6_1_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_2_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_3_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_4_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_5_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_6_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_7_PWM_BOTH_LOW      (0UL)
+#define EMB_DETECT_TMR6_8_PWM_BOTH_LOW      (0UL)
+
+#define EMB_DETECT_TMR6_1_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV0)
+#define EMB_DETECT_TMR6_2_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV1)
+#define EMB_DETECT_TMR6_3_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV2)
+#define EMB_DETECT_TMR6_4_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV3)
+#define EMB_DETECT_TMR6_5_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV4)
+#define EMB_DETECT_TMR6_6_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV5)
+#define EMB_DETECT_TMR6_7_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV6)
+#define EMB_DETECT_TMR6_8_PWM_BOTH_HIGH     (EMB_CTL2_PWMLV7)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Port_Selection EMB Port Selection
+ * @{
+ */
+#define EMB_PORT1_DISABLE                   (0UL)
+#define EMB_PORT2_DISABLE                   (0UL)
+#define EMB_PORT3_DISABLE                   (0UL)
+#define EMB_PORT4_DISABLE                   (0UL)
+
+#define EMB_PORT1_ENABLE                    (EMB_CTL1_PORTINEN1)
+#define EMB_PORT2_ENABLE                    (EMB_CTL1_PORTINEN2)
+#define EMB_PORT3_ENABLE                    (EMB_CTL1_PORTINEN3)
+#define EMB_PORT4_ENABLE                    (EMB_CTL1_PORTINEN4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Detect_Port_Level EMB Detect Port Level
+ * @{
+ */
+#define EMB_PORT1_DETECT_LVL_HIGH           (0UL)
+#define EMB_PORT2_DETECT_LVL_HIGH           (0UL)
+#define EMB_PORT3_DETECT_LVL_HIGH           (0UL)
+#define EMB_PORT4_DETECT_LVL_HIGH           (0UL)
+
+#define EMB_PORT1_DETECT_LVL_LOW            (EMB_CTL1_INVSEL1)
+#define EMB_PORT2_DETECT_LVL_LOW            (EMB_CTL1_INVSEL2)
+#define EMB_PORT3_DETECT_LVL_LOW            (EMB_CTL1_INVSEL3)
+#define EMB_PORT4_DETECT_LVL_LOW            (EMB_CTL1_INVSEL4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Port_Filter_Selection EMB Port Filter Selection
+ * @{
+ */
+#define EMB_PORT1_FILTER_DISABLE            (0UL)
+#define EMB_PORT2_FILTER_DISABLE            (0UL)
+#define EMB_PORT3_FILTER_DISABLE            (0UL)
+#define EMB_PORT4_FILTER_DISABLE            (0UL)
+
+#define EMB_PORT1_FILTER_ENABLE             (EMB_CTL2_NFEN1)
+#define EMB_PORT2_FILTER_ENABLE             (EMB_CTL2_NFEN2)
+#define EMB_PORT3_FILTER_ENABLE             (EMB_CTL2_NFEN3)
+#define EMB_PORT4_FILTER_ENABLE             (EMB_CTL2_NFEN4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Port_Filter_Clock_Division EMB Port Filter Clock Division
+ * @{
+ */
+#define EMB_PORT1_FILTER_CLK_DIV1           (0UL << EMB_CTL2_NFSEL1_POS)
+#define EMB_PORT1_FILTER_CLK_DIV8           (1UL << EMB_CTL2_NFSEL1_POS)
+#define EMB_PORT1_FILTER_CLK_DIV32          (2UL << EMB_CTL2_NFSEL1_POS)
+#define EMB_PORT1_FILTER_CLK_DIV128         (3UL << EMB_CTL2_NFSEL1_POS)
+
+#define EMB_PORT2_FILTER_CLK_DIV1           (0UL << EMB_CTL2_NFSEL2_POS)
+#define EMB_PORT2_FILTER_CLK_DIV8           (1UL << EMB_CTL2_NFSEL2_POS)
+#define EMB_PORT2_FILTER_CLK_DIV32          (2UL << EMB_CTL2_NFSEL2_POS)
+#define EMB_PORT2_FILTER_CLK_DIV128         (3UL << EMB_CTL2_NFSEL2_POS)
+
+#define EMB_PORT3_FILTER_CLK_DIV1           (0UL << EMB_CTL2_NFSEL3_POS)
+#define EMB_PORT3_FILTER_CLK_DIV8           (1UL << EMB_CTL2_NFSEL3_POS)
+#define EMB_PORT3_FILTER_CLK_DIV32          (2UL << EMB_CTL2_NFSEL3_POS)
+#define EMB_PORT3_FILTER_CLK_DIV128         (3UL << EMB_CTL2_NFSEL3_POS)
+
+#define EMB_PORT4_FILTER_CLK_DIV1           (0UL << EMB_CTL2_NFSEL4_POS)
+#define EMB_PORT4_FILTER_CLK_DIV8           (1UL << EMB_CTL2_NFSEL4_POS)
+#define EMB_PORT4_FILTER_CLK_DIV32          (2UL << EMB_CTL2_NFSEL4_POS)
+#define EMB_PORT4_FILTER_CLK_DIV128         (3UL << EMB_CTL2_NFSEL4_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Flag_State EMB Flag State
+ * @{
+ */
+#define EMB_FLAG_PWMS                       (EMB_STAT_PWMSF)
+#define EMB_FLAG_CMP                        (EMB_STAT_CMPF)
+#define EMB_FLAG_OSC                        (EMB_STAT_OSF)
+#define EMB_FLAG_PORT1                      (EMB_STAT_PORTINF1)
+#define EMB_FLAG_PORT2                      (EMB_STAT_PORTINF2)
+#define EMB_FLAG_PORT3                      (EMB_STAT_PORTINF3)
+#define EMB_FLAG_PORT4                      (EMB_STAT_PORTINF4)
+#define EMB_STAT_PWMS                       (EMB_STAT_PWMST)
+#define EMB_STAT_CMP                        (EMB_STAT_CMPST)
+#define EMB_STAT_OSC                        (EMB_STAT_OSST)
+#define EMB_STAT_PORT1                      (EMB_STAT_PORTINST1)
+#define EMB_STAT_PORT2                      (EMB_STAT_PORTINST2)
+#define EMB_STAT_PORT3                      (EMB_STAT_PORTINST3)
+#define EMB_STAT_PORT4                      (EMB_STAT_PORTINST4)
+#define EMB_FLAG_ALL                        (EMB_FLAG_PWMS  | EMB_FLAG_CMP   | EMB_FLAG_OSC   | EMB_FLAG_PORT1 | \
+                                             EMB_FLAG_PORT2 | EMB_FLAG_PORT3 | EMB_FLAG_PORT4 | EMB_STAT_PWMS  | \
+                                             EMB_STAT_CMP   | EMB_STAT_OSC   | EMB_STAT_PORT1 | EMB_STAT_PORT2 | \
+                                             EMB_STAT_PORT3 | EMB_STAT_PORT4)
+#define EMB_FLAG_CLR_ALL                    (EMB_FLAG_PWMS  | EMB_FLAG_CMP   | EMB_FLAG_OSC   | EMB_FLAG_PORT1 | \
+                                             EMB_FLAG_PORT2 | EMB_FLAG_PORT3 | EMB_FLAG_PORT4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Interrupt EMB Interrupt
+ * @{
+ */
+#define EMB_INT_PWMS                        (EMB_INTEN_PWMSINTEN)
+#define EMB_INT_CMP                         (EMB_INTEN_CMPINTEN)
+#define EMB_INT_OSC                         (EMB_INTEN_OSINTEN)
+#define EMB_INT_PORT1                       (EMB_INTEN_PORTININTEN1)
+#define EMB_INT_PORT2                       (EMB_INTEN_PORTININTEN2)
+#define EMB_INT_PORT3                       (EMB_INTEN_PORTININTEN3)
+#define EMB_INT_PORT4                       (EMB_INTEN_PORTININTEN4)
+#define EMB_INT_ALL                         (EMB_INT_PWMS  | EMB_INT_CMP   | EMB_INT_OSC   | \
+                                             EMB_INT_PORT1 | EMB_INT_PORT2 | EMB_INT_PORT3 | EMB_INT_PORT4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Release_TMR_PWM_Condition EMB Release TMR PWM Condition
+ * @{
+ */
+#define EMB_RELEASE_PWM_COND_FLAG_ZERO      (0UL)
+#define EMB_RELEASE_PWM_COND_STAT_ZERO      (1UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EMB_Monitor_Event EMB Monitor Event
+ * @{
+ */
+#define EMB_EVT_PWMS                        (EMB_RLSSEL_PWMRSEL)
+#define EMB_EVT_CMP                         (EMB_RLSSEL_CMPRSEL)
+#define EMB_EVT_OSC                         (EMB_RLSSEL_OSRSEL)
+#define EMB_EVT_PORT1                       (EMB_RLSSEL_PORTINRSEL1)
+#define EMB_EVT_PORT2                       (EMB_RLSSEL_PORTINRSEL2)
+#define EMB_EVT_PORT3                       (EMB_RLSSEL_PORTINRSEL3)
+#define EMB_EVT_PORT4                       (EMB_RLSSEL_PORTINRSEL4)
+#define EMB_EVT_ALL                         (EMB_EVT_PWMS  | EMB_EVT_CMP   | EMB_EVT_OSC | EMB_EVT_PORT1 | \
+                                             EMB_EVT_PORT2 | EMB_EVT_PORT3 | EMB_EVT_PORT4)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EMB_Global_Functions
+ * @{
+ */
+int32_t EMB_TMR4_StructInit(stc_emb_tmr4_init_t *pstcEmbInit);
+int32_t EMB_TMR4_Init(CM_EMB_TypeDef *EMBx, const stc_emb_tmr4_init_t *pstcEmbInit);
+
+int32_t EMB_TMR6_StructInit(stc_emb_tmr6_init_t *pstcEmbInit);
+int32_t EMB_TMR6_Init(CM_EMB_TypeDef *EMBx, const stc_emb_tmr6_init_t *pstcEmbInit);
+
+void EMB_DeInit(CM_EMB_TypeDef *EMBx);
+void EMB_IntCmd(CM_EMB_TypeDef *EMBx, uint32_t u32IntType, en_functional_state_t enNewState);
+void EMB_ClearStatus(CM_EMB_TypeDef *EMBx, uint32_t u32Flag);
+en_flag_status_t EMB_GetStatus(const CM_EMB_TypeDef *EMBx, uint32_t u32Flag);
+void EMB_SWBrake(CM_EMB_TypeDef *EMBx, en_functional_state_t enNewState);
+
+void EMB_SetReleasePwmCond(CM_EMB_TypeDef *EMBx, uint32_t u32Event, uint32_t u32Cond);
+
+/**
+ * @}
+ */
+
+#endif /* LL_EMB_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_EMB_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_eth.h
+++ b/hc32f4a2/inc/hc32_ll_eth.h
@@ -1,0 +1,2461 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_eth.h
+ * @brief This file contains all the Macro Definitions of the ETH driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Add ETH_MAC_SetInterface function
+   2024-06-30       CDT             Rename _OPERA_ to _OP_ and delete redundant definition
+   2024-09-13       CDT             Modify ETH_PPS_OUTPUT_FREQ_1HZ as ETH_PPS_OUTPUT_PULSE_1HZ
+                                    Modify comment of defgroup ETH_PPS_Output_Frequency
+   2024-11-08       CDT             Extract the relevant code of PHY
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_ETH_H__
+#define __HC32_LL_ETH_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_ETH
+ * @{
+ */
+
+#if (LL_ETH_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup ETH_Global_Types ETH Global Types
+ * @{
+ */
+
+/**
+ * @brief ETH Common Initialization Structure Definition
+ */
+typedef struct {
+    uint8_t  au8MacAddr[6];             /*!< Specifies the MAC Address of used Hardware */
+    uint32_t u32Interface;              /*!< Specifies the media interface.
+                                             This parameter can be a value of @ref ETH_Interface */
+    uint32_t u32Speed;                  /*!< Specifies the Ethernet speed.
+                                             This parameter can be a value of @ref ETH_Speed */
+    uint32_t u32DuplexMode;             /*!< Specifies the MAC duplex mode.
+                                             This parameter can be a value of @ref ETH_Duplex_Mode */
+    uint32_t u32ChecksumMode;           /*!< Specifies the checksum check by hardware or by software.
+                                             This parameter can be a value of @ref ETH_Checksum_Mode */
+    uint32_t u32ReceiveMode;            /*!< Specifies the Ethernet Rx mode.
+                                             This parameter can be a value of @ref ETH_Receive_Mode */
+} stc_eth_comm_init_t;
+
+/**
+ * @brief ETH MAC Initialization Structure Definition
+ */
+typedef struct {
+    uint32_t u32TxClockPolarity;        /*!< Specifies the Tx clock polarity.
+                                             This parameter can be a value of @ref ETH_TX_CLK_POLARITY */
+    uint32_t u32RxClockPolarity;        /*!< Specifies the Rx/Ref clock polarity.
+                                             This parameter can be a value of @ref ETH_RX_CLK_POLARITY */
+    uint32_t u32SrcAddrMode;            /*!< Specifies the Source Address Insert or Replace Mode.
+                                             This parameter can be a value of @ref ETH_SRC_ADDR_Mode */
+    uint32_t u32TypeFrameStripFCS;      /*!< Specifies the validity of stripping FCS for type frame.
+                                             This parameter can be a value of @ref ETH_TypeFrame_Strip_FCS */
+    uint32_t u32Watchdog;               /*!< Specifies the validity of the Watchdog timer.
+                                             This parameter can be a value of @ref ETH_Watchdog */
+    uint32_t u32Jabber;                 /*!< Specifies the validity of the Jabber timer.
+                                             This parameter can be a value of @ref ETH_Jabber */
+    uint32_t u32InterframeGap;          /*!< Specifies the minimum gap between frames during transmission.
+                                             This parameter can be a value of @ref ETH_Interframe_Gap */
+    uint32_t u32CarrierSense;           /*!< Specifies the validity of the Carrier Sense (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Carrier_Sense */
+    uint32_t u32ReceiveOwn;             /*!< Specifies the validity of the Receive Own (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Receive_Own */
+    uint32_t u32ChecksumOffload;        /*!< Specifies the validity of the IPv4 checksum Offload.
+                                             This parameter can be a value of @ref ETH_Checksum_Offload */
+    uint32_t u32RetryTrans;             /*!< Specifies the validity of the MAC attempt to retry Transmit (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Retry_Transmit */
+    uint32_t u32AutoStripPadFCS;        /*!< Specifies the validity of the Automatic Stripping Pad/FCS of MAC.
+                                             This parameter can be a value of @ref ETH_Auto_Strip_Pad_FCS */
+    uint32_t u32BackOffLimit;           /*!< Specifies the BackOff limit value (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Back_Off_Limit */
+    uint32_t u32DeferralCheck;          /*!< Specifies the validity of the deferral check (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Deferral_Check */
+    uint16_t u16PauseTime;              /*!< Specifies the Pause Time in the transmit control frame.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint32_t u32ZeroQuantaPause;        /*!< Specifies the validity of the automatic generation Zero-Quanta Pause Control frame.
+                                             This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
+    uint32_t u32PauseLowThreshold;      /*!< Specifies the PAUSE Frame threshold.
+                                             This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+    uint32_t u32UnicastPauseFrame;      /*!< Specifies the validity of the detection unicast Pause frame.
+                                             This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
+    uint32_t u32ReceiveFlowControl;     /*!< Specifies the validity of the decoding function that receive Pause frame.
+                                             This parameter can be a value of @ref ETH_Receive_Flow_Control */
+    uint32_t u32TransFlowControl;       /*!< Specifies the validity of the MAC transmit Pause frame (Full-Duplex mode) or the MAC back-pressure operation (Half-Duplex mode).
+                                             This parameter can be a value of @ref ETH_Transmit_Flow_Control */
+    uint32_t u32ReceiveAll;             /*!< Specifies the validity of the all frames reception by the MAC (No filtering).
+                                             This parameter can be a value of @ref ETH_Receive_All */
+    uint32_t u32DropNotTcpUdp;          /*!< Specifies the validity of Dropping all IP datagram without TCP/UDP field.
+                                             This parameter can be a value of @ref ETH_Drop_Not_TcpUdp */
+    uint32_t u32VlanTagFilter;          /*!< Specifies the validity of the VLAN Tag Filter.
+                                             This parameter can be a value of @ref ETH_VLAN_Tag_Filter */
+    uint32_t u32SrcAddrFilter;          /*!< Specifies the Source Address Filter mode.
+                                             This parameter can be a value of @ref ETH_Source_Addr_Filter */
+    uint32_t u32PassControlFrame;       /*!< Specifies the forwarding mode of the control frame.
+                                             This parameter can be a value of @ref ETH_Pass_Control_Frame */
+    uint32_t u32BroadcastFrame;         /*!< Specifies the validity of the reception Broadcast Frame.
+                                             This parameter can be a value of @ref ETH_Reception_Broadcast_Frame */
+    uint32_t u32DestAddrFilter;         /*!< Specifies the destination filter mode for both unicast and multicast frame.
+                                             This parameter can be a value of @ref ETH_Destination_Addr_Filter */
+    uint32_t u32MulticastFrameFilter;   /*!< Specifies the Multicast Frame filter mode.
+                                             This parameter can be a value of @ref ETH_Multicast_Frame_Filter */
+    uint32_t u32UnicastFrameFilter;     /*!< Specifies the Unicast Frame filter mode.
+                                             This parameter can be a value of @ref ETH_Unicast_Frame_Filter */
+    uint32_t u32PromiscuousMode;        /*!< Specifies the validity of the Promiscuous Mode.
+                                             This parameter can be a value of @ref ETH_Promiscuous_Mode */
+    uint32_t u32HashTableHigh;          /*!< Specifies the higher 32 bits of Hash table.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t u32HashTableLow;           /*!< Specifies the lower 32 bits of Hash table.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t u32TxVlanMode;             /*!< Specifies the VLAN insert mode in Transmit frame.
+                                             This parameter can be a value of @ref ETH_Tx_VLAN_Insert_Mode */
+    uint16_t u16TxVlanTag;              /*!< Specifies the VLAN tag value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint32_t u32RxVlanFilter;           /*!< Specifies the VLAN filter mode in Receive frame.
+                                             This parameter can be a value of @ref ETH_Rx_VLAN_Filter */
+    uint32_t u32RxVlanCompare;          /*!< Specifies the bits for compare VLAN tag.
+                                             This parameter can be a value of @ref ETH_Rx_VLAN_Compare */
+    uint16_t u16RxVlanTag;              /*!< Specifies the VLAN tag value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint16_t u16RxVlanHashTable;        /*!< Specifies the lower 16 bits of VLAN Hash table.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+} stc_eth_mac_init_t;
+
+/**
+ * @brief ETH DMA Initialization Structure Definition
+ */
+typedef struct {
+    uint32_t u32BurstMode;              /*!< Specifies the AHB Master interface burst transmission Mode.
+                                             This parameter can be a value of @ref ETH_Burst_Mode */
+    uint32_t u32AddrAlign;              /*!< Specifies the validity of the Address Align.
+                                             This parameter can be a value of @ref ETH_Address_Align */
+    uint32_t u32RxBurstLen;             /*!< Specifies the maximum number of beats to be transferred in one Rx DMA transaction.
+                                             This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+    uint32_t u32TxBurstLen;             /*!< Specifies the maximum number of beats to be transferred in one Tx DMA transaction.
+                                             This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+    uint32_t u32EnhanceDesc;            /*!< Specifies the validity of the enhance descriptor format.
+                                             This parameter can be a value of @ref ETH_DMA_Enhance_Descriptor */
+    uint32_t u32DescSkipLen;            /*!< Specifies the number of word to skip between two unchain descriptors (Ring mode)
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 31 */
+    uint32_t u32Arbitration;            /*!< Specifies the DMA Tx/Rx arbitration.
+                                             This parameter can be a value of @ref ETH_DMA_Arbitration */
+    uint32_t u32DropChecksumErrorFrame; /*!< Specifies the validity of Dropping TCP/IP Checksum Error Frame.
+                                             This parameter can be a value of @ref ETH_Drop_TCPIP_Checksum_Error_Frame */
+    uint32_t u32ReceiveStoreForward;    /*!< Specifies the validity of the Receive store and forward mode.
+                                             This parameter can be a value of @ref ETH_Receive_Store_Forward */
+    uint32_t u32FlushReceiveFrame;      /*!< Specifies the validity of the flushing receive frame.
+                                             This parameter can be a value of @ref ETH_Flush_Receive_Frame */
+    uint32_t u32TransStoreForward;      /*!< Specifies the validity of the Transmit store and forward mode.
+                                             This parameter can be a value of @ref ETH_Transmit_Store_Forward */
+    uint32_t u32TransThreshold;      /*!< Specifies the Transmit Threshold.
+                                             This parameter can be a value of @ref ETH_Transmit_Threshold */
+    uint32_t u32ForwardErrorFrame;      /*!< Specifies the validity of the forward erroneous frame.
+                                             This parameter can be a value of @ref ETH_Forward_Error_Frame */
+    uint32_t u32ForwardUndersizeFrame;  /*!< Specifies the validity of the Rx FIFO to forward Undersize frame.
+                                             This parameter can be a value of @ref ETH_Forward_Undersize_Good_Frame */
+    uint32_t u32DropJumboFrame;         /*!< Specifies the validity of Dropping jumbo Frame.
+                                             This parameter can be a value of @ref ETH_Drop_Jumbo_Frame */
+    uint32_t u32ReceiveThreshold;       /*!< Specifies the threshold level of the Receive FIFO.
+                                             This parameter can be a value of @ref ETH_Receive_Threshold */
+    uint32_t u32SecFrameOperate;        /*!< Specifies the validity of the Operate on second frame mode.
+                                             This parameter can be a value of @ref ETH_Second_Frame_Operate */
+} stc_eth_dma_init_t;
+
+/**
+ * @brief ETH MMC Initialization Structure Definition
+ */
+typedef struct {
+    uint32_t u32PresetMode;             /*!< Specifies the MMC Counter preset mode.
+                                             This parameter can be a value of @ref ETH_MMC_Counter_Preset_Mode */
+    uint32_t u32ReadReset;              /*!< Specifies the validity of the MMC Reset on read.
+                                             This parameter can be a value of @ref ETH_MMC_Read_Reset */
+    uint32_t u32Reload;                 /*!< Specifies the validity of the MMC Counter reload.
+                                             This parameter can be a value of @ref ETH_MMC_Counter_Reload */
+} stc_eth_mmc_init_t;
+
+/**
+ * @brief ETH PTP Initialization Structure Definition
+ */
+typedef struct {
+    uint32_t u32DestAddrFilter;         /*!< Specifies the validity of the Destination address filter for the PTP frame.
+                                             This parameter can be a value of @ref ETH_PTP_Frame_Dest_Addr_Filter */
+    uint32_t u32SnapDatagramType;       /*!< Specifies the PTP snapshot datagram type.
+                                             This parameter can be a value of @ref ETH_PTP_Snapshot_Datagram_Type */
+    uint32_t u32SnapFrameType;          /*!< Specifies the PTP snapshot frame type.
+                                             This parameter can be any combination of @ref ETH_PTP_Snapshot_Frame_Type */
+    uint32_t u32DatagramVersion;        /*!< Specifies the PTP datagram version.
+                                             This parameter can be a value of @ref ETH_PTP_Datagram_Version */
+    uint32_t u32SubsecScale;            /*!< Specifies the PTP Time Stamp subsecond scale.
+                                             This parameter can be a value of @ref ETH_PTP_Subsecond_Scale */
+    uint32_t u32CalibMode;              /*!< Specifies the PTP Time Stamp calibration mode.
+                                             This parameter can be a value of @ref ETH_PTP_Calibration_Mode */
+    uint32_t u32BasicAddend;            /*!< Specifies the PTP Time Stamp Basic addend.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint8_t  u8SubsecAddend;            /*!< Specifies the PTP Time Stamp Subsecond addend.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFF */
+    uint32_t u32SecInitValue;           /*!< Specifies the PTP Time Stamp Second Initial value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t u32SubsecInitValue;        /*!< Specifies the PTP Time Stamp Subsecond Initial value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0x7FFFFFFF */
+} stc_eth_ptp_init_t;
+
+/**
+ * @brief ETH PPS Configuration Structure Definition
+ */
+typedef struct {
+    uint32_t u32TriggerFunc;            /*!< Specifies the arrival time trigger the function.
+                                             This parameter can be a value of @ref ETH_PPS_Trigger_Function */
+    uint32_t u32OutputMode;             /*!< Specifies the PPS output mode.
+                                             This parameter can be a value of @ref ETH_PPS_Output_Mode */
+    uint32_t u32OutputFreq;             /*!< Specifies the PPS output frequency.
+                                             This parameter can be any combination of @ref ETH_PPS_Output_Frequency */
+    uint32_t u32SecValue;               /*!< Specifies the PPS Target Time for Second.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t u32SubsecValue;            /*!< Specifies the PPS Target Time for Subsecond.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0x7FFFFFFF */
+} stc_eth_pps_config_t;
+
+/**
+ * @brief ETH DMA Descriptor Structure Definition
+ */
+typedef struct {
+    __IO uint32_t u32ControlStatus;     /*!< Control and Status */
+    uint32_t      u32ControlBufSize;    /*!< Control and Buffer1, Buffer2 lengths */
+    uint32_t      u32Buf1Addr;          /*!< Buffer1 address pointer */
+    uint32_t      u32Buf2NextDescAddr;  /*!< Buffer2 or next descriptor address pointer */
+    /*!< Enhance DMA Descriptors */
+    __IO uint32_t u32ExtendStatus;      /*!< Extend status */
+    uint32_t      Reserved;             /*!< Reserved */
+    uint32_t      u32TimestampLow;      /*!< Time Stamp Low value for transmit and receive */
+    uint32_t      u32TimestampHigh;     /*!< Time Stamp High value for transmit and receive */
+} stc_eth_dma_desc_t;
+
+/**
+ * @brief ETH DMA Received Frame Structure Definition
+ */
+typedef struct {
+    stc_eth_dma_desc_t *pstcFSDesc;     /*!< First Segment Rx Desc */
+    stc_eth_dma_desc_t *pstcLSDesc;     /*!< Last Segment Rx Desc  */
+    uint32_t           u32SegCount;     /*!< Segment count         */
+    uint32_t           u32Len;          /*!< Frame length          */
+    uint32_t           u32Buf;          /*!< Frame buffer          */
+} stc_eth_dma_rx_frame_t;
+
+/**
+ * @brief ETH Initialization Structure Definition
+ */
+typedef struct {
+    stc_eth_mac_init_t stcMacInit;      /*!< Ethernet MAC Initialization */
+    stc_eth_dma_init_t stcDmaInit;      /*!< Ethernet DMA Initialization */
+} stc_eth_init_t;
+
+/**
+ * @brief ETH Handle Structure Definition
+ */
+typedef struct {
+    stc_eth_comm_init_t    stcCommInit; /*!< ETH Common Initialization */
+    stc_eth_dma_desc_t     *stcRxDesc;  /*!< Rx descriptor to Get      */
+    stc_eth_dma_desc_t     *stcTxDesc;  /*!< Tx descriptor to Set      */
+    stc_eth_dma_rx_frame_t stcRxFrame;  /*!< last Rx frame             */
+} stc_eth_handle_t;
+
+/**
+ * @brief ETH MAC Address Configuration Structure Definition
+ */
+typedef struct {
+    uint32_t u32MacAddrFilter;          /*!< Specifies the MAC Address filter mode.
+                                             This parameter can be a value of @ref ETH_MAC_Address_Filter */
+    uint32_t u32MacAddrMask;            /*!< Specifies the MAC Address filter Mask.
+                                             This parameter can be a value of @ref ETH_MAC_Address_Filter_Mask */
+    uint8_t  au8MacAddr[6];             /*!< Specifies the MAC Address of used Hardware */
+} stc_eth_mac_addr_config_t;
+
+/**
+ * @brief ETH L3L4 Filter Configuration Structure Definition
+ */
+typedef struct {
+    uint32_t u32DestPortFilter;         /*!< Specifies the L4 Destination port filter mode.
+                                             This parameter can be a value of @ref ETH_L4_Dest_Port_Filter */
+    uint32_t u32SrcPortFilter;          /*!< Specifies the L4 Source port filter mode.
+                                             This parameter can be a value of @ref ETH_L4_Source_Port_Filter */
+    uint32_t u32PortFilterProtocol;     /*!< Specifies the L4 protocol for port filter operation.
+                                             This parameter can be a value of @ref ETH_L4_Port_Filter_Protocol */
+    uint16_t u16DestProtFilterValue;    /*!< Specifies the L4 Destination port filter value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint16_t u16SrcProtFilterValue;     /*!< Specifies the L4 Source port filter value.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint32_t u32Ip4DestAddrFilterMask;  /*!< Specifies the L3 Destination Address filter mask in IPv4.
+                                             This parameter can be a value of @ref ETH_L3_Dest_Addr_Filter_Mask */
+    uint32_t u32Ip4SrcAddrFilterMask;   /*!< Specifies the L3 Source Address filter Mask in IPv4.
+                                             This parameter can be a value of @ref ETH_L3_Source_Addr_Filter_Mask */
+    uint32_t u32Ip6AddrFilterMask;      /*!< Specifies the L3 Destination/Source Address filter Mask in IPv6.
+                                             This parameter can be a value of @ref ETH_L3_Dest_Source_Addr_Filter_Mask */
+    uint32_t u32DestAddrFilter;         /*!< Specifies the L3 Destination Address filter mode.
+                                             This parameter can be a value of @ref ETH_L3_Dest_Addr_Filter */
+    uint32_t u32SrcAddrFilter;          /*!< Specifies the L3 Source Address filter mode.
+                                             This parameter can be a value of @ref ETH_L3_Source_Addr_Filter */
+    uint32_t u32AddrFilterProtocol;     /*!< Specifies the L3 protocol for address filter operation.
+                                             This parameter can be a value of @ref ETH_L3_Addr_Filter_Protocol */
+    uint32_t u32Ip4DestAddrFilterValue; /*!< Specifies the L3 Destination Address filter value in IPv4.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t u32Ip4SrcAddrFilterValue;  /*!< Specifies the L3 Source Address filter value in IPv4.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t au32Ip6AddrFilterValue[4]; /*!< Specifies the L3 Destination/Source Address filter value in IPv6.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+} stc_eth_l3l4_filter_config_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ETH_Global_Macros ETH Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup ETH_Buffer_Define ETH Buffer Define
+ * @{
+ */
+#define ETH_MAX_PACKET_SIZE             (1524U)     /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_PAYLOAD + ETH_CRC */
+#define ETH_HEADER                      (14U)       /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+#define ETH_CRC                         (4U)        /*!< Ethernet CRC */
+#define ETH_EXTRA                       (2U)        /*!< Extra bytes in some cases */
+#define ETH_VLAN_TAG                    (4U)        /*!< Optional 802.1Q VLAN Tag */
+#define ETH_MIN_PAYLOAD                 (46U)       /*!< Ethernet minimum payload size */
+#define ETH_MAX_PAYLOAD                 (1500U)     /*!< Ethernet maximum payload size */
+#define ETH_JUMBO_FRAME_PAYLOAD         (9000U)     /*!< Jumbo frame payload size */
+
+/* In below are defined the size of one Ethernet driver transmit buffer ETH_TX_BUF_SIZE and the total count of the
+   driver transmit buffers ETH_TX_BUF_NUM.
+   The configured value for ETH_TX_BUF_SIZE and ETH_TX_BUF_NUM are only provided as example, they can be reconfigured
+   in the application layer to fit the application needs */
+
+/* Configure the transmit buffer size for each Ethernet driver */
+#ifndef ETH_TX_BUF_SIZE
+#define ETH_TX_BUF_SIZE                 ETH_MAX_PACKET_SIZE
+#endif
+
+/* Configure the number of Ethernet driver transmit buffers (in a chained linked list)*/
+#ifndef ETH_TX_BUF_NUM
+#define ETH_TX_BUF_NUM                  (4U)    /* 4 Tx buffers of size ETH_TX_BUF_SIZE */
+#endif
+
+/* In below are defined the size of one Ethernet driver receive buffer ETH_RX_BUF_SIZE and the total count of the
+   driver receive buffers ETH_RX_BUF_NUM.
+   The configured value for ETH_RX_BUF_SIZE and ETH_RX_BUF_NUM are only provided as example, they can be reconfigured
+   in the application layer to fit the application needs */
+
+/* Configure the receive buffer size for each Ethernet driver */
+#ifndef ETH_RX_BUF_SIZE
+#define ETH_RX_BUF_SIZE                 ETH_MAX_PACKET_SIZE
+#endif
+
+/* Configure the number of Ethernet drive receive buffers (in a chained linked list)*/
+#ifndef ETH_RX_BUF_NUM
+#define ETH_RX_BUF_NUM                  (4U)    /* 4 Rx buffers of size ETH_RX_BUF_SIZE */
+#endif
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_TX_Descriptor ETH DMA TX Descriptor
+ * @{
+ */
+
+/*
+  Normal DMA Tx Descriptor
+  -----------------------------------------------------------------------------------------------
+  TDES0 | OWN(31)  |  CTRL[30:26]  |  TTSE(25)  |  CTRL[24:18]  |  TTSS(17)  |  Status[16:0]     |
+  -----------------------------------------------------------------------------------------------
+  TDES1 | CTRL[31:29] | Buffer2 ByteCount[28:16] | Reserved[15:13] | Buffer1 ByteCount[12:0]     |
+  -----------------------------------------------------------------------------------------------
+  TDES2 |                         Buffer1 Address [31:0]                                         |
+  -----------------------------------------------------------------------------------------------
+  TDES3 |                   Buffer2 Address [31:0] / Next Descriptor Address [31:0]              |
+  -----------------------------------------------------------------------------------------------
+ */
+/**
+ * @brief Bit definition of TDES0 register
+ */
+#define ETH_DMA_TXDESC_OWN                          (0x80000000UL)  /*!< OWN bit */
+#define ETH_DMA_TXDESC_IOC                          (0x40000000UL)  /*!< Interrupt on Completion */
+#define ETH_DMA_TXDESC_TLS                          (0x20000000UL)  /*!< Transmit Last Segment */
+#define ETH_DMA_TXDESC_TFS                          (0x10000000UL)  /*!< Transmit First Segment */
+#define ETH_DMA_TXDESC_DCRC                         (0x08000000UL)  /*!< Disable CRC */
+#define ETH_DMA_TXDESC_DPAD                         (0x04000000UL)  /*!< Disable Padding */
+#define ETH_DMA_TXDESC_TTSE                         (0x02000000UL)  /*!< Transmit Time Stamp Enable */
+#define ETH_DMA_TXDESC_CRCR                         (0x01000000UL)  /*!< CRC Replace Control */
+#define ETH_DMA_TXDESC_CIC                          (0x00C00000UL)  /*!< Checksum Insertion Control: 4 cases */
+#define ETH_DMA_TXDESC_CIC_BYPASS                   (0x00000000UL)  /*!< Do Nothing: Checksum Engine is bypassed */
+#define ETH_DMA_TXDESC_CIC_IPV4_HEADER              (0x00400000UL)  /*!< IPV4 header Checksum Insertion */
+#define ETH_DMA_TXDESC_CIC_TCPUDPICMP_SEGMENT       (0x00800000UL)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMA_TXDESC_CIC_TCPUDPICMP_FULL          (0x00C00000UL)  /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+#define ETH_DMA_TXDESC_TER                          (0x00200000UL)  /*!< Transmit End of Ring */
+#define ETH_DMA_TXDESC_TSAC                         (0x00100000UL)  /*!< Second Address Chained */
+#define ETH_DMA_TXDESC_VLANC                        (0x000C0000UL)  /*!< VLAN Insertion Control: 4 cases */
+#define ETH_DMA_TXDESC_VLANC_BYPASS                 (0x00000000UL)  /*!< Do Nothing: VLAN Insertion is bypassed */
+#define ETH_DMA_TXDESC_VLANC_REMOVE_TAG             (0x00040000UL)  /*!< Remove Tag and Type fields in VLAN frame */
+#define ETH_DMA_TXDESC_VLANC_INSERT_TAG             (0x00080000UL)  /*!< Insert VLAN Tag value in ETH_MAC_VTACTLR Register into transmit frame */
+#define ETH_DMA_TXDESC_VLANC_REPLACE_TAG            (0x000C0000UL)  /*!< Replace VLAN tag value in transmit frame with VLAN tag value in ETH_MAC_VTACTLR register */
+#define ETH_DMA_TXDESC_TTSS                         (0x00020000UL)  /*!< Tx Time Stamp Status */
+#define ETH_DMA_TXDESC_IHE                          (0x00010000UL)  /*!< IP Header Error */
+#define ETH_DMA_TXDESC_ETSUM                        (0x00008000UL)  /*!< Tx Error summary: OR of the following bits: IHE || JTE || FFF || TPCE || LOCE || NCE || TLCE || ECE || EDE || UDE */
+#define ETH_DMA_TXDESC_JTE                          (0x00004000UL)  /*!< Jabber Timeout Error */
+#define ETH_DMA_TXDESC_FFF                          (0x00002000UL)  /*!< Frame Flushed */
+#define ETH_DMA_TXDESC_TPCE                         (0x00001000UL)  /*!< Payload Checksum Error */
+#define ETH_DMA_TXDESC_LOCE                         (0x00000800UL)  /*!< Loss Carrier Error */
+#define ETH_DMA_TXDESC_NCE                          (0x00000400UL)  /*!< No Carrier Error */
+#define ETH_DMA_TXDESC_TLCE                         (0x00000200UL)  /*!< Late Collision Error */
+#define ETH_DMA_TXDESC_ECE                          (0x00000100UL)  /*!< Excessive Collision Error */
+#define ETH_DMA_TXDESC_VLF                          (0x00000080UL)  /*!< VLAN Frame */
+#define ETH_DMA_TXDESC_COC                          (0x00000078UL)  /*!< Collision Count */
+#define ETH_DMA_TXDESC_EDE                          (0x00000004UL)  /*!< Excessive Deferral Error */
+#define ETH_DMA_TXDESC_UDE                          (0x00000002UL)  /*!< Underflow Error */
+#define ETH_DMA_TXDESC_DEE                          (0x00000001UL)  /*!< Deferred Error */
+#define ETH_DMA_TXDESC_STATUS_ALL                   (ETH_DMA_TXDESC_OWN   | ETH_DMA_TXDESC_IOC  | ETH_DMA_TXDESC_TLS | \
+                                                     ETH_DMA_TXDESC_DPAD  | ETH_DMA_TXDESC_DCRC | ETH_DMA_TXDESC_TFS | \
+                                                     ETH_DMA_TXDESC_TTSE  | ETH_DMA_TXDESC_CRCR | ETH_DMA_TXDESC_TER | \
+                                                     ETH_DMA_TXDESC_TSAC  | ETH_DMA_TXDESC_TTSS | ETH_DMA_TXDESC_IHE | \
+                                                     ETH_DMA_TXDESC_ETSUM |ETH_DMA_TXDESC_JTE   | ETH_DMA_TXDESC_FFF | \
+                                                     ETH_DMA_TXDESC_TPCE  | ETH_DMA_TXDESC_LOCE | ETH_DMA_TXDESC_NCE | \
+                                                     ETH_DMA_TXDESC_TLCE  | ETH_DMA_TXDESC_ECE  | ETH_DMA_TXDESC_VLF | \
+                                                     ETH_DMA_TXDESC_EDE   | ETH_DMA_TXDESC_UDE  | ETH_DMA_TXDESC_DEE)
+
+/**
+ * @brief Bit definition of TDES1 register
+ */
+#define ETH_DMA_TXDESC_SAIRC                        (0xE0000000UL)  /*!< Source Address Insertion or Replace Control: 5 cases */
+#define ETH_DMA_TXDESC_SAIRC_BYPASS                 (0x00000000UL)  /*!< Do Nothing: Source Address Insertion or Replace Control is bypassed */
+#define ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR0        (0x20000000UL)  /*!< Insert address value in MAC address register 0 into transmit frame as source address */
+#define ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR0       (0x40000000UL)  /*!< Replace source address in transmit frame with address value in MAC address register 0 */
+#define ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR1        (0xA0000000UL)  /*!< Insert address value in MAC address register 1 into transmit frame as source address */
+#define ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR1       (0xC0000000UL)  /*!< Replace source address in transmit frame with address value in MAC address register 1 */
+#define ETH_DMA_TXDESC_TBS2                         (0x1FFF0000UL)  /*!< Transmit Buffer2 Size */
+#define ETH_DMA_TXDESC_TBS1                         (0x00001FFFUL)  /*!< Transmit Buffer1 Size */
+
+/**
+ * @brief Bit definition of TDES2 register
+ */
+#define ETH_DMA_TXDESC_TBAP1                        (0xFFFFFFFFUL)  /*!< Buffer1 Address Pointer */
+
+/**
+ * @brief Bit definition of TDES3 register
+ */
+#define ETH_DMA_TXDESC_TBAP2                        (0xFFFFFFFFUL)  /*!< Buffer2 Address Pointer */
+
+/*
+  Enhance DMA Tx Descriptor
+  -----------------------------------------------------------------------------------------------
+  TDES4 |                                Reserved[31:0]                                          |
+  -----------------------------------------------------------------------------------------------
+  TDES5 |                                Reserved[31:0]                                          |
+  -----------------------------------------------------------------------------------------------
+  TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
+  -----------------------------------------------------------------------------------------------
+  TDES7 |                         Transmit Time Stamp High [31:0]                                |
+  -----------------------------------------------------------------------------------------------
+ */
+/**
+ * @brief Bit definition of TDES6 register
+ */
+#define ETH_DMA_TXDESC_TTSL                        (0xFFFFFFFFUL)  /*!< Transmit Time Stamp Low */
+
+/**
+ * @brief Bit definition of TDES7 register
+ */
+#define ETH_DMA_TXDESC_TTSH                        (0xFFFFFFFFUL)  /*!< Transmit Time Stamp High */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_RX_Descriptor ETH DMA RX Descriptor
+ * @{
+ */
+
+/*
+  Normal DMA Rx Descriptor
+  --------------------------------------------------------------------------------------------------------------------
+  RDES0 | OWN(31) |                                             Status [30:0]                                          |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES1 | CTRL(31) | Reserved[30:29] | Buffer2 ByteCount[28:16] | CTRL[15:14] | Reserved(13) | Buffer1 ByteCount[12:0] |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES2 |                                       Buffer1 Address [31:0]                                                 |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES3 |                          Buffer2 Address [31:0] / Next Descriptor Address [31:0]                             |
+  ---------------------------------------------------------------------------------------------------------------------
+*/
+/**
+ * @brief Bit definition of RDES0 register
+ */
+#define ETH_DMA_RXDESC_OWN                          (0x80000000UL)  /*!< OWN bit */
+#define ETH_DMA_RXDESC_DAF                          (0x40000000UL)  /*!< Destination Address Filter Fail for the received frame */
+#define ETH_DMA_RXDESC_FRAL                         (0x3FFF0000UL)  /*!< Receive frame length */
+#define ETH_DMA_RXDESC_ERSUM                        (0x00008000UL)  /*!< Rx Error summary: OR of the following bits: DPE || OVE || IPE_TSPA_GF || RLCE || WTE || REE || CRE in RDES0, or IPPE || IPHE in RDES4 */
+#define ETH_DMA_RXDESC_DPE                          (0x00004000UL)  /*!< Descriptor Error: no more descriptors for receive frame */
+#define ETH_DMA_RXDESC_SAF                          (0x00002000UL)  /*!< Source address Filter Fail for the received frame */
+#define ETH_DMA_RXDESC_LEE                          (0x00001000UL)  /*!< Length Error: Frame size not matching with length field */
+#define ETH_DMA_RXDESC_OVE                          (0x00000800UL)  /*!< Overflow Error: Frame was damaged due to buffer overflow */
+#define ETH_DMA_RXDESC_VLAT                         (0x00000400UL)  /*!< VLAN Tag: received frame is a VLAN frame */
+#define ETH_DMA_RXDESC_RFS                          (0x00000200UL)  /*!< First descriptor */
+#define ETH_DMA_RXDESC_RLS                          (0x00000100UL)  /*!< Last descriptor */
+#define ETH_DMA_RXDESC_IPE_TSPA_GF                  (0x00000080UL)  /*!< COE Error or Time stamp valid or jumbo frame */
+#define ETH_DMA_RXDESC_RLCE                         (0x00000040UL)  /*!< Late collision Error */
+#define ETH_DMA_RXDESC_FRAT                         (0x00000020UL)  /*!< Frame type: Ethernet or PTP */
+#define ETH_DMA_RXDESC_WTE                          (0x00000010UL)  /*!< Receive Watchdog Timeout */
+#define ETH_DMA_RXDESC_REE                          (0x00000008UL)  /*!< Receive error: error reported by PHY RX_ER */
+#define ETH_DMA_RXDESC_DBE                          (0x00000004UL)  /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
+#define ETH_DMA_RXDESC_CRE                          (0x00000002UL)  /*!< CRC error */
+#define ETH_DMA_RXDESC_DAS_ESA                      (0x00000001UL)  /*!< MAC Address Filter/Status bit extension */
+#define ETH_DMA_RXDESC_STATUS_ALL                   (ETH_DMA_RXDESC_OWN | ETH_DMA_RXDESC_DAF  | ETH_DMA_RXDESC_ERSUM | \
+                                                     ETH_DMA_RXDESC_DPE | ETH_DMA_RXDESC_CRE  | ETH_DMA_RXDESC_LEE   | \
+                                                     ETH_DMA_RXDESC_OVE | ETH_DMA_RXDESC_VLAT | ETH_DMA_RXDESC_RFS   | \
+                                                     ETH_DMA_RXDESC_RLS | ETH_DMA_RXDESC_SAF  | ETH_DMA_RXDESC_RLCE  | \
+                                                     ETH_DMA_RXDESC_WTE | ETH_DMA_RXDESC_FRAT | ETH_DMA_RXDESC_REE   | \
+                                                     ETH_DMA_RXDESC_DBE | ETH_DMA_RXDESC_DAS_ESA                     | \
+                                                     ETH_DMA_RXDESC_IPE_TSPA_GF)
+
+/**
+ * @brief Bit definition of RDES1 register
+ */
+#define ETH_DMA_RXDESC_DIC                          (0x80000000UL)  /*!< Disable Interrupt on Completion */
+#define ETH_DMA_RXDESC_RBS2                         (0x1FFF0000UL)  /*!< Receive Buffer2 Size */
+#define ETH_DMA_RXDESC_RER                          (0x00008000UL)  /*!< Receive End of Ring */
+#define ETH_DMA_RXDESC_RSAC                         (0x00004000UL)  /*!< Second Address Chained */
+#define ETH_DMA_RXDESC_RBS1                         (0x00001FFFUL)  /*!< Receive Buffer1 Size */
+
+/**
+ * @brief Bit definition of RDES2 register
+ */
+#define ETH_DMA_RXDESC_RBAP1                        (0xFFFFFFFFUL)  /*!< Buffer1 Address Pointer */
+
+/**
+ * @brief Bit definition of RDES3 register
+ */
+#define ETH_DMA_RXDESC_RBAP2                        (0xFFFFFFFFUL)  /*!< Buffer2 Address Pointer */
+
+/*
+  Enhance DMA Rx Descriptor
+  -----------------------------------------------------------------------------------------------
+  RDES4 |    Reserved[31:26] | Extend Status [25:24] | Reserved[23:15] | Extend Status [14:0]    |
+  -----------------------------------------------------------------------------------------------
+  RDES5 |                                    Reserved[31:0]                                      |
+  -----------------------------------------------------------------------------------------------
+  RDES6 |                               Receive Time Stamp Low [31:0]                            |
+  -----------------------------------------------------------------------------------------------
+  RDES7 |                               Receive Time Stamp High [31:0]                           |
+  -----------------------------------------------------------------------------------------------
+*/
+/**
+ * @brief Bit definition of RDES4 register
+ */
+#define ETH_DMA_RXDESC_L4FMS                        (0x02000000UL)  /*!< L4 Port Filter Status */
+#define ETH_DMA_RXDESC_L3FMS                        (0x01000000UL)  /*!< L3 Address Filter Status */
+#define ETH_DMA_RXDESC_TSPD                         (0x00004000UL)  /*!< Discard Time Stamp */
+#define ETH_DMA_RXDESC_PTPV                         (0x00002000UL)  /*!< PTP Version */
+#define ETH_DMA_RXDESC_PTPFT                        (0x00001000UL)  /*!< PTP Frame Type */
+#define ETH_DMA_RXDESC_MTP                          (0x00000F00UL)  /*!< PTP Datagram Type */
+#define ETH_DMA_RXDESC_MTP_NONE                     (0x00000000UL)  /*!< No PTP messages */
+#define ETH_DMA_RXDESC_MTP_SYNC                     (0x00000100UL)  /*!< SYNC message (all clock types) */
+#define ETH_DMA_RXDESC_MTP_FOLLOW_UP                (0x00000200UL)  /*!< Follow_Up message (all clock types) */
+#define ETH_DMA_RXDESC_MTP_DELAY_REQ                (0x00000300UL)  /*!< Delay_Req message (all clock types) */
+#define ETH_DMA_RXDESC_MTP_DELAY_RESP               (0x00000400UL)  /*!< Delay_Resp message (all clock types) */
+#define ETH_DMA_RXDESC_MTP_PDELAY_REQ               (0x00000500UL)  /*!< Pdelay_Req message (peer-to-peer transparent clock) */
+#define ETH_DMA_RXDESC_MTP_PDELAY_RESP              (0x00000600UL)  /*!< Pdelay_Resp message (peer-to-peer transparent clock) */
+#define ETH_DMA_RXDESC_MTP_PDELAY_RESP_FOLLOW_UP    (0x00000700UL)  /*!< Pdelay_Resp_Follow_Up message (peer-to-peer transparent clock) */
+#define ETH_DMA_RXDESC_MTP_ANNOUNCE                 (0x00000800UL)  /*!< Announce message (Ordinary or Boundary clock) */
+#define ETH_DMA_RXDESC_MTP_MANAGEMENT               (0x00000900UL)  /*!< Management message (Ordinary or Boundary clock) */
+#define ETH_DMA_RXDESC_MTP_SIGNALING                (0x00000A00UL)  /*!< Signaling message (Ordinary or Boundary clock) */
+#define ETH_DMA_RXDESC_MTP_DEFAULT                  (0x00000F00UL)  /*!< Default Datagram Type */
+#define ETH_DMA_RXDESC_IPV6DR                       (0x00000080UL)  /*!< IPv6 Packet Received */
+#define ETH_DMA_RXDESC_IPV4DR                       (0x00000040UL)  /*!< IPv4 Packet Received */
+#define ETH_DMA_RXDESC_IPCB                         (0x00000020UL)  /*!< COE engine Bypassed */
+#define ETH_DMA_RXDESC_IPPE                         (0x00000010UL)  /*!< IP Payload Error */
+#define ETH_DMA_RXDESC_IPHE                         (0x00000008UL)  /*!< IP Header Error */
+#define ETH_DMA_RXDESC_IPPT                         (0x00000007UL)  /*!< IP Payload Type: 4 cases */
+#define ETH_DMA_RXDESC_IPPT_UNKNOWN                 (0x00000000UL)  /*!< Unknown */
+#define ETH_DMA_RXDESC_IPPT_UDP                     (0x00000001UL)  /*!< UDP */
+#define ETH_DMA_RXDESC_IPPT_TCP                     (0x00000002UL)  /*!< TCP */
+#define ETH_DMA_RXDESC_IPPT_ICMP                    (0x00000003UL)  /*!< ICMP */
+#define ETH_DMA_RXDESC_EXTEND_STATUS_ALL            (ETH_DMA_RXDESC_L4FMS  | ETH_DMA_RXDESC_L3FMS  | \
+                                                     ETH_DMA_RXDESC_TSPD   | ETH_DMA_RXDESC_PTPV   | \
+                                                     ETH_DMA_RXDESC_PTPFT  | ETH_DMA_RXDESC_IPV6DR | \
+                                                     ETH_DMA_RXDESC_IPV4DR | ETH_DMA_RXDESC_IPCB   | \
+                                                     ETH_DMA_RXDESC_IPPE   | ETH_DMA_RXDESC_IPHE)
+
+/**
+ * @brief Bit definition of RDES6 register
+ */
+#define ETH_DMA_RXDESC_RTSL                         (0xFFFFFFFFUL)  /*!< Receive Time Stamp Low */
+
+/**
+ * @brief Bit definition of RDES7 register
+ */
+#define ETH_DMA_RXDESC_RTSH                         (0xFFFFFFFFUL)  /*!< Receive Time Stamp High */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_SMI_Clock_Division ETH SMI Clock Division
+ * @{
+ */
+#define ETH_SMI_CLK_DIV16                           (0x02UL << ETH_MAC_SMIADDR_SMIC_POS)
+#define ETH_SMI_CLK_DIV26                           (0x03UL << ETH_MAC_SMIADDR_SMIC_POS)
+#define ETH_SMI_CLK_DIV42                           (0x00UL << ETH_MAC_SMIADDR_SMIC_POS)
+#define ETH_SMI_CLK_DIV62                           (0x01UL << ETH_MAC_SMIADDR_SMIC_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Interface ETH Interface
+ * @{
+ */
+#define ETH_MAC_IF_MII                              (0UL)
+#define ETH_MAC_IF_RMII                             (ETH_MAC_IFCONFR_IFSEL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Speed ETH Speed
+ * @{
+ */
+#define ETH_MAC_SPEED_10M                           (0UL)
+#define ETH_MAC_SPEED_100M                          (ETH_MAC_CONFIGR_FES)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Duplex_Mode ETH Duplex Mode
+ * @{
+ */
+#define ETH_MAC_DUPLEX_MD_HALF                      (0UL)
+#define ETH_MAC_DUPLEX_MD_FULL                      (ETH_MAC_CONFIGR_DM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Checksum_Mode ETH Checksum Mode
+ * @{
+ */
+#define ETH_MAC_CHECKSUM_MD_SW                      (0UL)
+#define ETH_MAC_CHECKSUM_MD_HW                      (0x00000001UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_Mode ETH Receive Mode
+ * @{
+ */
+#define ETH_RX_MD_POLLING                           (0UL)
+#define ETH_RX_MD_INT                               (0x00000001UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_TX_CLK_POLARITY ETH TX Clock Polarity
+ * @{
+ */
+#define ETH_MAC_TX_CLK_POLARITY_KEEP                (0UL)
+#define ETH_MAC_TX_CLK_POLARITY_INVERSE             (ETH_MAC_IFCONFR_TCKINV)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_RX_CLK_POLARITY ETH RX Clock Polarity
+ * @{
+ */
+#define ETH_MAC_RX_CLK_POLARITY_KEEP                (0UL)
+#define ETH_MAC_RX_CLK_POLARITY_INVERSE             (ETH_MAC_IFCONFR_RCKINV)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_SRC_ADDR_Mode ETH Source Address Mode
+ * @{
+ */
+#define ETH_MAC_SRC_ADDR_MD_BY_DMA_TXDESC           (0UL)                                   /*!< Configure the Insert mode by Tx Descriptor of DMA */
+#define ETH_MAC_SRC_ADDR_MD_INSERT_MACADDR0         (0x02UL << ETH_MAC_CONFIGR_SAIRC_POS)   /*!< Insert address value in MAC address register 0 into transmit frame as source address */
+#define ETH_MAC_SRC_ADDR_MD_REPLACE_MACADDR0        (0x03UL << ETH_MAC_CONFIGR_SAIRC_POS)   /*!< Replace source address in transmit frame with address value in MAC address register 0 */
+#define ETH_MAC_SRC_ADDR_MD_INSERT_MACADDR1         (0x06UL << ETH_MAC_CONFIGR_SAIRC_POS)   /*!< Insert address value in MAC address register 1 into transmit frame as source address */
+#define ETH_MAC_SRC_ADDR_MD_REPLACE_MACADDR1        (0x07UL << ETH_MAC_CONFIGR_SAIRC_POS)   /*!< Replace source address in transmit frame with address value in MAC address register 1 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_TypeFrame_Strip_FCS ETH Type Frame Strip FCS
+ * @{
+ */
+#define ETH_MAC_TYPE_FRAME_STRIP_FCS_DISABLE        (0UL)
+#define ETH_MAC_TYPE_FRAME_STRIP_FCS_ENABLE         (ETH_MAC_CONFIGR_CST)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Watchdog ETH Watchdog
+ * @{
+ */
+#define ETH_MAC_WDT_DISABLE                         (ETH_MAC_CONFIGR_MWD)
+#define ETH_MAC_WDT_ENABLE                          (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Jabber ETH Jabber
+ * @{
+ */
+#define ETH_MAC_JABBER_DISABLE                      (ETH_MAC_CONFIGR_MJB)
+#define ETH_MAC_JABBER_ENABLE                       (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Interframe_Gap ETH Interframe Gap
+ * @{
+ */
+#define ETH_MAC_INTERFRAME_GAP_96BIT                (0UL)
+#define ETH_MAC_INTERFRAME_GAP_88BIT                (0x01UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_80BIT                (0x02UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_72BIT                (0x03UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_64BIT                (0x04UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_56BIT                (0x05UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_48BIT                (0x06UL << ETH_MAC_CONFIGR_IFG_POS)
+#define ETH_MAC_INTERFRAME_GAP_40BIT                (0x07UL << ETH_MAC_CONFIGR_IFG_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Carrier_Sense ETH Carrier Sense
+ * @{
+ */
+#define ETH_MAC_CARRIER_SENSE_DISABLE               (ETH_MAC_CONFIGR_DCRS)
+#define ETH_MAC_CARRIER_SENSE_ENABLE                (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_Own ETH Receive Own
+ * @{
+ */
+#define ETH_MAC_RX_OWN_DISABLE                      (ETH_MAC_CONFIGR_DO)
+#define ETH_MAC_RX_OWN_ENABLE                       (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Checksum_Offload ETH Checksum Offload
+ * @{
+ */
+#define ETH_MAC_CHECKSUM_OFFLOAD_DISABLE            (0UL)
+#define ETH_MAC_CHECKSUM_OFFLOAD_ENABLE             (ETH_MAC_CONFIGR_IPCO)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Retry_Transmit ETH Retry Transmit
+ * @{
+ */
+#define ETH_MAC_RETRY_TRANS_DISABLE                 (ETH_MAC_CONFIGR_DRTY)
+#define ETH_MAC_RETRY_TRANS_ENABLE                  (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Auto_Strip_Pad_FCS ETH Auto Strip Pad FCS
+ * @{
+ */
+#define ETH_MAC_AUTO_STRIP_PAD_FCS_DISABLE          (0UL)
+#define ETH_MAC_AUTO_STRIP_PAD_FCS_ENABLE           (ETH_MAC_CONFIGR_ACS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Back_Off_Limit ETH Back Off Limit
+ * @{
+ */
+#define ETH_MAC_BACKOFF_LIMIT10                     (0UL)
+#define ETH_MAC_BACKOFF_LIMIT8                      (ETH_MAC_CONFIGR_BL_0)
+#define ETH_MAC_BACKOFF_LIMIT4                      (ETH_MAC_CONFIGR_BL_1)
+#define ETH_MAC_BACKOFF_LIMIT1                      (ETH_MAC_CONFIGR_BL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Deferral_Check ETH Deferral Check
+ * @{
+ */
+#define ETH_MAC_DEFERRAL_CHECK_DISABLE              (0UL)
+#define ETH_MAC_DEFERRAL_CHECK_ENABLE               (ETH_MAC_CONFIGR_DC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
+ * @{
+ */
+#define ETH_MAC_ZERO_QUANTA_PAUSE_DISABLE           (ETH_MAC_FLOCTLR_DZPQ)
+#define ETH_MAC_ZERO_QUANTA_PAUSE_ENABLE            (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
+ * @{
+ */
+#define ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS4          (0UL)                   /*!< Pause time minus 4 slot times */
+#define ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS28         (ETH_MAC_FLOCTLR_PLT_0) /*!< Pause time minus 28 slot times */
+#define ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS144        (ETH_MAC_FLOCTLR_PLT_1) /*!< Pause time minus 144 slot times */
+#define ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS256        (ETH_MAC_FLOCTLR_PLT)   /*!< Pause time minus 256 slot times */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
+ * @{
+ */
+#define ETH_MAC_UNICAST_PAUSE_FRAME_DETECT_DISABLE  (0UL)
+#define ETH_MAC_UNICAST_PAUSE_FRAME_DETECT_ENABLE   (ETH_MAC_FLOCTLR_UNP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
+ * @{
+ */
+#define ETH_MAC_RX_FLOW_CTRL_DISABLE                (0UL)
+#define ETH_MAC_RX_FLOW_CTRL_ENABLE                 (ETH_MAC_FLOCTLR_RFE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
+ * @{
+ */
+#define ETH_MAC_TRANS_FLOW_CTRL_DISABLE             (0UL)
+#define ETH_MAC_TRANS_FLOW_CTRL_ENABLE              (ETH_MAC_FLOCTLR_TFE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_All ETH Receive All
+ * @{
+ */
+#define ETH_MAC_RX_ALL_DISABLE                      (0UL)
+#define ETH_MAC_RX_ALL_ENABLE                       (ETH_MAC_FLTCTLR_RA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Drop_Not_TcpUdp ETH Drop Not TcpUdp
+ * @{
+ */
+#define ETH_MAC_DROP_NOT_TCPUDP_DISABLE             (0UL)
+#define ETH_MAC_DROP_NOT_TCPUDP_ENABLE              (ETH_MAC_FLTCTLR_DNTU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_VLAN_Tag_Filter ETH VLAN Tag Filter
+ * @{
+ */
+#define ETH_MAC_VLAN_TAG_FILTER_DISABLE             (0UL)
+#define ETH_MAC_VLAN_TAG_FILTER_ENABLE              (ETH_MAC_FLTCTLR_VTFE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
+ * @{
+ */
+#define ETH_MAC_SRC_ADDR_FILTER_DISABLE             (0UL)
+#define ETH_MAC_SRC_ADDR_FILTER_NORMAL              (ETH_MAC_FLTCTLR_SAF)
+#define ETH_MAC_SRC_ADDR_FILTER_INVERSE             (ETH_MAC_FLTCTLR_SAF | ETH_MAC_FLTCTLR_SAIF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Pass_Control_Frame ETH Pass Control Frame
+ * @{
+ */
+#define ETH_MAC_PASS_CTRL_FRAME_BLOCK_ALL                   (0UL)                   /*!< MAC filter all control frame from reaching the application */
+#define ETH_MAC_PASS_CTRL_FRAME_FORWARD_NOT_PAUSE           (ETH_MAC_FLTCTLR_PCF_0) /*!< MAC forward all control frame except pause control frame to application even if they fail the address filter */
+#define ETH_MAC_PASS_CTRL_FRAME_FORWARD_ALL                 (ETH_MAC_FLTCTLR_PCF_1) /*!< MAC forward all control frame to application even if they fail the address filter */
+#define ETH_MAC_PASS_CTRL_FRAME_FORWARD_PASS_FILTER         (ETH_MAC_FLTCTLR_PCF)   /*!< MAC forward control frame that pass the address filter. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Reception_Broadcast_Frame ETH Reception Broadcast Frame
+ * @{
+ */
+#define ETH_MAC_RX_BROADCAST_FRAME_DISABLE                  (ETH_MAC_FLTCTLR_DBF)
+#define ETH_MAC_RX_BROADCAST_FRAME_ENABLE                   (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
+ * @{
+ */
+#define ETH_MAC_DEST_ADDR_FILTER_NORMAL             (0UL)
+#define ETH_MAC_DEST_ADDR_FILTER_INVERSE            (ETH_MAC_FLTCTLR_DAIF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Multicast_Frame_Filter ETH Multicast Frame Filter
+ * @{
+ */
+#define ETH_MAC_MULTICAST_FRAME_FILTER_NONE                 (ETH_MAC_FLTCTLR_PMF)
+#define ETH_MAC_MULTICAST_FRAME_FILTER_PERFECT              (0UL)
+#define ETH_MAC_MULTICAST_FRAME_FILTER_HASHTABLE            (ETH_MAC_FLTCTLR_HMC)
+#define ETH_MAC_MULTICAST_FRAME_FILTER_PERFECT_HASHTABLE    (ETH_MAC_FLTCTLR_HPF | ETH_MAC_FLTCTLR_HMC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Unicast_Frame_Filter ETH Unicast Frame Filter
+ * @{
+ */
+#define ETH_MAC_UNICAST_FRAME_FILTER_PERFECT                (0UL)
+#define ETH_MAC_UNICAST_FRAME_FILTER_HASHTABLE              (ETH_MAC_FLTCTLR_HUC)
+#define ETH_MAC_UNICAST_FRAME_FILTER_PERFECT_HASHTABLE      (ETH_MAC_FLTCTLR_HPF | ETH_MAC_FLTCTLR_HUC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
+ * @{
+ */
+#define ETH_MAC_PROMISCUOUS_MD_DISABLE              (0UL)
+#define ETH_MAC_PROMISCUOUS_MD_ENABLE               (ETH_MAC_FLTCTLR_PR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Tx_VLAN_Insert_Mode ETH Tx VLAN Insert Mode
+ * @{
+ */
+#define ETH_MAC_TXVLAN_MD_BY_DMA_TXDESC             (0UL)                                               /*!< Configure the Tx VLAN mode by Tx Descriptor of DMA */
+#define ETH_MAC_TXVLAN_MD_BYPASS                    (ETH_MAC_VTACTLR_VLANS)                             /*!< Do Nothing: VLAN Insertion is bypassed */
+#define ETH_MAC_TXVLAN_MD_REMOVE_TAG                (ETH_MAC_VTACTLR_VLANS | ETH_MAC_VTACTLR_VLANC_0)   /*!< Remove Tag and Type fields in VLAN frame */
+#define ETH_MAC_TXVLAN_MD_INSERT_TAG                (ETH_MAC_VTACTLR_VLANS | ETH_MAC_VTACTLR_VLANC_1)   /*!< Insert VLAN Tag value in ETH_MAC_VTACTLR Register into transmit frame */
+#define ETH_MAC_TXVLAN_MD_REPLACE_TAG               (ETH_MAC_VTACTLR_VLANS | ETH_MAC_VTACTLR_VLANC)     /*!< Replace VLAN tag value in transmit frame with VLAN tag value in ETH_MAC_VTACTLR register */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Rx_VLAN_Filter ETH Rx VLAN Filter
+ * @{
+ */
+#define ETH_MAC_RXVLAN_FILTER_NORMAL                (0UL)
+#define ETH_MAC_RXVLAN_FILTER_INVERSE               (ETH_MAC_VTAFLTR_VTIM)
+#define ETH_MAC_RXVLAN_FILTER_NORMAL_HASHTABLE      (ETH_MAC_VTAFLTR_VTHM)
+#define ETH_MAC_RXVLAN_FILTER_INVERSE_HASHTABLE     (ETH_MAC_VTAFLTR_VTHM | ETH_MAC_VTAFLTR_VTIM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Rx_VLAN_Compare ETH Rx VLAN Compare
+ * @{
+ */
+#define ETH_MAC_RXVLAN_CMP_16BIT                    (0UL)
+#define ETH_MAC_RXVLAN_CMP_12BIT                    (ETH_MAC_VTAFLTR_VTAL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L4_Dest_Port_Filter ETH L4 Dest Port Filter
+ * @{
+ */
+#define ETH_MAC_L4_DEST_PORT_FILTER_DISABLE         (0UL)
+#define ETH_MAC_L4_DEST_PORT_FILTER_NORMAL          (ETH_MAC_L34CTLR_L4DPM)
+#define ETH_MAC_L4_DEST_PORT_FILTER_INVERSE         (ETH_MAC_L34CTLR_L4DPIM | ETH_MAC_L34CTLR_L4DPM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L4_Source_Port_Filter ETH L4 Source Port Filter
+ * @{
+ */
+#define ETH_MAC_L4_SRC_PORT_FILTER_DISABLE          (0UL)
+#define ETH_MAC_L4_SRC_PORT_FILTER_NORMAL           (ETH_MAC_L34CTLR_L4SPM)
+#define ETH_MAC_L4_SRC_PORT_FILTER_INVERSE          (ETH_MAC_L34CTLR_L4SPIM | ETH_MAC_L34CTLR_L4SPM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L4_Port_Filter_Protocol ETH L4 Port Filter Protocol
+ * @{
+ */
+#define ETH_MAC_L4_PORT_FILTER_PROTOCOL_TCP         (0UL)                   /*!< Port filter for TCP frame */
+#define ETH_MAC_L4_PORT_FILTER_PROTOCOL_UDP         (ETH_MAC_L34CTLR_L4PEN) /*!< Port filter for UDP frame */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Dest_Addr_Filter_Mask ETH L3 Destination Addr Filter Mask
+ * @note The following definitions apply to IPv4.
+ * @{
+ */
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_NONE       (0x00000000UL)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT0       (0x01UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT1_0     (0x02UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT2_0     (0x03UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT3_0     (0x04UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT4_0     (0x05UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT5_0     (0x06UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT6_0     (0x07UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT7_0     (0x08UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT8_0     (0x09UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT9_0     (0x0AUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT10_0    (0x0BUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT11_0    (0x0CUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT12_0    (0x0DUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT13_0    (0x0EUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT14_0    (0x0FUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT15_0    (0x10UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT16_0    (0x11UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT17_0    (0x12UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT18_0    (0x13UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT19_0    (0x14UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT20_0    (0x15UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT21_0    (0x16UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT22_0    (0x17UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT23_0    (0x18UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT24_0    (0x19UL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT25_0    (0x1AUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT26_0    (0x1BUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT27_0    (0x1CUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT28_0    (0x1DUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT29_0    (0x1EUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT30_0    (0x1FUL << ETH_MAC_L34CTLR_L3HDBM_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Source_Addr_Filter_Mask ETH L3 Source Addr Filter Mask
+ * @note The following definitions apply to IPv4
+ * @{
+ */
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_NONE        (0x00000000UL)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT0        (0x01UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT1_0      (0x02UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT2_0      (0x03UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT3_0      (0x04UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT4_0      (0x05UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT5_0      (0x06UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT6_0      (0x07UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT7_0      (0x08UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT8_0      (0x09UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT9_0      (0x0AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT10_0     (0x0BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT11_0     (0x0CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT12_0     (0x0DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT13_0     (0x0EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT14_0     (0x0FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT15_0     (0x10UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT16_0     (0x11UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT17_0     (0x12UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT18_0     (0x13UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT19_0     (0x14UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT20_0     (0x15UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT21_0     (0x16UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT22_0     (0x17UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT23_0     (0x18UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT24_0     (0x19UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT25_0     (0x1AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT26_0     (0x1BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT27_0     (0x1CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT28_0     (0x1DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT29_0     (0x1EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT30_0     (0x1FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Dest_Source_Addr_Filter_Mask ETH L3 Destination Source Address Filter Mask
+ * @note The following definitions apply to IPv6.
+ * @{
+ */
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_NONE           (0x00000000UL)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT0           (0x01UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT1_0         (0x02UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT2_0         (0x03UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT3_0         (0x04UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT4_0         (0x05UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT5_0         (0x06UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT6_0         (0x07UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT7_0         (0x08UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT8_0         (0x09UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT9_0         (0x0AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT10_0        (0x0BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT11_0        (0x0CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT12_0        (0x0DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT13_0        (0x0EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT14_0        (0x0FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT15_0        (0x10UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT16_0        (0x11UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT17_0        (0x12UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT18_0        (0x13UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT19_0        (0x14UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT20_0        (0x15UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT21_0        (0x16UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT22_0        (0x17UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT23_0        (0x18UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT24_0        (0x19UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT25_0        (0x1AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT26_0        (0x1BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT27_0        (0x1CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT28_0        (0x1DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT29_0        (0x1EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT30_0        (0x1FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT31_0        (0x20UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT32_0        (0x21UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT33_0        (0x22UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT34_0        (0x23UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT35_0        (0x24UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT36_0        (0x25UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT37_0        (0x26UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT38_0        (0x27UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT39_0        (0x28UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT40_0        (0x29UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT41_0        (0x2AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT42_0        (0x2BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT43_0        (0x2CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT44_0        (0x2DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT45_0        (0x2EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT46_0        (0x2FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT47_0        (0x30UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT48_0        (0x31UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT49_0        (0x32UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT50_0        (0x33UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT51_0        (0x34UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT52_0        (0x35UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT53_0        (0x36UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT54_0        (0x37UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT55_0        (0x38UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT56_0        (0x39UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT57_0        (0x3AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT58_0        (0x3BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT59_0        (0x3CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT60_0        (0x3DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT61_0        (0x3EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT62_0        (0x3FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT63_0        (0x40UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT64_0        (0x41UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT65_0        (0x42UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT66_0        (0x43UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT67_0        (0x44UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT68_0        (0x45UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT69_0        (0x46UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT70_0        (0x47UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT71_0        (0x48UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT72_0        (0x49UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT73_0        (0x4AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT74_0        (0x4BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT75_0        (0x4CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT76_0        (0x4DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT77_0        (0x4EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT78_0        (0x4FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT79_0        (0x50UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT80_0        (0x51UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT81_0        (0x52UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT82_0        (0x53UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT83_0        (0x54UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT84_0        (0x55UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT85_0        (0x56UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT86_0        (0x57UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT87_0        (0x58UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT88_0        (0x59UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT89_0        (0x5AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT90_0        (0x5BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT91_0        (0x5CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT92_0        (0x5DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT93_0        (0x5EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT94_0        (0x5FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT95_0        (0x60UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT96_0        (0x61UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT97_0        (0x62UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT98_0        (0x63UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT99_0        (0x64UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT100_0       (0x65UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT101_0       (0x66UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT102_0       (0x67UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT103_0       (0x68UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT104_0       (0x69UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT105_0       (0x6AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT106_0       (0x6BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT107_0       (0x6CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT108_0       (0x6DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT109_0       (0x6EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT110_0       (0x6FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT111_0       (0x70UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT112_0       (0x71UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT113_0       (0x72UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT114_0       (0x73UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT115_0       (0x74UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT116_0       (0x75UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT117_0       (0x76UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT118_0       (0x77UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT119_0       (0x78UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT120_0       (0x79UL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT121_0       (0x7AUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT122_0       (0x7BUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT123_0       (0x7CUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT124_0       (0x7DUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT125_0       (0x7EUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+#define ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT126_0       (0x7FUL << ETH_MAC_L34CTLR_L3HSBM_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Dest_Addr_Filter ETH L3 Destination Addr Filter
+ * @{
+ */
+#define ETH_MAC_L3_DEST_ADDR_FILTER_DISABLE         (0UL)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_NORMAL          (ETH_MAC_L34CTLR_L3DAM)
+#define ETH_MAC_L3_DEST_ADDR_FILTER_INVERSE         (ETH_MAC_L34CTLR_L3DAIM | ETH_MAC_L34CTLR_L3DAM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Source_Addr_Filter ETH L3 Source Addr Filter
+ * @{
+ */
+#define ETH_MAC_L3_SRC_ADDR_FILTER_DISABLE          (0UL)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_NORMAL           (ETH_MAC_L34CTLR_L3SAM)
+#define ETH_MAC_L3_SRC_ADDR_FILTER_INVERSE          (ETH_MAC_L34CTLR_L3SAIM | ETH_MAC_L34CTLR_L3SAM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_L3_Addr_Filter_Protocol ETH L3 Addr Filter Protocol
+ * @{
+ */
+#define ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV4        (0UL)                   /*!< Ip Address filter for IPv4 */
+#define ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV6        (ETH_MAC_L34CTLR_L3PEN) /*!< Ip Address filter for IPv6 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MAC_Address_Index ETH MAC Address Index
+ * @{
+ */
+#define ETH_MAC_ADDR_IDX0                           (0x00000000UL)
+#define ETH_MAC_ADDR_IDX1                           (0x00000008UL)
+#define ETH_MAC_ADDR_IDX2                           (0x00000010UL)
+#define ETH_MAC_ADDR_IDX3                           (0x00000018UL)
+#define ETH_MAC_ADDR_IDX4                           (0x00000020UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MAC_Address_Filter ETH MAC Address Filter
+ * @note The parameter is invalid in ETH_MAC_ADDR_IDX0.
+ * @{
+ */
+#define ETH_MAC_ADDR_FILTER_DISABLE                 (0UL)                                           /*!< Disable perfect filter with MAC address. */
+#define ETH_MAC_ADDR_FILTER_PERFECT_DEST_ADDR       (ETH_MAC_MACADHR1_AE1)                          /*!< Filter the Destination address of the received frame with MAC address. */
+#define ETH_MAC_ADDR_FILTER_PERFECT_SRC_ADDR        (ETH_MAC_MACADHR1_AE1 | ETH_MAC_MACADHR1_SA1)   /*!< Filter the source address of the received frame with MAC address. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MAC_Address_Filter_Mask ETH MAC Address Filter Mask
+ * @note The parameter is invalid in ETH_MAC_ADDR_IDX0.
+ * @{
+ */
+#define ETH_MAC_ADDR_MASK_DISABLE                   (0UL)                       /*!< Disable MAC Address Mask */
+#define ETH_MAC_ADDR_MASK_BYTE6                     (ETH_MAC_MACADHR1_MBC1_5)   /*!< Mask MAC Address high reg bits [15:8] */
+#define ETH_MAC_ADDR_MASK_BYTE5                     (ETH_MAC_MACADHR1_MBC1_4)   /*!< Mask MAC Address high reg bits [7:0] */
+#define ETH_MAC_ADDR_MASK_BYTE4                     (ETH_MAC_MACADHR1_MBC1_3)   /*!< Mask MAC Address low reg bits [31:24] */
+#define ETH_MAC_ADDR_MASK_BYTE3                     (ETH_MAC_MACADHR1_MBC1_2)   /*!< Mask MAC Address low reg bits [23:16] */
+#define ETH_MAC_ADDR_MASK_BYTE2                     (ETH_MAC_MACADHR1_MBC1_1)   /*!< Mask MAC Address low reg bits [15:8] */
+#define ETH_MAC_ADDR_MASK_BYTE1                     (ETH_MAC_MACADHR1_MBC1_0)   /*!< Mask MAC Address low reg bits [7:0] */
+#define ETH_MAC_ADDR_MASK_ALL                       (ETH_MAC_MACADHR1_MBC1)     /*!< Mask MAC Address low reg bits [31:0] and low high bits [15:0] */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MAC_INT_Flag ETH MAC Interrupt Flag
+ * @{
+ */
+#define ETH_MAC_INT_FLAG_TSPIS                      (ETH_MAC_INTSTSR_TSPIS)     /*!< Time stamp trigger flag (on MAC) */
+#define ETH_MAC_INT_FLAG_MMCTXIS                    (ETH_MAC_INTSTSR_MMCTXIS)   /*!< MMC transmit flag  */
+#define ETH_MAC_INT_FLAG_MMCRXIS                    (ETH_MAC_INTSTSR_MMCRXIS)   /*!< MMC receive flag */
+#define ETH_MAC_INT_FLAG_MMCIS                      (ETH_MAC_INTSTSR_MMCIS)     /*!< MMC flag (on MAC) */
+#define ETH_MAC_INT_FLAG_PMTIS                      (ETH_MAC_INTSTSR_PMTIS)     /*!< PMT flag (on MAC) */
+#define ETH_MAC_INT_FLAG_ALL                        (ETH_MAC_INT_FLAG_TSPIS   | ETH_MAC_INT_FLAG_MMCTXIS | \
+                                                     ETH_MAC_INT_FLAG_MMCRXIS | ETH_MAC_INT_FLAG_MMCIS   | \
+                                                     ETH_MAC_INT_FLAG_PMTIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MAC_Interrupt ETH MAC Interrupt
+ * @{
+ */
+#define ETH_MAC_INT_TSPIM                           (ETH_MAC_INTMSKR_TSPIM)   /*!< Time stamp trigger interrupt (on MAC) */
+#define ETH_MAC_INT_PMTIM                           (ETH_MAC_INTMSKR_PMTIM)   /*!< PMT interrupt (on MAC) */
+#define ETH_MAC_INT_ALL                             (ETH_MAC_INT_TSPIM | ETH_MAC_INT_PMTIM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Burst_Mode ETH Burst Mode
+ * @{
+ */
+#define ETH_DMA_BURST_MD_NORMAL                     (0UL)                     /*!< DMA master interface only use SINGLE and INCR access type */
+#define ETH_DMA_BURST_MD_FIXED                      (ETH_DMA_BUSMODR_FBST)    /*!< DMA master interface use SINGLE and INCR, INCR8, INCR16 access type */
+#define ETH_DMA_BURST_MD_MIXED                      (ETH_DMA_BUSMODR_MBST)    /*!< DMA master interface will start all burst transmission with INCR length greater than 16 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Address_Align ETH Address Align
+ * @{
+ */
+#define ETH_DMA_ADDR_ALIGN_DISABLE                  (0UL)
+#define ETH_DMA_ADDR_ALIGN_ENABLE                   (ETH_DMA_BUSMODR_AAL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
+ * @{
+ */
+#define ETH_DMA_RX_BURST_LEN_1BEAT                  (0x01UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 1 */
+#define ETH_DMA_RX_BURST_LEN_2BEAT                  (0x02UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 2 */
+#define ETH_DMA_RX_BURST_LEN_4BEAT                  (0x04UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_DMA_RX_BURST_LEN_8BEAT                  (0x08UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_DMA_RX_BURST_LEN_16BEAT                 (0x10UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_DMA_RX_BURST_LEN_32BEAT                 (0x20UL << ETH_DMA_BUSMODR_RPBL_POS)                    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_8BEAT            (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_1BEAT)    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_16BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_2BEAT)    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_32BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_4BEAT)    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_64BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_8BEAT)    /*!< Maximum number of beats to be transferred in one RxDMA transaction is 64 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_128BEAT          (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_16BEAT)   /*!< Maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_DMA_RX_BURST_LEN_8XPBL_256BEAT          (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_RX_BURST_LEN_32BEAT)   /*!< Maximum number of beats to be transferred in one RxDMA transaction is 256 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
+ * @{
+ */
+#define ETH_DMA_TX_BURST_LEN_1BEAT                  (0x01UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+#define ETH_DMA_TX_BURST_LEN_2BEAT                  (0x02UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+#define ETH_DMA_TX_BURST_LEN_4BEAT                  (0x04UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_DMA_TX_BURST_LEN_8BEAT                  (0x08UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_DMA_TX_BURST_LEN_16BEAT                 (0x10UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_DMA_TX_BURST_LEN_32BEAT                 (0x20UL << ETH_DMA_BUSMODR_TPBL_POS)                    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_8BEAT            (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_1BEAT)    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_16BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_2BEAT)    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_32BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_4BEAT)    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_64BEAT           (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_8BEAT)    /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_128BEAT          (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_16BEAT)   /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_DMA_TX_BURST_LEN_8XPBL_256BEAT          (ETH_DMA_BUSMODR_M8PBL | ETH_DMA_TX_BURST_LEN_32BEAT)   /*!< Maximum number of beats to be transferred in one TxDMA (or both) transaction is 256 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Enhance_Descriptor ETH DMA Enhance Descriptor
+ * @{
+ */
+#define ETH_DMA_ENHANCE_DESC_DISABLE                (0UL)
+#define ETH_DMA_ENHANCE_DESC_ENABLE                 (ETH_DMA_BUSMODR_DSEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
+ * @{
+ */
+#define ETH_DMA_ARBITRATION_LOOP_RXTX_1_1           (0UL)
+#define ETH_DMA_ARBITRATION_LOOP_RXTX_2_1           (ETH_DMA_BUSMODR_PRAT_0)
+#define ETH_DMA_ARBITRATION_LOOP_RXTX_3_1           (ETH_DMA_BUSMODR_PRAT_1)
+#define ETH_DMA_ARBITRATION_LOOP_RXTX_4_1           (ETH_DMA_BUSMODR_PRAT)
+#define ETH_DMA_ARBITRATION_LOOP_TXRX_1_1           (ETH_DMA_BUSMODR_TXPR)
+#define ETH_DMA_ARBITRATION_LOOP_TXRX_2_1           (ETH_DMA_BUSMODR_TXPR | ETH_DMA_BUSMODR_PRAT_0)
+#define ETH_DMA_ARBITRATION_LOOP_TXRX_3_1           (ETH_DMA_BUSMODR_TXPR | ETH_DMA_BUSMODR_PRAT_1)
+#define ETH_DMA_ARBITRATION_LOOP_TXRX_4_1           (ETH_DMA_BUSMODR_TXPR | ETH_DMA_BUSMODR_PRAT)
+#define ETH_DMA_ARBITRATION_FIXED_RX_PRIOR_TX       (ETH_DMA_BUSMODR_DMAA)
+#define ETH_DMA_ARBITRATION_FIXED_TX_PRIOR_RX       (ETH_DMA_BUSMODR_TXPR | ETH_DMA_BUSMODR_DMAA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Drop_TCPIP_Checksum_Error_Frame ETH Drop TCPIP Checksum Error Frame
+ * @{
+ */
+#define ETH_DMA_DROP_CHECKSUM_ERR_FRAME_DISABLE     (ETH_DMA_OPRMODR_DTCOE)
+#define ETH_DMA_DROP_CHECKSUM_ERR_FRAME_ENABLE      (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
+ * @{
+ */
+#define ETH_DMA_RX_STORE_FORWARD_DISABLE            (0UL)
+#define ETH_DMA_RX_STORE_FORWARD_ENABLE             (ETH_DMA_OPRMODR_RSF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Flush_Receive_Frame ETH Flush Receive Frame
+ * @{
+ */
+#define ETH_DMA_FLUSH_RX_FRAME_DISABLE              (ETH_DMA_OPRMODR_DFRF)
+#define ETH_DMA_FLUSH_RX_FRAME_ENABLE               (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
+ * @{
+ */
+#define ETH_DMA_TRANS_STORE_FORWARD_DISABLE         (0UL)
+#define ETH_DMA_TRANS_STORE_FORWARD_ENABLE          (ETH_DMA_OPRMODR_TSF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Transmit_Threshold ETH Transmit Threshold
+ * @{
+ */
+#define ETH_DMA_TRANS_THRESHOLD_64BYTE              (0UL)                               /*!< Threshold level of the Transmit FIFO is 64 Bytes  */
+#define ETH_DMA_TRANS_THRESHOLD_128BYTE             (0x01UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 128 Bytes */
+#define ETH_DMA_TRANS_THRESHOLD_192BYTE             (0x02UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 192 Bytes */
+#define ETH_DMA_TRANS_THRESHOLD_256BYTE             (0x03UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 256 Bytes */
+#define ETH_DMA_TRANS_THRESHOLD_40BYTE              (0x04UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 40 Bytes  */
+#define ETH_DMA_TRANS_THRESHOLD_32BYTE              (0x05UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 32 Bytes  */
+#define ETH_DMA_TRANS_THRESHOLD_24BYTE              (0x06UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 24 Bytes  */
+#define ETH_DMA_TRANS_THRESHOLD_16BYTE              (0x07UL << ETH_DMA_OPRMODR_TTC_POS) /*!< Threshold level of the Transmit FIFO is 16 Bytes  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Forward_Error_Frame ETH Forward Error Frame
+ * @{
+ */
+#define ETH_DMA_FORWARD_ERR_FRAME_DISABLE           (0UL)
+#define ETH_DMA_FORWARD_ERR_FRAME_ENABLE            (ETH_DMA_OPRMODR_FEF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Forward_Undersize_Good_Frame ETH Forward Undersize Good Frame
+ * @{
+ */
+#define ETH_DMA_FORWARD_UNDERSIZE_FRAME_DISABLE     (0UL)
+#define ETH_DMA_FORWARD_UNDERSIZE_FRAME_ENABLE      (ETH_DMA_OPRMODR_FUF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Drop_Jumbo_Frame ETH Drop Jumbo Frame
+ * @{
+ */
+#define ETH_DMA_DROP_JUMBO_FRAME_DISABLE            (0UL)
+#define ETH_DMA_DROP_JUMBO_FRAME_ENABLE             (ETH_DMA_OPRMODR_DGF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Receive_Threshold ETH Receive Threshold
+ * @{
+ */
+#define ETH_DMA_RX_THRESHOLD_64BYTE                 (0UL)                   /*!< Threshold level of the Receive FIFO is 64 Bytes */
+#define ETH_DMA_RX_THRESHOLD_32BYTE                 (ETH_DMA_OPRMODR_RTC_0) /*!< Threshold level of the Receive FIFO is 32 Bytes */
+#define ETH_DMA_RX_THRESHOLD_96BYTE                 (ETH_DMA_OPRMODR_RTC_1) /*!< Threshold level of the Receive FIFO is 96 Bytes */
+#define ETH_DMA_RX_THRESHOLD_128BYTE                (ETH_DMA_OPRMODR_RTC)   /*!< Threshold level of the Receive FIFO is 128 Bytes */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
+ * @{
+ */
+#define ETH_DMA_SEC_FRAME_OP_DISABLE                (0UL)
+#define ETH_DMA_SEC_FRAME_OP_ENABLE                 (ETH_DMA_OPRMODR_OSF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Flag ETH DMA Flag
+ * @{
+ */
+#define ETH_DMA_FLAG_PTPS                           (ETH_DMA_DMASTSR_PTPS)  /*!< Time-stamp trigger status */
+#define ETH_DMA_FLAG_PMTS                           (ETH_DMA_DMASTSR_PMTS)  /*!< PMT trigger status */
+#define ETH_DMA_FLAG_MMCS                           (ETH_DMA_DMASTSR_MMCS)  /*!< MMC trigger status */
+#define ETH_DMA_FLAG_NIS                            (ETH_DMA_DMASTSR_NIS)   /*!< Normal interrupt summary flag */
+#define ETH_DMA_FLAG_AIS                            (ETH_DMA_DMASTSR_AIS)   /*!< Abnormal interrupt summary flag */
+#define ETH_DMA_FLAG_ERS                            (ETH_DMA_DMASTSR_ERS)   /*!< Early receive flag */
+#define ETH_DMA_FLAG_FBS                            (ETH_DMA_DMASTSR_FBS)   /*!< Fatal bus error flag */
+#define ETH_DMA_FLAG_ETS                            (ETH_DMA_DMASTSR_ETS)   /*!< Early transmit flag */
+#define ETH_DMA_FLAG_RWS                            (ETH_DMA_DMASTSR_RWS)   /*!< Receive watchdog timeout flag */
+#define ETH_DMA_FLAG_RSS                            (ETH_DMA_DMASTSR_RSS)   /*!< Receive stopped flag */
+#define ETH_DMA_FLAG_RUS                            (ETH_DMA_DMASTSR_RUS)   /*!< Receive buffer unavailable flag */
+#define ETH_DMA_FLAG_RIS                            (ETH_DMA_DMASTSR_RIS)   /*!< Receive flag */
+#define ETH_DMA_FLAG_UNS                            (ETH_DMA_DMASTSR_UNS)   /*!< Transmit Underflow flag */
+#define ETH_DMA_FLAG_OVS                            (ETH_DMA_DMASTSR_OVS)   /*!< Receive Overflow flag */
+#define ETH_DMA_FLAG_TJS                            (ETH_DMA_DMASTSR_TJS)   /*!< Transmit jabber timeout flag */
+#define ETH_DMA_FLAG_TUS                            (ETH_DMA_DMASTSR_TUS)   /*!< Transmit buffer unavailable flag */
+#define ETH_DMA_FLAG_TSS                            (ETH_DMA_DMASTSR_TSS)   /*!< Transmit stopped flag */
+#define ETH_DMA_FLAG_TIS                            (ETH_DMA_DMASTSR_TIS)   /*!< Transmit interrupt flag */
+#define ETH_DMA_FLAG_ALL                            (ETH_DMA_FLAG_PTPS | ETH_DMA_FLAG_PMTS | ETH_DMA_FLAG_MMCS | \
+                                                     ETH_DMA_FLAG_NIS  | ETH_DMA_FLAG_AIS  | ETH_DMA_FLAG_ERS  | \
+                                                     ETH_DMA_FLAG_FBS  | ETH_DMA_FLAG_ETS  | ETH_DMA_FLAG_RWS  | \
+                                                     ETH_DMA_FLAG_RSS  | ETH_DMA_FLAG_RUS  | ETH_DMA_FLAG_RIS  | \
+                                                     ETH_DMA_FLAG_UNS  | ETH_DMA_FLAG_OVS  | ETH_DMA_FLAG_TJS  | \
+                                                     ETH_DMA_FLAG_TUS  | ETH_DMA_FLAG_TSS  | ETH_DMA_FLAG_TIS)
+#define ETH_DMA_FLAG_CLR_ALL                        (ETH_DMA_FLAG_NIS  | ETH_DMA_FLAG_AIS  | ETH_DMA_FLAG_ERS  | \
+                                                     ETH_DMA_FLAG_FBS  | ETH_DMA_FLAG_ETS  | ETH_DMA_FLAG_RWS  | \
+                                                     ETH_DMA_FLAG_RSS  | ETH_DMA_FLAG_RUS  | ETH_DMA_FLAG_RIS  | \
+                                                     ETH_DMA_FLAG_UNS  | ETH_DMA_FLAG_OVS  | ETH_DMA_FLAG_TJS  | \
+                                                     ETH_DMA_FLAG_TUS  | ETH_DMA_FLAG_TSS  | ETH_DMA_FLAG_TIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Error_State ETH DMA Error State
+ * @{
+ */
+#define ETH_DMA_ERR_STATE_RX_WR_DATA                (0UL)                                   /*!< RxDMA generates error while writing data */
+#define ETH_DMA_ERR_STATE_TX_RD_DATA                (0x03UL << ETH_DMA_DMASTSR_EBUS_POS)    /*!< TxDMA generates error while reading data */
+#define ETH_DMA_ERR_STATE_RX_WR_DESC                (0x04UL << ETH_DMA_DMASTSR_EBUS_POS)    /*!< RxDMA generates error while writing descriptor */
+#define ETH_DMA_ERR_STATE_TX_WR_DESC                (0x05UL << ETH_DMA_DMASTSR_EBUS_POS)    /*!< TxDMA generates error while writing descriptor */
+#define ETH_DMA_ERR_STATE_RX_RD_DESC                (0x06UL << ETH_DMA_DMASTSR_EBUS_POS)    /*!< RxDMA generates error while reading descriptor */
+#define ETH_DMA_ERR_STATE_TX_RD_DESC                (0x07UL << ETH_DMA_DMASTSR_EBUS_POS)    /*!< TxDMA generates error while reading descriptor */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Transmit_State ETH DMA Transmit State
+ * @{
+ */
+#define ETH_DMA_TRANS_STATE_STOPPED                 (0UL)                                   /*!< Stopped - Reset or Stop Tx Command issued */
+#define ETH_DMA_TRANS_STATE_FETCHING                (0x01UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Running - Fetching the Tx descriptor */
+#define ETH_DMA_TRANS_STATE_WAITING                 (0x02UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Running - Waiting for status */
+#define ETH_DMA_TRANS_STATE_READING                 (0x03UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Running - Reading the data from host memory */
+#define ETH_DMA_TRANS_STATE_WRITING                 (0x04UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Running - Writing the time stamp */
+#define ETH_DMA_TRANS_STATE_SUSPENDED               (0x06UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Suspended - Tx Descriptor unavailable */
+#define ETH_DMA_TRANS_STATE_CLOSING                 (0x07UL << ETH_DMA_DMASTSR_TSTS_POS)    /*!< Running - Closing Rx descriptor */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Receive_State ETH DMA Receive State
+ * @{
+ */
+#define ETH_DMA_RX_STATE_STOPPED                    (0UL)                                   /*!< Stopped - Reset or Stop Rx Command issued */
+#define ETH_DMA_RX_STATE_FETCHING                   (0x01UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Running - Fetching the Rx descriptor */
+#define ETH_DMA_RX_STATE_WAITING                    (0x03UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Running - Waiting for packet */
+#define ETH_DMA_RX_STATE_SUSPENDED                  (0x04UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Suspended - Rx Descriptor unavailable */
+#define ETH_DMA_RX_STATE_CLOSING                    (0x05UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Running - Closing descriptor */
+#define ETH_DMA_RX_STATE_WRITING                    (0x06UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Running - Writing the time stamp */
+#define ETH_DMA_RX_STATE_QUEUING                    (0x07UL << ETH_DMA_DMASTSR_RSTS_POS)    /*!< Running - Queuing the receive frame into host memory */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Interrupt ETH DMA Interrupt
+ * @{
+ */
+#define ETH_DMA_INT_NIE                             (ETH_DMA_INTENAR_NIE)   /*!< Normal interrupt summary */
+#define ETH_DMA_INT_AIE                             (ETH_DMA_INTENAR_AIE)   /*!< Abnormal interrupt summary */
+#define ETH_DMA_INT_ERE                             (ETH_DMA_INTENAR_ERE)   /*!< Early receive interrupt */
+#define ETH_DMA_INT_FBE                             (ETH_DMA_INTENAR_FBE)   /*!< Fatal bus error interrupt */
+#define ETH_DMA_INT_ETE                             (ETH_DMA_INTENAR_ETE)   /*!< Early transmit interrupt */
+#define ETH_DMA_INT_RWE                             (ETH_DMA_INTENAR_RWE)   /*!< Receive watchdog timeout interrupt */
+#define ETH_DMA_INT_RSE                             (ETH_DMA_INTENAR_RSE)   /*!< Receive process stopped interrupt */
+#define ETH_DMA_INT_RUE                             (ETH_DMA_INTENAR_RUE)   /*!< Receive buffer unavailable interrupt */
+#define ETH_DMA_INT_RIE                             (ETH_DMA_INTENAR_RIE)   /*!< Receive interrupt */
+#define ETH_DMA_INT_UNE                             (ETH_DMA_INTENAR_UNE)   /*!< Transmit Underflow interrupt */
+#define ETH_DMA_INT_OVE                             (ETH_DMA_INTENAR_OVE)   /*!< Receive Overflow interrupt */
+#define ETH_DMA_INT_TJE                             (ETH_DMA_INTENAR_TJE)   /*!< Transmit jabber timeout interrupt */
+#define ETH_DMA_INT_TUE                             (ETH_DMA_INTENAR_TUE)   /*!< Transmit buffer unavailable interrupt */
+#define ETH_DMA_INT_TSE                             (ETH_DMA_INTENAR_TSE)   /*!< Transmit process stopped interrupt */
+#define ETH_DMA_INT_TIE                             (ETH_DMA_INTENAR_TIE)   /*!< Transmit interrupt */
+#define ETH_DMA_INT_ALL                             (ETH_DMA_INT_NIE | ETH_DMA_INT_AIE | ETH_DMA_INT_ERE | \
+                                                     ETH_DMA_INT_FBE | ETH_DMA_INT_ETE | ETH_DMA_INT_RWE | \
+                                                     ETH_DMA_INT_RSE | ETH_DMA_INT_RUE | ETH_DMA_INT_RIE | \
+                                                     ETH_DMA_INT_UNE | ETH_DMA_INT_OVE | ETH_DMA_INT_TJE | \
+                                                     ETH_DMA_INT_TUE | ETH_DMA_INT_TSE | ETH_DMA_INT_TIE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Overflow ETH DMA Overflow
+ * @{
+ */
+#define ETH_DMA_OVF_RXFIFO_CNT                      (ETH_DMA_RFRCNTR_OVFOVF)  /*!< Overflow bit for FIFO overflow counter */
+#define ETH_DMA_OVF_MISS_FRAME_CNT                  (ETH_DMA_RFRCNTR_UNAOVF)  /*!< Overflow bit for miss frame counter */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Descriptor_Own ETH DMA Descriptor Own
+ * @{
+ */
+#define ETH_DMA_DESC_OWN_CPU                        (0UL)                   /*!< The descriptor is owned by CPU */
+#define ETH_DMA_DESC_OWN_DMA                        (ETH_DMA_TXDESC_OWN)    /*!< The descriptor is owned by DMA */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Descriptor_Buffer ETH DMA Descriptor Buffer
+ * @{
+ */
+#define ETH_DMA_DESC_BUF1                           (0x00UL)    /*!< DMA Descriptor Buffer1 */
+#define ETH_DMA_DESC_BUF2                           (0x01UL)    /*!< DMA Descriptor Buffer2 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Tx_Descriptor_Checksum_Insertion_Control ETH DMA Tx Descriptor Checksum Insertion Control
+ * @{
+ */
+#define ETH_DMA_TXDESC_CHECKSUM_BYPASS              (ETH_DMA_TXDESC_CIC_BYPASS)              /*!< Checksum Engine is bypassed */
+#define ETH_DMA_TXDESC_CHECKSUM_IPV4_HEADER         (ETH_DMA_TXDESC_CIC_IPV4_HEADER)          /*!< IPv4 header checksum insertion  */
+#define ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_SEGMENT  (ETH_DMA_TXDESC_CIC_TCPUDPICMP_SEGMENT)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_FULL     (ETH_DMA_TXDESC_CIC_TCPUDPICMP_FULL)     /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Tx_Descriptor_VLAN_Insertion_Control ETH DMA Tx Descriptor VLAN Insertion Control
+ * @{
+ */
+#define ETH_DMA_TXDESC_VLAN_BYPASS                  (ETH_DMA_TXDESC_VLANC_BYPASS)        /*!< VLAN Insertion is bypassed */
+#define ETH_DMA_TXDESC_VLAN_REMOVE_TAG              (ETH_DMA_TXDESC_VLANC_REMOVE_TAG)    /*!< Remove Tag and Type fields in VLAN frame */
+#define ETH_DMA_TXDESC_VLAN_INSERT_TAG              (ETH_DMA_TXDESC_VLANC_INSERT_TAG)    /*!< Insert VLAN Tag value in ETH_MAC_VTACTLR Register into transmit frame */
+#define ETH_DMA_TXDESC_VLAN_REPLACE_TAG             (ETH_DMA_TXDESC_VLANC_REPLACE_TAG)   /*!< Replace VLAN tag value in transmit frame with VLAN tag value in ETH_MAC_VTACTLR register */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_DMA_Tx_Descriptor_SA_Insertion_Control ETH DMA Tx Descriptor SA Insertion Control
+ * @{
+ */
+#define ETH_DMA_TXDESC_SRC_ADDR_BYPASS              (ETH_DMA_TXDESC_SAIRC_BYPASS)           /*!< Source Address Insertion or Replace Control is bypassed */
+#define ETH_DMA_TXDESC_SRC_ADDR_INSERT_MACADDR0     (ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR0)  /*!< Insert address value in MAC address register 0 into transmit frame as source address */
+#define ETH_DMA_TXDESC_SRC_ADDR_REPLACE_MACADDR0    (ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR0) /*!< Replace source address in transmit frame with address value in MAC address register 0 */
+#define ETH_DMA_TXDESC_SRC_ADDR_INSERT_MACADDR1     (ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR1)  /*!< Insert address value in MAC address register 1 into transmit frame as source address */
+#define ETH_DMA_TXDESC_SRC_ADDR_REPLACE_MACADDR1    (ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR1) /*!< Replace source address in transmit frame with address value in MAC address register 1 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PMT_Flag ETH PMT Flag
+ * @{
+ */
+#define ETH_PMT_FLAG_RTWKFR                         (ETH_MAC_PMTCTLR_RTWKFR)  /*!< Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_PMT_FLAG_WKFR                           (ETH_MAC_PMTCTLR_WKFR)    /*!< Wake-Up Frame Received */
+#define ETH_PMT_FLAG_MPFR                           (ETH_MAC_PMTCTLR_MPFR)    /*!< Magic Packet Received */
+#define ETH_PMT_FLAG_ALL                            (ETH_PMT_FLAG_RTWKFR | ETH_PMT_FLAG_WKFR | ETH_PMT_FLAG_MPFR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PMT_Wakeup_Source ETH PMT Wakeup Source
+ * @{
+ */
+#define ETH_PMT_WAKEUP_SRC_GLOBAL_UNICAST           (ETH_MAC_PMTCTLR_GLUB)  /*!< Global unicast */
+#define ETH_PMT_WAKEUP_SRC_WAKEUP_FRAME             (ETH_MAC_PMTCTLR_WKEN)  /*!< Wake-Up Frame */
+#define ETH_PMT_WAKEUP_SRC_MAGIC_PACKET             (ETH_MAC_PMTCTLR_MPEN)  /*!< Magic Packet */
+#define ETH_PMT_WAKEUP_SRC_ALL                      (ETH_PMT_WAKEUP_SRC_GLOBAL_UNICAST | \
+                                                     ETH_PMT_WAKEUP_SRC_WAKEUP_FRAME   | \
+                                                     ETH_PMT_WAKEUP_SRC_MAGIC_PACKET)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Counter_Preset_Mode ETH MMC Counter Preset Mode
+ * @{
+ */
+#define ETH_MMC_CNT_PRESET_MD_DISABLE               (0UL)                                               /*!< Disable preset */
+#define ETH_MMC_CNT_PRESET_MD_HALF_VALUE            (ETH_MMC_MMCCTLR_MCPSET)                            /*!< Half-Value preset: 0x7FF0 */
+#define ETH_MMC_CNT_PRESET_MD_FULL_VALUE            (ETH_MMC_MMCCTLR_MCPSEL | ETH_MMC_MMCCTLR_MCPSET)   /*!< Full-Value preset: 0xFFF0 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Read_Reset ETH MMC Read Reset
+ * @{
+ */
+#define ETH_MMC_RD_RST_DISABLE                      (0UL)
+#define ETH_MMC_RD_RST_ENABLE                       (ETH_MMC_MMCCTLR_ROR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Counter_Reload ETH MMC Counter Reload
+ * @{
+ */
+#define ETH_MMC_CNT_RELOAD_DISABLE                  (ETH_MMC_MMCCTLR_COS)
+#define ETH_MMC_CNT_RELOAD_ENABLE                   (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Tx_Flag ETH MMC Tx Flag
+ * @{
+ */
+#define ETH_MMC_FLAG_TXEDEIS                        (ETH_MMC_TRSSTSR_TXEDEIS)   /*!< When Tx excessive deferral error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXUGIS                         (ETH_MMC_TRSSTSR_TXUGIS)    /*!< When Tx unicast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXCAEIS                        (ETH_MMC_TRSSTSR_TXCAEIS)   /*!< When Tx carrier error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXECEIS                        (ETH_MMC_TRSSTSR_TXECEIS)   /*!< When Tx excessive collision error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXLCEIS                        (ETH_MMC_TRSSTSR_TXLCEIS)   /*!< When Tx deferral collision error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXDEEIS                        (ETH_MMC_TRSSTSR_TXDEEIS)   /*!< When Tx deferral error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXMGIS                         (ETH_MMC_TRSSTSR_TXMGIS)    /*!< When Tx multicast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TXBGIS                         (ETH_MMC_TRSSTSR_TXBGIS)    /*!< When Tx broadcast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_TX_ALL                         (ETH_MMC_FLAG_TXEDEIS | ETH_MMC_FLAG_TXUGIS  | \
+                                                     ETH_MMC_FLAG_TXCAEIS | ETH_MMC_FLAG_TXECEIS | \
+                                                     ETH_MMC_FLAG_TXLCEIS | ETH_MMC_FLAG_TXDEEIS | \
+                                                     ETH_MMC_FLAG_TXMGIS  | ETH_MMC_FLAG_TXBGIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Rx_Flag ETH MMC Rx Flag
+ * @{
+ */
+#define ETH_MMC_FLAG_RXOEIS                         (ETH_MMC_REVSTSR_RXOEIS)   /*!< When Rx out of scope error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXLEIS                         (ETH_MMC_REVSTSR_RXLEIS)   /*!< When Rx length error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXUGIS                         (ETH_MMC_REVSTSR_RXUGIS)   /*!< When Rx unicast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXREIS                         (ETH_MMC_REVSTSR_RXREIS)   /*!< When Rx short error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXAEIS                         (ETH_MMC_REVSTSR_RXAEIS)   /*!< When Rx alignment error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXCEIS                         (ETH_MMC_REVSTSR_RXCEIS)   /*!< When Rx crc error frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXMGIS                         (ETH_MMC_REVSTSR_RXMGIS)   /*!< When Rx multicast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RXBGIS                         (ETH_MMC_REVSTSR_RXBGIS)   /*!< When Rx broadcast good frame counter reaches half or all the maximum value */
+#define ETH_MMC_FLAG_RX_ALL                         (ETH_MMC_FLAG_RXOEIS | ETH_MMC_FLAG_RXLEIS | ETH_MMC_FLAG_RXUGIS | \
+                                                     ETH_MMC_FLAG_RXREIS | ETH_MMC_FLAG_RXAEIS | ETH_MMC_FLAG_RXCEIS | \
+                                                     ETH_MMC_FLAG_RXMGIS | ETH_MMC_FLAG_RXBGIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Tx_Interrupt ETH MMC Tx Interrupt
+ * @{
+ */
+#define ETH_MMC_INT_TXEDEIM                         (ETH_MMC_TITCTLR_TXEDEIM)   /*!< Tx excessive deferral error frame interrupt */
+#define ETH_MMC_INT_TXUGIM                          (ETH_MMC_TITCTLR_TXUGIM)    /*!< Tx unicast good frame interrupt */
+#define ETH_MMC_INT_TXCAEIM                         (ETH_MMC_TITCTLR_TXCAEIM)   /*!< Tx carrier error frame interrupt */
+#define ETH_MMC_INT_TXECEIM                         (ETH_MMC_TITCTLR_TXECEIM)   /*!< Tx excessive collision error frame interrupt */
+#define ETH_MMC_INT_TXLCEIM                         (ETH_MMC_TITCTLR_TXLCEIM)   /*!< Tx deferral collision error frame interrupt */
+#define ETH_MMC_INT_TXDEEIM                         (ETH_MMC_TITCTLR_TXDEEIM)   /*!< Tx deferral error frame interrupt */
+#define ETH_MMC_INT_TXMGIM                          (ETH_MMC_TITCTLR_TXMGIM)    /*!< Tx multicast good frame interrupt */
+#define ETH_MMC_INT_TXBGIM                          (ETH_MMC_TITCTLR_TXBGIM)    /*!< Tx broadcast good frame interrupt */
+#define ETH_MMC_INT_TX_ALL                          (ETH_MMC_INT_TXEDEIM | ETH_MMC_INT_TXUGIM  | ETH_MMC_INT_TXCAEIM | \
+                                                     ETH_MMC_INT_TXECEIM | ETH_MMC_INT_TXLCEIM | ETH_MMC_INT_TXDEEIM | \
+                                                     ETH_MMC_INT_TXMGIM  | ETH_MMC_INT_TXBGIM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Rx_Interrupt ETH MMC Rx Interrupt
+ * @{
+ */
+#define ETH_MMC_INT_RXOEIM                          (ETH_MMC_RITCTLR_RXOEIM)   /*!< Rx out of scope error frame interrupt */
+#define ETH_MMC_INT_RXLEIM                          (ETH_MMC_RITCTLR_RXLEIM)   /*!< Rx length error frame interrupt */
+#define ETH_MMC_INT_RXUGIM                          (ETH_MMC_RITCTLR_RXUGIM)   /*!< Rx unicast good frame interrupt */
+#define ETH_MMC_INT_RXREIM                          (ETH_MMC_RITCTLR_RXREIM)   /*!< Rx short error frame interrupt */
+#define ETH_MMC_INT_RXAEIM                          (ETH_MMC_RITCTLR_RXAEIM)   /*!< Rx alignment error frame interrupt */
+#define ETH_MMC_INT_RXCEIM                          (ETH_MMC_RITCTLR_RXCEIM)   /*!< Rx crc error frame interrupt */
+#define ETH_MMC_INT_RXMGIM                          (ETH_MMC_RITCTLR_RXMGIM)   /*!< Rx multicast good frame interrupt */
+#define ETH_MMC_INT_RXBGIM                          (ETH_MMC_RITCTLR_RXBGIM)   /*!< Rx broadcast good frame interrupt */
+#define ETH_MMC_INT_RX_ALL                          (ETH_MMC_INT_RXOEIM | ETH_MMC_INT_RXLEIM | ETH_MMC_INT_RXUGIM | \
+                                                     ETH_MMC_INT_RXREIM | ETH_MMC_INT_RXAEIM | ETH_MMC_INT_RXCEIM | \
+                                                     ETH_MMC_INT_RXMGIM | ETH_MMC_INT_RXBGIM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_MMC_Statistical_Register ETH MMC Statistical Register
+ * @{
+ */
+#define ETH_MMC_REG_TXBRGFR                         (0x011CU)   /*!< Tx broadcast good frame Statistical Register */
+#define ETH_MMC_REG_TXMUGFR                         (0x0120U)   /*!< Tx multicast good frame Statistical Register */
+#define ETH_MMC_REG_TXDEEFR                         (0x0154U)   /*!< Tx deferral error frame Statistical Register */
+#define ETH_MMC_REG_TXLCEFR                         (0x0158U)   /*!< Tx deferral collision error frame Statistical Register */
+#define ETH_MMC_REG_TXECEFR                         (0x015CU)   /*!< Tx excessive collision error frame Statistical Register */
+#define ETH_MMC_REG_TXCAEFR                         (0x0160U)   /*!< Tx carrier error frame Statistical Register */
+#define ETH_MMC_REG_TXUNGFR                         (0x0168U)   /*!< Tx unicast good frame Statistical Register */
+#define ETH_MMC_REG_TXEDEFR                         (0x016CU)   /*!< Tx excessive deferral error frame Statistical Register */
+#define ETH_MMC_REG_RXBRGFR                         (0x018CU)   /*!< Rx broadcast good frame Statistical Register */
+#define ETH_MMC_REG_RXMUGFR                         (0x0190U)   /*!< Rx multicast good frame Statistical Register */
+#define ETH_MMC_REG_RXCREFR                         (0x0194U)   /*!< Rx crc error frame Statistical Register */
+#define ETH_MMC_REG_RXALEFR                         (0x0198U)   /*!< Rx alignment error frame Statistical Register */
+#define ETH_MMC_REG_RXRUEFR                         (0x019CU)   /*!< Rx short error frame Statistical Register */
+#define ETH_MMC_REG_RXUNGFR                         (0x01C4U)   /*!< Rx unicast good frame Statistical Register */
+#define ETH_MMC_REG_RXLEEFR                         (0x01C8U)   /*!< Rx length error frame Statistical Register */
+#define ETH_MMC_REG_RXOREFR                         (0x01CCU)   /*!< Rx out of scope error frame Statistical Register */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Frame_Dest_Addr_Filter ETH PTP Frame Destination Address Filter
+ * @{
+ */
+#define ETH_PTP_DEST_ADDR_FILTER_DISABLE            (0x00800000UL)
+#define ETH_PTP_DEST_ADDR_FILTER_ENABLE             (ETH_PTP_TSPCTLR_TSPADF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Snapshot_Datagram_Type ETH PTP Snapshot Datagram Type
+ * @{
+ */
+#define ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY             (0UL)                                       /*!< SYNC Follow_Up Delay_Req Delay_Resp */
+#define ETH_PTP_DATAGRAM_TYPE_SYNC                          (0x01UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< SYNC */
+#define ETH_PTP_DATAGRAM_TYPE_DELAY                         (0x03UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< Delay_Req */
+#define ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY_PDELAY      (0x04UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< SYNC Follow_Up Delay_Req Delay_Resp Pdelay_Req Pdelay_Resp Pdelay_Resp_Follow_Up */
+#define ETH_PTP_DATAGRAM_TYPE_SYNC_PDELAY                   (0x05UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< SYNC Pdelay_Req Pdelay_Resp */
+#define ETH_PTP_DATAGRAM_TYPE_DELAY_PDELAY                  (0x07UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< Delay_Req Pdelay_Req Pdelay_Resp */
+#define ETH_PTP_DATAGRAM_TYPE_SYNC_DELAY                    (0x08UL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< SYNC Delay_Req */
+#define ETH_PTP_DATAGRAM_TYPE_PDELAY                        (0x0CUL << ETH_PTP_TSPCTLR_TSPMTSEL_POS)    /*!< Pdelay_Req Pdelay_Resp */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Snapshot_Frame_Type ETH PTP Snapshot Frame Type
+ * @{
+ */
+#define ETH_PTP_FRAME_TYPE_IPV4_FRAME               (ETH_PTP_TSPCTLR_TSPOVIPV4) /*!< Time stamp snapshot for IPv4 frame */
+#define ETH_PTP_FRAME_TYPE_IPV6_FRAME               (ETH_PTP_TSPCTLR_TSPOVIPV6) /*!< Time stamp snapshot for IPv6 frame */
+#define ETH_PTP_FRAME_TYPE_ETH_FRAME                (ETH_PTP_TSPCTLR_TSPOVETH)  /*!< Time stamp snapshot for PTP over ethernet frame */
+#define ETH_PTP_FRAME_TYPE_RX_FRAME                 (ETH_PTP_TSPCTLR_TSPEALL)   /*!< Time stamp snapshot for all received frame */
+#define ETH_PTP_FRAME_TYPE_ALL                      (ETH_PTP_FRAME_TYPE_IPV4_FRAME | \
+                                                     ETH_PTP_FRAME_TYPE_IPV6_FRAME | \
+                                                     ETH_PTP_FRAME_TYPE_ETH_FRAME  | \
+                                                     ETH_PTP_FRAME_TYPE_RX_FRAME)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Datagram_Version ETH PTP Datagram Version
+ * @{
+ */
+#define ETH_PTP_DATAGRAM_VER_IEEE1588V1             (0UL)
+#define ETH_PTP_DATAGRAM_VER_IEEE1588V2             (ETH_PTP_TSPCTLR_TSPVER)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Subsecond_Scale ETH PTP Subsecond Scale
+ * @{
+ */
+#define ETH_PTP_SUBSEC_SCALE_HEX                    (0UL)                     /*!< The Second register increase 1 when SubSecond count to 0x7FFFFFFFH */
+#define ETH_PTP_SUBSEC_SCALE_DEC                    (ETH_PTP_TSPCTLR_TSPSSR)  /*!< The Second register increase 1 when SubSecond count to 0x3B9AC9FFH */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Calibration_Mode ETH PTP Calibration Mode
+ * @{
+ */
+#define ETH_PTP_CALIB_MD_COARSE                     (0UL)                       /*!< Coarse calibration */
+#define ETH_PTP_CALIB_MD_FINE                       (ETH_PTP_TSPCTLR_TSPUPSEL)  /*!< Fine calibration */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Time_Update_Sign ETH PTP Time Update Sign
+ * @{
+ */
+#define ETH_PTP_TIME_UPDATE_SIGN_MINUS              (0UL)                       /*!< Minus for update register value */
+#define ETH_PTP_TIME_UPDATE_SIGN_PLUS               (ETH_PTP_TMUNSER_TSPUPNS)   /*!< Plus for update register value */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PTP_Flag ETH PTP Flag
+ * @{
+ */
+#define ETH_PTP_FLAG_TSERR1                         (ETH_PTP_TSPSTSR_TSERR1)  /*!< Target time 1 error */
+#define ETH_PTP_FLAG_TSTAR1                         (ETH_PTP_TSPSTSR_TSTAR1)  /*!< Target time 1 reached  */
+#define ETH_PTP_FLAG_TSERR0                         (ETH_PTP_TSPSTSR_TSERR0)  /*!< Target time 0 error */
+#define ETH_PTP_FLAG_TSTAR0                         (ETH_PTP_TSPSTSR_TSTAR0)  /*!< Target time 0 reached */
+#define ETH_PTP_FLAG_TSOVF                          (ETH_PTP_TSPSTSR_TSOVF)   /*!< System time overflow */
+#define ETH_PTP_FLAG_ALL                            (ETH_PTP_FLAG_TSERR1 | ETH_PTP_FLAG_TSTAR1 | ETH_PTP_FLAG_TSERR0 | \
+                                                     ETH_PTP_FLAG_TSTAR0 | ETH_PTP_FLAG_TSOVF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PPS_Channel ETH PPS Channel
+ * @{
+ */
+#define ETH_PPS_CH0                                 (0x00U)
+#define ETH_PPS_CH1                                 (0x01U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PPS_Trigger_Function ETH PPS Trigger Function
+ * @{
+ */
+#define ETH_PPS_TRIG_FUNC_INT_EVT                   (0UL)                       /*!< The Target register is used only for interrupt output event */
+#define ETH_PPS_TRIG_FUNC_INT_PPS_EVT               (ETH_PTP_PPSCTLR_TT0SEL_1)  /*!< The Target register is used for interrupt out event and PPS single output event */
+#define ETH_PPS_TRIG_FUNC_PPS_EVT                   (ETH_PTP_PPSCTLR_TT0SEL)    /*!< The Target register is used for PPS single output event */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PPS_Output_Mode ETH PPS Output Mode
+ * @note PPS1(ETH_PPS_CH1) only supports single output mode(ETH_PPS_OUTPUT_MD_ONCE).
+ * @{
+ */
+#define ETH_PPS_OUTPUT_MD_CONT                      (0UL)                     /*!< Continuous output mode */
+#define ETH_PPS_OUTPUT_MD_ONCE                      (ETH_PTP_PPSCTLR_PPSOMD)  /*!< Once output mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ETH_PPS_Output_Frequency ETH PPS Output Frequency
+ * @note PPS1(ETH_PPS_CH1) only supports generate a pulse(ETH_PPS_OUTPUT_ONE_PULSE).
+ * @{
+ */
+#define ETH_PPS_OUTPUT_PULSE_1HZ                    (0UL)                                   /*!< Output 1HZ pulse signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_2HZ                     (0x01UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 2HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_4HZ                     (0x02UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 4HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_8HZ                     (0x03UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 8HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_16HZ                    (0x04UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 16HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_32HZ                    (0x05UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 32HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_64HZ                    (0x06UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 64HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_128HZ                   (0x07UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 128HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_256HZ                   (0x08UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 256HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_512HZ                   (0x09UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 512HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_1024HZ                  (0x0AUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 1024HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_2048HZ                  (0x0BUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 2048HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_4096HZ                  (0x0CUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 4096HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_8192HZ                  (0x0DUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 8192HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_16384HZ                 (0x0EUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 16384HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_FREQ_32768HZ                 (0x0FUL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< Output 32768HZ square signal in continuous output mode */
+#define ETH_PPS_OUTPUT_ONE_PULSE                    (0x01UL << ETH_PTP_PPSCTLR_PPSFRE0_POS) /*!< One pulse is generated in single output mode */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup ETH_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Generate MAC pause control frame.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void ETH_MAC_GeneratePauseCtrlFrame(void)
+{
+    WRITE_REG32(bCM_ETH->MAC_FLOCTLR_b.FCA_BPA, ENABLE);
+}
+
+/**
+ * @brief  Get MAC flow control status.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+__STATIC_INLINE en_flag_status_t ETH_MAC_GetFlowControlStatus(void)
+{
+    return ((en_flag_status_t)READ_REG32(bCM_ETH->MAC_FLOCTLR_b.FCA_BPA));
+}
+
+/**
+ * @brief  Resume the DMA Transmit.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void ETH_DMA_ResumeTrans(void)
+{
+    WRITE_REG32(CM_ETH->DMA_TXPOLLR, 0U);
+}
+
+/**
+ * @brief  Resume the DMA Receive.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void ETH_DMA_ResumeReceive(void)
+{
+    WRITE_REG32(CM_ETH->DMA_RXPOLLR, 0U);
+}
+
+/**
+ * @brief  Get DMA error status.
+ * @param  None
+ * @retval uint32_t                     The new DMA error status
+ *         The error status may be one of the following values:
+ *           - ETH_DMA_ERR_STATE_RX_WR_DATA:    TxDMA generates error while reading descriptor
+ *           - ETH_DMA_ERR_STATE_TX_RD_DATA:    TxDMA generates error while reading descriptor
+ *           - ETH_DMA_ERR_STATE_RX_WR_DESC:    TxDMA generates error while reading descriptor
+ *           - ETH_DMA_ERR_STATE_TX_WR_DESC:    TxDMA generates error while reading descriptor
+ *           - ETH_DMA_ERR_STATE_RX_RD_DESC:    TxDMA generates error while reading descriptor
+ *           - ETH_DMA_ERR_STATE_TX_RD_DESC:    TxDMA generates error while reading descriptor
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetErrorStatus(void)
+{
+    return (READ_REG32_BIT(CM_ETH->DMA_DMASTSR, ETH_DMA_DMASTSR_EBUS));
+}
+
+/**
+ * @brief  Get DMA transmit status.
+ * @param  None
+ * @retval uint32_t                     The new DMA transmit status
+ *           The transmit status may be one of the following values:
+ *           - ETH_DMA_TRANS_STATE_STOPPED:     Stopped - Reset or Stop Tx Command issued
+ *           - ETH_DMA_TRANS_STATE_FETCHING:    Running - Fetching the Tx descriptor
+ *           - ETH_DMA_TRANS_STATE_WAITING:     Running - Waiting for status
+ *           - ETH_DMA_TRANS_STATE_READING:     Running - Reading the data from host memory
+ *           - ETH_DMA_TRANS_STATE_WRITING:     Running - Writing the time stamp
+ *           - ETH_DMA_TRANS_STATE_SUSPENDED:   Suspended - Tx Descriptor unavailable
+ *           - ETH_DMA_TRANS_STATE_CLOSING:     Running - Closing Rx descriptor
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetTransStatus(void)
+{
+    return (READ_REG32_BIT(CM_ETH->DMA_DMASTSR, ETH_DMA_DMASTSR_TSTS));
+}
+
+/**
+ * @brief  Get DMA receive status.
+ * @param  None
+ * @retval uint32_t                     The new DMA receive status
+ *           The receive status may be one of the following values:
+ *           - ETH_DMA_RX_STATE_STOPPED:    Stopped - Reset or Stop Rx Command issued
+ *           - ETH_DMA_RX_STATE_FETCHING:   Running - Fetching the Rx descriptor
+ *           - ETH_DMA_RX_STATE_WAITING:    Running - Waiting for packet
+ *           - ETH_DMA_RX_STATE_SUSPENDED:  Suspended - Rx Descriptor unavailable
+ *           - ETH_DMA_RX_STATE_CLOSING:    Running - Closing descriptor
+ *           - ETH_DMA_RX_STATE_WRITING:    Running - Writing the time stamp
+ *           - ETH_DMA_RX_STATE_QUEUING:    Running - Queuing the receive frame into host memory
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetReceiveStatus(void)
+{
+    return (READ_REG32_BIT(CM_ETH->DMA_DMASTSR, ETH_DMA_DMASTSR_RSTS));
+}
+
+/**
+ * @brief  Get DMA Rx Overflow Missed Frame Counter value.
+ * @param  None
+ * @retval uint32_t                     Rx Overflow Missed Frame Counter value
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetOvfMissFrameCount(void)
+{
+    return ((READ_REG32_BIT(CM_ETH->DMA_RFRCNTR, ETH_DMA_RFRCNTR_OVFCNT)) >> ETH_DMA_RFRCNTR_OVFCNT_POS);
+}
+
+/**
+ * @brief  Get DMA Buffer Unavailable Missed Frame Counter value.
+ * @param  None
+ * @retval uint32_t                     Buffer Unavailable Missed Frame Counter value
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetBufUnavailableMissFrameCount(void)
+{
+    return (READ_REG32_BIT(CM_ETH->DMA_RFRCNTR, ETH_DMA_RFRCNTR_UNACNT));
+}
+
+/**
+ * @brief  Get DMA current Tx descriptor start address.
+ * @param  None
+ * @retval uint32_t                     Transmit descriptor start address
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetCurrentTxDescAddr(void)
+{
+    return (READ_REG32(CM_ETH->DMA_CHTXDER));
+}
+
+/**
+ * @brief  Get DMA current Rx descriptor start address.
+ * @param  None
+ * @retval uint32_t                     Receive descriptor start address
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetCurrentRxDescAddr(void)
+{
+    return (READ_REG32(CM_ETH->DMA_CHRXDER));
+}
+
+/**
+ * @brief  Get DMA current Tx buffer address.
+ * @param  None
+ * @retval uint32_t                     Transmit buffer address
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetCurrentTxBufAddr(void)
+{
+    return (READ_REG32(CM_ETH->DMA_CHTXBFR));
+}
+
+/**
+ * @brief  Get DMA current Rx buffer address.
+ * @param  None
+ * @retval uint32_t                     Receive buffer address
+ */
+__STATIC_INLINE uint32_t ETH_DMA_GetCurrentRxBufAddr(void)
+{
+    return (READ_REG32(CM_ETH->DMA_CHRXBFR));
+}
+
+/**
+ * @brief  Get PMT wakeup frame filter register pointer index.
+ * @param  None
+ * @retval uint8_t                      Filter register pointer index.
+ */
+__STATIC_INLINE uint8_t ETH_PMT_GetWakeupFramePointerIndex(void)
+{
+    return ((uint8_t)(READ_REG32_BIT(CM_ETH->MAC_PMTCTLR, ETH_MAC_PMTCTLR_RTWKPT) >> ETH_MAC_PMTCTLR_RTWKPT_POS));
+}
+
+/**
+ * @brief  Get PTP snapshot frame type.
+ * @param  None
+ * @retval uint32_t                     Receive frame type
+ */
+__STATIC_INLINE uint32_t ETH_PTP_GetSnapFrameType(void)
+{
+    return (READ_REG32_BIT(CM_ETH->PTP_TSPCTLR, ETH_PTP_FRAME_TYPE_ALL));
+}
+
+int32_t ETH_DeInit(void);
+int32_t ETH_Init(stc_eth_handle_t *pstcEthHandle, stc_eth_init_t *pstcEthInit);
+int32_t ETH_CommStructInit(stc_eth_comm_init_t *pstcCommInit);
+int32_t ETH_StructInit(stc_eth_init_t *pstcEthInit);
+int32_t ETH_Start(void);
+int32_t ETH_Stop(void);
+
+/* PHY Functions */
+int32_t ETH_PHY_WriteReg(uint16_t u16PhyAddr, uint16_t u16Reg, uint16_t u16Value);
+int32_t ETH_PHY_ReadReg(uint16_t u16PhyAddr, uint16_t u16Reg, uint16_t *pu16Value);
+
+/* MAC Functions */
+void ETH_MAC_DeInit(void);
+int32_t ETH_MAC_Init(stc_eth_handle_t *pstcEthHandle, const stc_eth_mac_init_t *pstcMacInit);
+int32_t ETH_MAC_StructInit(stc_eth_mac_init_t *pstcMacInit);
+void ETH_MAC_SetMdcClock(void);
+void ETH_MAC_SetInterface(uint32_t u32Interface);
+void ETH_MAC_SetDuplexSpeed(uint32_t u32Mode, uint32_t u32Speed);
+void ETH_MAC_SetHashTable(uint32_t u32HashHigh, uint32_t u32HashLow);
+void ETH_MAC_SetTxVlanTagValue(uint16_t u16TxTag);
+void ETH_MAC_SetRxVlanTagValue(uint16_t u16RxTag);
+void ETH_MAC_SetRxVlanHashTable(uint16_t u16HashValue);
+void ETH_MAC_LoopBackCmd(en_functional_state_t enNewState);
+void ETH_MAC_GeneratePauseCtrlFrame(void);
+void ETH_MAC_BackPressureCmd(en_functional_state_t enNewState);
+void ETH_MAC_TransCmd(en_functional_state_t enNewState);
+void ETH_MAC_ReceiveCmd(en_functional_state_t enNewState);
+void ETH_MAC_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t ETH_MAC_GetIntStatus(uint32_t u32Flag);
+en_flag_status_t ETH_MAC_GetFlowControlStatus(void);
+
+/* MAC Address Functions */
+void ETH_MACADDR_DeInit(uint32_t u32Index);
+int32_t ETH_MACADDR_Init(uint32_t u32Index, const stc_eth_mac_addr_config_t *pstcMacAddrInit);
+int32_t ETH_MACADDR_StructInit(stc_eth_mac_addr_config_t *pstcMacAddrInit);
+int32_t ETH_MACADDR_SetAddr(uint32_t u32Index, uint8_t au8Addr[]);
+int32_t ETH_MACADDR_GetAddr(uint32_t u32Index, uint8_t au8Addr[]);
+void ETH_MACADDR_SetFilterMode(uint32_t u32Index, uint32_t u32Mode);
+void ETH_MACADDR_SetFilterMask(uint32_t u32Index, uint32_t u32Mask);
+
+/* MAC L3L4 Filter Functions */
+void ETH_MAC_L3L4FilterDeInit(void);
+int32_t ETH_MAC_L3L4FilterInit(const stc_eth_l3l4_filter_config_t *pstcL3L4FilterInit);
+int32_t ETH_MAC_L3L4FilterStructInit(stc_eth_l3l4_filter_config_t *pstcL3L4FilterInit);
+void ETH_MAC_L3L4FilterCmd(en_functional_state_t enNewState);
+void ETH_MAC_SetPortFilterProtocol(uint32_t u32Protocol);
+void ETH_MAC_SetDestPortFilterValue(uint16_t u16Port);
+void ETH_MAC_SetSrcPortFilterValue(uint16_t u16Port);
+void ETH_MAC_SetAddrFilterProtocol(uint32_t u32Protocol);
+void ETH_MAC_SetIpv4DestAddrFilterValue(uint32_t u32Addr);
+void ETH_MAC_SetIpv4SrcAddrFilterValue(uint32_t u32Addr);
+int32_t ETH_MAC_SetIpv6AddrFilterValue(const uint32_t au32Addr[]);
+
+/* DMA Functions */
+void ETH_DMA_DeInit(void);
+int32_t ETH_DMA_Init(const stc_eth_dma_init_t *pstcDmaInit);
+int32_t ETH_DMA_StructInit(stc_eth_dma_init_t *pstcDmaInit);
+int32_t ETH_DMA_SoftwareReset(void);
+void ETH_DMA_ResumeTrans(void);
+void ETH_DMA_ResumeReceive(void);
+void ETH_DMA_SetTransPriorityRatio(uint32_t u32Ratio);
+void ETH_DMA_SetRxWatchdogCounter(uint8_t u8Value);
+int32_t ETH_DMA_FlushTransFIFO(void);
+void ETH_DMA_TransCmd(en_functional_state_t enNewState);
+void ETH_DMA_ReceiveCmd(en_functional_state_t enNewState);
+void ETH_DMA_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t ETH_DMA_GetStatus(uint32_t u32Flag);
+void ETH_DMA_ClearStatus(uint32_t u32Flag);
+uint32_t ETH_DMA_GetErrorStatus(void);
+uint32_t ETH_DMA_GetTransStatus(void);
+uint32_t ETH_DMA_GetReceiveStatus(void);
+en_flag_status_t ETH_DMA_GetOvfStatus(uint32_t u32Flag);
+uint32_t ETH_DMA_GetOvfMissFrameCount(void);
+uint32_t ETH_DMA_GetBufUnavailableMissFrameCount(void);
+uint32_t ETH_DMA_GetCurrentTxDescAddr(void);
+uint32_t ETH_DMA_GetCurrentRxDescAddr(void);
+uint32_t ETH_DMA_GetCurrentTxBufAddr(void);
+uint32_t ETH_DMA_GetCurrentRxBufAddr(void);
+
+/* DMA descriptor Functions */
+int32_t ETH_DMA_TxDescListInit(stc_eth_handle_t *pstcEthHandle, stc_eth_dma_desc_t astcTxDescTab[],
+                               const uint8_t au8TxBuf[], uint32_t u32TxBufCnt);
+int32_t ETH_DMA_RxDescListInit(stc_eth_handle_t *pstcEthHandle, stc_eth_dma_desc_t astcRxDescTab[],
+                               const uint8_t au8RxBuf[], uint32_t u32RxBufCnt);
+int32_t ETH_DMA_SetTransFrame(stc_eth_handle_t *pstcEthHandle, uint32_t u32FrameLen);
+int32_t ETH_DMA_GetReceiveFrame(stc_eth_handle_t *pstcEthHandle);
+int32_t ETH_DMA_GetReceiveFrame_Int(stc_eth_handle_t *pstcEthHandle);
+int32_t ETH_DMA_SetTxDescOwn(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Owner);
+int32_t ETH_DMA_SetTxDescBufSize(stc_eth_dma_desc_t *pstcTxDesc, uint8_t u8BufNum, uint32_t u32BufSize);
+int32_t ETH_DMA_TxDescChecksumInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32ChecksumMode);
+int32_t ETH_DMA_TxDescVlanInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32VlanMode);
+int32_t ETH_DMA_TxDescSrcAddrInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Mode);
+int32_t ETH_DMA_TxDescCrcCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState);
+int32_t ETH_DMA_TxDescPadCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState);
+int32_t ETH_DMA_TxDescTimestamp(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState);
+int32_t ETH_DMA_TxDescReplaceCrcCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState);
+int32_t ETH_DMA_TxDescIntCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState);
+en_flag_status_t ETH_DMA_GetTxDescStatus(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Flag);
+int32_t ETH_DMA_GetTxDescCollisionCount(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t *pu32Count);
+int32_t ETH_DMA_GetTxDescTimeStamp(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t *pu32High, uint32_t *pu32Low);
+int32_t ETH_DMA_SetRxDescOwn(stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Owner);
+int32_t ETH_DMA_RxDescIntCmd(stc_eth_dma_desc_t *pstcRxDesc, en_functional_state_t enNewState);
+en_flag_status_t ETH_DMA_GetRxDescStatus(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Flag);
+en_flag_status_t ETH_DMA_GetRxDescExtendStatus(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Flag);
+int32_t ETH_DMA_GetRxDescPayloadType(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32PayloadType);
+int32_t ETH_DMA_GetRxDescDatagramType(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32DatagramType);
+int32_t ETH_DMA_GetRxDescFrameLen(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32FrameLen);
+int32_t ETH_DMA_GetRxDescBufSize(const stc_eth_dma_desc_t *pstcRxDesc, uint8_t u8BufNum, uint32_t *pu32BufSize);
+int32_t ETH_DMA_GetRxDescTimeStamp(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32High, uint32_t *pu32Low);
+
+/* MAC PMT Functions */
+int32_t ETH_PMT_ResetWakeupFramePointer(void);
+int32_t ETH_PMT_WriteWakeupFrameReg(const uint32_t au32RegBuf[]);
+void ETH_PMT_ForwardWakeupFrameCmd(en_functional_state_t enNewState);
+void ETH_PMT_WakeupSrcCmd(uint32_t u32WakeupSrc, en_functional_state_t enNewState);
+int32_t ETH_PMT_EnterPowerDown(void);
+en_flag_status_t ETH_PMT_GetStatus(uint32_t u32Flag);
+uint8_t ETH_PMT_GetWakeupFramePointerIndex(void);
+
+/* MMC Functions */
+int32_t ETH_MMC_DeInit(void);
+int32_t ETH_MMC_Init(const stc_eth_mmc_init_t *pstcMmcInit);
+int32_t ETH_MMC_StructInit(stc_eth_mmc_init_t *pstcMmcInit);
+int32_t ETH_MMC_CounterReset(void);
+void ETH_MMC_ResetAfterReadCmd(en_functional_state_t enNewState);
+void ETH_MMC_Cmd(en_functional_state_t enNewState);
+void ETH_MMC_TxIntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+void ETH_MMC_RxIntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t ETH_MMC_GetTxStatus(uint32_t u32Flag);
+en_flag_status_t ETH_MMC_GetRxStatus(uint32_t u32Flag);
+uint32_t ETH_MMC_GetReg(uint32_t u32Reg);
+
+/* PTP Functions */
+void ETH_PTP_DeInit(void);
+int32_t ETH_PTP_Init(const stc_eth_ptp_init_t *pstcPtpInit);
+int32_t ETH_PTP_StructInit(stc_eth_ptp_init_t *pstcPtpInit);
+void ETH_PTP_SetSnapDatagramType(uint32_t u32DatagramType);
+void ETH_PTP_SetSnapFrameType(uint32_t u32FrameType);
+uint32_t ETH_PTP_GetSnapFrameType(void);
+void ETH_PTP_SetCalibMode(uint32_t u32CalibMode);
+int32_t ETH_PTP_UpdateBasicAddend(void);
+int32_t ETH_PTP_UpdateSysTime(void);
+int32_t ETH_PTP_SysTimeInit(void);
+int32_t ETH_PTP_GetSysTime(uint32_t *pu32Sec, uint32_t *pu32Subsec);
+void ETH_PTP_SetBasicAddend(uint32_t u32BasicAddend, uint8_t u8SubsecAddend);
+int32_t ETH_PTP_GetBasicAddend(uint32_t *pu32BasicAddend, uint8_t *pu8SubsecAddend);
+void ETH_PTP_SetUpdateTime(uint32_t u32Sign, uint32_t u32Sec, uint32_t u32Subsec);
+void ETH_PTP_Cmd(en_functional_state_t enNewState);
+void ETH_PTP_IntCmd(en_functional_state_t enNewState);
+en_flag_status_t ETH_PTP_GetStatus(uint32_t u32Flag);
+
+/* PTP PPS Functions */
+void ETH_PPS_DeInit(uint8_t u8Ch);
+int32_t ETH_PPS_Init(uint8_t u8Ch, const stc_eth_pps_config_t *pstcPpsInit);
+int32_t ETH_PPS_StructInit(stc_eth_pps_config_t *pstcPpsInit);
+void ETH_PPS_SetTargetTime(uint8_t u8Ch, uint32_t u32Sec, uint32_t u32Subsec);
+void ETH_PPS_SetTriggerFunc(uint8_t u8Ch, uint32_t u32Func);
+void ETH_PPS_SetPpsOutputFreq(uint8_t u8Ch, uint32_t u32Freq);
+void ETH_PPS_SetPps0OutputMode(uint32_t u32Mode);
+
+/**
+ * @}
+ */
+
+#endif /* LL_ETH_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_ETH_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_event_port.h
+++ b/hc32f4a2/inc/hc32_ll_event_port.h
@@ -1,0 +1,231 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_event_port.h
+ * @brief This file contains all the functions prototypes of the Event Port
+ *        driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_EVENT_PORT_H__
+#define __HC32_LL_EVENT_PORT_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EVENT_PORT
+ * @{
+ */
+
+#if (LL_EVENT_PORT_ENABLE == DDL_ON)
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EP_Global_Types Event Port Global Types
+ * @{
+ */
+
+/**
+ * @brief  Event Pin Set and Reset enumeration
+ */
+typedef enum {
+    EVT_PIN_RESET = 0U,         /*!< Pin reset    */
+    EVT_PIN_SET   = 1U          /*!< Pin set      */
+} en_ep_state_t;
+
+typedef struct {
+    uint32_t u32PinDir;         /*!< Input/Output setting, @ref EP_PinDirection_Sel for details */
+    en_ep_state_t enPinState;   /*!< Corresponding pin initial state, @ref en_ep_state_t for details */
+    uint32_t u32PinTriggerOps;  /*!< Corresponding pin state after triggered, @ref EP_TriggerOps_Sel for details */
+    uint32_t u32Edge;           /*!< Event port trigger edge, @ref EP_Trigger_Sel for details */
+    uint32_t u32Filter;         /*!< Filter clock function setting, @ref EP_FilterClock_Sel for details */
+    uint32_t u32FilterClock;    /*!< Filter clock, ref@ EP_FilterClock_Div for details */
+} stc_ep_init_t;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EP_Global_Macros Event Port Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup EP_Port_source EP Port Source
+ * @{
+ */
+#define EVT_PORT_1          (0U)        /*!< Event port 1 */
+#define EVT_PORT_2          (1U)        /*!< Event port 2 */
+#define EVT_PORT_3          (2U)        /*!< Event port 3 */
+#define EVT_PORT_4          (3U)        /*!< Event port 4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_pins_define EP Pin Source
+ * @{
+ */
+#define EVT_PIN_00          (0x0001U)   /*!< Event port Pin 00 */
+#define EVT_PIN_01          (0x0002U)   /*!< Event port Pin 01 */
+#define EVT_PIN_02          (0x0004U)   /*!< Event port Pin 02 */
+#define EVT_PIN_03          (0x0008U)   /*!< Event port Pin 03 */
+#define EVT_PIN_04          (0x0010U)   /*!< Event port Pin 04 */
+#define EVT_PIN_05          (0x0020U)   /*!< Event port Pin 05 */
+#define EVT_PIN_06          (0x0040U)   /*!< Event port Pin 06 */
+#define EVT_PIN_07          (0x0080U)   /*!< Event port Pin 07 */
+#define EVT_PIN_08          (0x0100U)   /*!< Event port Pin 08 */
+#define EVT_PIN_09          (0x0200U)   /*!< Event port Pin 09 */
+#define EVT_PIN_10          (0x0400U)   /*!< Event port Pin 10 */
+#define EVT_PIN_11          (0x0800U)   /*!< Event port Pin 11 */
+#define EVT_PIN_12          (0x1000U)   /*!< Event port Pin 12 */
+#define EVT_PIN_13          (0x2000U)   /*!< Event port Pin 13 */
+#define EVT_PIN_14          (0x4000U)   /*!< Event port Pin 14 */
+#define EVT_PIN_15          (0x8000U)   /*!< Event port Pin 15 */
+#define EVT_PIN_All         (0xFFFFU)   /*!< All event pins are selected */
+#define EVT_PIN_MASK        (0xFFFFU)   /*!< Event pin mask for assert test */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_PinDirection_Sel EP Pin Input/Output Direction Selection
+ * @{
+ */
+#define EP_DIR_IN           (0UL)       /*!< EP input */
+#define EP_DIR_OUT          (1UL)       /*!< EP output */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_FilterClock_Sel Event Port Filter Function Selection
+ * @{
+ */
+#define EP_FILTER_OFF       (0UL)       /*!< EP filter function OFF */
+
+#define EP_FILTER_ON        (1UL)       /*!< EP filter function ON */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_FilterClock_Div Event Port Filter Sampling Clock Division Selection
+ * @{
+ */
+#define EP_FCLK_DIV1        (0UL)                               /*!< PCLK as EP filter clock source */
+#define EP_FCLK_DIV8        (1UL << AOS_PEVNTNFCR_DIVS1_POS)    /*!< PCLK div8 as EP filter clock source */
+#define EP_FCLK_DIV32       (2UL << AOS_PEVNTNFCR_DIVS1_POS)    /*!< PCLK div32 as EP filter clock source */
+#define EP_FCLK_DIV64       (3UL << AOS_PEVNTNFCR_DIVS1_POS)    /*!< PCLK div64 as EP filter clock source */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_Trigger_Sel Event Port Trigger Edge Selection
+ * @{
+ */
+#define EP_TRIG_NONE        (0UL)       /*!< No Trigger by edge */
+#define EP_TRIG_FALLING     (1UL)       /*!< Trigger by falling edge */
+#define EP_TRIG_RISING      (2UL)       /*!< Trigger by rising edge */
+#define EP_TRIG_BOTH        (3UL)       /*!< Trigger by falling and rising edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EP_TriggerOps_Sel Event Port Operation
+ * @{
+ */
+#define EP_OPS_NONE         (0UL)       /*!< Pin no action after triggered */
+#define EP_OPS_LOW          (1UL)       /*!< Pin output low after triggered */
+#define EP_OPS_HIGH         (2UL)       /*!< Pin output high after triggered */
+#define EP_OPS_TOGGLE       (3UL)       /*!< Pin toggle after triggered */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EP_Global_Functions
+ * @{
+ */
+void EP_DeInit(void);
+int32_t EP_StructInit(stc_ep_init_t *pstcEventPortInit);
+
+int32_t EP_Init(uint8_t u8EventPort, uint16_t u16EventPin, const stc_ep_init_t *pstcEventPortInit);
+int32_t EP_SetTriggerEdge(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Edge);
+int32_t EP_SetTriggerOps(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Ops);
+en_ep_state_t EP_ReadInputPins(uint8_t u8EventPort, uint16_t u16EventPin);
+uint16_t EP_ReadInputPort(uint8_t u8EventPort);
+en_ep_state_t EP_ReadOutputPins(uint8_t u8EventPort, uint16_t u16EventPin);
+uint16_t EP_ReadOutputPort(uint8_t u8EventPort);
+void EP_SetPins(uint8_t u8EventPort, uint16_t u16EventPin);
+void EP_ResetPins(uint8_t u8EventPort, uint16_t u16EventPin);
+void EP_SetDir(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Dir);
+
+/**
+ * @}
+ */
+
+#endif /* LL_EVENT_PORT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_EVENT_PORT_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_fcg.h
+++ b/hc32f4a2/inc/hc32_ll_fcg.h
@@ -1,0 +1,254 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fcg.h
+ * @brief This file contains all the functions prototypes of the FCG driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_FCG_H__
+#define __HC32_LL_FCG_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_FCG
+ * @{
+ */
+
+#if (LL_FCG_ENABLE == DDL_ON)
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup FCG_Global_Macros FCG Global Macros
+ * @{
+ */
+/**
+ * @defgroup FCG_FCG0_Peripheral FCG FCG0 peripheral
+ * @{
+ */
+#define FCG0_PERIPH_SRAMH               (PWC_FCG0_SRAMH)
+#define FCG0_PERIPH_SRAM1               (PWC_FCG0_SRAM1)
+#define FCG0_PERIPH_SRAM2               (PWC_FCG0_SRAM2)
+#define FCG0_PERIPH_SRAM3               (PWC_FCG0_SRAM3)
+#define FCG0_PERIPH_SRAM4               (PWC_FCG0_SRAM4)
+#define FCG0_PERIPH_SRAMB               (PWC_FCG0_SRAMB)
+#define FCG0_PERIPH_KEY                 (PWC_FCG0_KEY)
+#define FCG0_PERIPH_DMA1                (PWC_FCG0_DMA1)
+#define FCG0_PERIPH_DMA2                (PWC_FCG0_DMA2)
+#define FCG0_PERIPH_FCM                 (PWC_FCG0_FCM)
+#define FCG0_PERIPH_AOS                 (PWC_FCG0_AOS)
+#define FCG0_PERIPH_CTC                 (PWC_FCG0_CTC)
+#define FCG0_PERIPH_MAU                 (PWC_FCG0_MAU)
+#define FCG0_PERIPH_AES                 (PWC_FCG0_AES)
+#define FCG0_PERIPH_HASH                (PWC_FCG0_HASH)
+#define FCG0_PERIPH_TRNG                (PWC_FCG0_TRNG)
+#define FCG0_PERIPH_CRC                 (PWC_FCG0_CRC)
+#define FCG0_PERIPH_DCU1                (PWC_FCG0_DCU1)
+#define FCG0_PERIPH_DCU2                (PWC_FCG0_DCU2)
+#define FCG0_PERIPH_DCU3                (PWC_FCG0_DCU3)
+#define FCG0_PERIPH_DCU4                (PWC_FCG0_DCU4)
+#define FCG0_PERIPH_DCU5                (PWC_FCG0_DCU5)
+#define FCG0_PERIPH_DCU6                (PWC_FCG0_DCU6)
+#define FCG0_PERIPH_DCU7                (PWC_FCG0_DCU7)
+#define FCG0_PERIPH_DCU8                (PWC_FCG0_DCU8)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCG_FCG1_Peripheral FCG FCG1 peripheral
+ * @{
+ */
+#define FCG1_PERIPH_CAN1                (PWC_FCG1_CAN1)
+#define FCG1_PERIPH_CAN2                (PWC_FCG1_CAN2)
+#define FCG1_PERIPH_ETHMAC              (PWC_FCG1_ETHMAC)
+#define FCG1_PERIPH_QSPI                (PWC_FCG1_QSPI)
+#define FCG1_PERIPH_I2C1                (PWC_FCG1_I2C1)
+#define FCG1_PERIPH_I2C2                (PWC_FCG1_I2C2)
+#define FCG1_PERIPH_I2C3                (PWC_FCG1_I2C3)
+#define FCG1_PERIPH_I2C4                (PWC_FCG1_I2C4)
+#define FCG1_PERIPH_I2C5                (PWC_FCG1_I2C5)
+#define FCG1_PERIPH_I2C6                (PWC_FCG1_I2C6)
+#define FCG1_PERIPH_SDIOC1              (PWC_FCG1_SDIOC1)
+#define FCG1_PERIPH_SDIOC2              (PWC_FCG1_SDIOC2)
+#define FCG1_PERIPH_I2S1                (PWC_FCG1_I2S1)
+#define FCG1_PERIPH_I2S2                (PWC_FCG1_I2S2)
+#define FCG1_PERIPH_I2S3                (PWC_FCG1_I2S3)
+#define FCG1_PERIPH_I2S4                (PWC_FCG1_I2S4)
+#define FCG1_PERIPH_SPI1                (PWC_FCG1_SPI1)
+#define FCG1_PERIPH_SPI2                (PWC_FCG1_SPI2)
+#define FCG1_PERIPH_SPI3                (PWC_FCG1_SPI3)
+#define FCG1_PERIPH_SPI4                (PWC_FCG1_SPI4)
+#define FCG1_PERIPH_SPI5                (PWC_FCG1_SPI5)
+#define FCG1_PERIPH_SPI6                (PWC_FCG1_SPI6)
+#define FCG1_PERIPH_USBFS               (PWC_FCG1_USBFS)
+#define FCG1_PERIPH_USBHS               (PWC_FCG1_USBHS)
+#define FCG1_PERIPH_FMAC1               (PWC_FCG1_FMAC1)
+#define FCG1_PERIPH_FMAC2               (PWC_FCG1_FMAC2)
+#define FCG1_PERIPH_FMAC3               (PWC_FCG1_FMAC3)
+#define FCG1_PERIPH_FMAC4               (PWC_FCG1_FMAC4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCG_FCG2_Peripheral FCG FCG2 peripheral
+ * @{
+ */
+#define FCG2_PERIPH_TMR6_1              (PWC_FCG2_TMR6_1)
+#define FCG2_PERIPH_TMR6_2              (PWC_FCG2_TMR6_2)
+#define FCG2_PERIPH_TMR6_3              (PWC_FCG2_TMR6_3)
+#define FCG2_PERIPH_TMR6_4              (PWC_FCG2_TMR6_4)
+#define FCG2_PERIPH_TMR6_5              (PWC_FCG2_TMR6_5)
+#define FCG2_PERIPH_TMR6_6              (PWC_FCG2_TMR6_6)
+#define FCG2_PERIPH_TMR6_7              (PWC_FCG2_TMR6_7)
+#define FCG2_PERIPH_TMR6_8              (PWC_FCG2_TMR6_8)
+#define FCG2_PERIPH_TMR4_1              (PWC_FCG2_TMR4_1)
+#define FCG2_PERIPH_TMR4_2              (PWC_FCG2_TMR4_2)
+#define FCG2_PERIPH_TMR4_3              (PWC_FCG2_TMR4_3)
+#define FCG2_PERIPH_HRPWM               (PWC_FCG2_HRPWM)
+#define FCG2_PERIPH_TMR0_1              (PWC_FCG2_TMR0_1)
+#define FCG2_PERIPH_TMR0_2              (PWC_FCG2_TMR0_2)
+#define FCG2_PERIPH_EMB                 (PWC_FCG2_EMB)
+#define FCG2_PERIPH_TMR2_1              (PWC_FCG2_TMR2_1)
+#define FCG2_PERIPH_TMR2_2              (PWC_FCG2_TMR2_2)
+#define FCG2_PERIPH_TMR2_3              (PWC_FCG2_TMR2_3)
+#define FCG2_PERIPH_TMR2_4              (PWC_FCG2_TMR2_4)
+#define FCG2_PERIPH_TMRA_1              (PWC_FCG2_TMRA_1)
+#define FCG2_PERIPH_TMRA_2              (PWC_FCG2_TMRA_2)
+#define FCG2_PERIPH_TMRA_3              (PWC_FCG2_TMRA_3)
+#define FCG2_PERIPH_TMRA_4              (PWC_FCG2_TMRA_4)
+#define FCG2_PERIPH_TMRA_5              (PWC_FCG2_TMRA_5)
+#define FCG2_PERIPH_TMRA_6              (PWC_FCG2_TMRA_6)
+#define FCG2_PERIPH_TMRA_7              (PWC_FCG2_TMRA_7)
+#define FCG2_PERIPH_TMRA_8              (PWC_FCG2_TMRA_8)
+#define FCG2_PERIPH_TMRA_9              (PWC_FCG2_TMRA_9)
+#define FCG2_PERIPH_TMRA_10             (PWC_FCG2_TMRA_10)
+#define FCG2_PERIPH_TMRA_11             (PWC_FCG2_TMRA_11)
+#define FCG2_PERIPH_TMRA_12             (PWC_FCG2_TMRA_12)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCG_FCG3_Peripheral FCG FCG3 peripheral
+ * @{
+ */
+#define FCG3_PERIPH_ADC1                (PWC_FCG3_ADC1)
+#define FCG3_PERIPH_ADC2                (PWC_FCG3_ADC2)
+#define FCG3_PERIPH_ADC3                (PWC_FCG3_ADC3)
+#define FCG3_PERIPH_CMBIAS              (PWC_FCG3_CMBIAS)
+#define FCG3_PERIPH_DAC1                (PWC_FCG3_DAC1)
+#define FCG3_PERIPH_DAC2                (PWC_FCG3_DAC2)
+#define FCG3_PERIPH_CMP1_2              (PWC_FCG3_CMP12)
+#define FCG3_PERIPH_CMP3_4              (PWC_FCG3_CMP34)
+#define FCG3_PERIPH_OTS                 (PWC_FCG3_OTS)
+#define FCG3_PERIPH_DVP                 (PWC_FCG3_DVP)
+#define FCG3_PERIPH_SMC                 (PWC_FCG3_SMC)
+#define FCG3_PERIPH_DMC                 (PWC_FCG3_DMC)
+#define FCG3_PERIPH_NFC                 (PWC_FCG3_NFC)
+#define FCG3_PERIPH_USART1              (PWC_FCG3_USART1)
+#define FCG3_PERIPH_USART2              (PWC_FCG3_USART2)
+#define FCG3_PERIPH_USART3              (PWC_FCG3_USART3)
+#define FCG3_PERIPH_USART4              (PWC_FCG3_USART4)
+#define FCG3_PERIPH_USART5              (PWC_FCG3_USART5)
+#define FCG3_PERIPH_USART6              (PWC_FCG3_USART6)
+#define FCG3_PERIPH_USART7              (PWC_FCG3_USART7)
+#define FCG3_PERIPH_USART8              (PWC_FCG3_USART8)
+#define FCG3_PERIPH_USART9              (PWC_FCG3_USART9)
+#define FCG3_PERIPH_USART10             (PWC_FCG3_USART10)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCG_FCGx_Peripheral_Mask FCG FCGx Peripheral Mask
+ * @{
+ */
+#define FCG_FCG0_PERIPH_MASK            (0xFFFFE4F1UL)
+#define FCG_FCG1_PERIPH_MASK            (0x0FFFFFFFUL)
+#define FCG_FCG2_PERIPH_MASK            (0xFFFFBFFFUL)
+#define FCG_FCG3_PERIPH_MASK            (0x3FF7933FUL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup FCG_Global_Functions
+ * @{
+ */
+
+void FCG_Fcg0PeriphClockCmd(uint32_t u32Fcg0Periph, en_functional_state_t enNewState);
+
+void FCG_Fcg1PeriphClockCmd(uint32_t u32Fcg1Periph, en_functional_state_t enNewState);
+void FCG_Fcg2PeriphClockCmd(uint32_t u32Fcg2Periph, en_functional_state_t enNewState);
+void FCG_Fcg3PeriphClockCmd(uint32_t u32Fcg3Periph, en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_FCG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_FCG_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_fcm.h
+++ b/hc32f4a2/inc/hc32_ll_fcm.h
@@ -1,0 +1,300 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fcm.h
+ * @brief This file contains all the functions prototypes of the FCM driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify API FCM_DeInit()
+   2024-06-30       CDT             Interface add instance
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_FCM_H__
+#define __HC32_LL_FCM_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_FCM
+ * @{
+ */
+
+#if (LL_FCM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup FCM_Global_Types FCM Global Types
+ * @{
+ */
+/**
+ * @brief  FCM Init structure definition
+ */
+typedef struct {
+    uint16_t u16LowerLimit;         /*!< FCM lower limit value */
+    uint16_t u16UpperLimit;         /*!< FCM upper limit value */
+    uint32_t u32TargetClock;        /*!< FCM target clock source selection, @ref FCM_Target_Clock_Src */
+    uint32_t u32TargetClockDiv;     /*!< FCM target clock source division selection, @ref FCM_Target_Clock_Div */
+    uint32_t u32ExtRefClockEnable;  /*!< FCM external reference clock function config, @ref FCM_Ext_Ref_Clock_Config */
+    uint32_t u32RefClockEdge;       /*!< FCM reference clock trigger edge selection, @ref FCM_Ref_Clock_Edge */
+    uint32_t u32DigitalFilter;      /*!< FCM digital filter function config, @ref FCM_Digital_Filter_Config */
+    uint32_t u32RefClock;           /*!< FCM reference clock source selection, @ref FCM_Ref_Clock_Src */
+    uint32_t u32RefClockDiv;        /*!< FCM reference clock source division selection, @ref FCM_Ref_Clock_Div */
+    uint32_t u32ExceptionType;      /*!< FCM exception type select,  @ref FCM_Exception_Type */
+} stc_fcm_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup FCM_Global_Macros FCM Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup FCM_Target_Clock_Src FCM Target Clock Source
+ * @{
+ */
+#define FCM_TARGET_CLK_XTAL         (0x00UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_XTAL32       (0x01UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_HRC          (0x02UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_LRC          (0x03UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_SWDTLRC      (0x04UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_PCLK1        (0x05UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_PLLAP        (0x06UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_MRC          (0x07UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_PLLHP        (0x08UL << FCM_MCCR_MCKS_POS)
+#define FCM_TARGET_CLK_RTCLRC       (0x09UL << FCM_MCCR_MCKS_POS)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Target_Clock_Div FCM Target Clock Division
+ * @{
+ */
+#define FCM_TARGET_CLK_DIV1         (0x00UL << FCM_MCCR_MDIVS_POS)
+#define FCM_TARGET_CLK_DIV4         (0x01UL << FCM_MCCR_MDIVS_POS)
+#define FCM_TARGET_CLK_DIV8         (0x02UL << FCM_MCCR_MDIVS_POS)
+#define FCM_TARGET_CLK_DIV32        (0x03UL << FCM_MCCR_MDIVS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Ext_Ref_Clock_Config FCM External Reference Clock Config
+ * @{
+ */
+#define FCM_EXT_REF_OFF             (0x00UL)
+#define FCM_EXT_REF_ON              (FCM_RCCR_EXREFE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Ref_Clock_Edge FCM Reference Clock Edge
+ * @{
+ */
+#define FCM_REF_CLK_RISING          (0x00UL)
+#define FCM_REF_CLK_FALLING         (FCM_RCCR_EDGES_0)
+#define FCM_REF_CLK_BOTH            (FCM_RCCR_EDGES_1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Digital_Filter_Config FCM Digital Filter Config
+ * @{
+ */
+#define FCM_DIG_FILTER_OFF          (0x00UL)
+#define FCM_DIG_FILTER_DIV1         (FCM_RCCR_DNFS_0)
+#define FCM_DIG_FILTER_DIV4         (FCM_RCCR_DNFS_1)
+#define FCM_DIG_FILTER_DIV16        (FCM_RCCR_DNFS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Ref_Clock_Src FCM Reference Clock Source
+ * @{
+ */
+#define FCM_REF_CLK_EXTCLK          (0x00UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_XTAL            (0x10UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_XTAL32          (0x11UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_HRC             (0x12UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_LRC             (0x13UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_SWDTLRC         (0x14UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_PCLK1           (0x15UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_PLLAP           (0x16UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_MRC             (0x17UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_PLLHP           (0x18UL << FCM_RCCR_RCKS_POS)
+#define FCM_REF_CLK_RTCLRC          (0x19UL << FCM_RCCR_RCKS_POS)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Ref_Clock_Div FCM Reference Clock Division
+ * @{
+ */
+#define FCM_REF_CLK_DIV32           (0x00UL << FCM_RCCR_RDIVS_POS)
+#define FCM_REF_CLK_DIV128          (0x01UL << FCM_RCCR_RDIVS_POS)
+#define FCM_REF_CLK_DIV1024         (0x02UL << FCM_RCCR_RDIVS_POS)
+#define FCM_REF_CLK_DIV8192         (0x03UL << FCM_RCCR_RDIVS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Abnormal_Reset_Func FCM Abnormal Reset Function Config
+ * @{
+ */
+#define FCM_ERR_RST_OFF             (0x00UL)
+#define FCM_ERR_RST_ON              (FCM_RIER_ERRE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Exception_Type FCM Exception Type
+ * @{
+ */
+#define FCM_EXP_TYPE_INT            (0x00UL)
+#define FCM_EXP_TYPE_RST            (FCM_RIER_ERRINTRS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Int_Type FCM Interrupt Type
+ * @{
+ */
+#define FCM_INT_OVF                 (FCM_RIER_OVFIE)
+#define FCM_INT_END                 (FCM_RIER_MENDIE)
+#define FCM_INT_ERR                 (FCM_RIER_ERRIE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FCM_Flag_Sel FCM Status Flag Selection
+ * @{
+ */
+#define FCM_FLAG_ERR                (FCM_SR_ERRF)
+#define FCM_FLAG_END                (FCM_SR_MENDF)
+#define FCM_FLAG_OVF                (FCM_SR_OVF)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup FCM_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Set FCM upper limit value.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  u16Limit
+ * @retval None.
+ */
+__STATIC_INLINE void FCM_SetUpperLimit(CM_FCM_TypeDef *FCMx, uint16_t u16Limit)
+{
+    WRITE_REG32(FCMx->UVR, u16Limit);
+}
+
+/**
+ * @brief  Set FCM lower limit value.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  u16Limit
+ * @retval None
+ */
+__STATIC_INLINE void FCM_SetLowerLimit(CM_FCM_TypeDef *FCMx, uint16_t u16Limit)
+{
+    WRITE_REG32(FCMx->LVR, u16Limit);
+}
+
+int32_t FCM_Init(CM_FCM_TypeDef *FCMx, const stc_fcm_init_t *pstcFcmInit);
+int32_t FCM_StructInit(stc_fcm_init_t *pstcFcmInit);
+int32_t FCM_DeInit(CM_FCM_TypeDef *FCMx);
+uint16_t FCM_GetCountValue(CM_FCM_TypeDef *FCMx);
+void FCM_SetUpperLimit(CM_FCM_TypeDef *FCMx, uint16_t u16Limit);
+void FCM_SetLowerLimit(CM_FCM_TypeDef *FCMx, uint16_t u16Limit);
+void FCM_SetTargetClock(CM_FCM_TypeDef *FCMx, uint32_t u32ClockSrc, uint32_t u32Div);
+void FCM_SetRefClock(CM_FCM_TypeDef *FCMx, uint32_t u32ClockSrc, uint32_t u32Div);
+en_flag_status_t FCM_GetStatus(CM_FCM_TypeDef *FCMx, uint32_t u32Flag);
+void FCM_ClearStatus(CM_FCM_TypeDef *FCMx, uint32_t u32Flag);
+void FCM_ResetCmd(CM_FCM_TypeDef *FCMx, en_functional_state_t enNewState);
+void FCM_IntCmd(CM_FCM_TypeDef *FCMx, uint32_t u32IntType, en_functional_state_t enNewState);
+void FCM_Cmd(CM_FCM_TypeDef *FCMx, en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_FCM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_FCM_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_fmac.h
+++ b/hc32f4a2/inc/hc32_ll_fmac.h
@@ -1,0 +1,204 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fmac.h
+ * @brief This file contains all the functions prototypes of the FMAC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify API FMAC_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_FMAC_H__
+#define __HC32_LL_FMAC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_FMAC
+ * @{
+ */
+
+#if (LL_FMAC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup FMAC_Global_Types FMAC Global Types
+ * @{
+ */
+
+/**
+ * @brief FMAC configuration structure
+ */
+typedef struct {
+    uint32_t u32Stage;                  /*!< FMAC filter stage number config.
+                                             This parameter can be a value of @ref FMAC_Filter_Stage.*/
+    uint32_t u32Shift;                  /*!< FMAC filter result right shift bits.
+                                             This parameter can be a value of @ref FMAC_Filter_Shift.*/
+    int16_t *pi16Factor;                /*!< FMAC filter factor config. FIR factor array */
+    uint32_t u32IntCmd;                 /*!< Enable or disable FMAC interrupt.
+                                             This parameter can be a value of @ref FMAC_Interrupt_Selection.*/
+} stc_fmac_init_t;
+
+/**
+ * @brief FMAC result definition
+ */
+typedef struct {
+    uint32_t u32ResultHigh;             /*!< The high value of the result.    */
+    uint32_t u32ResultLow;              /*!< The low value of the result.     */
+} stc_fmac_result_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup FMAC_Global_Macros FMAC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup FMAC_Interrupt_Selection FMAC Interrupt Selection
+ * @{
+ */
+#define FMAC_INT_ENABLE                 (FMAC_IER_INTEN)
+#define FMAC_INT_DISABLE                (0x0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FMAC_Filter_Shift FMAC Filter Shift
+ * @{
+ */
+#define FMAC_FIR_SHIFT_0BIT             (0U)
+#define FMAC_FIR_SHIFT_1BIT             (1U)
+#define FMAC_FIR_SHIFT_2BIT             (2U)
+#define FMAC_FIR_SHIFT_3BIT             (3U)
+#define FMAC_FIR_SHIFT_4BIT             (4U)
+#define FMAC_FIR_SHIFT_5BIT             (5U)
+#define FMAC_FIR_SHIFT_6BIT             (6U)
+#define FMAC_FIR_SHIFT_7BIT             (7U)
+#define FMAC_FIR_SHIFT_8BIT             (8U)
+#define FMAC_FIR_SHIFT_9BIT             (9U)
+#define FMAC_FIR_SHIFT_10BIT            (10U)
+#define FMAC_FIR_SHIFT_11BIT            (11U)
+#define FMAC_FIR_SHIFT_12BIT            (12U)
+#define FMAC_FIR_SHIFT_13BIT            (13U)
+#define FMAC_FIR_SHIFT_14BIT            (14U)
+#define FMAC_FIR_SHIFT_15BIT            (15U)
+#define FMAC_FIR_SHIFT_16BIT            (16U)
+#define FMAC_FIR_SHIFT_17BIT            (17U)
+#define FMAC_FIR_SHIFT_18BIT            (18U)
+#define FMAC_FIR_SHIFT_19BIT            (19U)
+#define FMAC_FIR_SHIFT_20BIT            (20U)
+#define FMAC_FIR_SHIFT_21BIT            (21U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup FMAC_Filter_Stage FMAC Filter Stage
+ * @{
+ */
+#define FMAC_FIR_STAGE_0                (0U)
+#define FMAC_FIR_STAGE_1                (1U)
+#define FMAC_FIR_STAGE_2                (2U)
+#define FMAC_FIR_STAGE_3                (3U)
+#define FMAC_FIR_STAGE_4                (4U)
+#define FMAC_FIR_STAGE_5                (5U)
+#define FMAC_FIR_STAGE_6                (6U)
+#define FMAC_FIR_STAGE_7                (7U)
+#define FMAC_FIR_STAGE_8                (8U)
+#define FMAC_FIR_STAGE_9                (9U)
+#define FMAC_FIR_STAGE_10               (10U)
+#define FMAC_FIR_STAGE_11               (11U)
+#define FMAC_FIR_STAGE_12               (12U)
+#define FMAC_FIR_STAGE_13               (13U)
+#define FMAC_FIR_STAGE_14               (14U)
+#define FMAC_FIR_STAGE_15               (15U)
+#define FMAC_FIR_STAGE_16               (16U)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup FMAC_Global_Functions
+ * @{
+ */
+int32_t FMAC_StructInit(stc_fmac_init_t *pstcFmacInit);
+int32_t FMAC_DeInit(CM_FMAC_TypeDef *FMACx);
+int32_t FMAC_Init(CM_FMAC_TypeDef *FMACx, const stc_fmac_init_t *pstcFmacInit);
+void FMAC_Cmd(CM_FMAC_TypeDef *FMACx, en_functional_state_t enNewState);
+void FMAC_SetResultShift(CM_FMAC_TypeDef *FMACx, uint32_t u32ShiftNum);
+void FMAC_SetStageFactor(CM_FMAC_TypeDef *FMACx, uint32_t u32FilterStage, int16_t *pi16Factor);
+void FMAC_IntCmd(CM_FMAC_TypeDef *FMACx, en_functional_state_t enNewState);
+void FMAC_FIRInput(CM_FMAC_TypeDef *FMACx, int16_t i16Factor);
+en_flag_status_t FMAC_GetStatus(const CM_FMAC_TypeDef *FMACx);
+int32_t FMAC_GetResult(const CM_FMAC_TypeDef *FMACx, stc_fmac_result_t *pstcResult);
+/**
+ * @}
+ */
+
+#endif /* LL_FMAC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_FMAC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_gpio.h
+++ b/hc32f4a2/inc/hc32_ll_gpio.h
@@ -1,0 +1,448 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_gpio.h
+ * @brief This file contains all the functions prototypes of the GPIO driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add API GPIO_AnalogCmd() and GPIO_ExIntCmd()
+   2023-06-30       CDT             Rename GPIO_ExIntCmd() as GPIO_ExtIntCmd
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_GPIO_H__
+#define __HC32_LL_GPIO_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_GPIO
+ * @{
+ */
+
+#if (LL_GPIO_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Global_Types GPIO Global Types
+ * @{
+ */
+
+/**
+ * @brief  GPIO Pin Set and Reset enumeration
+ */
+typedef enum {
+    PIN_RESET = 0U,           /*!< Pin reset    */
+    PIN_SET   = 1U            /*!< Pin set      */
+} en_pin_state_t;
+
+/**
+ * @brief  GPIO Init structure definition
+ */
+typedef struct {
+    uint16_t u16PinState;       /*!< Set pin state to High or Low, @ref GPIO_PinState_Sel for details       */
+    uint16_t u16PinDir;         /*!< Pin mode setting, @ref GPIO_PinDirection_Sel for details               */
+    uint16_t u16PinOutputType;  /*!< Output type setting, @ref GPIO_PinOutType_Sel for details              */
+    uint16_t u16PinDrv;         /*!< Pin drive capacity setting, @ref GPIO_PinDrv_Sel for details           */
+    uint16_t u16Latch;          /*!< Pin latch setting, @ref GPIO_PinLatch_Sel for details                  */
+    uint16_t u16PullUp;         /*!< Internal pull-up resistor setting, @ref GPIO_PinPU_Sel for details     */
+    uint16_t u16Invert;         /*!< Pin input/output invert setting, @ref GPIO_PinInvert_Sel for details   */
+    uint16_t u16ExtInt;         /*!< External interrupt pin setting, @ref GPIO_PinExtInt_Sel for details    */
+    uint16_t u16PinInputType;   /*!< Input type setting, @ref GPIO_PinInType_Sel for details                */
+    uint16_t u16PinAttr;        /*!< Digital or analog attribute setting, @ref GPIO_PinMode_Sel for details */
+} stc_gpio_init_t;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Global_Macros GPIO Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup GPIO_Pins_Define GPIO Pin Source
+ * @{
+ */
+#define GPIO_PIN_00                 (0x0001U)  /*!< Pin 00 selected   */
+#define GPIO_PIN_01                 (0x0002U)  /*!< Pin 01 selected   */
+#define GPIO_PIN_02                 (0x0004U)  /*!< Pin 02 selected   */
+#define GPIO_PIN_03                 (0x0008U)  /*!< Pin 03 selected   */
+#define GPIO_PIN_04                 (0x0010U)  /*!< Pin 04 selected   */
+#define GPIO_PIN_05                 (0x0020U)  /*!< Pin 05 selected   */
+#define GPIO_PIN_06                 (0x0040U)  /*!< Pin 06 selected   */
+#define GPIO_PIN_07                 (0x0080U)  /*!< Pin 07 selected   */
+#define GPIO_PIN_08                 (0x0100U)  /*!< Pin 08 selected   */
+#define GPIO_PIN_09                 (0x0200U)  /*!< Pin 09 selected   */
+#define GPIO_PIN_10                 (0x0400U)  /*!< Pin 10 selected   */
+#define GPIO_PIN_11                 (0x0800U)  /*!< Pin 11 selected   */
+#define GPIO_PIN_12                 (0x1000U)  /*!< Pin 12 selected   */
+#define GPIO_PIN_13                 (0x2000U)  /*!< Pin 13 selected   */
+#define GPIO_PIN_14                 (0x4000U)  /*!< Pin 14 selected   */
+#define GPIO_PIN_15                 (0x8000U)  /*!< Pin 15 selected   */
+#define GPIO_PIN_ALL                (0xFFFFU)  /*!< All pins selected */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_All_Pins_Define GPIO All Pin Definition for Each Product
+ * @{
+ */
+#define GPIO_PIN_A_ALL              (0xFFFFU)   /*!< Pin A all*/
+#define GPIO_PIN_B_ALL              (0xFFFFU)   /*!< Pin B all*/
+#define GPIO_PIN_C_ALL              (0xFFFFU)   /*!< Pin C all*/
+#define GPIO_PIN_D_ALL              (0xFFFFU)   /*!< Pin D all*/
+#define GPIO_PIN_E_ALL              (0xFFFFU)   /*!< Pin E all*/
+#define GPIO_PIN_F_ALL              (0xFFFFU)   /*!< Pin F all*/
+#define GPIO_PIN_G_ALL              (0xFFFFU)   /*!< Pin G all*/
+#define GPIO_PIN_H_ALL              (0xFFFFU)   /*!< Pin H all*/
+#define GPIO_PIN_I_ALL              (0x3FFFU)   /*!< Pin I all*/
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_Port_Source GPIO Port Source
+ * @{
+ */
+#define GPIO_PORT_A                 (0x00U)     /*!< Port A selected  */
+#define GPIO_PORT_B                 (0x01U)     /*!< Port B selected  */
+#define GPIO_PORT_C                 (0x02U)     /*!< Port C selected  */
+#define GPIO_PORT_D                 (0x03U)     /*!< Port D selected  */
+#define GPIO_PORT_E                 (0x04U)     /*!< Port E selected  */
+#define GPIO_PORT_F                 (0x05U)     /*!< Port F selected  */
+#define GPIO_PORT_G                 (0x06U)     /*!< Port G selected  */
+#define GPIO_PORT_H                 (0x07U)     /*!< Port H selected  */
+#define GPIO_PORT_I                 (0x08U)     /*!< Port I selected  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_Function_Sel GPIO Function Selection
+ * @{
+ */
+#define GPIO_FUNC_0               (0U)
+#define GPIO_FUNC_1               (1U)
+#define GPIO_FUNC_2               (2U)
+#define GPIO_FUNC_3               (3U)
+#define GPIO_FUNC_4               (4U)
+#define GPIO_FUNC_5               (5U)
+#define GPIO_FUNC_6               (6U)
+#define GPIO_FUNC_7               (7U)
+#define GPIO_FUNC_8               (8U)
+#define GPIO_FUNC_9               (9U)
+#define GPIO_FUNC_10              (10U)
+#define GPIO_FUNC_11              (11U)
+#define GPIO_FUNC_12              (12U)
+#define GPIO_FUNC_13              (13U)
+#define GPIO_FUNC_14              (14U)
+#define GPIO_FUNC_15              (15U)
+#define GPIO_FUNC_16              (16U)
+#define GPIO_FUNC_17              (17U)
+#define GPIO_FUNC_18              (18U)
+#define GPIO_FUNC_19              (19U)
+#define GPIO_FUNC_20              (20U)
+#define GPIO_FUNC_32              (32U)
+#define GPIO_FUNC_33              (33U)
+#define GPIO_FUNC_34              (34U)
+#define GPIO_FUNC_35              (35U)
+#define GPIO_FUNC_36              (36U)
+#define GPIO_FUNC_37              (37U)
+#define GPIO_FUNC_38              (38U)
+#define GPIO_FUNC_39              (39U)
+#define GPIO_FUNC_40              (40U)
+#define GPIO_FUNC_41              (41U)
+#define GPIO_FUNC_42              (42U)
+#define GPIO_FUNC_43              (43U)
+#define GPIO_FUNC_44              (44U)
+#define GPIO_FUNC_45              (45U)
+#define GPIO_FUNC_46              (46U)
+#define GPIO_FUNC_47              (47U)
+#define GPIO_FUNC_48              (48U)
+#define GPIO_FUNC_49              (49U)
+#define GPIO_FUNC_50              (50U)
+#define GPIO_FUNC_51              (51U)
+#define GPIO_FUNC_52              (52U)
+#define GPIO_FUNC_53              (53U)
+#define GPIO_FUNC_54              (54U)
+#define GPIO_FUNC_55              (55U)
+#define GPIO_FUNC_56              (56U)
+#define GPIO_FUNC_57              (57U)
+#define GPIO_FUNC_58              (58U)
+#define GPIO_FUNC_59              (59U)
+#define GPIO_FUNC_60              (60U)
+#define GPIO_FUNC_61              (61U)
+#define GPIO_FUNC_62              (62U)
+#define GPIO_FUNC_63              (63U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_DebugPin_Sel GPIO Debug Pin Selection
+ * @{
+ */
+#define GPIO_PIN_TCK                (0x01U)
+#define GPIO_PIN_TMS                (0x02U)
+#define GPIO_PIN_TDO                (0x04U)
+#define GPIO_PIN_TDI                (0x08U)
+#define GPIO_PIN_TRST               (0x10U)
+#define GPIO_PIN_DEBUG_JTAG         (0x1FU)
+#define GPIO_PIN_SWCLK              (0x01U)
+#define GPIO_PIN_SWDIO              (0x02U)
+#define GPIO_PIN_SWO                (0x04U)
+#define GPIO_PIN_DEBUG_SWD          (0x07U)
+#define GPIO_PIN_DEBUG              (0x1FU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_ReadCycle_Sel GPIO Pin Read Wait Cycle Selection
+ * @{
+ */
+#define GPIO_RD_WAIT0              (0x00U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT1              (0x01U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT2              (0x02U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT3              (0x03U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT4              (0x04U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT5              (0x05U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT6              (0x06U << GPIO_PCCR_RDWT_POS)
+#define GPIO_RD_WAIT7              (0x07U << GPIO_PCCR_RDWT_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinState_Sel GPIO Pin Output State Selection
+ * @{
+ */
+#define PIN_STAT_RST               (0U)
+#define PIN_STAT_SET               (GPIO_PCR_POUT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinDirection_Sel GPIO Pin Input/Output Direction Selection
+ * @{
+ */
+#define PIN_DIR_IN                  (0U)
+#define PIN_DIR_OUT                 (GPIO_PCR_POUTE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinOutType_Sel GPIO Pin Output Type Selection
+ * @{
+ */
+#define PIN_OUT_TYPE_CMOS           (0U)
+#define PIN_OUT_TYPE_NMOS           (GPIO_PCR_NOD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinDrv_Sel GPIO Pin Drive Capacity Selection
+ * @{
+ */
+#define PIN_LOW_DRV                 (0U)
+#define PIN_MID_DRV                 (GPIO_PCR_DRV_0)
+#define PIN_HIGH_DRV                (GPIO_PCR_DRV_1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinLatch_Sel GPIO Pin Output Latch Selection
+ * @{
+ */
+#define PIN_LATCH_OFF               (0U)
+#define PIN_LATCH_ON                (GPIO_PCR_LTE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinPU_Sel GPIO Pin Internal Pull-Up Resistor Selection
+ * @{
+ */
+#define PIN_PU_OFF                  (0U)
+#define PIN_PU_ON                   (GPIO_PCR_PUU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinInvert_Sel GPIO Pin I/O Invert Selection
+ * @{
+ */
+#define PIN_INVT_OFF                (0U)
+#define PIN_INVT_ON                 (GPIO_PCR_INVE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinInType_Sel GPIO Pin Input Type Selection
+ * @{
+ */
+#define PIN_IN_TYPE_SMT             (0U)
+#define PIN_IN_TYPE_CMOS            (GPIO_PCR_CINSEL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinExtInt_Sel GPIO Pin External Interrupt Selection
+ * @{
+ */
+#define PIN_EXTINT_OFF              (0U)
+#define PIN_EXTINT_ON               (GPIO_PCR_INTE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinMode_Sel GPIO Pin Mode Selection
+ * @{
+ */
+#define PIN_ATTR_DIGITAL            (0U)
+#define PIN_ATTR_ANALOG             (GPIO_PCR_DDIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_PinSubFuncSet_Sel GPIO Pin Sub-function Enable or Disable
+ * @{
+ */
+#define PIN_SUBFUNC_DISABLE         (0U)
+#define PIN_SUBFUNC_ENABLE          (GPIO_PFSR_BFE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_Register_Protect_Key GPIO Registers Protect Key
+ * @{
+ */
+#define GPIO_REG_LOCK_KEY            (0xA500U)
+#define GPIO_REG_UNLOCK_KEY          (0xA501U)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup GPIO_Global_Functions
+ * @{
+ */
+/**
+ * @brief  GPIO lock. PSPCR, PCCR, PINAER, PCRxy, PFSRxy write disable
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void GPIO_REG_Lock(void)
+{
+    WRITE_REG16(CM_GPIO->PWPR, GPIO_REG_LOCK_KEY);
+}
+
+/**
+ * @brief  GPIO unlock. PSPCR, PCCR, PINAER, PCRxy, PFSRxy write enable
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void GPIO_REG_Unlock(void)
+{
+    WRITE_REG16(CM_GPIO->PWPR, GPIO_REG_UNLOCK_KEY);
+}
+
+int32_t GPIO_Init(uint8_t u8Port, uint16_t u16Pin, const stc_gpio_init_t *pstcGpioInit);
+void GPIO_DeInit(void);
+int32_t GPIO_StructInit(stc_gpio_init_t *pstcGpioInit);
+void GPIO_SetDebugPort(uint8_t u8DebugPort, en_functional_state_t enNewState);
+void GPIO_SetFunc(uint8_t u8Port, uint16_t u16Pin, uint16_t u16Func);
+void GPIO_SubFuncCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState);
+void GPIO_SetSubFunc(uint8_t u8Func);
+void GPIO_SetReadWaitCycle(uint16_t u16ReadWait);
+void GPIO_InputMOSCmd(uint8_t u8Port, en_functional_state_t enNewState);
+void GPIO_OutputCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState);
+en_pin_state_t GPIO_ReadInputPins(uint8_t u8Port, uint16_t u16Pin);
+uint16_t GPIO_ReadInputPort(uint8_t u8Port);
+en_pin_state_t GPIO_ReadOutputPins(uint8_t u8Port, uint16_t u16Pin);
+uint16_t GPIO_ReadOutputPort(uint8_t u8Port);
+void GPIO_SetPins(uint8_t u8Port, uint16_t u16Pin);
+void GPIO_ResetPins(uint8_t u8Port, uint16_t u16Pin);
+void GPIO_WritePort(uint8_t u8Port, uint16_t u16PortVal);
+void GPIO_TogglePins(uint8_t u8Port, uint16_t u16Pin);
+void GPIO_ExtIntCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState);
+void GPIO_AnalogCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState);
+/**
+ * @}
+ */
+
+#endif /* LL_GPIO_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_GPIO_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_hash.h
+++ b/hc32f4a2/inc/hc32_ll_hash.h
@@ -1,0 +1,216 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_hash.h
+ * @brief This file contains all the functions prototypes of the HASH driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add HASH_DeInit function
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_HASH_H__
+#define __HC32_LL_HASH_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_HASH
+ * @{
+ */
+
+#if (LL_HASH_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup HASH_Global_Macros HASH Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup HASH_Mode HASH Mode
+ * @{
+ */
+#define HASH_MD_SHA256              (0x0UL)                     /*!< SHA256 operating mode */
+#define HASH_MD_HMAC                (HASH_CR_MODE_0)            /*!< HMAC operating mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Key_Size_Mode HASH Key Size Mode
+ * @{
+ */
+#define HASH_KEY_MD_SHORT_SIZE      (0x0UL)                     /*!< Key length <= 64 Bytes */
+#define HASH_KEY_MD_LONG_SIZE       (HASH_CR_LKEY)              /*!< Key length > 64 Bytes */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Interrupt HASH Interrupt
+ * @{
+ */
+#define HASH_INT_GRP                (HASH_CR_HEIE)              /*!< A set of data operations complete interrupt */
+#define HASH_INT_ALL_CPLT           (HASH_CR_HCIE)              /*!< All data operations complete interrupt */
+#define HASH_INT_ALL                (HASH_INT_GRP | HASH_INT_ALL_CPLT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Msg_Group HASH Messages Group
+ * @{
+ */
+#define HASH_MSG_GRP_FIRST          (HASH_CR_FST_GRP)           /*!< The first group of messages or keys */
+#define HASH_MSG_GRP_END            (HASH_CR_KMSG_END)          /*!< The last group of messages or keys */
+#define HASH_MSG_GRP_ONLY_ONE       (HASH_CR_FST_GRP | \
+                                     HASH_CR_KMSG_END)          /*!< Only one set of message or key */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Status_Flag HASH Status Flag
+ * @{
+ */
+#define HASH_FLAG_START             (HASH_CR_START)             /*!< Operation in progress */
+#define HASH_FLAG_BUSY              (HASH_CR_BUSY)              /*!< HASH in operation */
+#define HASH_FLAG_CYC_END           (HASH_CR_CYC_END)           /*!< key or message operation completed */
+#define HASH_FLAG_HMAC_END          (HASH_CR_HMAC_END)          /*!< HMAC operation completed */
+#define HASH_FLAG_ALL               (HASH_FLAG_START | HASH_FLAG_BUSY | \
+                                     HASH_FLAG_CYC_END | HASH_FLAG_HMAC_END)
+#define HASH_FLAG_CLR_ALL           (HASH_FLAG_CYC_END | HASH_FLAG_HMAC_END)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Trigger_Event HASH Trigger Event
+ * @{
+ */
+#define HASH_TRIG_EVT_DMA1_TC0      (EVT_SRC_DMA1_TC0)          /*!< Select the DMA1 ch0 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC1      (EVT_SRC_DMA1_TC1)          /*!< Select the DMA1 ch1 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC2      (EVT_SRC_DMA1_TC2)          /*!< Select the DMA1 ch2 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC3      (EVT_SRC_DMA1_TC3)          /*!< Select the DMA1 ch3 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC4      (EVT_SRC_DMA1_TC4)          /*!< Select the DMA1 ch4 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC5      (EVT_SRC_DMA1_TC5)          /*!< Select the DMA1 ch5 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC6      (EVT_SRC_DMA1_TC6)          /*!< Select the DMA1 ch6 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_TC7      (EVT_SRC_DMA1_TC7)          /*!< Select the DMA1 ch7 transfer complete*/
+#define HASH_TRIG_EVT_DMA1_BTC0     (EVT_SRC_DMA1_BTC0)         /*!< Select the DMA1 ch0 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC1     (EVT_SRC_DMA1_BTC1)         /*!< Select the DMA1 ch1 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC2     (EVT_SRC_DMA1_BTC2)         /*!< Select the DMA1 ch2 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC3     (EVT_SRC_DMA1_BTC3)         /*!< Select the DMA1 ch3 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC4     (EVT_SRC_DMA1_BTC4)         /*!< Select the DMA1 ch4 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC5     (EVT_SRC_DMA1_BTC5)         /*!< Select the DMA1 ch5 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC6     (EVT_SRC_DMA1_BTC6)         /*!< Select the DMA1 ch6 block transfer complete */
+#define HASH_TRIG_EVT_DMA1_BTC7     (EVT_SRC_DMA1_BTC7)         /*!< Select the DMA1 ch7 block transfer complete */
+
+#define HASH_TRIG_EVT_DMA2_TC0      (EVT_SRC_DMA2_TC0)          /*!< Select the DMA2 ch0 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC1      (EVT_SRC_DMA2_TC1)          /*!< Select the DMA2 ch1 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC2      (EVT_SRC_DMA2_TC2)          /*!< Select the DMA2 ch2 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC3      (EVT_SRC_DMA2_TC3)          /*!< Select the DMA2 ch3 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC4      (EVT_SRC_DMA2_TC4)          /*!< Select the DMA2 ch4 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC5      (EVT_SRC_DMA2_TC5)          /*!< Select the DMA2 ch5 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC6      (EVT_SRC_DMA2_TC6)          /*!< Select the DMA2 ch6 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_TC7      (EVT_SRC_DMA2_TC7)          /*!< Select the DMA2 ch7 transfer complete*/
+#define HASH_TRIG_EVT_DMA2_BTC0     (EVT_SRC_DMA2_BTC0)         /*!< Select the DMA2 ch0 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC1     (EVT_SRC_DMA2_BTC1)         /*!< Select the DMA2 ch1 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC2     (EVT_SRC_DMA2_BTC2)         /*!< Select the DMA2 ch2 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC3     (EVT_SRC_DMA2_BTC3)         /*!< Select the DMA2 ch3 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC4     (EVT_SRC_DMA2_BTC4)         /*!< Select the DMA2 ch4 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC5     (EVT_SRC_DMA2_BTC5)         /*!< Select the DMA2 ch5 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC6     (EVT_SRC_DMA2_BTC6)         /*!< Select the DMA2 ch6 block transfer complete */
+#define HASH_TRIG_EVT_DMA2_BTC7     (EVT_SRC_DMA2_BTC7)         /*!< Select the DMA2 ch7 block transfer complete */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup HASH_Global_Functions
+ * @{
+ */
+
+int32_t HASH_DeInit(void);
+int32_t HASH_Calculate(const uint8_t *pu8SrcData, uint32_t u32SrcDataSize, uint8_t *pu8MsgDigest);
+
+int32_t HASH_HMAC_Calculate(const uint8_t *pu8SrcData, uint32_t u32SrcDataSize,
+                            const uint8_t *pu8Key, uint32_t u32KeySize,
+                            uint8_t *pu8MsgDigest);
+
+int32_t HASH_IntCmd(uint32_t u32HashInt, en_functional_state_t enNewState);
+en_flag_status_t HASH_GetStatus(uint32_t u32Flag);
+int32_t HASH_ClearStatus(uint32_t u32Flag);
+
+int32_t HASH_SetMode(uint32_t u32HashMode);
+int32_t HASH_SetKeySizeMode(uint32_t u32SizeMode);
+int32_t HASH_SetMsgGroup(uint32_t u32MsgGroup);
+int32_t HASH_Start(void);
+void HASH_GetMsgDigest(uint8_t *pu8MsgDigest);
+
+/**
+ * @}
+ */
+
+#endif /* LL_HASH_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_HASH_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_hrpwm.h
+++ b/hc32f4a2/inc/hc32_ll_hrpwm.h
@@ -1,0 +1,141 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_hrpwm.h
+ * @brief This file contains all the functions prototypes of the HRPWM driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+   2024-11-08       CDT             Modify macro definition group HRPWM_Global_Macros and unified the abbreviation of Calibrate
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_HRPWM_H__
+#define __HC32_LL_HRPWM_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+#include "hc32_ll_utility.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_HRPWM
+ * @{
+ */
+
+#if (LL_HRPWM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup HRPWM_Global_Macros HRPWM Global Macros
+ * @{
+ */
+
+#define HRPWM_CH_MIN                        (1UL)
+#define HRPWM_CH_MAX                        (16UL)
+
+/**
+ * @defgroup HRPWM_Calib_Unit_Define HRPWM Calibrate Unit Define
+ * @{
+ */
+#define HRPWM_CALIB_UNIT0                   (0x00UL)
+#define HRPWM_CALIB_UNIT1                   (0x01UL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup HRPWM_Global_Functions
+ * @{
+ */
+
+/* HRPWM Judge the condition of calibration function */
+en_functional_state_t HRPWM_CondConfirm(void);
+
+/* Process for getting HRPWM Calibrate function code */
+int32_t HRPWM_CalibProcess(uint32_t u32Unit, uint8_t *pu8Code);
+
+/* HRPWM Calibrate function enable or disable for specified unit */
+void HRPWM_CalibCmd(uint32_t u32Unit, en_functional_state_t enNewState);
+/* HRPWM Calibrate function status get for specified unit */
+en_functional_state_t HRPWM_GetCalibState(uint32_t u32Unit);
+/* HRPWM Calibrate code get for specified unit */
+uint8_t HRPWM_GetCalibCode(uint32_t u32Unit);
+
+/* HRPWM function enable or disable for specified channel */
+void HRPWM_ChCmd(uint32_t u32Ch, en_functional_state_t enNewState);
+/* HRPWM positive edge adjust enable or disable for specified channel */
+void HRPWM_ChPositiveAdjustCmd(uint32_t u32Ch, en_functional_state_t enNewState);
+/* HRPWM negative edge adjust enable or disable for specified channel */
+void HRPWM_ChNegativeAdjustCmd(uint32_t u32Ch, en_functional_state_t enNewState);
+/* HRPWM positive edge adjust delay counts configuration for specified channel */
+void HRPWM_ChPositiveAdjustConfig(uint32_t u32Ch, uint8_t u8DelayNum);
+/* HRPWM negative edge adjust delay counts configuration for specified channel */
+void HRPWM_ChNegativeAdjustConfig(uint32_t u32Ch, uint8_t u8DelayNum);
+
+/**
+ * @}
+ */
+
+#endif /* LL_HRPWM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_HRPWM_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_i2c.h
+++ b/hc32f4a2/inc/hc32_ll_i2c.h
@@ -1,0 +1,361 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_i2c.h
+ * @brief This file contains all the functions prototypes of the Inter-Integrated
+ *        Circuit(I2C) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add API I2C_SlaveAddrCmd()
+   2023-09-30       CDT             Modify typo
+                                    Move macro define I2C_SRC_CLK to head file and add macro I2C_WIDTH_MAX_IMME
+   2023-12-15       CDT             Adjust I2C_FLAG_ALL & I2C_FLAG_CLR_ALL & I2C_INT_ALL
+                                    Add I2C_Flag_Clear def group
+                                    Fix I2C_Deinit
+   2024-11-08       CDT             Rename related to SMBus Alert Response Address
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_I2C_H__
+#define __HC32_LL_I2C_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_I2C
+ * @{
+ */
+
+#if (LL_I2C_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup I2C_Global_Types I2C Global Types
+ * @{
+ */
+
+/**
+ * @brief I2c configuration structure
+ */
+typedef struct {
+    uint32_t u32ClockDiv;           /*!< I2C clock division for i2c source clock */
+    uint32_t u32Baudrate;           /*!< I2C baudrate config */
+    uint32_t u32SclTime;            /*!< The SCL rising and falling time, count of T(i2c source clock after frequency divider) */
+} stc_i2c_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup I2C_Global_Macros I2C Global Macros
+ * @{
+ */
+
+#define I2C_SRC_CLK                   (SystemCoreClock >> ((CM_CMU->SCFGR & CMU_SCFGR_PCLK3S) >> CMU_SCFGR_PCLK3S_POS))
+
+#define I2C_WIDTH_MAX_IMME            (68UL)
+
+/**
+ * @defgroup I2C_Trans_Dir I2C Transfer Direction
+ * @{
+ */
+#define I2C_DIR_TX                    (0x0U)
+#define I2C_DIR_RX                    (0x1U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Addr_Config I2C Address Configure
+ * @{
+ */
+#define I2C_ADDR_DISABLE              (0U)
+#define I2C_ADDR_7BIT                 (I2C_SLR0_SLADDR0EN)
+#define I2C_ADDR_10BIT                (I2C_SLR0_ADDRMOD0 | I2C_SLR0_SLADDR0EN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Clock_Division I2C Clock Division
+ * @{
+ */
+#define I2C_CLK_DIV1                  (0UL)         /*!< I2c source clock/1 */
+#define I2C_CLK_DIV2                  (1UL)         /*!< I2c source clock/2 */
+#define I2C_CLK_DIV4                  (2UL)         /*!< I2c source clock/4 */
+#define I2C_CLK_DIV8                  (3UL)         /*!< I2c source clock/8 */
+#define I2C_CLK_DIV16                 (4UL)         /*!< I2c source clock/16 */
+#define I2C_CLK_DIV32                 (5UL)         /*!< I2c source clock/32 */
+#define I2C_CLK_DIV64                 (6UL)         /*!< I2c source clock/64 */
+#define I2C_CLK_DIV128                (7UL)         /*!< I2c source clock/128 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Address_Num I2C Address Number
+ * @{
+ */
+#define I2C_ADDR0                     (0UL)
+#define I2C_ADDR1                     (1UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Ack_Config I2C ACK Configure
+ * @{
+ */
+#define I2C_ACK                       (0UL)         /*!< Send ACK after date receive */
+#define I2C_NACK                      (I2C_CR1_ACK) /*!< Send NACK after date received */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Smbus_Match_Config I2C SMBUS Address Match Configure
+ * @{
+ */
+#define I2C_SMBUS_MATCH_ALERT         (I2C_CR1_SMBALRTEN)
+#define I2C_SMBUS_MATCH_DEFAULT       (I2C_CR1_SMBDEFAULTEN)
+#define I2C_SMBUS_MATCH_HOST          (I2C_CR1_SMBHOSTEN)
+#define I2C_SMBUS_MATCH_ALL           (I2C_CR1_SMBALRTEN | I2C_CR1_SMBDEFAULTEN | I2C_CR1_SMBHOSTEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Digital_Filter_Clock I2C Digital Filter Clock
+ * @{
+ */
+#define I2C_DIG_FILTER_CLK_DIV1       (0UL << I2C_FLTR_DNF_POS) /*!< I2C Clock/1 */
+#define I2C_DIG_FILTER_CLK_DIV2       (1UL << I2C_FLTR_DNF_POS) /*!< I2C Clock/2 */
+#define I2C_DIG_FILTER_CLK_DIV3       (2UL << I2C_FLTR_DNF_POS) /*!< I2C Clock/3 */
+#define I2C_DIG_FILTER_CLK_DIV4       (3UL << I2C_FLTR_DNF_POS) /*!< I2C Clock/4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Flag I2C Flag
+ * @{
+ */
+#define I2C_FLAG_START                (I2C_SR_STARTF)      /*!< Start condition detected */
+#define I2C_FLAG_MATCH_ADDR0          (I2C_SR_SLADDR0F)    /*!< Address 0 detected */
+#define I2C_FLAG_MATCH_ADDR1          (I2C_SR_SLADDR1F)    /*!< Address 1 detected */
+#define I2C_FLAG_TX_CPLT              (I2C_SR_TENDF)       /*!< Transfer end */
+#define I2C_FLAG_STOP                 (I2C_SR_STOPF)       /*!< Stop condition detected */
+#define I2C_FLAG_RX_FULL              (I2C_SR_RFULLF)      /*!< Receive buffer full */
+#define I2C_FLAG_TX_EMPTY             (I2C_SR_TEMPTYF)     /*!< Transfer buffer empty */
+#define I2C_FLAG_ARBITRATE_FAIL       (I2C_SR_ARLOF)       /*!< Arbitration fails */
+#define I2C_FLAG_ACKR                 (I2C_SR_ACKRF)       /*!< ACK status */
+#define I2C_FLAG_NACKF                (I2C_SR_NACKF)       /*!< NACK detected */
+#define I2C_FLAG_TMOUTF               (I2C_SR_TMOUTF)      /*!<  Time out detected */
+#define I2C_FLAG_MASTER               (I2C_SR_MSL)         /*!< Master mode flag */
+#define I2C_FLAG_BUSY                 (I2C_SR_BUSY)        /*!< Bus busy status */
+#define I2C_FLAG_TRA                  (I2C_SR_TRA)         /*!< Transfer mode flag */
+#define I2C_FLAG_GENERAL_CALL         (I2C_SR_GENCALLF)    /*!< General call detected */
+#define I2C_FLAG_SMBUS_DEFAULT_MATCH  (I2C_SR_SMBDEFAULTF) /*!< SMBUS device default address detected */
+#define I2C_FLAG_SMBUS_HOST_MATCH     (I2C_SR_SMBHOSTF)    /*!< SMBUS host address detected */
+#define I2C_FLAG_SMBUS_ALERT_MATCH    (I2C_SR_SMBALRTF)    /*!< SMBUS alert response address detected */
+
+#define I2C_FLAG_ALL                  (I2C_FLAG_START          | I2C_FLAG_NACKF               | \
+                                       I2C_FLAG_MATCH_ADDR0    | I2C_FLAG_TMOUTF              | \
+                                       I2C_FLAG_MATCH_ADDR1    | I2C_FLAG_MASTER              | \
+                                       I2C_FLAG_TX_CPLT        | I2C_FLAG_BUSY                | \
+                                       I2C_FLAG_STOP           | I2C_FLAG_TRA                 | \
+                                       I2C_FLAG_RX_FULL        | I2C_FLAG_GENERAL_CALL        | \
+                                       I2C_FLAG_TX_EMPTY       | I2C_FLAG_SMBUS_DEFAULT_MATCH | \
+                                       I2C_FLAG_ARBITRATE_FAIL | I2C_FLAG_SMBUS_HOST_MATCH    | \
+                                       I2C_FLAG_ACKR           | I2C_FLAG_SMBUS_ALERT_MATCH)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Flag_Clear I2C Flag to clear
+ * @{
+ */
+#define I2C_FLAG_CLR_START                  (I2C_CLR_STARTFCLR)      /*!< Start condition detected */
+#define I2C_FLAG_CLR_MATCH_ADDR0            (I2C_CLR_SLADDR0FCLR)    /*!< Address 0 detected */
+#define I2C_FLAG_CLR_MATCH_ADDR1            (I2C_CLR_SLADDR1FCLR)    /*!< Address 1 detected */
+#define I2C_FLAG_CLR_TX_CPLT                (I2C_CLR_TENDFCLR)       /*!< Transfer end */
+#define I2C_FLAG_CLR_STOP                   (I2C_CLR_STOPFCLR)       /*!< Stop condition detected */
+#define I2C_FLAG_CLR_RX_FULL                (I2C_CLR_RFULLFCLR)      /*!< Receive buffer full */
+#define I2C_FLAG_CLR_ARBITRATE_FAIL         (I2C_CLR_ARLOFCLR)       /*!< Arbitration fails */
+#define I2C_FLAG_CLR_NACK                   (I2C_CLR_NACKFCLR)       /*!< NACK detected */
+#define I2C_FLAG_CLR_TMOUTF                 (I2C_CLR_TMOUTFCLR)      /*!< Time out detected */
+#define I2C_FLAG_CLR_GENERAL_CALL           (I2C_CLR_GENCALLFCLR)    /*!< General call detected */
+#define I2C_FLAG_CLR_SMBUS_DEFAULT_MATCH    (I2C_CLR_SMBDEFAULTFCLR) /*!< SMBUS device default address detected */
+#define I2C_FLAG_CLR_SMBUS_HOST_MATCH       (I2C_CLR_SMBHOSTFCLR)    /*!< SMBUS host address detected */
+#define I2C_FLAG_CLR_SMBUS_ALERT_MATCH      (I2C_CLR_SMBALRTFCLR)    /*!< SMBUS alert response address detected */
+
+#define I2C_FLAG_CLR_ALL              (I2C_FLAG_CLR_START       | I2C_FLAG_CLR_ARBITRATE_FAIL      | \
+                                       I2C_FLAG_CLR_MATCH_ADDR0 | I2C_FLAG_CLR_NACK                | \
+                                       I2C_FLAG_CLR_MATCH_ADDR1 | I2C_FLAG_CLR_TMOUTF              | \
+                                       I2C_FLAG_CLR_TX_CPLT     | I2C_FLAG_CLR_GENERAL_CALL        | \
+                                       I2C_FLAG_CLR_STOP        | I2C_FLAG_CLR_SMBUS_DEFAULT_MATCH | \
+                                       I2C_FLAG_CLR_RX_FULL     | I2C_FLAG_CLR_SMBUS_HOST_MATCH    | \
+                                       I2C_FLAG_CLR_SMBUS_ALERT_MATCH)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2C_Int_Flag I2C Interrupt Flag Bits
+ * @{
+ */
+#define I2C_INT_START                 (I2C_CR2_STARTIE)
+#define I2C_INT_MATCH_ADDR0           (I2C_CR2_SLADDR0IE)
+#define I2C_INT_MATCH_ADDR1           (I2C_CR2_SLADDR1IE)
+#define I2C_INT_TX_CPLT               (I2C_CR2_TENDIE)
+#define I2C_INT_STOP                  (I2C_CR2_STOPIE)
+#define I2C_INT_RX_FULL               (I2C_CR2_RFULLIE)
+#define I2C_INT_TX_EMPTY              (I2C_CR2_TEMPTYIE)
+#define I2C_INT_ARBITRATE_FAIL        (I2C_CR2_ARLOIE)
+#define I2C_INT_NACK                  (I2C_CR2_NACKIE)
+#define I2C_INT_TMOUTIE               (I2C_CR2_TMOUTIE)
+#define I2C_INT_GENERAL_CALL          (I2C_CR2_GENCALLIE)
+#define I2C_INT_SMBUS_DEFAULT_MATCH   (I2C_CR2_SMBDEFAULTIE)
+#define I2C_INT_SMBUS_HOST_MATCH      (I2C_CR2_SMBHOSTIE)
+#define I2C_INT_SMBUS_ALERT_MATCH     (I2C_CR2_SMBALRTIE)
+#define I2C_INT_ALL                   (I2C_INT_START       | I2C_INT_ARBITRATE_FAIL      | \
+                                       I2C_INT_MATCH_ADDR0 | I2C_INT_NACK                | \
+                                       I2C_INT_MATCH_ADDR1 | I2C_INT_TMOUTIE             | \
+                                       I2C_INT_TX_CPLT     | I2C_INT_GENERAL_CALL        | \
+                                       I2C_INT_STOP        | I2C_INT_SMBUS_DEFAULT_MATCH | \
+                                       I2C_INT_RX_FULL     | I2C_INT_SMBUS_HOST_MATCH    | \
+                                       I2C_INT_TX_EMPTY    | I2C_INT_SMBUS_ALERT_MATCH)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup I2C_Global_Functions
+ * @{
+ */
+
+/* Initialization and Configuration **********************************/
+int32_t I2C_StructInit(stc_i2c_init_t *pstcI2cInit);
+int32_t I2C_BaudrateConfig(CM_I2C_TypeDef *I2Cx, const stc_i2c_init_t *pstcI2cInit, float32_t *pf32Error);
+int32_t I2C_DeInit(CM_I2C_TypeDef *I2Cx);
+int32_t I2C_Init(CM_I2C_TypeDef *I2Cx, const stc_i2c_init_t *pstcI2cInit, float32_t *pf32Error);
+void I2C_SlaveAddrConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32AddrNum, uint32_t u32AddrMode, uint32_t u32Addr);
+void I2C_SlaveAddrCmd(CM_I2C_TypeDef *I2Cx, uint32_t u32AddrNum, en_functional_state_t enNewState);
+void I2C_Cmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_FastAckCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_BusWaitCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+
+void I2C_SmbusConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32SmbusConfig, en_functional_state_t enNewState);
+void I2C_SmbusCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+
+void I2C_DigitalFilterConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32FilterClock);
+void I2C_DigitalFilterCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+
+void I2C_AnalogFilterCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+
+void I2C_GeneralCallCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_SWResetCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_IntCmd(CM_I2C_TypeDef *I2Cx, uint32_t u32IntType, en_functional_state_t enNewState);
+
+/* Start/Restart/Stop ************************************************/
+void I2C_GenerateStart(CM_I2C_TypeDef *I2Cx);
+void I2C_GenerateRestart(CM_I2C_TypeDef *I2Cx);
+void I2C_GenerateStop(CM_I2C_TypeDef *I2Cx);
+
+/* Status management *************************************************/
+en_flag_status_t I2C_GetStatus(const CM_I2C_TypeDef *I2Cx, uint32_t u32Flag);
+void I2C_ClearStatus(CM_I2C_TypeDef *I2Cx, uint32_t u32Flag);
+
+/* Data transfer *****************************************************/
+void I2C_WriteData(CM_I2C_TypeDef *I2Cx, uint8_t u8Data);
+uint8_t I2C_ReadData(const CM_I2C_TypeDef *I2Cx);
+void I2C_AckConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32AckConfig);
+
+/* Time out function *************************************************/
+void I2C_SCLHighTimeoutConfig(CM_I2C_TypeDef *I2Cx, uint16_t u16TimeoutH);
+void I2C_SCLLowTimeoutConfig(CM_I2C_TypeDef *I2Cx, uint16_t u16TimeoutL);
+void I2C_SCLHighTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_SCLLowTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+void I2C_SCLTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState);
+
+/* High level functions for reference ********************************/
+int32_t I2C_Start(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout);
+int32_t I2C_Restart(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout);
+int32_t I2C_TransAddr(CM_I2C_TypeDef *I2Cx, uint16_t u16Addr, uint8_t u8Dir, uint32_t u32Timeout);
+int32_t I2C_Trans10BitAddr(CM_I2C_TypeDef *I2Cx, uint16_t u16Addr, uint8_t u8Dir, uint32_t u32Timeout);
+int32_t I2C_TransData(CM_I2C_TypeDef *I2Cx, const uint8_t au8TxData[], uint32_t u32Size, uint32_t u32Timeout);
+int32_t I2C_ReceiveData(CM_I2C_TypeDef *I2Cx, uint8_t au8RxData[], uint32_t u32Size, uint32_t u32Timeout);
+int32_t I2C_MasterReceiveDataAndStop(CM_I2C_TypeDef *I2Cx, uint8_t au8RxData[], uint32_t u32Size, uint32_t u32Timeout);
+int32_t I2C_Stop(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout);
+int32_t I2C_WaitStatus(const CM_I2C_TypeDef *I2Cx, uint32_t u32Flag, en_flag_status_t enStatus, uint32_t u32Timeout);
+
+/**
+ * @}
+ */
+
+#endif /* LL_I2C_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_I2C_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_i2s.h
+++ b/hc32f4a2/inc/hc32_ll_i2s.h
@@ -1,0 +1,348 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_i2s.h
+ * @brief This file contains all the functions prototypes of the I2S driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-08-31       CDT             Optimize I2S_DeInit()
+   2024-11-08       CDT             Removed I2S_RST_TYPE_CODEC
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_I2S_H__
+#define __HC32_LL_I2S_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_I2S
+ * @{
+ */
+
+#if (LL_I2S_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup I2S_Global_Types I2S Global Types
+ * @{
+ */
+
+/**
+ * @brief I2S Init structure definition
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Specifies the clock source of I2S.
+                                             This parameter can be a value of @ref I2S_Clock_Source */
+    uint32_t u32Mode;                   /*!< Specifies the master/slave mode of I2S.
+                                             This parameter can be a value of @ref I2S_Mode */
+    uint32_t u32Protocol;               /*!< Specifies the communication protocol of I2S.
+                                             This parameter can be a value of @ref I2S_Protocol */
+    uint32_t u32TransMode;              /*!< Specifies the transmission mode for the I2S communication.
+                                             This parameter can be a value of @ref I2S_Trans_Mode */
+    uint32_t u32AudioFreq;              /*!< Specifies the frequency selected for the I2S communication.
+                                             This parameter can be a value of @ref I2S_Audio_Frequency */
+    uint32_t u32ChWidth;                /*!< Specifies the channel length for the I2S communication.
+                                             This parameter can be a value of @ref I2S_Channel_Length */
+    uint32_t u32DataWidth;              /*!< Specifies the data length for the I2S communication.
+                                             This parameter can be a value of @ref I2S_Data_Length */
+    uint32_t u32MCKOutput;              /*!< Specifies the validity of the MCK output for I2S.
+                                             This parameter can be a value of @ref I2S_MCK_Output */
+    uint32_t u32TransFIFOLevel;         /*!< Specifies the level of transfer FIFO.
+                                             This parameter can be a value of @ref I2S_Trans_Level */
+    uint32_t u32ReceiveFIFOLevel;       /*!< Specifies the level of receive FIFO.
+                                             This parameter can be a value of @ref I2S_Receive_Level */
+} stc_i2s_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup I2S_Global_Macros I2S Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup I2S_External_Clock_Frequency I2S External Clock Frequency
+ * @{
+ */
+#ifndef I2S_EXT_CLK_FREQ
+#define I2S_EXT_CLK_FREQ                        (12288000UL)    /*!< Value of the external oscillator */
+#endif /* I2S_EXT_CLK_FREQ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Clock_Source I2S Clock Source
+ * @{
+ */
+#define I2S_CLK_SRC_PLL                         (I2S_CTRL_I2SPLLSEL)  /*!< Internal PLL Clock */
+#define I2S_CLK_SRC_EXT                         (I2S_CTRL_CLKSEL)     /*!< External Clock     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Mode I2S Mode
+ * @{
+ */
+#define I2S_MD_MASTER                           (0UL)           /*!< Master mode */
+#define I2S_MD_SLAVE                            (I2S_CTRL_WMS)  /*!< Slave mode  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Protocol I2S Communication Protocol
+ * @{
+ */
+#define I2S_PROTOCOL_PHILLIPS                   (0UL)                                 /*!< Phillips protocol        */
+#define I2S_PROTOCOL_MSB                        (I2S_CFGR_I2SSTD_0)                   /*!< MSB justified protocol   */
+#define I2S_PROTOCOL_LSB                        (I2S_CFGR_I2SSTD_1)                   /*!< LSB justified protocol   */
+#define I2S_PROTOCOL_PCM_SHORT                  (I2S_CFGR_I2SSTD)                     /*!< PCM short-frame protocol */
+#define I2S_PROTOCOL_PCM_LONG                   (I2S_CFGR_I2SSTD | I2S_CFGR_PCMSYNC)  /*!< PCM long-frame protocol  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Trans_Mode I2S Transfer Mode
+ * @{
+ */
+#define I2S_TRANS_MD_HALF_DUPLEX_RX             (0UL)                               /*!< Receive only and half duplex mode */
+#define I2S_TRANS_MD_HALF_DUPLEX_TX             (I2S_CTRL_SDOE)                     /*!< Send only and half duplex mode    */
+#define I2S_TRANS_MD_FULL_DUPLEX                (I2S_CTRL_DUPLEX | I2S_CTRL_SDOE)   /*!< Full duplex mode                  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Audio_Frequency I2S Audio Frequency
+ * @{
+ */
+#define I2S_AUDIO_FREQ_192K                     (192000UL)  /*!< FS = 192000Hz */
+#define I2S_AUDIO_FREQ_96K                      (96000UL)   /*!< FS = 96000Hz  */
+#define I2S_AUDIO_FREQ_48K                      (48000UL)   /*!< FS = 48000Hz  */
+#define I2S_AUDIO_FREQ_44K                      (44100UL)   /*!< FS = 44100Hz  */
+#define I2S_AUDIO_FREQ_32K                      (32000UL)   /*!< FS = 32000Hz  */
+#define I2S_AUDIO_FREQ_22K                      (22050UL)   /*!< FS = 22050Hz  */
+#define I2S_AUDIO_FREQ_16K                      (16000UL)   /*!< FS = 16000Hz  */
+#define I2S_AUDIO_FREQ_8K                       (8000UL)    /*!< FS = 8000Hz   */
+#define I2S_AUDIO_FREQ_DEFAULT                  (2UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Channel_Length I2S Channel Length
+ * @{
+ */
+#define I2S_CH_LEN_16BIT                        (0UL)             /*!< Channel length is 16bits */
+#define I2S_CH_LEN_32BIT                        (I2S_CFGR_CHLEN)  /*!< Channel length is 32bits */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Data_Length I2S Data Length
+ * @{
+ */
+#define I2S_DATA_LEN_16BIT                      (0UL)                 /*!< Transfer data length is 16bits */
+#define I2S_DATA_LEN_24BIT                      (I2S_CFGR_DATLEN_0)   /*!< Transfer data length is 24bits */
+#define I2S_DATA_LEN_32BIT                      (I2S_CFGR_DATLEN_1)   /*!< Transfer data length is 32bits */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_MCK_Output I2S MCK Output
+ * @{
+ */
+#define I2S_MCK_OUTPUT_DISABLE                  (0UL)             /*!< Disable the drive clock(MCK) output */
+#define I2S_MCK_OUTPUT_ENABLE                   (I2S_CTRL_MCKOE)  /*!< Enable the drive clock(MCK) output  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Trans_Level I2S Transfer Level
+ * @{
+ */
+#define I2S_TRANS_LVL0                          (0x00UL << I2S_CTRL_TXBIRQWL_POS)   /*!< Transfer FIFO level is 0 */
+#define I2S_TRANS_LVL1                          (0x01UL << I2S_CTRL_TXBIRQWL_POS)   /*!< Transfer FIFO level is 1 */
+#define I2S_TRANS_LVL2                          (0x02UL << I2S_CTRL_TXBIRQWL_POS)   /*!< Transfer FIFO level is 2 */
+
+#define I2S_TRANS_LVL3                          (0x03UL << I2S_CTRL_TXBIRQWL_POS)   /*!< Transfer FIFO level is 3 */
+#define I2S_TRANS_LVL4                          (0x04UL << I2S_CTRL_TXBIRQWL_POS)   /*!< Transfer FIFO level is 4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Receive_Level I2S Receive Level
+ * @{
+ */
+#define I2S_RECEIVE_LVL0                        (0x00UL << I2S_CTRL_RXBIRQWL_POS)   /*!< Receive FIFO level is 0 */
+#define I2S_RECEIVE_LVL1                        (0x01UL << I2S_CTRL_RXBIRQWL_POS)   /*!< Receive FIFO level is 1 */
+#define I2S_RECEIVE_LVL2                        (0x02UL << I2S_CTRL_RXBIRQWL_POS)   /*!< Receive FIFO level is 2 */
+
+#define I2S_RECEIVE_LVL3                        (0x03UL << I2S_CTRL_RXBIRQWL_POS)   /*!< Receive FIFO level is 3 */
+#define I2S_RECEIVE_LVL4                        (0x04UL << I2S_CTRL_RXBIRQWL_POS)   /*!< Receive FIFO level is 4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Com_Func I2S Communication Function
+ * @{
+ */
+#define I2S_FUNC_TX                             (I2S_CTRL_TXE)  /*!< Transfer function */
+#define I2S_FUNC_RX                             (I2S_CTRL_RXE)  /*!< Receive function  */
+#define I2S_FUNC_ALL                            (I2S_FUNC_TX | I2S_FUNC_RX)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Reset_Type I2S Reset Type
+ * @{
+ */
+#define I2S_RST_TYPE_FIFO                       (I2S_CTRL_FIFOR)    /*!< Reset FIFO of I2S  */
+#define I2S_RST_TYPE_SW                         (I2S_CTRL_SRST)     /*!< I2S software reset */
+
+#define I2S_RST_TYPE_ALL                        (I2S_RST_TYPE_FIFO | I2S_RST_TYPE_SW)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Interrupt I2S Interrupt
+ * @{
+ */
+#define I2S_INT_TX                              (I2S_CTRL_TXIE)   /*!< Transfer interrupt            */
+#define I2S_INT_RX                              (I2S_CTRL_RXIE)   /*!< Receive interrupt             */
+#define I2S_INT_ERR                             (I2S_CTRL_EIE)    /*!< Communication error interrupt */
+#define I2S_INT_ALL                             (I2S_INT_TX | I2S_INT_RX | I2S_INT_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup I2S_Flag I2S Flag
+ * @{
+ */
+#define I2S_FLAG_TX_ALARM                       (I2S_SR_TXBA)           /*!< Transfer buffer alarm flag          */
+#define I2S_FLAG_RX_ALARM                       (I2S_SR_RXBA)           /*!< Receive buffer alarm flag           */
+#define I2S_FLAG_TX_EMPTY                       (I2S_SR_TXBE)           /*!< Transfer buffer empty flag          */
+#define I2S_FLAG_TX_FULL                        (I2S_SR_TXBF)           /*!< Transfer buffer full flag           */
+#define I2S_FLAG_RX_EMPTY                       (I2S_SR_RXBE)           /*!< Receive buffer empty flag           */
+#define I2S_FLAG_RX_FULL                        (I2S_SR_RXBF)           /*!< Receive buffer full flag            */
+#define I2S_FLAG_TX_ERR                         (I2S_ER_TXERR << 16U)   /*!< Transfer overflow or underflow flag */
+#define I2S_FLAG_RX_ERR                         (I2S_ER_RXERR << 16U)   /*!< Receive overflow flag               */
+#define I2S_FLAG_ALL                            (I2S_FLAG_TX_ALARM | I2S_FLAG_RX_ALARM | I2S_FLAG_TX_EMPTY | \
+                                                 I2S_FLAG_TX_FULL  | I2S_FLAG_RX_EMPTY | I2S_FLAG_RX_FULL  | \
+                                                 I2S_FLAG_TX_ERR   | I2S_FLAG_RX_ERR)
+#define I2S_FLAG_CLR_ALL                        (I2S_FLAG_TX_ERR   | I2S_FLAG_RX_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup I2S_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration functions */
+int32_t I2S_DeInit(CM_I2S_TypeDef *I2Sx);
+int32_t I2S_Init(CM_I2S_TypeDef *I2Sx, const stc_i2s_init_t *pstcI2sInit);
+int32_t I2S_StructInit(stc_i2s_init_t *pstcI2sInit);
+void I2S_SWReset(CM_I2S_TypeDef *I2Sx, uint32_t u32Type);
+void I2S_SetTransMode(CM_I2S_TypeDef *I2Sx, uint32_t u32Mode);
+void I2S_SetTransFIFOLevel(CM_I2S_TypeDef *I2Sx, uint32_t u32Level);
+void I2S_SetReceiveFIFOLevel(CM_I2S_TypeDef *I2Sx, uint32_t u32Level);
+void I2S_SetProtocol(CM_I2S_TypeDef *I2Sx, uint32_t u32Protocol);
+int32_t I2S_SetAudioFreq(CM_I2S_TypeDef *I2Sx, uint32_t u32Freq);
+void I2S_MCKOutputCmd(CM_I2S_TypeDef *I2Sx, en_functional_state_t enNewState);
+void I2S_FuncCmd(CM_I2S_TypeDef *I2Sx, uint32_t u32Func, en_functional_state_t enNewState);
+
+/* Transfer and receive data functions */
+void I2S_WriteData(CM_I2S_TypeDef *I2Sx, uint32_t u32Data);
+uint32_t I2S_ReadData(const CM_I2S_TypeDef *I2Sx);
+int32_t I2S_Trans(CM_I2S_TypeDef *I2Sx, const void *pvTxBuf, uint32_t u32Len, uint32_t u32Timeout);
+int32_t I2S_Receive(const CM_I2S_TypeDef *I2Sx, void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout);
+int32_t I2S_TransReceive(CM_I2S_TypeDef *I2Sx, const void *pvTxBuf,
+                         void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout);
+
+/* Interrupt and flag management functions */
+void I2S_IntCmd(CM_I2S_TypeDef *I2Sx, uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t I2S_GetStatus(const CM_I2S_TypeDef *I2Sx, uint32_t u32Flag);
+void I2S_ClearStatus(CM_I2S_TypeDef *I2Sx, uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_I2S_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_I2S_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_icg.h
+++ b/hc32f4a2/inc/hc32_ll_icg.h
@@ -1,0 +1,424 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_icg.h
+ * @brief This file contains all the Macro Definitions of the ICG driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Delete ICG2 function
+   2023-12-15       CDT             Modify macro define: ICG_SWDT_LPM_CNT_CONTINUE -> ICG_SWDT_LPM_CNT_CONT
+   2024-06-30       CDT             Delete ICG2 function
+   2024-11-08       CDT             Modify comment of ICG_BOR_Voltage_Threshold
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_ICG_H__
+#define __HC32_LL_ICG_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_ICG
+ * @{
+ */
+
+#if (LL_ICG_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ICG_Global_Macros ICG Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup ICG_SWDT_Reset_State ICG SWDT Reset State
+ * @{
+ */
+#define ICG_SWDT_RST_START                      (0UL)                   /*!< SWDT auto start after reset */
+#define ICG_SWDT_RST_STOP                       (ICG_ICG0_SWDTAUTS)     /*!< SWDT stop after reset       */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_SWDT_Exception_Type ICG SWDT Exception Type
+ * @{
+ */
+#define ICG_SWDT_EXP_TYPE_INT                   (0UL)               /*!< SWDT trigger interrupt */
+#define ICG_SWDT_EXP_TYPE_RST                   (ICG_ICG0_SWDTITS)  /*!< SWDT trigger reset     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_SWDT_Count_Period ICG SWDT Count Period
+ * @{
+ */
+#define ICG_SWDT_CNT_PERIOD256                  (0UL)                   /*!< 256 clock cycle   */
+#define ICG_SWDT_CNT_PERIOD4096                 (ICG_ICG0_SWDTPERI_0)   /*!< 4096 clock cycle  */
+#define ICG_SWDT_CNT_PERIOD16384                (ICG_ICG0_SWDTPERI_1)   /*!< 16384 clock cycle */
+#define ICG_SWDT_CNT_PERIOD65536                (ICG_ICG0_SWDTPERI)     /*!< 65536 clock cycle */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_SWDT_Clock_Division ICG SWDT Clock Division
+ * @{
+ */
+#define ICG_SWDT_CLK_DIV1                       (0UL)                               /*!< CLK      */
+#define ICG_SWDT_CLK_DIV16                      (0x04UL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/16   */
+#define ICG_SWDT_CLK_DIV32                      (0x05UL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/32   */
+#define ICG_SWDT_CLK_DIV64                      (0x06UL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/64   */
+#define ICG_SWDT_CLK_DIV128                     (0x07UL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/128  */
+#define ICG_SWDT_CLK_DIV256                     (0x08UL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/256  */
+#define ICG_SWDT_CLK_DIV2048                    (0x0BUL << ICG_ICG0_SWDTCKS_POS)    /*!< CLK/2048 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_SWDT_Refresh_Range ICG SWDT Refresh Range
+ * @{
+ */
+#define ICG_SWDT_RANGE_0TO25PCT                 (0x01UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~25%             */
+#define ICG_SWDT_RANGE_25TO50PCT                (0x02UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 25%~50%            */
+#define ICG_SWDT_RANGE_0TO50PCT                 (0x03UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~50%             */
+#define ICG_SWDT_RANGE_50TO75PCT                (0x04UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 50%~75%            */
+#define ICG_SWDT_RANGE_0TO25PCT_50TO75PCT       (0x05UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~25% & 50%~75%   */
+#define ICG_SWDT_RANGE_25TO75PCT                (0x06UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 25%~75%            */
+#define ICG_SWDT_RANGE_0TO75PCT                 (0x07UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~75%             */
+#define ICG_SWDT_RANGE_75TO100PCT               (0x08UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 75%~100%           */
+#define ICG_SWDT_RANGE_0TO25PCT_75TO100PCT      (0x09UL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~25% & 75%~100%  */
+#define ICG_SWDT_RANGE_25TO50PCT_75TO100PCT     (0x0AUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 25%~50% & 75%~100% */
+#define ICG_SWDT_RANGE_0TO50PCT_75TO100PCT      (0x0BUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~50% & 75%~100%  */
+#define ICG_SWDT_RANGE_50TO100PCT               (0x0CUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 50%~100%           */
+#define ICG_SWDT_RANGE_0TO25PCT_50TO100PCT      (0x0DUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~25% & 50%~100%  */
+#define ICG_SWDT_RANGE_25TO100PCT               (0x0EUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 25%~100%           */
+#define ICG_SWDT_RANGE_0TO100PCT                (0x0FUL << ICG_ICG0_SWDTWDPT_POS)   /*!< 0%~100%            */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_SWDT_LPM_Count ICG SWDT Low Power Mode Count
+ * @brief    Counting control of SWDT in sleep/stop mode
+ * @{
+ */
+#define ICG_SWDT_LPM_CNT_CONT                   (0UL)                   /*!< Continue counting in sleep/stop mode */
+#define ICG_SWDT_LPM_CNT_STOP                   (ICG_ICG0_SWDTSLPOFF)   /*!< Stop counting in sleep/stop mode     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Reset_State ICG WDT Reset State
+ * @{
+ */
+#define ICG_WDT_RST_START                       (0UL)               /*!< WDT auto start after reset */
+#define ICG_WDT_RST_STOP                        (ICG_ICG0_WDTAUTS)  /*!< WDT stop after reset       */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Exception_Type ICG WDT Exception Type
+ * @{
+ */
+#define ICG_WDT_EXP_TYPE_INT                    (0UL)               /*!< WDT trigger interrupt */
+#define ICG_WDT_EXP_TYPE_RST                    (ICG_ICG0_WDTITS)   /*!< WDT trigger reset     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Count_Period ICG WDT Count Period
+ * @{
+ */
+#define REDEF_ICG_WDTPERI_POS                   ICG_ICG0_WDTPERI_POS
+
+#define ICG_WDT_CNT_PERIOD256                   (0UL)                               /*!< 256 clock cycle   */
+#define ICG_WDT_CNT_PERIOD4096                  (0x01UL << REDEF_ICG_WDTPERI_POS)   /*!< 4096 clock cycle  */
+#define ICG_WDT_CNT_PERIOD16384                 (0x02UL << REDEF_ICG_WDTPERI_POS)   /*!< 16384 clock cycle */
+#define ICG_WDT_CNT_PERIOD65536                 (0x03UL << REDEF_ICG_WDTPERI_POS)   /*!< 65536 clock cycle */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Clock_Division ICG WDT Clock Division
+ * @{
+ */
+#define REDEF_ICG_WDTCKS_POS                    ICG_ICG0_WDTCKS_POS
+
+#define ICG_WDT_CLK_DIV4                        (0x02UL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/4    */
+#define ICG_WDT_CLK_DIV64                       (0x06UL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/64   */
+#define ICG_WDT_CLK_DIV128                      (0x07UL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/128  */
+#define ICG_WDT_CLK_DIV256                      (0x08UL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/256  */
+#define ICG_WDT_CLK_DIV512                      (0x09UL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/512  */
+#define ICG_WDT_CLK_DIV1024                     (0x0AUL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/1024 */
+#define ICG_WDT_CLK_DIV2048                     (0x0BUL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/2048 */
+#define ICG_WDT_CLK_DIV8192                     (0x0DUL << REDEF_ICG_WDTCKS_POS)    /*!< CLK/8192 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Refresh_Range ICG WDT Refresh Range
+ * @{
+ */
+#define REDEF_ICG_WDTWDPT_POS                   ICG_ICG0_WDTWDPT_POS
+
+#define ICG_WDT_RANGE_0TO25PCT                  (0x01UL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~25%             */
+#define ICG_WDT_RANGE_25TO50PCT                 (0x02UL << REDEF_ICG_WDTWDPT_POS)   /*!< 25%~50%            */
+#define ICG_WDT_RANGE_0TO50PCT                  (0x03UL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~50%             */
+#define ICG_WDT_RANGE_50TO75PCT                 (0x04UL << REDEF_ICG_WDTWDPT_POS)   /*!< 50%~75%            */
+#define ICG_WDT_RANGE_0TO25PCT_50TO75PCT        (0x05UL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~25% & 50%~75%   */
+#define ICG_WDT_RANGE_25TO75PCT                 (0x06UL << REDEF_ICG_WDTWDPT_POS)   /*!< 25%~75%            */
+#define ICG_WDT_RANGE_0TO75PCT                  (0x07UL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~75%             */
+#define ICG_WDT_RANGE_75TO100PCT                (0x08UL << REDEF_ICG_WDTWDPT_POS)   /*!< 75%~100%           */
+#define ICG_WDT_RANGE_0TO25PCT_75TO100PCT       (0x09UL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~25% & 75%~100%  */
+#define ICG_WDT_RANGE_25TO50PCT_75TO100PCT      (0x0AUL << REDEF_ICG_WDTWDPT_POS)   /*!< 25%~50% & 75%~100% */
+#define ICG_WDT_RANGE_0TO50PCT_75TO100PCT       (0x0BUL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~50% & 75%~100%  */
+#define ICG_WDT_RANGE_50TO100PCT                (0x0CUL << REDEF_ICG_WDTWDPT_POS)   /*!< 50%~100%           */
+#define ICG_WDT_RANGE_0TO25PCT_50TO100PCT       (0x0DUL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~25% & 50%~100%  */
+#define ICG_WDT_RANGE_25TO100PCT                (0x0EUL << REDEF_ICG_WDTWDPT_POS)   /*!< 25%~100%           */
+#define ICG_WDT_RANGE_0TO100PCT                 (0x0FUL << REDEF_ICG_WDTWDPT_POS)   /*!< 0%~100%            */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_LPM_Count ICG WDT Low Power Mode Count
+ * @brief    Counting control of WDT in sleep mode
+ * @{
+ */
+#define ICG_WDT_LPM_CNT_CONT                    (0UL)                   /*!< Continue counting in sleep mode */
+#define ICG_WDT_LPM_CNT_STOP                    (ICG_ICG0_WDTSLPOFF)    /*!< Stop counting in sleep mode     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_BOR_Voltage_Threshold ICG BOR Voltage Threshold
+ * @{
+ */
+#define ICG_BOR_VOL_THRESHOLD_LVL0              (0UL)                   /*!< BOR voltage threshold 2.0V */
+#define ICG_BOR_VOL_THRESHOLD_LVL1              (ICG_ICG1_BOR_LEV_0)    /*!< BOR voltage threshold 2.1V */
+#define ICG_BOR_VOL_THRESHOLD_LVL2              (ICG_ICG1_BOR_LEV_1)    /*!< BOR voltage threshold 2.2V */
+#define ICG_BOR_VOL_THRESHOLD_LVL3              (ICG_ICG1_BOR_LEV)      /*!< BOR voltage threshold 2.4V */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_BOR_Reset_State ICG BOR Reset State
+ * @{
+ */
+#define ICG_BOR_RST_ENABLE                      (0UL)               /*!< Enable BOR voltage detection after reset  */
+#define ICG_BOR_RST_DISABLE                     (ICG_ICG1_BORDIS)   /*!< Disable BOR voltage detection after reset */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_HRC_Frequency_Select ICG HRC Frequency Select
+ * @{
+ */
+
+#define ICG_HRC_20M                             (0UL)                   /*!< HRC = 20MHZ */
+#define ICG_HRC_16M                             (ICG_ICG1_HRCFREQSEL)   /*!< HRC = 16MHZ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_HRC_Reset_State ICG HRC Reset State
+ * @{
+ */
+#define ICG_HRC_RST_OSCILLATION                 (0UL)               /*!< HRC Oscillation after reset */
+#define ICG_HRC_RST_STOP                        (ICG_ICG1_HRCSTOP)  /*!< HRC stop after reset        */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_FLASH_Protect_Reset_State ICG FLASH Protect Reset State
+ * @brief Enable or disable D-BUS read protection for addresses 0x00000000 - 0x0001FFFF
+ * @{
+ */
+#define ICG_FLASH_PROTECT_RST_DISABLE           (0xFFFFFFFFUL)  /*!< Disable D-BUS read protection after reset */
+#define ICG_FLASH_PROTECT_RST_ENABLE            (0x00004450UL)  /*!< Enable D-BUS read protection after reset  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_Register_Configuration ICG Register Configuration
+ * @{
+ */
+
+/**
+ * @defgroup ICG_SWDT_Preload_Configuration ICG SWDT Preload Configuration
+ * @{
+ */
+/* SWDT register bits config */
+#define ICG_RB_SWDT_AUTS                        (ICG_SWDT_RST_STOP)
+#define ICG_RB_SWDT_ITS                         (ICG_SWDT_EXP_TYPE_RST)
+#define ICG_RB_SWDT_PERI                        (ICG_SWDT_CNT_PERIOD65536)
+#define ICG_RB_SWDT_CKS                         (ICG_SWDT_CLK_DIV2048)
+#define ICG_RB_SWDT_WDPT                        (ICG_SWDT_RANGE_0TO100PCT)
+#define ICG_RB_SWDT_SLTPOFF                     (ICG_SWDT_LPM_CNT_STOP)
+
+/* SWDT register value */
+#define ICG_REG_SWDT_CONFIG                     (ICG_RB_SWDT_AUTS | ICG_RB_SWDT_ITS  | ICG_RB_SWDT_PERI | \
+                                                 ICG_RB_SWDT_CKS  | ICG_RB_SWDT_WDPT | ICG_RB_SWDT_SLTPOFF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_WDT_Preload_Configuration ICG WDT Preload Configuration
+ * @{
+ */
+/* WDT register bits config */
+#define ICG_RB_WDT_AUTS                         (ICG_WDT_RST_STOP)
+#define ICG_RB_WDT_ITS                          (ICG_WDT_EXP_TYPE_RST)
+#define ICG_RB_WDT_PERI                         (ICG_WDT_CNT_PERIOD65536)
+#define ICG_RB_WDT_CKS                          (ICG_WDT_CLK_DIV8192)
+#define ICG_RB_WDT_WDPT                         (ICG_WDT_RANGE_0TO100PCT)
+#define ICG_RB_WDT_SLTPOFF                      (ICG_WDT_LPM_CNT_STOP)
+
+/* WDT register value */
+#define ICG_REG_WDT_CONFIG                      (ICG_RB_WDT_AUTS | ICG_RB_WDT_ITS  | ICG_RB_WDT_PERI | \
+                                                 ICG_RB_WDT_CKS  | ICG_RB_WDT_WDPT | ICG_RB_WDT_SLTPOFF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_BOR_Preload_Configuration ICG BOR Preload Configuration
+ * @{
+ */
+/* BOR register bits config */
+#define ICG_RB_BOR_LEV                          (ICG_BOR_VOL_THRESHOLD_LVL3)
+#define ICG_RB_BOR_DIS                          (ICG_BOR_RST_DISABLE)
+
+/* BOR register value */
+#define ICG_REG_BOR_CONFIG                      (ICG_RB_BOR_LEV | ICG_RB_BOR_DIS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_HRC_Preload_Configuration ICG HRC Preload Configuration
+ * @{
+ */
+/* HRC register bits config */
+#define ICG_RB_HRC_FREQSEL                      (ICG_HRC_16M)
+#define ICG_RB_HRC_STOP                         (ICG_HRC_RST_STOP)
+
+/* HRC register value */
+#define ICG_REG_HRC_CONFIG                      (ICG_RB_HRC_FREQSEL | ICG_RB_HRC_STOP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_FLASH_Protect_Preload_Configuration ICG FLASH Protect Preload Configuration
+ * @{
+ */
+/* FLASH Read Protect register value */
+#define ICG_REG_FLASH_PROTECT_CONFIG            (ICG_FLASH_PROTECT_RST_DISABLE)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ICG_Register_Value ICG Register Value
+ * @{
+ */
+/* ICG register value */
+#ifndef ICG_REG_CFG0_CONST
+#define ICG_REG_CFG0_CONST                      (ICG_REG_WDT_CONFIG | ICG_REG_SWDT_CONFIG | 0xE000E000UL)
+#endif
+#ifndef ICG_REG_CFG1_CONST
+#define ICG_REG_CFG1_CONST                      (ICG_REG_BOR_CONFIG | ICG_REG_HRC_CONFIG  | 0xFFF8FEFEUL)
+#endif
+#ifndef ICG_REG_CFG3_CONST
+#define ICG_REG_CFG3_CONST                      (ICG_REG_FLASH_PROTECT_CONFIG | 0xFFFF0000UL)
+#endif
+/* ICG reserved value */
+#define ICG_REG_RESV_CONST                      (0xFFFFFFFFUL)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+
+#endif /* LL_ICG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_ICG_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_interrupts.h
+++ b/hc32f4a2/inc/hc32_ll_interrupts.h
@@ -1,0 +1,590 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_interrupts.h
+ * @brief This file contains all the functions prototypes of the interrupt driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-06-30       CDT             Modify INTC filter B macros correspond with RM
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_INTERRUPTS_H__
+#define __HC32_LL_INTERRUPTS_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_INTERRUPTS
+ * @{
+ */
+
+#if (LL_INTERRUPTS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup INTC_Global_Types INTC Global Types
+ * @{
+ */
+
+/**
+ * @brief  Interrupt registration structure definition
+ */
+typedef struct {
+    en_int_src_t enIntSrc;  /*!< Peripheral interrupt number, can be any value @ref en_int_src_t    */
+    IRQn_Type enIRQn;       /*!< Peripheral IRQ type, can be INT000_IRQn~INT127_IRQn @ref IRQn_Type */
+    func_ptr_t pfnCallback; /*!< Callback function for corresponding peripheral IRQ                 */
+} stc_irq_signin_config_t;
+
+/**
+ * @brief  NMI initialize configuration structure definition
+ */
+typedef struct {
+    uint32_t u32Src;            /*!< NMI trigger source, @ref NMI_TriggerSrc_Sel for details */
+} stc_nmi_init_t;
+
+/**
+ * @brief  EXTINT initialize configuration structure definition
+ */
+typedef struct {
+    uint32_t u32Filter;         /*!< ExtInt filter (A) function setting, @ref EXTINT_FilterClock_Sel for details */
+    uint32_t u32FilterClock;    /*!< ExtInt filter (A) clock division, @ref EXTINT_FilterClock_Div for details */
+    uint32_t u32Edge;           /*!< ExtInt trigger edge, @ref EXTINT_Trigger_Sel for details */
+    uint32_t u32FilterB;        /*!< ExtInt filter B function setting, @ref EXTINT_FilterBClock_Sel for details */
+    uint32_t u32FilterBClock;   /*!< ExtInt filter B time, @ref EXTINT_FilterBTim_Sel for details */
+} stc_extint_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup INTC_Global_Macros INTC Global Macros
+ * @{
+ */
+/**
+ * @defgroup INTC_Priority_Sel Interrupt Priority Level
+ * @{
+ */
+#define DDL_IRQ_PRIO_00                 (0U)
+#define DDL_IRQ_PRIO_01                 (1U)
+#define DDL_IRQ_PRIO_02                 (2U)
+#define DDL_IRQ_PRIO_03                 (3U)
+#define DDL_IRQ_PRIO_04                 (4U)
+#define DDL_IRQ_PRIO_05                 (5U)
+#define DDL_IRQ_PRIO_06                 (6U)
+#define DDL_IRQ_PRIO_07                 (7U)
+#define DDL_IRQ_PRIO_08                 (8U)
+#define DDL_IRQ_PRIO_09                 (9U)
+#define DDL_IRQ_PRIO_10                 (10U)
+#define DDL_IRQ_PRIO_11                 (11U)
+#define DDL_IRQ_PRIO_12                 (12U)
+#define DDL_IRQ_PRIO_13                 (13U)
+#define DDL_IRQ_PRIO_14                 (14U)
+#define DDL_IRQ_PRIO_15                 (15U)
+
+#define DDL_IRQ_PRIO_DEFAULT            (DDL_IRQ_PRIO_15)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup NMI_TriggerSrc_Sel NMI Trigger Source Selection
+ * @{
+ */
+#define NMI_SRC_SWDT                    (INTC_NMIFR_SWDTFR)
+#define NMI_SRC_LVD1                    (INTC_NMIFR_PVD1FR)
+#define NMI_SRC_LVD2                    (INTC_NMIFR_PVD2FR)
+#define NMI_SRC_XTAL                    (INTC_NMIFR_XTALSTPFR)
+#define NMI_SRC_SRAM_PARITY             (INTC_NMIFR_REPFR)
+#define NMI_SRC_SRAM_ECC                (INTC_NMIFR_RECCFR)
+#define NMI_SRC_BUS_ERR                 (INTC_NMIFR_BUSMFR)
+#define NMI_SRC_WDT                     (INTC_NMIFR_WDTFR)
+#define NMI_SRC_ALL                     (NMI_SRC_SWDT   | NMI_SRC_LVD1      | NMI_SRC_LVD2          |   \
+                                        NMI_SRC_XTAL    | NMI_SRC_BUS_ERR   | NMI_SRC_SRAM_PARITY   |   \
+                                        NMI_SRC_WDT     | NMI_SRC_SRAM_ECC)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_Channel_Sel External Interrupt Channel Selection
+ * @{
+ */
+#define EXTINT_CH00                     (1UL << 0U)
+#define EXTINT_CH01                     (1UL << 1U)
+#define EXTINT_CH02                     (1UL << 2U)
+#define EXTINT_CH03                     (1UL << 3U)
+#define EXTINT_CH04                     (1UL << 4U)
+#define EXTINT_CH05                     (1UL << 5U)
+#define EXTINT_CH06                     (1UL << 6U)
+#define EXTINT_CH07                     (1UL << 7U)
+#define EXTINT_CH08                     (1UL << 8U)
+#define EXTINT_CH09                     (1UL << 9U)
+#define EXTINT_CH10                     (1UL <<10U)
+#define EXTINT_CH11                     (1UL <<11U)
+#define EXTINT_CH12                     (1UL <<12U)
+#define EXTINT_CH13                     (1UL <<13U)
+#define EXTINT_CH14                     (1UL <<14U)
+#define EXTINT_CH15                     (1UL <<15U)
+#define EXTINT_CH_ALL                   (EXTINT_CH00 | EXTINT_CH01 | EXTINT_CH02 | EXTINT_CH03 |    \
+                                         EXTINT_CH04 | EXTINT_CH05 | EXTINT_CH06 | EXTINT_CH07 |    \
+                                         EXTINT_CH08 | EXTINT_CH09 | EXTINT_CH10 | EXTINT_CH11 |    \
+                                         EXTINT_CH12 | EXTINT_CH13 | EXTINT_CH14 | EXTINT_CH15)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup INT_Channel_Sel Interrupt Channel Selection
+ * @{
+ */
+#define INTC_INT0                       INTC_IER_IER0
+#define INTC_INT1                       INTC_IER_IER1
+#define INTC_INT2                       INTC_IER_IER2
+#define INTC_INT3                       INTC_IER_IER3
+#define INTC_INT4                       INTC_IER_IER4
+#define INTC_INT5                       INTC_IER_IER5
+#define INTC_INT6                       INTC_IER_IER6
+#define INTC_INT7                       INTC_IER_IER7
+#define INTC_INT8                       INTC_IER_IER8
+#define INTC_INT9                       INTC_IER_IER9
+#define INTC_INT10                      INTC_IER_IER10
+#define INTC_INT11                      INTC_IER_IER11
+#define INTC_INT12                      INTC_IER_IER12
+#define INTC_INT13                      INTC_IER_IER13
+#define INTC_INT14                      INTC_IER_IER14
+#define INTC_INT15                      INTC_IER_IER15
+#define INTC_INT16                      INTC_IER_IER16
+#define INTC_INT17                      INTC_IER_IER17
+#define INTC_INT18                      INTC_IER_IER18
+#define INTC_INT19                      INTC_IER_IER19
+#define INTC_INT20                      INTC_IER_IER20
+#define INTC_INT21                      INTC_IER_IER21
+#define INTC_INT22                      INTC_IER_IER22
+#define INTC_INT23                      INTC_IER_IER23
+#define INTC_INT24                      INTC_IER_IER24
+#define INTC_INT25                      INTC_IER_IER25
+#define INTC_INT26                      INTC_IER_IER26
+#define INTC_INT27                      INTC_IER_IER27
+#define INTC_INT28                      INTC_IER_IER28
+#define INTC_INT29                      INTC_IER_IER29
+#define INTC_INT30                      INTC_IER_IER30
+#define INTC_INT31                      INTC_IER_IER31
+#define INTC_INT_ALL                    (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup INTC_Event_Channel_Sel Event Channel Selection
+ * @{
+ */
+#define INTC_EVT0                       INTC_EVTER_EVTE0
+#define INTC_EVT1                       INTC_EVTER_EVTE1
+#define INTC_EVT2                       INTC_EVTER_EVTE2
+#define INTC_EVT3                       INTC_EVTER_EVTE3
+#define INTC_EVT4                       INTC_EVTER_EVTE4
+#define INTC_EVT5                       INTC_EVTER_EVTE5
+#define INTC_EVT6                       INTC_EVTER_EVTE6
+#define INTC_EVT7                       INTC_EVTER_EVTE7
+#define INTC_EVT8                       INTC_EVTER_EVTE8
+#define INTC_EVT9                       INTC_EVTER_EVTE9
+#define INTC_EVT10                      INTC_EVTER_EVTE10
+#define INTC_EVT11                      INTC_EVTER_EVTE11
+#define INTC_EVT12                      INTC_EVTER_EVTE12
+#define INTC_EVT13                      INTC_EVTER_EVTE13
+#define INTC_EVT14                      INTC_EVTER_EVTE14
+#define INTC_EVT15                      INTC_EVTER_EVTE15
+#define INTC_EVT16                      INTC_EVTER_EVTE16
+#define INTC_EVT17                      INTC_EVTER_EVTE17
+#define INTC_EVT18                      INTC_EVTER_EVTE18
+#define INTC_EVT19                      INTC_EVTER_EVTE19
+#define INTC_EVT20                      INTC_EVTER_EVTE20
+#define INTC_EVT21                      INTC_EVTER_EVTE21
+#define INTC_EVT22                      INTC_EVTER_EVTE22
+#define INTC_EVT23                      INTC_EVTER_EVTE23
+#define INTC_EVT24                      INTC_EVTER_EVTE24
+#define INTC_EVT25                      INTC_EVTER_EVTE25
+#define INTC_EVT26                      INTC_EVTER_EVTE26
+#define INTC_EVT27                      INTC_EVTER_EVTE27
+#define INTC_EVT28                      INTC_EVTER_EVTE28
+#define INTC_EVT29                      INTC_EVTER_EVTE29
+#define INTC_EVT30                      INTC_EVTER_EVTE30
+#define INTC_EVT31                      INTC_EVTER_EVTE31
+#define INTC_EVT_ALL                    (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWINT_Channel_Sel Software Interrupt Channel Selection
+ * @{
+ */
+#define SWINT_CH00                      INTC_SWIER_SWIE0
+#define SWINT_CH01                      INTC_SWIER_SWIE1
+#define SWINT_CH02                      INTC_SWIER_SWIE2
+#define SWINT_CH03                      INTC_SWIER_SWIE3
+#define SWINT_CH04                      INTC_SWIER_SWIE4
+#define SWINT_CH05                      INTC_SWIER_SWIE5
+#define SWINT_CH06                      INTC_SWIER_SWIE6
+#define SWINT_CH07                      INTC_SWIER_SWIE7
+#define SWINT_CH08                      INTC_SWIER_SWIE8
+#define SWINT_CH09                      INTC_SWIER_SWIE9
+#define SWINT_CH10                      INTC_SWIER_SWIE10
+#define SWINT_CH11                      INTC_SWIER_SWIE11
+#define SWINT_CH12                      INTC_SWIER_SWIE12
+#define SWINT_CH13                      INTC_SWIER_SWIE13
+#define SWINT_CH14                      INTC_SWIER_SWIE14
+#define SWINT_CH15                      INTC_SWIER_SWIE15
+#define SWINT_CH16                      INTC_SWIER_SWIE16
+#define SWINT_CH17                      INTC_SWIER_SWIE17
+#define SWINT_CH18                      INTC_SWIER_SWIE18
+#define SWINT_CH19                      INTC_SWIER_SWIE19
+#define SWINT_CH20                      INTC_SWIER_SWIE20
+#define SWINT_CH21                      INTC_SWIER_SWIE21
+#define SWINT_CH22                      INTC_SWIER_SWIE22
+#define SWINT_CH23                      INTC_SWIER_SWIE23
+#define SWINT_CH24                      INTC_SWIER_SWIE24
+#define SWINT_CH25                      INTC_SWIER_SWIE25
+#define SWINT_CH26                      INTC_SWIER_SWIE26
+#define SWINT_CH27                      INTC_SWIER_SWIE27
+#define SWINT_CH28                      INTC_SWIER_SWIE28
+#define SWINT_CH29                      INTC_SWIER_SWIE29
+#define SWINT_CH30                      INTC_SWIER_SWIE30
+#define SWINT_CH31                      INTC_SWIER_SWIE31
+#define SWINT_ALL                       (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_FilterClock_Sel External Interrupt Filter A Function Selection
+ * @{
+ */
+#define EXTINT_FILTER_OFF               (0UL)
+#define EXTINT_FILTER_ON                (INTC_EIRQCR_EFEN)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_FilterBClock_Sel External Interrupt Filter B Function Selection
+ * @{
+ */
+#define EXTINT_FILTER_B_OFF             (0UL)
+#define EXTINT_FILTER_B_ON              (INTC_EIRQCR_NOCEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_FilterClock_Div External Interrupt Filter A Sampling Clock Division Selection
+ * @{
+ */
+#define EXTINT_FCLK_DIV1                (0UL)
+#define EXTINT_FCLK_DIV8                (INTC_EIRQCR_EISMPCLK_0)
+#define EXTINT_FCLK_DIV32               (INTC_EIRQCR_EISMPCLK_1)
+#define EXTINT_FCLK_DIV64               (INTC_EIRQCR_EISMPCLK)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_FilterBTim_Sel External Interrupt Filter B Time Selection
+ * @{
+ */
+#define EXTINT_FILTER_B_LVL1            (0UL)
+#define EXTINT_FILTER_B_LVL2            (INTC_NOCCR_NOCSEL_0)
+#define EXTINT_FILTER_B_LVL3            (INTC_NOCCR_NOCSEL_1)
+#define EXTINT_FILTER_B_LVL4            (INTC_NOCCR_NOCSEL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXTINT_Trigger_Sel External Interrupt Trigger Edge Selection
+ * @{
+ */
+#define EXTINT_TRIG_FALLING             (0UL)
+#define EXTINT_TRIG_RISING              (INTC_EIRQCR_EIRQTRG_0)
+#define EXTINT_TRIG_BOTH                (INTC_EIRQCR_EIRQTRG_1)
+#define EXTINT_TRIG_LOW                 (INTC_EIRQCR_EIRQTRG)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup INTC_Stop_Wakeup_Source_Sel Stop Mode Wakeup Source Selection
+ * @{
+ */
+#define INTC_STOP_WKUP_EXTINT_CH0       INTC_WUPEN_EIRQWUEN_0
+#define INTC_STOP_WKUP_EXTINT_CH1       INTC_WUPEN_EIRQWUEN_1
+#define INTC_STOP_WKUP_EXTINT_CH2       INTC_WUPEN_EIRQWUEN_2
+#define INTC_STOP_WKUP_EXTINT_CH3       INTC_WUPEN_EIRQWUEN_3
+#define INTC_STOP_WKUP_EXTINT_CH4       INTC_WUPEN_EIRQWUEN_4
+#define INTC_STOP_WKUP_EXTINT_CH5       INTC_WUPEN_EIRQWUEN_5
+#define INTC_STOP_WKUP_EXTINT_CH6       INTC_WUPEN_EIRQWUEN_6
+#define INTC_STOP_WKUP_EXTINT_CH7       INTC_WUPEN_EIRQWUEN_7
+#define INTC_STOP_WKUP_EXTINT_CH8       INTC_WUPEN_EIRQWUEN_8
+#define INTC_STOP_WKUP_EXTINT_CH9       INTC_WUPEN_EIRQWUEN_9
+#define INTC_STOP_WKUP_EXTINT_CH10      INTC_WUPEN_EIRQWUEN_10
+#define INTC_STOP_WKUP_EXTINT_CH11      INTC_WUPEN_EIRQWUEN_11
+#define INTC_STOP_WKUP_EXTINT_CH12      INTC_WUPEN_EIRQWUEN_12
+#define INTC_STOP_WKUP_EXTINT_CH13      INTC_WUPEN_EIRQWUEN_13
+#define INTC_STOP_WKUP_EXTINT_CH14      INTC_WUPEN_EIRQWUEN_14
+#define INTC_STOP_WKUP_EXTINT_CH15      INTC_WUPEN_EIRQWUEN_15
+#define INTC_STOP_WKUP_SWDT             INTC_WUPEN_SWDTWUEN
+#define INTC_STOP_WKUP_LVD1             INTC_WUPEN_PVD1WUEN
+#define INTC_STOP_WKUP_LVD2             INTC_WUPEN_PVD2WUEN
+#define INTC_STOP_WKUP_CMP              INTC_WUPEN_CMPWUEN
+#define INTC_STOP_WKUP_WKTM             INTC_WUPEN_WKTMWUEN
+#define INTC_STOP_WKUP_RTC_ALM          INTC_WUPEN_RTCALMWUEN
+#define INTC_STOP_WKUP_RTC_PRD          INTC_WUPEN_RTCPRDWUEN
+#define INTC_STOP_WKUP_TMR0_CMP         INTC_WUPEN_TMR0GCMWUEN
+#define INTC_STOP_WKUP_TMR2_CMP         INTC_WUPEN_TMR2GCMWUEN
+#define INTC_STOP_WKUP_TMR2_OVF         INTC_WUPEN_TMR2OVFWUEN
+#define INTC_STOP_WKUP_USART1_RX        INTC_WUPEN_RXWUEN
+#define INTC_STOP_WKUP_USBHS            INTC_WUPEN_USHWUEN
+#define INTC_STOP_WKUP_USBFS            INTC_WUPEN_USFWUEN
+#define INTC_STOP_WKUP_ETH              INTC_WUPEN_ETHWUEN
+#define INTC_WUPEN_ALL                  (INTC_WUPEN_EIRQWUEN    | INTC_WUPEN_SWDTWUEN           |           \
+                                         INTC_WUPEN_PVD1WUEN    | INTC_WUPEN_PVD2WUEN           |           \
+                                         INTC_WUPEN_CMPWUEN     | INTC_WUPEN_WKTMWUEN           |           \
+                                         INTC_WUPEN_RTCALMWUEN  | INTC_WUPEN_RTCPRDWUEN         |           \
+                                         INTC_WUPEN_TMR0GCMWUEN | INTC_WUPEN_TMR2GCMWUEN        |           \
+                                         INTC_WUPEN_TMR2OVFWUEN | INTC_WUPEN_RXWUEN             |           \
+                                         INTC_WUPEN_USHWUEN     | INTC_WUPEN_USFWUEN            |           \
+                                         INTC_WUPEN_ETHWUEN)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup INTC_Global_Functions
+ * @{
+ */
+
+int32_t INTC_IrqSignIn(const stc_irq_signin_config_t *pstcIrqSignConfig);
+int32_t INTC_IrqSignOut(IRQn_Type enIRQn);
+void INTC_WakeupSrcCmd(uint32_t u32WakeupSrc, en_functional_state_t enNewState);
+void INTC_EventCmd(uint32_t u32Event, en_functional_state_t enNewState);
+void INTC_IntCmd(uint32_t u32Int, en_functional_state_t enNewState);
+void INTC_SWIntInit(uint32_t u32Ch, const func_ptr_t pfnCallback, uint32_t u32Priority);
+void INTC_SWIntCmd(uint32_t u32SWInt, en_functional_state_t enNewState);
+
+int32_t NMI_Init(const stc_nmi_init_t *pstcNmiInit);
+int32_t NMI_StructInit(stc_nmi_init_t *pstcNmiInit);
+en_flag_status_t NMI_GetNmiStatus(uint32_t u32Src);
+void NMI_NmiSrcCmd(uint32_t u32Src, en_functional_state_t enNewState);
+void NMI_ClearNmiStatus(uint32_t u32Src);
+
+int32_t EXTINT_Init(uint32_t u32Ch, const stc_extint_init_t *pstcExtIntInit);
+int32_t EXTINT_StructInit(stc_extint_init_t *pstcExtIntInit);
+en_flag_status_t EXTINT_GetExtIntStatus(uint32_t u32ExtIntCh);
+void EXTINT_ClearExtIntStatus(uint32_t u32ExtIntCh);
+
+void IRQ000_Handler(void);
+void IRQ001_Handler(void);
+void IRQ002_Handler(void);
+void IRQ003_Handler(void);
+void IRQ004_Handler(void);
+void IRQ005_Handler(void);
+void IRQ006_Handler(void);
+void IRQ007_Handler(void);
+
+void IRQ008_Handler(void);
+void IRQ009_Handler(void);
+void IRQ010_Handler(void);
+void IRQ011_Handler(void);
+void IRQ012_Handler(void);
+void IRQ013_Handler(void);
+void IRQ014_Handler(void);
+void IRQ015_Handler(void);
+
+void IRQ016_Handler(void);
+void IRQ017_Handler(void);
+void IRQ018_Handler(void);
+void IRQ019_Handler(void);
+void IRQ020_Handler(void);
+void IRQ021_Handler(void);
+void IRQ022_Handler(void);
+void IRQ023_Handler(void);
+
+void IRQ024_Handler(void);
+void IRQ025_Handler(void);
+void IRQ026_Handler(void);
+void IRQ027_Handler(void);
+void IRQ028_Handler(void);
+void IRQ029_Handler(void);
+void IRQ030_Handler(void);
+void IRQ031_Handler(void);
+void IRQ032_Handler(void);
+void IRQ033_Handler(void);
+void IRQ034_Handler(void);
+void IRQ035_Handler(void);
+void IRQ036_Handler(void);
+void IRQ037_Handler(void);
+void IRQ038_Handler(void);
+void IRQ039_Handler(void);
+void IRQ040_Handler(void);
+void IRQ041_Handler(void);
+void IRQ042_Handler(void);
+void IRQ043_Handler(void);
+void IRQ044_Handler(void);
+void IRQ045_Handler(void);
+void IRQ046_Handler(void);
+void IRQ047_Handler(void);
+void IRQ048_Handler(void);
+void IRQ049_Handler(void);
+void IRQ050_Handler(void);
+void IRQ051_Handler(void);
+void IRQ052_Handler(void);
+void IRQ053_Handler(void);
+void IRQ054_Handler(void);
+void IRQ055_Handler(void);
+void IRQ056_Handler(void);
+void IRQ057_Handler(void);
+void IRQ058_Handler(void);
+void IRQ059_Handler(void);
+void IRQ060_Handler(void);
+void IRQ061_Handler(void);
+void IRQ062_Handler(void);
+void IRQ063_Handler(void);
+void IRQ064_Handler(void);
+void IRQ065_Handler(void);
+void IRQ066_Handler(void);
+void IRQ067_Handler(void);
+void IRQ068_Handler(void);
+void IRQ069_Handler(void);
+void IRQ070_Handler(void);
+void IRQ071_Handler(void);
+void IRQ072_Handler(void);
+void IRQ073_Handler(void);
+void IRQ074_Handler(void);
+void IRQ075_Handler(void);
+void IRQ076_Handler(void);
+void IRQ077_Handler(void);
+void IRQ078_Handler(void);
+void IRQ079_Handler(void);
+void IRQ080_Handler(void);
+void IRQ081_Handler(void);
+void IRQ082_Handler(void);
+void IRQ083_Handler(void);
+void IRQ084_Handler(void);
+void IRQ085_Handler(void);
+void IRQ086_Handler(void);
+void IRQ087_Handler(void);
+void IRQ088_Handler(void);
+void IRQ089_Handler(void);
+void IRQ090_Handler(void);
+void IRQ091_Handler(void);
+void IRQ092_Handler(void);
+void IRQ093_Handler(void);
+void IRQ094_Handler(void);
+void IRQ095_Handler(void);
+void IRQ096_Handler(void);
+void IRQ097_Handler(void);
+void IRQ098_Handler(void);
+void IRQ099_Handler(void);
+void IRQ100_Handler(void);
+void IRQ101_Handler(void);
+void IRQ102_Handler(void);
+void IRQ103_Handler(void);
+void IRQ104_Handler(void);
+void IRQ105_Handler(void);
+void IRQ106_Handler(void);
+void IRQ107_Handler(void);
+void IRQ108_Handler(void);
+void IRQ109_Handler(void);
+void IRQ110_Handler(void);
+void IRQ111_Handler(void);
+void IRQ112_Handler(void);
+void IRQ113_Handler(void);
+void IRQ114_Handler(void);
+void IRQ115_Handler(void);
+void IRQ116_Handler(void);
+void IRQ117_Handler(void);
+void IRQ118_Handler(void);
+void IRQ119_Handler(void);
+void IRQ120_Handler(void);
+void IRQ121_Handler(void);
+void IRQ122_Handler(void);
+void IRQ123_Handler(void);
+void IRQ124_Handler(void);
+void IRQ125_Handler(void);
+void IRQ126_Handler(void);
+void IRQ127_Handler(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_INTERRUPTS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_INTERRUPTS_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_keyscan.h
+++ b/hc32f4a2/inc/hc32_ll_keyscan.h
@@ -1,0 +1,241 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_keyscan.h
+ * @brief This file contains all the functions prototypes of the KEYSCAN driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add function KEYSCAN_DeInit
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_KEYSCAN_H__
+#define __HC32_LL_KEYSCAN_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_KEYSCAN
+ * @{
+ */
+
+#if (LL_KEYSCAN_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup KEYSCAN_Global_Types KEYSCAN Global Types
+ * @{
+ */
+
+/**
+ * @brief  KEYSCAN configuration
+ */
+typedef struct {
+    uint32_t u32HizCycle;           /*!< Specifies the KEYSCAN Hiz cycles.
+                                        This parameter can be a value of @ref KEYSCAN_Hiz_Cycle_Sel */
+
+    uint32_t u32LowCycle;           /*!< Specifies the KEYSCAN low cycles.
+                                        This parameter can be a value of @ref KEYSCAN_Low_Cycle_Sel */
+
+    uint32_t u32KeyClock;           /*!< Specifies the KEYSCAN low cycles.
+                                        This parameter can be a value of @ref KEYSCAN_Clock_Sel */
+
+    uint32_t u32KeyOut;             /*!< Specifies the KEYSCAN low cycles.
+                                        This parameter can be a value of @ref KEYSCAN_Keyout_Sel */
+
+    uint32_t u32KeyIn;              /*!< Specifies the KEYSCAN low cycles.
+                                        This parameter can be a value of @ref KEYSCAN_Keyin_Sel */
+} stc_keyscan_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup KEYSCAN_Global_Macros KEYSCAN Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup KEYSCAN_Hiz_Cycle_Sel KEYSCAN Hiz cycles during low output selection
+ * @{
+ */
+#define KEYSCAN_HIZ_CYCLE_4     (0x00UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 4 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_8     (0x01UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 8 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_16    (0x02UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 16 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_32    (0x03UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 32 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_64    (0x04UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 64 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_256   (0x05UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 256 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_512   (0x06UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 512 cycles during low output */
+#define KEYSCAN_HIZ_CYCLE_1024  (0x07UL << KEYSCAN_SCR_T_HIZ_POS)       /*!< KEYSCAN HiZ keep 1024 cycles during low output */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup KEYSCAN_Low_Cycle_Sel KEYSCAN low level output cycles selection
+ * @{
+ */
+#define KEYSCAN_LOW_CYCLE_4     (0x02UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^2=4 cycles */
+#define KEYSCAN_LOW_CYCLE_8     (0x03UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^3=8 cycles */
+#define KEYSCAN_LOW_CYCLE_16    (0x04UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^4=16 cycles */
+#define KEYSCAN_LOW_CYCLE_32    (0x05UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^5=32 cycles */
+#define KEYSCAN_LOW_CYCLE_64    (0x06UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^6=64 cycles */
+#define KEYSCAN_LOW_CYCLE_128   (0x07UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^7=128 cycles */
+#define KEYSCAN_LOW_CYCLE_256   (0x08UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^8=256 cycles */
+#define KEYSCAN_LOW_CYCLE_512   (0x09UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^9=512 cycles */
+#define KEYSCAN_LOW_CYCLE_1K    (0x0AUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^10=1K cycles */
+#define KEYSCAN_LOW_CYCLE_2K    (0x0BUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^11=2K cycles */
+#define KEYSCAN_LOW_CYCLE_4K    (0x0CUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^12=4K cycles */
+#define KEYSCAN_LOW_CYCLE_8K    (0x0DUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^13=8K cycles */
+#define KEYSCAN_LOW_CYCLE_16K   (0x0EUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^14=16K cycles */
+#define KEYSCAN_LOW_CYCLE_32K   (0x0FUL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^15=32K cycles */
+#define KEYSCAN_LOW_CYCLE_64K   (0x10UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^16=64K cycles */
+#define KEYSCAN_LOW_CYCLE_128K  (0x11UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^17=128K cycles */
+#define KEYSCAN_LOW_CYCLE_256K  (0x12UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^18=256K cycles */
+#define KEYSCAN_LOW_CYCLE_512K  (0x13UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^19=512K cycles */
+#define KEYSCAN_LOW_CYCLE_1M    (0x14UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^20=1M cycles */
+#define KEYSCAN_LOW_CYCLE_2M    (0x15UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^21=2M cycles */
+#define KEYSCAN_LOW_CYCLE_4M    (0x16UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^22=4M cycles */
+#define KEYSCAN_LOW_CYCLE_8M    (0x17UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^23=8M cycles */
+#define KEYSCAN_LOW_CYCLE_16M   (0x18UL << KEYSCAN_SCR_T_LLEVEL_POS)    /*!< KEYSCAN low level output is 2^24=16M cycles */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup KEYSCAN_Clock_Sel KEYSCAN scan clock selection
+ * @{
+ */
+#define KEYSCAN_CLK_HCLK        (0x00UL)                    /*!< Use as HCLK KEYSCAN clock */
+#define KEYSCAN_CLK_LRC         (KEYSCAN_SCR_CKSEL_0)       /*!< Use as LRC KEYSCAN clock */
+#define KEYSCAN_CLK_XTAL32      (KEYSCAN_SCR_CKSEL_1)       /*!< Use as XTAL32 KEYSCAN clock */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup KEYSCAN_Keyout_Sel KEYSCAN keyout pins selection
+ * @{
+ */
+#define KEYSCAN_OUT_0T1         (0x01UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 1 are selected */
+#define KEYSCAN_OUT_0T2         (0x02UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 2 are selected */
+#define KEYSCAN_OUT_0T3         (0x03UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 3 are selected */
+#define KEYSCAN_OUT_0T4         (0x04UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 4 are selected */
+#define KEYSCAN_OUT_0T5         (0x05UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 5 are selected */
+#define KEYSCAN_OUT_0T6         (0x06UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 6 are selected */
+#define KEYSCAN_OUT_0T7         (0x07UL << KEYSCAN_SCR_KEYOUTSEL_POS)   /*!< KEYOUT 0 ~ 7 are selected */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup KEYSCAN_Keyin_Sel KEYSCAN keyin pins selection
+ * @{
+ */
+#define KEYSCAN_IN_0            (1UL << 0U)    /*!< KEYIN(EIRQ) 0 is selected */
+#define KEYSCAN_IN_1            (1UL << 1U)    /*!< KEYIN(EIRQ) 1 is selected */
+#define KEYSCAN_IN_2            (1UL << 2U)    /*!< KEYIN(EIRQ) 2 is selected */
+#define KEYSCAN_IN_3            (1UL << 3U)    /*!< KEYIN(EIRQ) 3 is selected */
+#define KEYSCAN_IN_4            (1UL << 4U)    /*!< KEYIN(EIRQ) 4 is selected */
+#define KEYSCAN_IN_5            (1UL << 5U)    /*!< KEYIN(EIRQ) 5 is selected */
+#define KEYSCAN_IN_6            (1UL << 6U)    /*!< KEYIN(EIRQ) 6 is selected */
+#define KEYSCAN_IN_7            (1UL << 7U)    /*!< KEYIN(EIRQ) 7 is selected */
+#define KEYSCAN_IN_8            (1UL << 8U)    /*!< KEYIN(EIRQ) 8  is selected */
+#define KEYSCAN_IN_9            (1UL << 9U)    /*!< KEYIN(EIRQ) 9  is selected */
+#define KEYSCAN_IN_10           (1UL << 10U)   /*!< KEYIN(EIRQ) 10 is selected */
+#define KEYSCAN_IN_11           (1UL << 11U)   /*!< KEYIN(EIRQ) 11 is selected */
+#define KEYSCAN_IN_12           (1UL << 12U)   /*!< KEYIN(EIRQ) 12 is selected */
+#define KEYSCAN_IN_13           (1UL << 13U)   /*!< KEYIN(EIRQ) 13 is selected */
+#define KEYSCAN_IN_14           (1UL << 14U)   /*!< KEYIN(EIRQ) 14 is selected */
+#define KEYSCAN_IN_15           (1UL << 15U)   /*!< KEYIN(EIRQ) 15 is selected */
+#define KEYSCAN_IN_ALL          (KEYSCAN_SCR_KEYINSEL)      /*!< KEYIN(EIRQ) mask */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup KEYSCAN_Global_Functions
+ * @{
+ */
+/**
+ * @brief  Get KEYOUT index.
+ * @param  None
+ * @retval uint32_t: KEYOUT index 0~7.
+ */
+__STATIC_INLINE uint32_t KEYSCAN_GetKeyoutIdx(void)
+{
+    return READ_REG32_BIT(CM_KEYSCAN->SSR, KEYSCAN_SSR_INDEX);
+}
+
+int32_t KEYSCAN_StructInit(stc_keyscan_init_t *pstcKeyscanInit);
+int32_t KEYSCAN_Init(const stc_keyscan_init_t *pstcKeyscanInit);
+void KEYSCAN_Cmd(en_functional_state_t enNewState);
+int32_t KEYSCAN_DeInit(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_KEYSCAN_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_KEYSCAN_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_mau.h
+++ b/hc32f4a2/inc/hc32_ll_mau.h
@@ -1,0 +1,124 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_mau.h
+ * @brief This file contains all the functions prototypes of the MAU driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add API MAU_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_MAU_H__
+#define __HC32_LL_MAU_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_MAU
+ * @{
+ */
+
+#if (LL_MAU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup MAU_Global_Macros MAU Global Macros
+ * @{
+ */
+
+#define MAU_SQRT_TIMEOUT               (HCLK_VALUE / 10000UL)/* About 1mS timeout */
+#define MAU_SQRT_OUTPUT_LSHIFT_MAX     (16U)
+
+#define MAU_SIN_Q15_SCALAR             (0x8000UL)
+#define MAU_SIN_ANGIDX_TOTAL           (0x1000UL)
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+
+/**
+ * @addtogroup MAU_Global_Functions
+ * @{
+ */
+
+void MAU_SqrtInit(CM_MAU_TypeDef *MAUx, uint8_t u8ShiftNum, en_functional_state_t enNewState);
+void MAU_SqrtDeInit(CM_MAU_TypeDef *MAUx);
+
+void MAU_SqrtResultLShiftConfig(CM_MAU_TypeDef *MAUx, uint8_t u8ShiftNum);
+void MAU_SqrtIntCmd(CM_MAU_TypeDef *MAUx, en_functional_state_t enNewState);
+void MAU_SqrtWriteData(CM_MAU_TypeDef *MAUx, uint32_t u32Radicand);
+en_flag_status_t MAU_SqrtGetStatus(const CM_MAU_TypeDef *MAUx);
+uint32_t MAU_SqrtReadData(const CM_MAU_TypeDef *MAUx);
+void MAU_SqrtStart(CM_MAU_TypeDef *MAUx);
+
+int32_t MAU_Sqrt(CM_MAU_TypeDef *MAUx, uint32_t u32Radicand, uint32_t *pu32Result);
+
+int16_t MAU_Sin(CM_MAU_TypeDef *MAUx, uint16_t u16AngleIdx);
+
+int32_t MAU_DeInit(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_MAU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_MAU_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_mpu.h
+++ b/hc32f4a2/inc/hc32_ll_mpu.h
@@ -1,0 +1,423 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_mpu.h
+ * @brief This file contains all the functions prototypes of the MPU driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Update define base on new head file
+   2023-12-15       CDT             Add structure stc_mpu_unit_init_t, and declaration of MPU_UnitInit(), MPU_UnitStructInit()
+                                    Refine def group MPU_Flag
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_MPU_H__
+#define __HC32_LL_MPU_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_MPU
+ * @{
+ */
+
+#if (LL_MPU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup MPU_Global_Types MPU Global Types
+ * @{
+ */
+
+/**
+ * @brief MPU Unit configure structure definition
+ */
+typedef struct {
+    uint32_t u32ExceptionType;          /*!< Specifies the type of exception that occurs when the unit accesses a protected region.
+                                             This parameter can be a value of @ref MPU_Exception_Type           */
+    uint32_t u32BackgroundWrite;        /*!< Specifies the unit's write permission for the background space.
+                                             This parameter can be a value of @ref MPU_Background_Write_Permission */
+    uint32_t u32BackgroundRead;         /*!< Specifies the unit's read permission for the background space
+                                             This parameter can be a value of @ref MPU_Background_Read_Permission  */
+} stc_mpu_unit_config_t;
+
+/**
+ * @brief MPU Unit initialize structure definition
+ */
+typedef struct {
+    uint32_t u32MpuState;               /*!< Specifies the unit's state of mpu
+                                             This parameter can be a value of @ref MPU_Unit_State             */
+    uint32_t u32ExceptionType;          /*!< Specifies the type of exception that occurs when the unit accesses a protected region.
+                                             This parameter can be a value of @ref MPU_Exception_Type          */
+    uint32_t u32BackgroundWrite;        /*!< Specifies the unit's write permission for the background space.
+                                             This parameter can be a value of @ref MPU_Background_Write_Permission */
+    uint32_t u32BackgroundRead;         /*!< Specifies the unit's read permission for the background space
+                                             This parameter can be a value of @ref MPU_Background_Read_Permission  */
+} stc_mpu_unit_init_t;
+
+/**
+ * @brief MPU Init structure definition
+ */
+typedef struct {
+    stc_mpu_unit_config_t stcDma1;      /*!< Configure storage protection unit of DMA1      */
+    stc_mpu_unit_config_t stcDma2;      /*!< Configure storage protection unit of DMA2      */
+    stc_mpu_unit_config_t stcUsbFSDma;  /*!< Configure storage protection unit of USBFS_DMA */
+    stc_mpu_unit_config_t stcUsbHSDma;  /*!< Configure storage protection unit of USBHS_DMA */
+    stc_mpu_unit_config_t stcEthDma;    /*!< Configure storage protection unit of ETH_DMA   */
+} stc_mpu_init_t;
+
+/**
+ * @brief MPU Region Permission structure definition
+ */
+typedef struct {
+    uint32_t u32RegionWrite;            /*!< Specifies the unit's write permission for the region.
+                                             This parameter can be a value of @ref MPU_Region_Write_Permission */
+    uint32_t u32RegionRead;             /*!< Specifies the unit's read permission  for the region.
+                                             This parameter can be a value of @ref MPU_Region_Read_Permission */
+} stc_mpu_region_permission_t;
+
+/**
+ * @brief MPU region initialization structure definition
+ * @note  The effective bits of the 'u32BaseAddr' are related to the 'u32Size' of the region,
+ *        and the low 'u32Size+1' bits are fixed at 0.
+ */
+typedef struct {
+    uint32_t u32BaseAddr;                       /*!< Specifies the base address of the region.
+                                                     This parameter can be a number between 0UL and 0xFFFFFFE0UL */
+    uint32_t u32Size;                           /*!< Specifies the size of the region.
+                                                     This parameter can be a value of @ref MPU_Region_Size       */
+    stc_mpu_region_permission_t stcDma1;        /*!< Specifies the DMA1 access permission for the region         */
+    stc_mpu_region_permission_t stcDma2;        /*!< Specifies the DMA2 access permission for the region         */
+    stc_mpu_region_permission_t stcUsbFSDma;    /*!< Specifies the USBFS_DMA access permission for the region    */
+    stc_mpu_region_permission_t stcUsbHSDma;    /*!< Specifies the USBHS_DMA access permission for the region    */
+    stc_mpu_region_permission_t stcEthDma;      /*!< Specifies the ETH_DMA access permission for the region      */
+} stc_mpu_region_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup MPU_Global_Macros MPU Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup MPU_Unit_Type MPU Unit Type
+ * @{
+ */
+#define MPU_UNIT_DMA1                           (0x01UL)  /*!< System DMA_1 MPU */
+#define MPU_UNIT_DMA2                           (0x02UL)  /*!< System DMA_2 MPU */
+#define MPU_UNIT_USBFS_DMA                      (0x04UL)  /*!< USBFS_DMA MPU    */
+#define MPU_UNIT_USBHS_DMA                      (0x08UL)  /*!< USBHS_DMA MPU    */
+#define MPU_UNIT_ETH_DMA                        (0x10UL)  /*!< ETH_DMA MPU      */
+#define MPU_UNIT_ALL                            (MPU_UNIT_DMA1 | MPU_UNIT_DMA2 | MPU_UNIT_USBFS_DMA | \
+                                                 MPU_UNIT_USBHS_DMA | MPU_UNIT_ETH_DMA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Region_Number MPU Region Number
+ * @note     'MPU_REGION_NUM8' to 'MPU_REGION_NUM15' are only valid when the MPU unit is 'MPU_UNIT_DMA1' or 'MPU_UNIT_DMA2'.
+ * @{
+ */
+#define MPU_REGION_NUM0                         (0x00UL)  /*!< MPU region number 0  */
+#define MPU_REGION_NUM1                         (0x01UL)  /*!< MPU region number 1  */
+#define MPU_REGION_NUM2                         (0x02UL)  /*!< MPU region number 2  */
+#define MPU_REGION_NUM3                         (0x03UL)  /*!< MPU region number 3  */
+#define MPU_REGION_NUM4                         (0x04UL)  /*!< MPU region number 4  */
+#define MPU_REGION_NUM5                         (0x05UL)  /*!< MPU region number 5  */
+#define MPU_REGION_NUM6                         (0x06UL)  /*!< MPU region number 6  */
+#define MPU_REGION_NUM7                         (0x07UL)  /*!< MPU region number 7  */
+#define MPU_REGION_NUM8                         (0x08UL)  /*!< MPU region number 8  */
+#define MPU_REGION_NUM9                         (0x09UL)  /*!< MPU region number 9  */
+#define MPU_REGION_NUM10                        (0x0AUL)  /*!< MPU region number 10 */
+#define MPU_REGION_NUM11                        (0x0BUL)  /*!< MPU region number 11 */
+#define MPU_REGION_NUM12                        (0x0CUL)  /*!< MPU region number 12 */
+#define MPU_REGION_NUM13                        (0x0DUL)  /*!< MPU region number 13 */
+#define MPU_REGION_NUM14                        (0x0EUL)  /*!< MPU region number 14 */
+#define MPU_REGION_NUM15                        (0x0FUL)  /*!< MPU region number 15 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Background_Write_Permission MPU Background Write Permission
+ * @{
+ */
+#define MPU_BACKGROUND_WR_DISABLE               (MPU_SCR_SMPUBWP)   /*!< Disable write the background space */
+#define MPU_BACKGROUND_WR_ENABLE                (0UL)               /*!< Enable write the background space  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Background_Read_Permission MPU Background Read Permission
+ * @{
+ */
+#define MPU_BACKGROUND_RD_DISABLE               (MPU_SCR_SMPUBRP)   /*!< Disable read the background space */
+#define MPU_BACKGROUND_RD_ENABLE                (0UL)               /*!< Enable read the background space  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Unit_State MPU unit state
+ * @{
+ */
+#define MPU_UNIT_ENABLE                         (MPU_SCR_SMPUE)
+#define MPU_UNIT_DISABLE                        (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Exception_Type MPU Exception Type
+ * @{
+ */
+#define MPU_EXP_TYPE_NONE                       (0UL)                   /*!< The host unit access protection regions will be ignored                                       */
+#define MPU_EXP_TYPE_BUS_ERR                    (MPU_SCR_SMPUACT_0)     /*!< The host unit access protection regions will be ignored and a bus error will be triggered     */
+#define MPU_EXP_TYPE_NMI                        (MPU_SCR_SMPUACT_1)     /*!< The host unit access protection regions will be ignored and a NMI interrupt will be triggered */
+#define MPU_EXP_TYPE_RST                        (MPU_SCR_SMPUACT)       /*!< The host unit access protection regions will trigger the reset                                */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Region_Write_Permission MPU Region Write Permission
+ * @{
+ */
+#define MPU_REGION_WR_DISABLE                   (MPU_SRGWP_RG0WP)       /*!< Disable write the region */
+#define MPU_REGION_WR_ENABLE                    (0UL)                   /*!< Enable write the region  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Region_Read_Permission MPU Region Read Permission
+ * @{
+ */
+#define MPU_REGION_RD_DISABLE                   (MPU_SRGRP_RG0RP)    /*!< Disable read the region */
+#define MPU_REGION_RD_ENABLE                    (0UL)                   /*!< Enable read the region  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Region_Size MPU Region Size
+ * @{
+ */
+#define MPU_REGION_SIZE_32BYTE                  (0x04UL)  /*!< 32 Byte   */
+#define MPU_REGION_SIZE_64BYTE                  (0x05UL)  /*!< 64 Byte   */
+#define MPU_REGION_SIZE_128BYTE                 (0x06UL)  /*!< 126 Byte  */
+#define MPU_REGION_SIZE_256BYTE                 (0x07UL)  /*!< 256 Byte  */
+#define MPU_REGION_SIZE_512BYTE                 (0x08UL)  /*!< 512 Byte  */
+#define MPU_REGION_SIZE_1KBYTE                  (0x09UL)  /*!< 1K Byte   */
+#define MPU_REGION_SIZE_2KBYTE                  (0x0AUL)  /*!< 2K Byte   */
+#define MPU_REGION_SIZE_4KBYTE                  (0x0BUL)  /*!< 4K Byte   */
+#define MPU_REGION_SIZE_8KBYTE                  (0x0CUL)  /*!< 8K Byte   */
+#define MPU_REGION_SIZE_16KBYTE                 (0x0DUL)  /*!< 16K Byte  */
+#define MPU_REGION_SIZE_32KBYTE                 (0x0EUL)  /*!< 32K Byte  */
+#define MPU_REGION_SIZE_64KBYTE                 (0x0FUL)  /*!< 64K Byte  */
+#define MPU_REGION_SIZE_128KBYTE                (0x10UL)  /*!< 128K Byte */
+#define MPU_REGION_SIZE_256KBYTE                (0x11UL)  /*!< 256K Byte */
+#define MPU_REGION_SIZE_512KBYTE                (0x12UL)  /*!< 512K Byte */
+#define MPU_REGION_SIZE_1MBYTE                  (0x13UL)  /*!< 1M Byte   */
+#define MPU_REGION_SIZE_2MBYTE                  (0x14UL)  /*!< 2M Byte   */
+#define MPU_REGION_SIZE_4MBYTE                  (0x15UL)  /*!< 4M Byte   */
+#define MPU_REGION_SIZE_8MBYTE                  (0x16UL)  /*!< 8M Byte   */
+#define MPU_REGION_SIZE_16MBYTE                 (0x17UL)  /*!< 16M Byte  */
+#define MPU_REGION_SIZE_32MBYTE                 (0x18UL)  /*!< 32M Byte  */
+#define MPU_REGION_SIZE_64MBYTE                 (0x19UL)  /*!< 64M Byte  */
+#define MPU_REGION_SIZE_128MBYTE                (0x1AUL)  /*!< 128M Byte */
+#define MPU_REGION_SIZE_256MBYTE                (0x1BUL)  /*!< 256M Byte */
+#define MPU_REGION_SIZE_512MBYTE                (0x1CUL)  /*!< 512M Byte */
+#define MPU_REGION_SIZE_1GBYTE                  (0x1DUL)  /*!< 1G Byte   */
+#define MPU_REGION_SIZE_2GBYTE                  (0x1EUL)  /*!< 2G Byte   */
+#define MPU_REGION_SIZE_4GBYTE                  (0x1FUL)  /*!< 4G Byte   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Flag MPU Flag
+ * @{
+ */
+#define MPU_FLAG_DMA1                           (MPU_SR_SMPU1EAF)   /*!< System DMA_1 error flag */
+#define MPU_FLAG_DMA2                           (MPU_SR_SMPU2EAF)   /*!< System DMA_2 error flag */
+#define MPU_FLAG_USBFS_DMA                      (MPU_SR_FMPUEAF)    /*!< USBFS_DMA error flag    */
+#define MPU_FLAG_USBHS_DMA                      (MPU_SR_HMPUEAF)    /*!< USBHS_DMA error flag    */
+#define MPU_FLAG_ETH_DMA                        (MPU_SR_EMPUEAF)    /*!< ETH_DMA error flag      */
+#define MPU_FLAG_ALL                            (MPU_FLAG_DMA1       | MPU_FLAG_DMA2 | MPU_FLAG_USBFS_DMA | \
+                                                 MPU_FLAG_USBHS_DMA  | MPU_FLAG_ETH_DMA)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_IP_Type MPU IP Type
+ * @note     IP access protection is not available in privileged mode.
+ * @{
+ */
+#define MPU_IP_AES                              (MPU_IPPR_AESRDP)       /*!< AES module                              */
+#define MPU_IP_HASH                             (MPU_IPPR_HASHRDP)      /*!< HASH module                             */
+#define MPU_IP_TRNG                             (MPU_IPPR_TRNGRDP)      /*!< TRNG module                             */
+#define MPU_IP_CRC                              (MPU_IPPR_CRCRDP)       /*!< CRC module                              */
+#define MPU_IP_EFM                              (MPU_IPPR_EFMRDP)       /*!< EFM module                              */
+#define MPU_IP_WDT                              (MPU_IPPR_WDTRDP)       /*!< WDT module                              */
+#define MPU_IP_SWDT                             (MPU_IPPR_SWDTRDP)      /*!< SWDT module                             */
+#define MPU_IP_BKSRAM                           (MPU_IPPR_BKSRAMRDP)    /*!< BKSRAM module                           */
+#define MPU_IP_RTC                              (MPU_IPPR_RTCRDP)       /*!< RTC module                              */
+#define MPU_IP_MPU                              (MPU_IPPR_DMPURDP)      /*!< MPU module                              */
+#define MPU_IP_SRAMC                            (MPU_IPPR_SRAMCRDP)     /*!< SRAMC module                            */
+#define MPU_IP_INTC                             (MPU_IPPR_INTCRDP)      /*!< INTC module                             */
+#define MPU_IP_RMU_CMU_PWC                      (MPU_IPPR_SYSCRDP)      /*!< RMU, CMU and PWC modules                */
+#define MPU_IP_FCG                              (MPU_IPPR_MSTPRDP)      /*!< PWR_FCG0/1/2/3 and PWR_FCG0PC registers */
+#define MPU_IP_ALL                              (MPU_IP_AES | MPU_IP_HASH | MPU_IP_TRNG  | MPU_IP_CRC    | \
+                                                 MPU_IP_EFM | MPU_IP_WDT  | MPU_IP_SWDT  | MPU_IP_BKSRAM | \
+                                                 MPU_IP_RTC | MPU_IP_MPU  | MPU_IP_SRAMC | MPU_IP_INTC   | \
+                                                 MPU_IP_FCG | MPU_IP_RMU_CMU_PWC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_IP_Exception_Type MPU IP Exception Type
+ * @{
+ */
+#define MPU_IP_EXP_TYPE_NONE                    (0UL)               /*!< Access to the protected IP will be ignored          */
+#define MPU_IP_EXP_TYPE_BUS_ERR                 (MPU_IPPR_BUSERRE)  /*!< Access to the protected IP will trigger a bus error */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup MPU_Register_Protect_Key INTC Registers Protect Key
+ * @{
+ */
+#define MPU_REG_LOCK_KEY                        (0x96A4UL)
+#define MPU_REG_UNLOCK_KEY                      (0x96A5UL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup MPU_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  MPU write protect unlock.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void MPU_REG_Unlock(void)
+{
+    WRITE_REG32(CM_MPU->WP, MPU_REG_UNLOCK_KEY);
+}
+
+/**
+ * @brief  MPU write protect lock.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void MPU_REG_Lock(void)
+{
+    WRITE_REG32(CM_MPU->WP, MPU_REG_LOCK_KEY);
+}
+
+void MPU_REG_Unlock(void);
+void MPU_REG_Lock(void);
+
+void MPU_DeInit(void);
+int32_t MPU_Init(const stc_mpu_init_t *pstcMpuInit);
+int32_t MPU_StructInit(stc_mpu_init_t *pstcMpuInit);
+int32_t MPU_UnitInit(uint32_t u32Unit, stc_mpu_unit_init_t *pstcUnitInit);
+int32_t MPU_UnitStructInit(stc_mpu_unit_init_t *pstcUnitInit);
+void MPU_SetExceptionType(uint32_t u32Unit, uint32_t u32Type);
+void MPU_BackgroundWriteCmd(uint32_t u32Unit, en_functional_state_t enNewState);
+void MPU_BackgroundReadCmd(uint32_t u32Unit, en_functional_state_t enNewState);
+void MPU_UnitCmd(uint32_t u32Unit, en_functional_state_t enNewState);
+en_flag_status_t MPU_GetStatus(uint32_t u32Flag);
+void MPU_ClearStatus(uint32_t u32Flag);
+
+int32_t MPU_RegionInit(uint32_t u32Num, const stc_mpu_region_init_t *pstcRegionInit);
+int32_t MPU_RegionStructInit(stc_mpu_region_init_t *pstcRegionInit);
+void MPU_SetRegionBaseAddr(uint32_t u32Num, uint32_t u32Addr);
+void MPU_SetRegionSize(uint32_t u32Num, uint32_t u32Size);
+void MPU_RegionWriteCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState);
+void MPU_RegionReadCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState);
+void MPU_RegionCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState);
+
+void MPU_IP_SetExceptionType(uint32_t u32Type);
+void MPU_IP_WriteCmd(uint32_t u32Periph, en_functional_state_t enNewState);
+void MPU_IP_ReadCmd(uint32_t u32Periph, en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_MPU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_MPU_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_nfc.h
+++ b/hc32f4a2/inc/hc32_ll_nfc.h
@@ -1,0 +1,611 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_nfc.h
+ * @brief This file contains all the functions prototypes of the EXMC NFC
+ *        (External Memory Controller: NAND Flash Controller) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Add API function: EXMC_NFC_Read/EXMC_NFC_Write
+   2024-06-30       CDT             Update API function parameter: EXMC_NFC_Read/EXMC_NFC_Write
+   2024-08-31       CDT             API EXMC_NFC_DeInit add return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_NFC_H__
+#define __HC32_LL_NFC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EXMC
+ * @{
+ */
+
+/**
+ * @addtogroup LL_NFC
+ * @{
+ */
+
+#if (LL_NFC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_NFC_Global_Types EXMC_NFC Global Types
+ * @{
+ */
+
+/**
+ * @brief  EXMC_NFC Column for NFC_IDXR0/1 Structure definition
+ */
+typedef struct {
+    uint32_t u32Bank;                   /*!< Defines IDXR bank.
+                                             This parameter can be a value of @ref EXMC_NFC_Bank */
+    uint32_t u32Page;                   /*!< Defines IDXR page. */
+    uint32_t u32Column;                 /*!< Defines IDXR column. */
+} stc_exmc_nfc_column_t;
+
+/**
+ * @brief  EXMC_NFC Base Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32CapacitySize;           /*!< Defines the capacity size.
+                                             This parameter can be a value of @ref EXMC_NFC_BANK_Memory_Capacity. */
+    uint32_t u32MemoryWidth;            /*!< Defines the memory width.
+                                             This parameter can be a value of @ref EXMC_NFC_Memory_Width. */
+    uint32_t u32BankNum;                /*!< Defines the bank number.
+                                             This parameter can be a value of @ref EXMC_NFC_Bank_Number */
+    uint32_t u32PageSize;               /*!< Defines the page size.
+                                             This parameter can be a value of @ref EXMC_NFC_Page_Size. */
+    uint32_t u32WriteProtect;           /*!< Defines the write protect.
+                                             This parameter can be a value of @ref EXMC_NFC_Write_Protect. */
+    uint32_t u32EccMode;                /*!< Defines the ECC mode.
+                                             This parameter can be a value of @ref EXMC_NFC_ECC_Mode. */
+    uint32_t u32RowAddrCycle;           /*!< Defines the row address cycle.
+                                             This parameter can be a value of @ref EXMC_NFC_Row_Address_Cycle. */
+    uint8_t  u8SpareSizeForUserData;    /*!< Defines the spare column size for user data.
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+} stc_exmc_nfc_base_config_t;
+
+/**
+ * @brief  EXMC_NFC Timing Register 0 Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32TS;                     /*!< Defines the CLE/ALE/CE setup time in memory clock cycles(tALS/tCS/tCLS).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TWP;                    /*!< Defines the WE# pulse width time in memory clock cycles(tWP).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TRP;                    /*!< Defines the RE# pulse width time in memory clock cycles(tRP).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TH;                     /*!< Defines the CLE/ALE/CE hold time in memory clock cycles(tALH/tCH/tCLH).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+} stc_exmc_nfc_timing_reg0_config_t;
+
+/**
+ * @brief  EXMC_NFC Timing Register 1 Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32TWH;                    /*!< Defines the WE# pulse width HIGH time in memory clock cycles(tWH).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TRH;                    /*!< Defines the RE# HIGH hold time in memory clock cycles(tREH).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TRR;                    /*!< Defines the Ready to RE# LOW time in memory clock cycles(tRR).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TWB;                    /*!< Defines the WE# HIGH to busy time in memory clock cycles(tWB).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+} stc_exmc_nfc_timing_reg1_config_t;
+
+/**
+ * @brief  EXMC_NFC Timing Register 2 Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32TCCS;                   /*!< Defines the command(change read/write column) delay time in memory clock cycles.
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TWTR;                   /*!< Defines the WE# HIGH to RE# LOW time in memory clock cycles(tWHR).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TRTW;                   /*!< Defines the RE# HIGH to WE# LOW time in memory clock cycles(tRHW).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+    uint32_t u32TADL;                   /*!< Defines the Address to Data Loading time in memory clock cycles(tADL).
+                                             This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF */
+} stc_exmc_nfc_timing_reg2_config_t;
+
+/**
+ * @brief  EXMC_NFC Initialization Structure definition
+ */
+typedef struct {
+    uint32_t                          u32OpenPage;   /*!< NFC memory open-page selection.
+                                                          This structure details refer @ref EXMC_NFC_Open_Page. */
+    stc_exmc_nfc_base_config_t        stcBaseConfig; /*!< NFC memory base configure.
+                                                          This structure details refer @ref stc_exmc_nfc_base_config_t. */
+    stc_exmc_nfc_timing_reg0_config_t stcTimingReg0; /*!< NFC memory timing configure 0.
+                                                          This structure details refer @ref stc_exmc_nfc_timing_reg0_config_t. */
+    stc_exmc_nfc_timing_reg1_config_t stcTimingReg1; /*!< NFC memory timing configure 1.
+                                                          This structure details refer @ref stc_exmc_nfc_timing_reg1_config_t. */
+    stc_exmc_nfc_timing_reg2_config_t stcTimingReg2; /*!< NFC memory timing configure 2.
+                                                          This structure details refer @ref stc_exmc_nfc_timing_reg2_config_t. */
+} stc_exmc_nfc_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_NFC_Global_Macros EXMC_NFC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_NFC_Bank EXMC_NFC Bank
+ * @{
+ */
+#define EXMC_NFC_BANK0                      (0UL)     /*!< Bank 0 */
+#define EXMC_NFC_BANK1                      (1UL)     /*!< Bank 1 */
+#define EXMC_NFC_BANK2                      (2UL)     /*!< Bank 2 */
+#define EXMC_NFC_BANK3                      (3UL)     /*!< Bank 3 */
+#define EXMC_NFC_BANK4                      (4UL)     /*!< Bank 4 */
+#define EXMC_NFC_BANK5                      (5UL)     /*!< Bank 5 */
+#define EXMC_NFC_BANK6                      (6UL)     /*!< Bank 6 */
+#define EXMC_NFC_BANK7                      (7UL)     /*!< Bank 7 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Page_Size EXMC_NFC Page Size
+ * @{
+ */
+#define EXMC_NFC_PAGE_SIZE_2KBYTE           (NFC_BACR_PAGE_0)
+#define EXMC_NFC_PAGE_SIZE_4KBYTE           (NFC_BACR_PAGE_1)
+#define EXMC_NFC_PAGE_SIZE_8KBYTE           (NFC_BACR_PAGE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_BANK_Memory_Capacity EXMC_NFC BANK Memory Capacity
+ * @{
+ */
+#define EXMC_NFC_BANK_CAPACITY_512MBIT      (3UL)
+#define EXMC_NFC_BANK_CAPACITY_1GBIT        (4UL)
+#define EXMC_NFC_BANK_CAPACITY_2GBIT        (5UL)
+#define EXMC_NFC_BANK_CAPACITY_4GBIT        (6UL)
+#define EXMC_NFC_BANK_CAPACITY_8GBIT        (7UL)
+#define EXMC_NFC_BANK_CAPACITY_16GBIT       (0UL)
+#define EXMC_NFC_BANK_CAPACITY_32GBIT       (1UL)
+#define EXMC_NFC_BANK_CAPACITY_64GBIT       (2UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Memory_Width EXMC_NFC Memory Width
+ * @{
+ */
+#define EXMC_NFC_MEMORY_WIDTH_8BIT          (0UL)
+#define EXMC_NFC_MEMORY_WIDTH_16BIT         (NFC_BACR_B16BIT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Bank_Number EXMC_NFC Bank Number
+ * @{
+ */
+#define EXMC_NFC_1BANK                      (0UL)
+#define EXMC_NFC_2BANKS                     (NFC_BACR_BANK_0)
+#define EXMC_NFC_4BANKS                     (NFC_BACR_BANK_1)
+#define EXMC_NFC_8BANKS                     (NFC_BACR_BANK)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Open_Page EXMC_NFC Open Page
+ * @{
+ */
+#define EXMC_NFC_OPEN_PAGE_DISABLE          (0UL)
+#define EXMC_NFC_OPEN_PAGE_ENABLE           (PERIC_NFC_STCR_OPENP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Write_Protect EXMC_NFC Write Protect
+ * @{
+ */
+#define EXMC_NFC_WR_PROTECT_ENABLE          (0UL)
+#define EXMC_NFC_WR_PROTECT_DISABLE         (NFC_BACR_WP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_ECC_Mode EXMC_NFC ECC Mode
+ * @{
+ */
+#define EXMC_NFC_1BIT_ECC                   (0UL)
+#define EXMC_NFC_4BIT_ECC                   (NFC_BACR_ECCM_0)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Row_Address_Cycle EXMC_NFC Row Address Cycle
+ * @{
+ */
+#define EXMC_NFC_2_ROW_ADDR_CYCLE           (0UL)
+#define EXMC_NFC_3_ROW_ADDR_CYCLE           (NFC_BACR_RAC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_ECC_Calculate_Bytes EXMC_NFC ECC Calculate Bytes
+ * @{
+ */
+#define EXMC_NFC_ECC_CALCULATE_BLOCK_BYTE   (512UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_ECC_Value_Bytes EXMC_NFC ECC Value Bytes
+ * @{
+ */
+#define EXMC_NFC_1BIT_ECC_VALUE_BYTE        (3UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_1Bit_ECC_Result EXMC_NFC 1Bit ECC Result
+ * @{
+ */
+#define EXMC_NFC_1BIT_ECC_NONE_ERR          (0UL)
+#define EXMC_NFC_1BIT_ECC_SINGLE_BIT_ERR    (NFC_ECCR_SE)
+#define EXMC_NFC_1BIT_ECC_MULTIPLE_BITS_ERR (NFC_ECCR_ME)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_1Bit_ECC_Error_Bit_Location EXMC_NFC 1Bit ECC Error Bit Location
+ * @{
+ */
+#define EXMC_NFC_1BIT_ECC_ERR_BIT0          (0UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT1          (1UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT2          (2UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT3          (3UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT4          (4UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT5          (5UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT6          (6UL)
+#define EXMC_NFC_1BIT_ECC_ERR_BIT7          (7UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_ECC_Section EXMC_NFC ECC Section
+ * @{
+ */
+#define EXMC_NFC_ECC_SECTION0               (0UL)
+#define EXMC_NFC_ECC_SECTION1               (1UL)
+#define EXMC_NFC_ECC_SECTION2               (2UL)
+#define EXMC_NFC_ECC_SECTION3               (3UL)
+#define EXMC_NFC_ECC_SECTION4               (4UL)
+#define EXMC_NFC_ECC_SECTION5               (5UL)
+#define EXMC_NFC_ECC_SECTION6               (6UL)
+#define EXMC_NFC_ECC_SECTION7               (7UL)
+#define EXMC_NFC_ECC_SECTION8               (8UL)
+#define EXMC_NFC_ECC_SECTION9               (9UL)
+#define EXMC_NFC_ECC_SECTION10              (10UL)
+#define EXMC_NFC_ECC_SECTION11              (11UL)
+#define EXMC_NFC_ECC_SECTION12              (12UL)
+#define EXMC_NFC_ECC_SECTION13              (13UL)
+#define EXMC_NFC_ECC_SECTION14              (14UL)
+#define EXMC_NFC_ECC_SECTION15              (15UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Interrupt EXMC_NFC Interrupt
+ * @{
+ */
+#define EXMC_NFC_INT_RB_BANK0                   (NFC_IENR_RBEN_0)
+#define EXMC_NFC_INT_RB_BANK1                   (NFC_IENR_RBEN_1)
+#define EXMC_NFC_INT_RB_BANK2                   (NFC_IENR_RBEN_2)
+#define EXMC_NFC_INT_RB_BANK3                   (NFC_IENR_RBEN_3)
+#define EXMC_NFC_INT_RB_BANK4                   (NFC_IENR_RBEN_4)
+#define EXMC_NFC_INT_RB_BANK5                   (NFC_IENR_RBEN_5)
+#define EXMC_NFC_INT_RB_BANK6                   (NFC_IENR_RBEN_6)
+#define EXMC_NFC_INT_RB_BANK7                   (NFC_IENR_RBEN_7)
+#define EXMC_NFC_INT_ECC_ERROR                  (NFC_IENR_ECCEEN)
+#define EXMC_NFC_INT_ECC_CALC_COMPLETION        (NFC_IENR_ECCCEN)
+#define EXMC_NFC_INT_ECC_CORRECTABLE_ERR        (NFC_IENR_ECCECEN)
+#define EXMC_NFC_INT_ECC_UNCORRECTABLE_ERR      (NFC_IENR_ECCEUEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Flag EXMC_NFC Flag
+ * @{
+ */
+#define EXMC_NFC_FLAG_RB_BANK0                  (NFC_ISTR_RBST_0)
+#define EXMC_NFC_FLAG_RB_BANK1                  (NFC_ISTR_RBST_1)
+#define EXMC_NFC_FLAG_RB_BANK2                  (NFC_ISTR_RBST_2)
+#define EXMC_NFC_FLAG_RB_BANK3                  (NFC_ISTR_RBST_3)
+#define EXMC_NFC_FLAG_RB_BANK4                  (NFC_ISTR_RBST_4)
+#define EXMC_NFC_FLAG_RB_BANK5                  (NFC_ISTR_RBST_5)
+#define EXMC_NFC_FLAG_RB_BANK6                  (NFC_ISTR_RBST_6)
+#define EXMC_NFC_FLAG_RB_BANK7                  (NFC_ISTR_RBST_7)
+#define EXMC_NFC_FLAG_ECC_ERR                   (NFC_ISTR_ECCEST)
+#define EXMC_NFC_FLAG_ECC_CALC_COMPLETION       (NFC_ISTR_ECCCST)
+#define EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR       (NFC_ISTR_ECCECST)
+#define EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR     (NFC_ISTR_ECCEUST)
+#define EXMC_NFC_FLAG_ECC_CALCULATING           (1UL << 31UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Max_Timeout EXMC_NFC Max Timeout
+ * @{
+ */
+#define EXMC_NFC_MAX_TIMEOUT                    (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Memory_Command EXMC_NFC Memory Command
+ * @{
+ */
+#define EXMC_NFC_CMD_RD_1ST                             (0x00UL)
+#define EXMC_NFC_CMD_RD_2ND                             (0xE0UL)
+
+#define EXMC_NFC_CMD_COPYBACK_READ_1ST                  (0x00UL)
+#define EXMC_NFC_CMD_COPYBACK_READ_2ND                  (0x35UL)
+
+#define EXMC_NFC_CMD_CHANGE_RD_COL_1ST                  (0x05UL)
+#define EXMC_NFC_CMD_CHANGE_RD_COL_2ND                  (0xE0UL)
+
+#define EXMC_NFC_CMD_CHANGE_RD_COL_ENHANCED_1ST         (0x06UL)
+#define EXMC_NFC_CMD_CHANGE_RD_COL_ENHANCED_2ND         (0xE0UL)
+
+#define EXMC_NFC_CMD_RD_CACHE_RANDOM_1ST                (0x00UL)
+#define EXMC_NFC_CMD_RD_CACHE_RANDOM_2ND                (0x31UL)
+
+#define EXMC_NFC_CMD_CALCULATE_ECC                      (0x23UL)
+
+#define EXMC_NFC_CMD_RD_CACHE_SEQ                       (0x31UL)
+
+#define EXMC_NFC_CMD_RD_CACHE_END                       (0x3FUL)
+
+#define EXMC_NFC_CMD_BLK_ERASE_1ST                      (0x60UL)
+#define EXMC_NFC_CMD_BLK_ERASE_2ND                      (0xD0UL)
+
+#define EXMC_NFC_CMD_BLK_ERASE_INTERLEAVED_1ST          (0x60UL)
+#define EXMC_NFC_CMD_BLK_ERASE_INTERLEAVED_2ND          (0xD1UL)
+
+#define EXMC_NFC_CMD_RD_STATUS                          (0x70UL)
+
+#define EXMC_NFC_CMD_RD_STATUS_ENHANCED                 (0x78UL)
+
+#define EXMC_NFC_CMD_PAGE_PROGRAM_1ST                   (0x80UL)
+#define EXMC_NFC_CMD_PAGE_PROGRAM_2ND                   (0x10UL)
+
+#define EXMC_NFC_CMD_PAGE_PROGRAM_INTERLEAVED_1ST       (0x80UL)
+#define EXMC_NFC_CMD_PAGE_PROGRAM_INTERLEAVED_2ND       (0x11UL)
+
+#define EXMC_NFC_CMD_PAGE_CACHE_PROGRAM_1ST             (0x80UL)
+#define EXMC_NFC_CMD_PAGE_CACHE_PROGRAM_2ND             (0x15UL)
+
+#define EXMC_NFC_CMD_COPYBACK_PROGRAM_1ST               (0x85UL)
+#define EXMC_NFC_CMD_COPYBACK_PROGRAM_2ND               (0x10UL)
+
+#define EXMC_NFC_CMD_COPYBACK_PROGRAM_INTERLEAVED_1ST   (0x85UL)
+#define EXMC_NFC_CMD_COPYBACK_PROGRAM_INTERLEAVED_2ND   (0x11UL)
+
+#define EXMC_NFC_CMD_CHANGE_WR_COL                      (0x85UL)
+
+#define EXMC_NFC_CMD_CHANGE_ROW_ADDR                    (0x85UL)
+
+#define EXMC_NFC_CMD_RD_ID                              (0x90UL)
+
+#define EXMC_NFC_CMD_RD_PARAMETER_PAGE                  (0xECUL)
+
+#define EXMC_NFC_CMD_RD_UNIQUE_ID                       (0xEDUL)
+
+#define EXMC_NFC_CMD_GET_FEATURES                       (0xEEUL)
+
+#define EXMC_NFC_CMD_SET_FEATURES                       (0xEFUL)
+
+#define EXMC_NFC_CMD_RST_LUN                            (0xFAUL)
+
+#define EXMC_NFC_CMD_ASYNCHRONOUS_RST                   (0xFCUL)
+
+#define EXMC_NFC_CMD_DESELECT_CHIP                      (0xFEUL)
+
+#define EXMC_NFC_CMD_RESET                              (0xFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EXMC_NFC_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Set EXMC_NFC command register value.
+ * @param  [in] u32Value            The combination value of command @ref EXMC_NFC_Memory_Command and arguments.
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_NFC_WriteCmdReg(uint32_t u32Value)
+{
+    WRITE_REG32(CM_NFC->CMDR, u32Value);
+}
+
+/**
+ * @brief  Set EXMC_NFC Index register value.
+ * @param  [in] u32Value            The value of NFC_IDXR0.
+ *         This parameter can be a value between Min_Data = 0 and Max_Data = 0xFFFFFFFF
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_NFC_WriteIDXR0(uint32_t u32Value)
+{
+    WRITE_REG32(CM_NFC->IDXR0, u32Value);
+}
+
+/**
+ * @brief  Set EXMC_NFC Index register value.
+ * @param  [in] u8Value             The value of NFC_IDXR1.
+ *         This parameter can be a value between Min_Data = 0 and Max_Data = 0xFF
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_NFC_WriteIDXR1(uint8_t u8Value)
+{
+    WRITE_REG32(CM_NFC->IDXR1, u8Value);
+}
+
+/**
+ * @brief  De-select NFC bank.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_NFC_DeselectChip(void)
+{
+    WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_DESELECT_CHIP);
+}
+
+/**
+ * @brief  Get the 4BIT ECC error section.
+ * @param  None
+ * @retval The 4BIT ECC error section
+ */
+__STATIC_INLINE uint16_t EXMC_NFC_Get4BitEccErrSection(void)
+{
+    return (uint16_t)READ_REG32(CM_NFC->ECC_STAT);
+}
+
+/* Initialization and configuration EXMC_NFC functions */
+int32_t EXMC_NFC_StructInit(stc_exmc_nfc_init_t *pstcNfcInit);
+int32_t EXMC_NFC_Init(const stc_exmc_nfc_init_t *pstcNfcInit);
+int32_t EXMC_NFC_DeInit(void);
+
+void EXMC_NFC_Cmd(en_functional_state_t enNewState);
+void EXMC_NFC_EccCmd(en_functional_state_t enNewState);
+void EXMC_NFC_WriteProtectCmd(en_functional_state_t enNewState);
+void EXMC_NFC_IntCmd(uint16_t u16IntType, en_functional_state_t enNewState);
+en_flag_status_t EXMC_NFC_GetStatus(uint32_t u32Flag);
+void EXMC_NFC_ClearStatus(uint32_t u32Flag);
+en_flag_status_t EXMC_NFC_GetIntResultStatus(uint32_t u32Flag);
+uint32_t EXMC_NFC_Get1BitEccResult(uint32_t u32Section);
+uint32_t EXMC_NFC_Get1BitEccErrBitLocation(uint32_t u32Section);
+uint32_t EXMC_NFC_Get1BitEccErrByteLocation(uint32_t u32Section);
+void EXMC_NFC_SetSpareAreaSize(uint8_t u8SpareSizeForUserData);
+void EXMC_NFC_SetEccMode(uint32_t u32EccMode);
+int32_t EXMC_NFC_GetSyndrome(uint32_t u32Section, uint16_t au16Synd[], uint8_t u8Len);
+
+/* EXMC_NFC command functions */
+uint32_t EXMC_NFC_ReadStatus(uint32_t u32Bank);
+uint32_t EXMC_NFC_ReadStatusEnhanced(uint32_t u32Bank, uint32_t u32RowAddr);
+int32_t EXMC_NFC_Reset(uint32_t u32Bank, uint32_t u32Timeout);
+int32_t EXMC_NFC_AsyncReset(uint32_t u32Bank, uint32_t u32Timeout);
+int32_t EXMC_NFC_ResetLun(uint32_t u32Bank, uint32_t u32RowAddr, uint32_t u32Timeout);
+int32_t EXMC_NFC_ReadId(uint32_t u32Bank, uint32_t u32IdAddr,
+                        uint8_t au8DevId[], uint32_t u32NumBytes, uint32_t u32Timeout);
+int32_t EXMC_NFC_ReadUniqueId(uint32_t u32Bank, uint32_t au32UniqueId[], uint8_t u8NumWords, uint32_t u32Timeout);
+int32_t EXMC_NFC_ReadParameterPage(uint32_t u32Bank,
+                                   uint32_t au32Data[], uint16_t u16NumWords, uint32_t u32Timeout);
+int32_t EXMC_NFC_SetFeature(uint32_t u32Bank, uint8_t u8FeatureAddr,
+                            const uint32_t au32Data[], uint8_t u8NumWords, uint32_t u32Timeout);
+int32_t EXMC_NFC_GetFeature(uint32_t u32Bank, uint8_t u8FeatureAddr,
+                            uint32_t au32Data[], uint8_t u8NumWords, uint32_t u32Timeout);
+int32_t EXMC_NFC_EraseBlock(uint32_t u32Bank, uint32_t u32RowAddr, uint32_t u32Timeout);
+int32_t EXMC_NFC_Read(stc_exmc_nfc_column_t *pstcColumn,
+                      uint32_t au32Data[], uint32_t u32NumWords,
+                      en_functional_state_t enEccState, uint32_t u32Timeout);
+int32_t EXMC_NFC_Write(stc_exmc_nfc_column_t *pstcColumn,
+                       const uint32_t au32Data[], uint32_t u32NumWords,
+                       en_functional_state_t enEccState, uint32_t u32Timeout);
+int32_t EXMC_NFC_ReadPageMeta(uint32_t u32Bank, uint32_t u32Page, uint8_t *pu8Data,
+                              uint32_t u32NumBytes, uint32_t u32Timeout);
+int32_t EXMC_NFC_WritePageMeta(uint32_t u32Bank, uint32_t u32Page,
+                               const uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout);
+int32_t EXMC_NFC_ReadPageHwEcc(uint32_t u32Bank, uint32_t u32Page,
+                               uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout);
+int32_t EXMC_NFC_WritePageHwEcc(uint32_t u32Bank, uint32_t u32Page,
+                                const uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout);
+/**
+ * @}
+ */
+
+#endif /* LL_NFC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_NFC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_ots.h
+++ b/hc32f4a2/inc/hc32_ll_ots.h
@@ -1,0 +1,204 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_ots.h
+ * @brief This file contains all the functions prototypes of the OTS driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+                                    Modify API OTS_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_OTS_H__
+#define __HC32_LL_OTS_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_OTS
+ * @{
+ */
+
+#if (LL_OTS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup OTS_Global_Types OTS Global Types
+ * @{
+ */
+
+/**
+ * @brief Conditions of default parameters(slope K and offset M).
+ * @note Parameter 'u8T1' CANNOT equal to parameter 'u8T2'.
+ */
+typedef struct {
+    uint16_t u16ClockFreq;                  /*!< Frequency(MHz) of clock sources that OTS is going to use. */
+    uint8_t u8T1;                           /*!< Temperature value T1 for the default parameter.
+                                                 This parameter can be a value of @ref OTS_Param_Temp_Cond */
+    uint8_t u8T2;                           /*!< Temperature value T2 for the default parameter.
+                                                 This parameter can be a value of @ref OTS_Param_Temp_Cond */
+} stc_para_temp_cond_t;
+
+/**
+ * @brief OTS initialization structure.
+ */
+typedef struct {
+    uint16_t u16ClockSrc;                   /*!< Specifies clock source for OTS.
+                                                 This parameter can be a value of @ref OTS_Clock_Source */
+    uint16_t u16AutoOffEn;                  /*!< Enable or disable OTS automatic-off(after sampled temperature).
+                                                 This parameter can be a value of @ref OTS_Auto_Off_En */
+    float32_t f32SlopeK;                    /*!< K: Temperature slope (calculated by calibration experiment).
+                                                 If you want to use the default parameters(slope K and offset M),
+                                                 specify both 'f32SlopeK' and 'f32OffsetM' as ZERO. */
+    float32_t f32OffsetM;                   /*!< M: Temperature offset (calculated by calibration experiment).
+                                                 If you want to use the default parameters(slope K and offset M),
+                                                 specify both 'f32SlopeK' and 'f32OffsetM' as ZERO. */
+    stc_para_temp_cond_t stcParaCond;       /*!< Specifies the temperature conditions of the default parameters(slope K and offset M) if you
+                                                 want to use the default parameters. */
+} stc_ots_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup OTS_Global_Macros OTS Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup OTS_Clock_Source OTS Clock Source
+ * @{
+ */
+#define OTS_CLK_XTAL                    (0x0U)              /*!< Select XTAL as OTS clock. */
+#define OTS_CLK_HRC                     (OTS_CTL_OTSCK)     /*!< Select HRC as OTS clock */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Auto_Off_En OTS Automatic Off Function Control
+ * @{
+ */
+#define OTS_AUTO_OFF_DISABLE            (0x0U)              /*!< OTS automatically turned off when sampled done. */
+#define OTS_AUTO_OFF_ENABLE             (OTS_CTL_TSSTP)     /*!< OTS is still on when sampled done. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Param_Temp_Cond OTS Parameter Temperature Condition
+ * @{
+ */
+#define OTS_PARAM_TEMP_COND_TN40        (0U)                /*!< -40 degrees Celsius. */
+#define OTS_PARAM_TEMP_COND_T25         (1U)                /*!< 25 degrees Celsius. */
+#define OTS_PARAM_TEMP_COND_T125        (2U)                /*!< 125 degrees Celsius. */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup OTS_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Start OTS.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void OTS_Start(void)
+{
+    WRITE_REG32(bCM_OTS->CTL_b.OTSST, 1U);
+}
+
+/**
+ * @brief  Stop OTS.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void OTS_Stop(void)
+{
+    WRITE_REG32(bCM_OTS->CTL_b.OTSST, 0U);
+}
+
+int32_t OTS_Init(const stc_ots_init_t *pstcOTSInit);
+int32_t OTS_StructInit(stc_ots_init_t *pstcOTSInit);
+int32_t OTS_DeInit(void);
+
+int32_t OTS_Polling(float32_t *pf32Temp, uint32_t u32Timeout);
+
+void OTS_IntCmd(en_functional_state_t enNewState);
+
+int32_t OTS_ScalingExperiment(uint16_t *pu16Dr1, uint16_t *pu16Dr2,
+                              uint16_t *pu16Ecr, float32_t *pf32A,
+                              uint32_t u32Timeout);
+
+float32_t OTS_CalculateTemp(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_OTS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_OTS_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_pwc.h
+++ b/hc32f4a2/inc/hc32_ll_pwc.h
@@ -1,0 +1,715 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_pwc.h
+ * @brief This file contains all the functions prototypes of the PWC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Refine API PWC_STOP_Enter()
+   2023-06-30       CDT             Modify group PWC_Stop_Type
+   2023-09-30       CDT             Add function PWC_LVD_DeInit
+                                    Modify the PWC_LVD_Detection_Voltage_Sel comment
+   2023-12-15       CDT             Refine API PWC_SLEEP_Enter()
+                                    Add API PWC_PD_SetIoState & PWC_PD_SetMode and add return value to PWC_PD_Enter
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_PWC_H__
+#define __HC32_LL_PWC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_PWC
+ * @{
+ */
+
+#if (LL_PWC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup PWC_Global_Types PWC Global Types
+ * @{
+ */
+/**
+ * @brief PWC LVD Init
+ */
+typedef struct {
+    uint32_t u32State;              /*!< LVD function setting, @ref PWC_LVD_Config for details */
+    uint32_t u32CompareOutputState; /*!< LVD compare output function setting, @ref PWC_LVD_CMP_Config for details */
+    uint32_t u32ExceptionType;      /*!< LVD interrupt or reset selection, @ref PWC_LVD_Exception_Type_Sel for details */
+    uint32_t u32Filter;             /*!< LVD digital filter function setting, @ref PWC_LVD_DF_Config for details */
+    uint32_t u32FilterClock;        /*!< LVD digital filter clock setting, @ref PWC_LVD_DFS_Clk_Sel for details */
+    uint32_t u32ThresholdVoltage;   /*!< LVD detect voltage setting, @ref PWC_LVD_Detection_Voltage_Sel for details */
+    uint32_t u32TriggerEdge;        /*!< LVD trigger setting, @ref PWC_LVD_TRIG_Sel for details */
+} stc_pwc_lvd_init_t;
+
+/**
+ * @brief PWC power down mode innit
+ */
+typedef struct {
+    uint8_t u8Mode;         /*!< Power down mode, @ref PWC_PDMode_Sel for details. */
+    uint8_t u8IOState;      /*!< IO state in power down mode, @ref PWC_PDMode_IO_Sel for details. */
+    uint8_t u8VcapCtrl;     /*!< Power down Wakeup time control, @ref PWC_PD_VCAP_Sel for details. */
+} stc_pwc_pd_mode_config_t;
+
+/**
+ * @brief PWC Stop mode Init
+ */
+typedef struct {
+    uint16_t u16Clock;          /*!< System clock setting after wake-up from stop mode,
+                                    @ref PWC_STOP_CLK_Sel for details.        */
+    uint8_t u8StopDrv;          /*!< Stop mode drive capacity,
+                                    @ref PWC_STOP_DRV_Sel for details.        */
+    uint16_t u16ExBusHold;      /*!< Expos status in stop mode,
+                                    @ref PWC_STOP_EXBUS_Sel for details.      */
+    uint16_t u16FlashWait;      /*!< Waiting flash stable after wake-up from stop mode,
+                                    @ref PWC_STOP_Flash_Wait_Sel for details. */
+} stc_pwc_stop_mode_config_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup PWC_Global_Macros PWC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup PWC_PDMode_Sel Power down mode selection
+ * @{
+ */
+#define PWC_PD_MD1                      (0x00U)        /*!< Power down mode 1 */
+#define PWC_PD_MD2                      (0x01U)        /*!< Power down mode 2 */
+#define PWC_PD_MD3                      (0x02U)        /*!< Power down mode 3 */
+#define PWC_PD_MD4                      (0x03U)        /*!< Power down mode 4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_PDMode_IO_Sel IO state config in Power down mode
+ * @{
+ */
+#define PWC_PD_IO_KEEP1                 (0x00U)                 /*!< IO state retain in PD mode and configurable after wakeup */
+#define PWC_PD_IO_KEEP2                 (PWC_PWRC0_IORTN_0)     /*!< IO state retain in PD mode and configurable after wakeup & set IORTN[1:0]=00b */
+#define PWC_PD_IO_HIZ                   (PWC_PWRC0_IORTN_1)     /*!< IO state switch to HiZ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_PD_VCAP_Sel Wakeup speed config in Power down mode
+ * @{
+ */
+#define PWC_PD_VCAP_0P1UF               (0x00U)        /*!< VCAP1/VCAP2 = 0.1uF x2 or 0.22uF x1 */
+#define PWC_PD_VCAP_0P047UF             (0x01U)        /*!< VCAP1/VCAP2 = 0.047uF x2 or 0.1uF x1 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_STOP_DRV_Sel Drive capacity while enter stop mode
+ * @{
+ */
+#define PWC_STOP_DRV_HIGH               (0x00U)                 /*!< Enter stop mode from high speed mode */
+#define PWC_STOP_DRV_LOW                (PWC_PWRC1_STPDAS)      /*!< Enter stop mode from ultra low speed mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_STOP_EXBUS_Sel ExBus status while enter stop mode
+ * @{
+ */
+#define PWC_STOP_EXBUS_HIZ              (0x00U)                 /*!< Ex-Bus Hiz in stop mode */
+#define PWC_STOP_EXBUS_HOLD             (PWC_STPMCR_EXBUSOE)    /*!< Ex-Bus keep in stop mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_STOP_CLK_Sel System clock setting after wake-up from stop mode
+ * @{
+ */
+#define PWC_STOP_CLK_KEEP               (0x00U)                 /*!< Keep System clock setting after wake-up from stop mode */
+#define PWC_STOP_CLK_MRC                (PWC_STPMCR_CKSMRC)     /*!< System clock switch to MRC after wake-up from stop mode */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_STOP_Flash_Wait_Sel Whether wait flash stable or not after wake-up from stop mode
+ * @{
+ */
+#define PWC_STOP_FLASH_WAIT_ON          (0x00U)                 /*!< Wait flash stable after wake-up from stop mode */
+#define PWC_STOP_FLASH_WAIT_OFF         (PWC_STPMCR_FLNWT)      /*!< Don't wait flash stable after wake-up from stop mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_Stop_Type PWC stop mode type.
+ * @{
+ */
+#define PWC_STOP_WFI                    (0x00U)                 /*!< Enter stop mode by WFI, and wake-up by interrupt handle. */
+#define PWC_STOP_WFE_INT                (0x01U)                 /*!< Enter stop mode by WFE, and wake-up by interrupt request. */
+#define PWC_STOP_WFE_EVT                (0x02U)                 /*!< Enter stop mode by WFE, and wake-up by event. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_Stop_Type PWC stop mode type.
+ * @{
+ */
+#define PWC_SLEEP_WFI                   (0x00U)                 /*!< Enter sleep mode by WFI, and wake-up by interrupt handle. */
+#define PWC_SLEEP_WFE_INT               (0x01U)                 /*!< Enter sleep mode by WFE, and wake-up by interrupt request. */
+#define PWC_SLEEP_WFE_EVT               (0x02U)                 /*!< Enter sleep mode by WFE, and wake-up by event. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_RAM_Config Operating mode for RAM Config
+ * @{
+ */
+#define PWC_RAM_HIGH_SPEED              (0x8043U)               /*!< MCU operating under high frequency (lower than 240MHz) */
+#define PWC_RAM_ULOW_SPEED              (0x9062U)               /*!< MCU operating under ultra low frequency (lower than 8MHz) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_PD_Periph_Ram  Peripheral ram to power down
+ * @{
+ */
+#define PWC_RAM_PD_CAN1                 (PWC_PRAMLPC_PRAMPDC0)
+#define PWC_RAM_PD_CAN2                 (PWC_PRAMLPC_PRAMPDC1)
+#define PWC_RAM_PD_CACHE                (PWC_PRAMLPC_PRAMPDC2)
+#define PWC_RAM_PD_USBFS                (PWC_PRAMLPC_PRAMPDC3)
+#define PWC_RAM_PD_USBHS                (PWC_PRAMLPC_PRAMPDC4)
+#define PWC_RAM_PD_ETHERTX              (PWC_PRAMLPC_PRAMPDC5)
+#define PWC_RAM_PD_ETHERRX              (PWC_PRAMLPC_PRAMPDC6)
+#define PWC_RAM_PD_SDIO1                (PWC_PRAMLPC_PRAMPDC7)
+#define PWC_RAM_PD_SDIO2                (PWC_PRAMLPC_PRAMPDC8)
+#define PWC_RAM_PD_NFC                  (PWC_PRAMLPC_PRAMPDC9)
+#define PWC_RAM_PD_ALL                  (0x3FFU)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_PD_Ram  Peripheral ram to power down
+ * @{
+ */
+#define PWC_RAM_PD_SRAM1_1              (PWC_RAMPC0_RAMPDC0)    /*< 0x20000000 ~ 0x2000FFFF */
+#define PWC_RAM_PD_SRAM1_2              (PWC_RAMPC0_RAMPDC1)    /*< 0x20010000 ~ 0x2001FFFF */
+#define PWC_RAM_PD_SRAM2_1              (PWC_RAMPC0_RAMPDC2)    /*< 0x20020000 ~ 0x2002FFFF */
+#define PWC_RAM_PD_SRAM2_2              (PWC_RAMPC0_RAMPDC3)    /*< 0x20030000 ~ 0x2003FFFF */
+#define PWC_RAM_PD_SRAM3_1              (PWC_RAMPC0_RAMPDC4)    /*< 0x20040000 ~ 0x2004FFFF */
+#define PWC_RAM_PD_SRAM3_2              (PWC_RAMPC0_RAMPDC5)    /*< 0x20050000 ~ 0x20057FFF */
+#define PWC_RAM_PD_SRAM4                (PWC_RAMPC0_RAMPDC6)    /*< 0x20058000 ~ 0x2005FFFF */
+#define PWC_RAM_PD_SRAMH_1              (PWC_RAMPC0_RAMPDC7)    /*< 0x1FFE0000 ~ 0x1FFE7FFF */
+#define PWC_RAM_PD_SRAMH_2              (PWC_RAMPC0_RAMPDC8)    /*< 0x1FFE8000 ~ 0x1FFEFFFF */
+#define PWC_RAM_PD_SRAMH_3              (PWC_RAMPC0_RAMPDC9)    /*< 0x1FFF0000 ~ 0x1FFF7FFF */
+#define PWC_RAM_PD_SRAMH_4              (PWC_RAMPC0_RAMPDC10)   /*< 0x1FFF8000 ~ 0x1FFFFFFF */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_Channel PWC LVD channel
+ * @{
+ */
+#define PWC_LVD_CH1                     (0x00U)
+#define PWC_LVD_CH2                     (0x01U)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_Config PWC LVD Config
+ * @{
+ */
+#define PWC_LVD_ON                      (PWC_PVDCR0_PVD1EN)
+#define PWC_LVD_OFF                     (0x00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_Exception_Type_Sel PWC LVD Exception Type Select
+ * @{
+ */
+#define PWC_LVD_EXP_TYPE_NONE           (0x00U)
+#define PWC_LVD_EXP_TYPE_INT            (0x0101U)
+#define PWC_LVD_EXP_TYPE_NMI            (0x0001U)
+#define PWC_LVD_EXP_TYPE_RST            (PWC_PVDCR1_PVD1IRE | PWC_PVDCR1_PVD1IRS)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_CMP_Config PWC LVD Compare Config
+ * @{
+ */
+#define PWC_LVD_CMP_OFF                 (0x00U)
+#define PWC_LVD_CMP_ON                  (PWC_PVDCR1_PVD1CMPOE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_DF_Config LVD digital filter ON or OFF
+ * @{
+ */
+#define PWC_LVD_FILTER_ON               (0x00U)
+#define PWC_LVD_FILTER_OFF              (0x01U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_DFS_Clk_Sel LVD digital filter sample ability
+ * @note     modified this value must when PWC_LVD_FILTER_OFF
+ * @{
+ */
+#define PWC_LVD_FILTER_LRC_DIV4        (0x00UL << PWC_PVDFCR_PVD1NFCKS_POS)     /*!< 0.25 LRC cycle */
+#define PWC_LVD_FILTER_LRC_DIV2        (0x01UL << PWC_PVDFCR_PVD1NFCKS_POS)     /*!< 0.5 LRC cycle  */
+#define PWC_LVD_FILTER_LRC_DIV1        (0x02UL << PWC_PVDFCR_PVD1NFCKS_POS)     /*!< 1 LRC cycle    */
+#define PWC_LVD_FILTER_LRC_MUL2        (0x03UL << PWC_PVDFCR_PVD1NFCKS_POS)     /*!< 2 LRC cycles   */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_Detection_Voltage_Sel PWC LVD Detection voltage
+ * @{
+ * @note
+ * @verbatim
+ *       |  LVL0   |  LVL1   |  LVL2   |  LVL3   |  LVL4   |  LVL5   |  LVL6   |  LVL7   |  EXVCC |
+ * LVD1  |  2.10V  |  2.20V  |  2.40V  |  2.60V  |  2.70V  |  2.80V  |  2.95V  |  3.05V  |   --   |
+ * LVD2  |  2.20V  |  2.40V  |  2.60V  |  2.70V  |  2.85V  |  2.95V  |  3.05V  |  1.15V  |  EXVCC |
+ * @endverbatim
+ */
+#define PWC_LVD_THRESHOLD_LVL0          (0x00U)
+#define PWC_LVD_THRESHOLD_LVL1          (0x01U)
+#define PWC_LVD_THRESHOLD_LVL2          (0x02U)
+#define PWC_LVD_THRESHOLD_LVL3          (0x03U)
+#define PWC_LVD_THRESHOLD_LVL4          (0x04U)
+#define PWC_LVD_THRESHOLD_LVL5          (0x05U)
+#define PWC_LVD_THRESHOLD_LVL6          (0x06U)
+#define PWC_LVD_THRESHOLD_LVL7          (0x07U)
+#define PWC_LVD_EXTVCC                  (0x07U)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_TRIG_Sel LVD trigger setting
+ * @{
+ */
+#define PWC_LVD_TRIG_FALLING            (0x00UL << PWC_PVDICR_PVD1EDGS_POS)
+#define PWC_LVD_TRIG_RISING             (0x01UL << PWC_PVDICR_PVD1EDGS_POS)
+#define PWC_LVD_TRIG_BOTH               (0x02UL << PWC_PVDICR_PVD1EDGS_POS)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_LVD_Flag LVD flag
+ * @{
+ */
+#define PWC_LVD1_FLAG_DETECT            (PWC_PVDDSR_PVD1DETFLG)          /*!< VCC across VLVD1   */
+#define PWC_LVD2_FLAG_DETECT            (PWC_PVDDSR_PVD2DETFLG)          /*!< VCC across VLVD2   */
+#define PWC_LVD1_FLAG_MON               (PWC_PVDDSR_PVD1MON)             /*!< VCC > VLVD1        */
+#define PWC_LVD2_FLAG_MON               (PWC_PVDDSR_PVD2MON)             /*!< VCC > VLVD2        */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKUP_Event_Sel Power down mode wakeup event selection
+ * @{
+ */
+#define PWC_PD_WKUP0_POS                (0U)
+#define PWC_PD_WKUP1_POS                (8U)
+#define PWC_PD_WKUP2_POS                (16U)
+#define PWC_PD_WKUP_WKUP00              (PWC_PDWKE0_WKE00 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP01              (PWC_PDWKE0_WKE01 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP02              (PWC_PDWKE0_WKE02 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP03              (PWC_PDWKE0_WKE03 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP10              (PWC_PDWKE0_WKE10 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP11              (PWC_PDWKE0_WKE11 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP12              (PWC_PDWKE0_WKE12 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP13              (PWC_PDWKE0_WKE13 << PWC_PD_WKUP0_POS)
+#define PWC_PD_WKUP_WKUP20              (PWC_PDWKE1_WKE20 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP21              (PWC_PDWKE1_WKE21 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP22              (PWC_PDWKE1_WKE22 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP23              (PWC_PDWKE1_WKE23 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP30              (PWC_PDWKE1_WKE30 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP31              (PWC_PDWKE1_WKE31 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP32              (PWC_PDWKE1_WKE32 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_WKUP33              (PWC_PDWKE1_WKE33 << PWC_PD_WKUP1_POS)
+#define PWC_PD_WKUP_LVD1                (PWC_PDWKE2_VD1WKE << PWC_PD_WKUP2_POS)
+#define PWC_PD_WKUP_LVD2                (PWC_PDWKE2_VD2WKE << PWC_PD_WKUP2_POS)
+#define PWC_PD_WKUP_RTCPRD              (PWC_PDWKE2_RTCPRDWKE << PWC_PD_WKUP2_POS)
+#define PWC_PD_WKUP_RTCALM              (PWC_PDWKE2_RTCALMWKE << PWC_PD_WKUP2_POS)
+#define PWC_PD_WKUP_WKTM                (PWC_PDWKE2_WKTMWKE << PWC_PD_WKUP2_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKUP_Trigger_Event_Sel Power down mode wakeup event selection to set trigger edge.
+ * @{
+ */
+#define PWC_PD_WKUP_TRIG_LVD1           (PWC_PDWKES_VD1EGS)
+#define PWC_PD_WKUP_TRIG_LVD2           (PWC_PDWKES_VD2EGS)
+#define PWC_PD_WKUP_TRIG_WKUP0          (PWC_PDWKES_WK0EGS)
+#define PWC_PD_WKUP_TRIG_WKUP1          (PWC_PDWKES_WK1EGS)
+#define PWC_PD_WKUP_TRIG_WKUP2          (PWC_PDWKES_WK2EGS)
+#define PWC_PD_WKUP_TRIG_WKUP3          (PWC_PDWKES_WK3EGS)
+
+#define PWC_PD_WKUP_TRIG_ALL            (PWC_PD_WKUP_TRIG_LVD1  | PWC_PD_WKUP_TRIG_LVD2  | PWC_PD_WKUP_TRIG_WKUP0 | \
+                                         PWC_PD_WKUP_TRIG_WKUP1 | PWC_PD_WKUP_TRIG_WKUP2 | PWC_PD_WKUP_TRIG_WKUP3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKUP_Trigger_Edge_Sel Power down mode wakeup trigger edge selection
+ * @{
+ */
+#define PWC_PD_WKUP_TRIG_FALLING        (0x00U)
+#define PWC_PD_WKUP_TRIG_RISING         (0x01U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKUP_Event_Flag_Sel Power down mode wakeup Event status selection
+ * @{
+ */
+#define PWC_PD_WKUP_FLAG0_POS           (0U)
+#define PWC_PD_WKUP_FLAG1_POS           (8U)
+#define PWC_PD_WKUP_FLAG_WKUP0          (PWC_PDWKF0_PTWK0F << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_WKUP1          (PWC_PDWKF0_PTWK1F << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_WKUP2          (PWC_PDWKF0_PTWK2F << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_WKUP3          (PWC_PDWKF0_PTWK3F << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_LVD1           (PWC_PDWKF0_VD1WKF << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_LVD2           (PWC_PDWKF0_VD2WKF << PWC_PD_WKUP_FLAG0_POS)
+#define PWC_PD_WKUP_FLAG_RTCPRD         (PWC_PDWKF1_RTCPRDWKF << PWC_PD_WKUP_FLAG1_POS)
+#define PWC_PD_WKUP_FLAG_RTCALM         (PWC_PDWKF1_RTCALMWKF << PWC_PD_WKUP_FLAG1_POS)
+#define PWC_PD_WKUP_FLAG_WKTM           (PWC_PDWKF1_WKTMWKF << PWC_PD_WKUP_FLAG1_POS)
+
+#define PWC_PD_WKUP_FLAG_ALL            (PWC_PD_WKUP_FLAG_WKUP0  | PWC_PD_WKUP_FLAG_WKUP1  | PWC_PD_WKUP_FLAG_WKUP2 | \
+                                         PWC_PD_WKUP_FLAG_WKUP3  | PWC_PD_WKUP_FLAG_LVD1   | PWC_PD_WKUP_FLAG_LVD2  | \
+                                         PWC_PD_WKUP_FLAG_RTCPRD | PWC_PD_WKUP_FLAG_RTCALM | PWC_PD_WKUP_FLAG_WKTM)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_Monitor_Power PWC Power Monitor voltage definition
+ * @{
+ */
+#define PWC_PWR_MON_IREF                (0x00U)                 /*!< Internal reference voltage */
+#define PWC_PWR_MON_VBAT_DIV2           (PWC_PWRC4_ADBUFS)      /*!< 1/2 VBAT voltage */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_VBAT_Reference_Voltage PWC VBAT Reference Voltage
+ * @{
+ */
+#define PWC_VBAT_REF_VOL_1P8V           (0x00U)  /*!< Vbat reference voltage is 1.8V */
+#define PWC_VBAT_REF_VOL_2P1V           (0x01U)  /*!< Vbat reference voltage is 2.1V */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_BACKUP_RAM_Flag PWC Backup RAM Flag
+ * @{
+ */
+#define PWC_BACKUP_RAM_FLAG_RAMPDF      (PWC_VBATCR_RAMPDF)     /*!< Backup RAM power down flag */
+#define PWC_BACKUP_RAM_FLAG_RAMVALID    (PWC_VBATCR_RAMVALID)   /*!< Backup RAM read/write flag */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKT_State PWC WKT State
+ * @{
+ */
+#define PWC_WKT_OFF                    (0x00U)
+#define PWC_WKT_ON                     (PWC_WKTC2_WKTCE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_WKT_Clock_Source PWC WKT Clock Source
+ * @{
+ */
+#define PWC_WKT_CLK_SRC_64HZ            (0x00U << PWC_WKTC2_WKCKS_POS)      /*!< 64Hz Clock   */
+#define PWC_WKT_CLK_SRC_XTAL32          (0x01U << PWC_WKTC2_WKCKS_POS)      /*!< XTAL32 Clock */
+#define PWC_WKT_CLK_SRC_RTCLRC          (0x02U << PWC_WKTC2_WKCKS_POS)      /*!< RTCLRC Clock */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_Ldo_Sel PWC LDO Selection
+ * @{
+ */
+#define PWC_LDO_HRC                     (PWC_PWRC1_VHRCSD)
+#define PWC_LDO_PLL                     (PWC_PWRC1_VPLLSD)
+#define PWC_LDO_MASK                    (PWC_LDO_HRC | PWC_LDO_PLL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup PWC_REG_Write_Unlock_Code PWC register unlock code.
+ * @brief Lock/unlock Code for each module
+@verbatim
+ *        PWC_UNLOCK_CODE0:
+ *          Below registers are locked in CLK module.
+ *              XTALCFGR, XTALSTBCR, XTALCR, XTALSTDCR, XTALSTDSR, HRCTRM, HRCCR,
+ *              MRCTRM, MRCCR, PLLCFGR, PLLCR, UPLLCFGR, UPLLCR, OSCSTBSR, CKSWR,
+ *              SCFGR, USBCKCFGR, TPIUCKCFGR, MCO1CFGR, MCO2CFGR, XTAL32CR,
+ *              XTALC32CFGR, XTAL32NFR, LRCCR, LRCTRM.
+ *        PWC_UNLOCK_CODE1:
+ *          Below registers are locked in PWC module.
+ *              PWRC0, PWRC1, PWRC2, PWRC3, PDWKE0, PDWKE1, PDWKE2, PDWKES, PDWKF0,
+ *              PDWKF1, PWCMR, PWR_STPMCR, RAMPC0, RAMOPM.
+ *          Below registers are locked in CLK module.
+ *              PERICKSEL, I2SCKSEL,
+ *          Below register is locked in RMU module.
+ *              RSTF0
+ *        PWC_UNLOCK_CODE2:
+ *          Below registers are locked in PWC module.
+ *              PVDCR0, PVDCR1, PVDFCR, PVDLCR, PVDICR, PVDDSR
+@endverbatim
+ * @{
+ */
+#define PWC_WRITE_ENABLE                (0xA500U)
+#define PWC_UNLOCK_CODE0                (0xA501U)
+#define PWC_UNLOCK_CODE1                (0xA502U)
+#define PWC_UNLOCK_CODE2                (0xA508U)
+
+/**
+ * @brief PWC FCG0 Unlock/Lock code
+ */
+#define PWC_FCG0_REG_UNLOCK_KEY          (0xA5A50001UL)
+#define PWC_FCG0_REG_LOCK_KEY            (0xA5A50000UL)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup PWC_Global_Functions
+ * @{
+ */
+/**
+ * @brief  Lock PWC, CLK, RMU register.
+ * @param  [in] u16Module Lock code for each module.
+ *   @arg  PWC_UNLOCK_CODE0
+ *   @arg  PWC_UNLOCK_CODE1
+ *   @arg  PWC_UNLOCK_CODE2
+ * @retval None
+ */
+__STATIC_INLINE void PWC_REG_Lock(uint16_t u16Module)
+{
+    CM_PWC->FPRC = (PWC_WRITE_ENABLE | (uint16_t)((uint16_t)(~u16Module) & (CM_PWC->FPRC)));
+}
+
+/**
+ * @brief  Unlock PWC, CLK, RMU register.
+ * @param  [in] u16Module Unlock code for each module.
+ *   @arg  PWC_UNLOCK_CODE0
+ *   @arg  PWC_UNLOCK_CODE1
+ *   @arg  PWC_UNLOCK_CODE2
+ * @retval None
+ */
+__STATIC_INLINE void PWC_REG_Unlock(uint16_t u16Module)
+{
+    SET_REG16_BIT(CM_PWC->FPRC, u16Module);
+}
+
+/**
+ * @brief  Lock PWC_FCG0 register .
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void PWC_FCG0_REG_Lock(void)
+{
+    WRITE_REG32(CM_PWC->FCG0PC, PWC_FCG0_REG_LOCK_KEY);
+}
+
+/**
+ * @brief  Unlock PWR_FCG0 register.
+ * @param  None
+ * @retval None
+ * @note Call this function before FCG_Fcg0PeriphClockCmd()
+ */
+__STATIC_INLINE void PWC_FCG0_REG_Unlock(void)
+{
+    WRITE_REG32(CM_PWC->FCG0PC, PWC_FCG0_REG_UNLOCK_KEY);
+}
+
+/* PWC PD Function */
+int32_t PWC_PD_Enter(void);
+int32_t PWC_PD_StructInit(stc_pwc_pd_mode_config_t *pstcPDModeConfig);
+int32_t PWC_PD_Config(const stc_pwc_pd_mode_config_t *pstcPDModeConfig);
+void PWC_PD_SetIoState(uint8_t u8IoState);
+void PWC_PD_SetMode(uint8_t u8PdMode);
+void PWC_PD_WakeupCmd(uint32_t u32Event, en_functional_state_t enNewState);
+void PWC_PD_SetWakeupTriggerEdge(uint8_t u8Event, uint8_t u8TrigEdge);
+en_flag_status_t PWC_PD_GetWakeupStatus(uint16_t u16Flag);
+void PWC_PD_ClearWakeupStatus(uint16_t u16Flag);
+void PWC_PD_PeriphRamCmd(uint32_t u32PeriphRam, en_functional_state_t enNewState);
+void PWC_PD_RamCmd(uint32_t u32Ram, en_functional_state_t enNewState);
+
+/* PWC WKTM Function */
+void PWC_WKT_Config(uint16_t u16ClkSrc, uint16_t u16CmpVal);
+void PWC_WKT_SetCompareValue(uint16_t u16CmpVal);
+uint16_t PWC_WKT_GetCompareValue(void);
+void PWC_WKT_Cmd(en_functional_state_t enNewState);
+en_flag_status_t PWC_WKT_GetStatus(void);
+void PWC_WKT_ClearStatus(void);
+
+void PWC_RamModeConfig(uint16_t u16Mode);
+
+/* PWC Sleep Function */
+void PWC_SLEEP_Enter(uint8_t u8SleepType);
+
+/* PWC Stop Function */
+void PWC_STOP_Enter(uint8_t u8StopType);
+int32_t PWC_STOP_StructInit(stc_pwc_stop_mode_config_t *pstcStopConfig);
+int32_t PWC_STOP_Config(const stc_pwc_stop_mode_config_t *pstcStopConfig);
+void PWC_STOP_ClockSelect(uint8_t u8Clock);
+void PWC_STOP_SetDrv(uint8_t u8StopDrv);
+void PWC_STOP_FlashWaitCmd(en_functional_state_t enNewState);
+
+void PWC_STOP_ExBusHoldConfig(uint16_t u16ExBusHold);
+
+/* PWC Speed Switch Function */
+int32_t PWC_HighSpeedToLowSpeed(void);
+int32_t PWC_LowSpeedToHighSpeed(void);
+
+/* PWC LDO Function */
+void PWC_LDO_Cmd(uint16_t u16Ldo, en_functional_state_t enNewState);
+
+/* PWC LVD/PVD Function */
+int32_t PWC_LVD_Init(uint8_t u8Ch, const stc_pwc_lvd_init_t *pstcLvdInit);
+void PWC_LVD_DeInit(uint8_t u8Ch);
+int32_t PWC_LVD_StructInit(stc_pwc_lvd_init_t *pstcLvdInit);
+void PWC_LVD_Cmd(uint8_t u8Ch, en_functional_state_t enNewState);
+void PWC_LVD_ExtInputCmd(en_functional_state_t enNewState);
+void PWC_LVD_CompareOutputCmd(uint8_t u8Ch, en_functional_state_t enNewState);
+void PWC_LVD_DigitalFilterCmd(uint8_t u8Ch, en_functional_state_t enNewState);
+void PWC_LVD_SetFilterClock(uint8_t u8Ch, uint32_t u32Clock);
+void PWC_LVD_SetThresholdVoltage(uint8_t u8Ch, uint32_t u32Voltage);
+void PWC_LVD_ClearStatus(uint8_t u8Flag);
+en_flag_status_t PWC_LVD_GetStatus(uint8_t u8Flag);
+
+/* PWC Power Monitor Function */
+void PWC_PowerMonitorCmd(en_functional_state_t enNewState);
+void PWC_SetPowerMonitorVoltageSrc(uint8_t u8VoltageSrc);
+
+/* PWC VBAT Function */
+void PWC_VBAT_SetMonitorVoltage(uint8_t u8RefVoltage);
+void PWC_VBAT_MonitorCmd(en_functional_state_t enNewState);
+en_flag_status_t PWC_VBAT_GetVoltageStatus(void);
+void PWC_VBAT_VoltageDivMonitorCmd(en_functional_state_t enNewState);
+void PWC_VBAT_Reset(void);
+void PWC_VBAT_PowerCmd(en_functional_state_t enNewState);
+
+/* PWC Backup RAM Function */
+void PWC_BKR_PowerCmd(en_functional_state_t enNewState);
+en_flag_status_t PWC_BKR_GetStatus(uint8_t u8Flag);
+void PWC_BKR_Write(uint8_t u8RegNum, uint8_t u8RegVal);
+uint8_t PWC_BKR_Read(uint8_t u8RegNum);
+
+/* PWC RAM Function */
+
+/**
+ * @}
+ */
+
+#endif /* LL_PWC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_PWC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_qspi.h
+++ b/hc32f4a2/inc/hc32_ll_qspi.h
@@ -1,0 +1,446 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_qspi.h
+ * @brief This file contains all the functions prototypes of the QSPI driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify return value type of QSPI_DeInit function
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_QSPI_H__
+#define __HC32_LL_QSPI_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_QSPI
+ * @{
+ */
+
+#if (LL_QSPI_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup QSPI_Global_Types QSPI Global Types
+ * @{
+ */
+
+/**
+ * @brief QSPI initialization structure definition
+ */
+typedef struct {
+    uint32_t u32ClockDiv;               /*!< Specifies the clock division.
+                                             This parameter can be a value of @ref QSPI_Clock_Division */
+    uint32_t u32SpiMode;                /*!< Specifies the SPI mode.
+                                             This parameter can be a value of @ref QSPI_SPI_Mode */
+    uint32_t u32PrefetchMode;           /*!< Specifies the prefetch mode.
+                                             This parameter can be a value of @ref QSPI_Prefetch_Mode */
+    uint32_t u32ReadMode;               /*!< Specifies the read mode.
+                                             This parameter can be a value of @ref QSPI_Read_Mode */
+    uint32_t u32DummyCycle;             /*!< Specifies the number of dummy cycles.
+                                             This parameter can be a value of @ref QSPI_Dummy_Cycle */
+    uint32_t u32AddrWidth;              /*!< Specifies the address width.
+                                             This parameter can be a value of @ref QSPI_Addr_Width */
+    uint32_t u32SetupTime;              /*!< Specifies the advance time of QSSN setup.
+                                             This parameter can be a value of @ref QSPI_QSSN_Setup_Time */
+    uint32_t u32ReleaseTime;            /*!< Specifies the delay time of QSSN release.
+                                             This parameter can be a value of @ref QSPI_QSSN_Release_Time */
+    uint32_t u32IntervalTime;           /*!< Specifies the minimum interval time of QSSN.
+                                             This parameter can be a value of @ref QSPI_QSSN_Interval_Time */
+} stc_qspi_init_t;
+
+/**
+ * @brief QSPI Custom read mode structure definition
+ */
+typedef struct {
+    uint32_t u32InstrProtocol;          /*!< Specifies the instruction stage protocol.
+                                             This parameter can be a value of @ref QSPI_Instruction_Protocol */
+    uint32_t u32AddrProtocol;           /*!< Specifies the address stage protocol.
+                                             This parameter can be a value of @ref QSPI_Addr_Protocol */
+    uint32_t u32DataProtocol;           /*!< Specifies the data stage protocol.
+                                             This parameter can be a value of @ref QSPI_Data_Protocol */
+    uint8_t  u8InstrCode;               /*!< Specifies the instruction code in custom read mode.
+                                             This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFF */
+} stc_qspi_custom_mode_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup QSPI_Global_Macros QSPI Global Macros
+ * @{
+ */
+
+/* QSPI memory mapping base and end address */
+#define QSPI_ROM_BASE                           (0x98000000UL)
+#define QSPI_ROM_END                            (0x9BFFFFFFUL)
+
+/**
+ * @defgroup QSPI_Clock_Division QSPI Clock Division
+ * @{
+ */
+#define QSPI_CLK_DIV2                           (0x01UL << QSPI_CR_DIV_POS)     /*!< Clock division by 2    */
+#define QSPI_CLK_DIV3                           (0x02UL << QSPI_CR_DIV_POS)     /*!< Clock division by 3    */
+#define QSPI_CLK_DIV4                           (0x03UL << QSPI_CR_DIV_POS)     /*!< Clock division by 4    */
+#define QSPI_CLK_DIV5                           (0x04UL << QSPI_CR_DIV_POS)     /*!< Clock division by 5    */
+#define QSPI_CLK_DIV6                           (0x05UL << QSPI_CR_DIV_POS)     /*!< Clock division by 6    */
+#define QSPI_CLK_DIV7                           (0x06UL << QSPI_CR_DIV_POS)     /*!< Clock division by 7    */
+#define QSPI_CLK_DIV8                           (0x07UL << QSPI_CR_DIV_POS)     /*!< Clock division by 8    */
+#define QSPI_CLK_DIV9                           (0x08UL << QSPI_CR_DIV_POS)     /*!< Clock division by 9    */
+#define QSPI_CLK_DIV10                          (0x09UL << QSPI_CR_DIV_POS)     /*!< Clock division by 10   */
+#define QSPI_CLK_DIV11                          (0x0AUL << QSPI_CR_DIV_POS)     /*!< Clock division by 11   */
+#define QSPI_CLK_DIV12                          (0x0BUL << QSPI_CR_DIV_POS)     /*!< Clock division by 12   */
+#define QSPI_CLK_DIV13                          (0x0CUL << QSPI_CR_DIV_POS)     /*!< Clock division by 13   */
+#define QSPI_CLK_DIV14                          (0x0DUL << QSPI_CR_DIV_POS)     /*!< Clock division by 14   */
+#define QSPI_CLK_DIV15                          (0x0EUL << QSPI_CR_DIV_POS)     /*!< Clock division by 15   */
+#define QSPI_CLK_DIV16                          (0x0FUL << QSPI_CR_DIV_POS)     /*!< Clock division by 16   */
+#define QSPI_CLK_DIV17                          (0x10UL << QSPI_CR_DIV_POS)     /*!< Clock division by 17   */
+#define QSPI_CLK_DIV18                          (0x11UL << QSPI_CR_DIV_POS)     /*!< Clock division by 18   */
+#define QSPI_CLK_DIV19                          (0x12UL << QSPI_CR_DIV_POS)     /*!< Clock division by 19   */
+#define QSPI_CLK_DIV20                          (0x13UL << QSPI_CR_DIV_POS)     /*!< Clock division by 20   */
+#define QSPI_CLK_DIV21                          (0x14UL << QSPI_CR_DIV_POS)     /*!< Clock division by 21   */
+#define QSPI_CLK_DIV22                          (0x15UL << QSPI_CR_DIV_POS)     /*!< Clock division by 22   */
+#define QSPI_CLK_DIV23                          (0x16UL << QSPI_CR_DIV_POS)     /*!< Clock division by 23   */
+#define QSPI_CLK_DIV24                          (0x17UL << QSPI_CR_DIV_POS)     /*!< Clock division by 24   */
+#define QSPI_CLK_DIV25                          (0x18UL << QSPI_CR_DIV_POS)     /*!< Clock division by 25   */
+#define QSPI_CLK_DIV26                          (0x19UL << QSPI_CR_DIV_POS)     /*!< Clock division by 26   */
+#define QSPI_CLK_DIV27                          (0x1AUL << QSPI_CR_DIV_POS)     /*!< Clock division by 27   */
+#define QSPI_CLK_DIV28                          (0x1BUL << QSPI_CR_DIV_POS)     /*!< Clock division by 28   */
+#define QSPI_CLK_DIV29                          (0x1CUL << QSPI_CR_DIV_POS)     /*!< Clock division by 29   */
+#define QSPI_CLK_DIV30                          (0x1DUL << QSPI_CR_DIV_POS)     /*!< Clock division by 30   */
+#define QSPI_CLK_DIV31                          (0x1EUL << QSPI_CR_DIV_POS)     /*!< Clock division by 31   */
+#define QSPI_CLK_DIV32                          (0x1FUL << QSPI_CR_DIV_POS)     /*!< Clock division by 32   */
+#define QSPI_CLK_DIV33                          (0x20UL << QSPI_CR_DIV_POS)     /*!< Clock division by 33   */
+#define QSPI_CLK_DIV34                          (0x21UL << QSPI_CR_DIV_POS)     /*!< Clock division by 34   */
+#define QSPI_CLK_DIV35                          (0x22UL << QSPI_CR_DIV_POS)     /*!< Clock division by 35   */
+#define QSPI_CLK_DIV36                          (0x23UL << QSPI_CR_DIV_POS)     /*!< Clock division by 36   */
+#define QSPI_CLK_DIV37                          (0x24UL << QSPI_CR_DIV_POS)     /*!< Clock division by 37   */
+#define QSPI_CLK_DIV38                          (0x25UL << QSPI_CR_DIV_POS)     /*!< Clock division by 38   */
+#define QSPI_CLK_DIV39                          (0x26UL << QSPI_CR_DIV_POS)     /*!< Clock division by 39   */
+#define QSPI_CLK_DIV40                          (0x27UL << QSPI_CR_DIV_POS)     /*!< Clock division by 40   */
+#define QSPI_CLK_DIV41                          (0x28UL << QSPI_CR_DIV_POS)     /*!< Clock division by 41   */
+#define QSPI_CLK_DIV42                          (0x29UL << QSPI_CR_DIV_POS)     /*!< Clock division by 42   */
+#define QSPI_CLK_DIV43                          (0x2AUL << QSPI_CR_DIV_POS)     /*!< Clock division by 43   */
+#define QSPI_CLK_DIV44                          (0x2BUL << QSPI_CR_DIV_POS)     /*!< Clock division by 44   */
+#define QSPI_CLK_DIV45                          (0x2CUL << QSPI_CR_DIV_POS)     /*!< Clock division by 45   */
+#define QSPI_CLK_DIV46                          (0x2DUL << QSPI_CR_DIV_POS)     /*!< Clock division by 46   */
+#define QSPI_CLK_DIV47                          (0x2EUL << QSPI_CR_DIV_POS)     /*!< Clock division by 47   */
+#define QSPI_CLK_DIV48                          (0x2FUL << QSPI_CR_DIV_POS)     /*!< Clock division by 48   */
+#define QSPI_CLK_DIV49                          (0x30UL << QSPI_CR_DIV_POS)     /*!< Clock division by 49   */
+#define QSPI_CLK_DIV50                          (0x31UL << QSPI_CR_DIV_POS)     /*!< Clock division by 50   */
+#define QSPI_CLK_DIV51                          (0x32UL << QSPI_CR_DIV_POS)     /*!< Clock division by 51   */
+#define QSPI_CLK_DIV52                          (0x33UL << QSPI_CR_DIV_POS)     /*!< Clock division by 52   */
+#define QSPI_CLK_DIV53                          (0x34UL << QSPI_CR_DIV_POS)     /*!< Clock division by 53   */
+#define QSPI_CLK_DIV54                          (0x35UL << QSPI_CR_DIV_POS)     /*!< Clock division by 54   */
+#define QSPI_CLK_DIV55                          (0x36UL << QSPI_CR_DIV_POS)     /*!< Clock division by 55   */
+#define QSPI_CLK_DIV56                          (0x37UL << QSPI_CR_DIV_POS)     /*!< Clock division by 56   */
+#define QSPI_CLK_DIV57                          (0x38UL << QSPI_CR_DIV_POS)     /*!< Clock division by 57   */
+#define QSPI_CLK_DIV58                          (0x39UL << QSPI_CR_DIV_POS)     /*!< Clock division by 58   */
+#define QSPI_CLK_DIV59                          (0x3AUL << QSPI_CR_DIV_POS)     /*!< Clock division by 59   */
+#define QSPI_CLK_DIV60                          (0x3BUL << QSPI_CR_DIV_POS)     /*!< Clock division by 60   */
+#define QSPI_CLK_DIV61                          (0x3CUL << QSPI_CR_DIV_POS)     /*!< Clock division by 61   */
+#define QSPI_CLK_DIV62                          (0x3DUL << QSPI_CR_DIV_POS)     /*!< Clock division by 62   */
+#define QSPI_CLK_DIV63                          (0x3EUL << QSPI_CR_DIV_POS)     /*!< Clock division by 63   */
+#define QSPI_CLK_DIV64                          (0x3FUL << QSPI_CR_DIV_POS)     /*!< Clock division by 64   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_SPI_Mode QSPI SPI Mode
+ * @{
+ */
+#define QSPI_SPI_MD0                            (0UL)               /*!< Selects SPI mode 0 */
+#define QSPI_SPI_MD3                            (QSPI_CR_SPIMD3)    /*!< Selects SPI mode 3 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Prefetch_Mode QSPI Prefetch Mode
+ * @{
+ */
+#define QSPI_PREFETCH_MD_INVD                   (0UL)                           /*!< Disable prefetch                              */
+#define QSPI_PREFETCH_MD_EDGE_STOP              (QSPI_CR_PFE)                   /*!< Stop prefetch at the edge of byte             */
+#define QSPI_PREFETCH_MD_IMMED_STOP             (QSPI_CR_PFE | QSPI_CR_PFSAE)   /*!< Stop prefetch at current position immediately */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Read_Mode QSPI Read Mode
+ * @{
+ */
+#define QSPI_RD_MD_STD_RD                       (0UL)                           /*!< Standard read mode (no dummy cycles)                   */
+#define QSPI_RD_MD_FAST_RD                      (0x01UL << QSPI_CR_MDSEL_POS)   /*!< Fast read mode (dummy cycles between address and data) */
+#define QSPI_RD_MD_DUAL_OUTPUT_FAST_RD          (0x02UL << QSPI_CR_MDSEL_POS)   /*!< Fast read dual output mode (data on 2 lines)           */
+#define QSPI_RD_MD_DUAL_IO_FAST_RD              (0x03UL << QSPI_CR_MDSEL_POS)   /*!< Fast read dual I/O mode (address and data on 2 lines)  */
+#define QSPI_RD_MD_QUAD_OUTPUT_FAST_RD          (0x04UL << QSPI_CR_MDSEL_POS)   /*!< Fast read quad output mode (data on 4 lines)           */
+#define QSPI_RD_MD_QUAD_IO_FAST_RD              (0x05UL << QSPI_CR_MDSEL_POS)   /*!< Fast read quad I/O mode (address and data on 4 lines)  */
+#define QSPI_RD_MD_CUSTOM_STANDARD_RD           (0x06UL << QSPI_CR_MDSEL_POS)   /*!< Custom standard read mode                              */
+#define QSPI_RD_MD_CUSTOM_FAST_RD               (0x07UL << QSPI_CR_MDSEL_POS)   /*!< Custom fast read mode                                  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Dummy_Cycle QSPI Dummy Cycle
+ * @{
+ */
+#define QSPI_DUMMY_CYCLE3                       (0UL)                           /*!< Dummy cycle is 3   */
+#define QSPI_DUMMY_CYCLE4                       (0x01UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 4   */
+#define QSPI_DUMMY_CYCLE5                       (0x02UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 5   */
+#define QSPI_DUMMY_CYCLE6                       (0x03UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 6   */
+#define QSPI_DUMMY_CYCLE7                       (0x04UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 7   */
+#define QSPI_DUMMY_CYCLE8                       (0x05UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 8   */
+#define QSPI_DUMMY_CYCLE9                       (0x06UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 9   */
+#define QSPI_DUMMY_CYCLE10                      (0x07UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 10  */
+#define QSPI_DUMMY_CYCLE11                      (0x08UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 11  */
+#define QSPI_DUMMY_CYCLE12                      (0x09UL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 12  */
+#define QSPI_DUMMY_CYCLE13                      (0x0AUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 13  */
+#define QSPI_DUMMY_CYCLE14                      (0x0BUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 14  */
+#define QSPI_DUMMY_CYCLE15                      (0x0CUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 15  */
+#define QSPI_DUMMY_CYCLE16                      (0x0DUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 16  */
+#define QSPI_DUMMY_CYCLE17                      (0x0EUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 15  */
+#define QSPI_DUMMY_CYCLE18                      (0x0FUL << QSPI_FCR_DMCYCN_POS) /*!< Dummy cycle is 16  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Addr_Width QSPI Address Width
+ * @{
+ */
+#define QSPI_ADDR_WIDTH_8BIT                    (0x0U)                              /*!< QSPI address width is 8 bits   */
+#define QSPI_ADDR_WIDTH_16BIT                   (QSPI_FCR_AWSL_0)                   /*!< QSPI address width is 16 bits  */
+#define QSPI_ADDR_WIDTH_24BIT                   (QSPI_FCR_AWSL_1)                   /*!< QSPI address width is 24 bits  */
+#define QSPI_ADDR_WIDTH_32BIT_INSTR_24BIT       (QSPI_FCR_AWSL)                     /*!< QSPI address width is 32 bits and don't use 4-byte address read instruction code */
+#define QSPI_ADDR_WIDTH_32BIT_INSTR_32BIT       (QSPI_FCR_AWSL | QSPI_FCR_FOUR_BIC) /*!< QSPI address width is 32 bits and use 4-byte address read instruction code       */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_QSSN_Setup_Time QSPI QSSN Setup Time
+ * @{
+ */
+#define QSPI_QSSN_SETUP_ADVANCE_QSCK0P5         (0UL)               /*!< Output QSSN signal 0.5 QSCK before the first rising edge of QSCK */
+#define QSPI_QSSN_SETUP_ADVANCE_QSCK1P5         (QSPI_FCR_SSNLD)    /*!< Output QSSN signal 1.5 QSCK before the first rising edge of QSCK */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_QSSN_Release_Time QSPI QSSN Release Time
+ * @{
+ */
+#define QSPI_QSSN_RELEASE_DELAY_QSCK0P5         (0UL)                       /*!< Release QSSN signal 0.5 QSCK after the last rising edge of QSCK */
+#define QSPI_QSSN_RELEASE_DELAY_QSCK1P5         (QSPI_FCR_SSNHD)            /*!< Release QSSN signal 1.5 QSCK after the last rising edge of QSCK */
+#define QSPI_QSSN_RELEASE_DELAY_QSCK32          (QSPI_CSCR_SSNW_0 << 8U)    /*!< Release QSSN signal 32 QSCK after the last rising edge of QSCK  */
+#define QSPI_QSSN_RELEASE_DELAY_QSCK128         (QSPI_CSCR_SSNW_1 << 8U)    /*!< Release QSSN signal 128 QSCK after the last rising edge of QSCK */
+#define QSPI_QSSN_RELEASE_DELAY_INFINITE        (QSPI_CSCR_SSNW   << 8U)    /*!< Never release QSSN signal after the last rising edge of QSCK    */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_QSSN_Interval_Time QSPI QSSN Interval Time
+ * @{
+ */
+#define QSPI_QSSN_INTERVAL_QSCK1                (0UL)                           /*!< Minimum interval time is 1 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK2                (0x01UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 2 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK3                (0x02UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 3 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK4                (0x03UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 4 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK5                (0x04UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 5 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK6                (0x05UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 6 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK7                (0x06UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 7 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK8                (0x07UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 8 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK9                (0x08UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 9 QSCK    */
+#define QSPI_QSSN_INTERVAL_QSCK10               (0x09UL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 10 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK11               (0x0AUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 11 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK12               (0x0BUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 12 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK13               (0x0CUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 13 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK14               (0x0DUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 14 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK15               (0x0EUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 15 QSCK   */
+#define QSPI_QSSN_INTERVAL_QSCK16               (0x0FUL << QSPI_CSCR_SSHW_POS)  /*!< Minimum interval time is 16 QSCK   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Instruction_Protocol QSPI Instruction Protocol
+ * @{
+ */
+#define QSPI_INSTR_PROTOCOL_1LINE               (0x0U)              /*!< Instruction on 1 line  */
+#define QSPI_INSTR_PROTOCOL_2LINE               (QSPI_CR_IPRSL_0)   /*!< Instruction on 2 lines */
+#define QSPI_INSTR_PROTOCOL_4LINE               (QSPI_CR_IPRSL_1)   /*!< Instruction on 4 lines */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Addr_Protocol QSPI Address Protocol
+ * @{
+ */
+#define QSPI_ADDR_PROTOCOL_1LINE                (0x0U)              /*!< Address on 1 line  */
+#define QSPI_ADDR_PROTOCOL_2LINE                (QSPI_CR_APRSL_0)   /*!< Address on 2 lines */
+#define QSPI_ADDR_PROTOCOL_4LINE                (QSPI_CR_APRSL_1)   /*!< Address on 4 lines */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Data_Protocol QSPI Data Protocol
+ * @{
+ */
+#define QSPI_DATA_PROTOCOL_1LINE                (0x0U)              /*!< Data on 1 line  */
+#define QSPI_DATA_PROTOCOL_2LINE                (QSPI_CR_DPRSL_0)   /*!< Data on 2 lines */
+#define QSPI_DATA_PROTOCOL_4LINE                (QSPI_CR_DPRSL_1)   /*!< Data on 4 lines */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_WP_Pin_Level QSPI WP Pin Level
+ * @{
+ */
+#define QSPI_WP_PIN_LOW                         (0x0U)          /*!< WP(QSIO2) pin output low  */
+#define QSPI_WP_PIN_HIGH                        (QSPI_FCR_WPOL) /*!< WP(QSIO2) pin output high */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup QSPI_Status_Flag QSPI Status Flag
+ * @{
+ */
+#define QSPI_FLAG_DIRECT_COMM_BUSY              (QSPI_SR_BUSY)  /*!< Serial transfer being processed                          */
+#define QSPI_FLAG_XIP_MD                        (QSPI_SR_XIPF)  /*!< XIP mode                                                 */
+#define QSPI_FLAG_ROM_ACCESS_ERR                (QSPI_SR_RAER)  /*!< ROM access detection status in direct communication mode */
+#define QSPI_FLAG_PREFETCH_BUF_FULL             (QSPI_SR_PFFUL) /*!< Prefetch buffer is full                                  */
+#define QSPI_FLAG_PREFETCH_STOP                 (QSPI_SR_PFAN)  /*!< Prefetch function operating                              */
+
+#define QSPI_FLAG_ALL                           (QSPI_FLAG_DIRECT_COMM_BUSY | QSPI_FLAG_XIP_MD            | \
+                                                 QSPI_FLAG_ROM_ACCESS_ERR   | QSPI_FLAG_PREFETCH_BUF_FULL | \
+                                                 QSPI_FLAG_PREFETCH_STOP)
+#define QSPI_FLAG_CLR_ALL                       (QSPI_FLAG_ROM_ACCESS_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup QSPI_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Write data in direct communication mode.
+ * @param  [in] u8Value                 Byte data.
+ * @retval None
+ */
+__STATIC_INLINE void QSPI_WriteDirectCommValue(uint8_t u8Value)
+{
+    WRITE_REG32(CM_QSPI->DCOM, u8Value);
+}
+
+/**
+ * @brief  Read data in direct communication mode.
+ * @param  None
+ * @retval uint8_t                      Byte data.
+ */
+__STATIC_INLINE uint8_t QSPI_ReadDirectCommValue(void)
+{
+    return (uint8_t)CM_QSPI->DCOM;
+}
+
+/* Initialization and configuration functions */
+int32_t QSPI_DeInit(void);
+int32_t QSPI_Init(const stc_qspi_init_t *pstcQspiInit);
+int32_t QSPI_StructInit(stc_qspi_init_t *pstcQspiInit);
+void QSPI_SetWpPinLevel(uint32_t u32Level);
+void QSPI_SetPrefetchMode(uint32_t u32Mode);
+void QSPI_SelectMemoryBlock(uint8_t u8Block);
+void QSPI_SetReadMode(uint32_t u32Mode);
+int32_t QSPI_CustomReadConfig(const stc_qspi_custom_mode_t *pstcCustomMode);
+void QSPI_XipModeCmd(uint8_t u8ModeCode, en_functional_state_t enNewState);
+
+/* Transfer and receive data functions */
+void QSPI_EnterDirectCommMode(void);
+void QSPI_ExitDirectCommMode(void);
+void QSPI_WriteDirectCommValue(uint8_t u8Value);
+uint8_t QSPI_ReadDirectCommValue(void);
+
+/* Interrupt and flag management functions */
+uint8_t QSPI_GetPrefetchBufSize(void);
+en_flag_status_t QSPI_GetStatus(uint32_t u32Flag);
+void QSPI_ClearStatus(uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_QSPI_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_QSPI_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_rmu.h
+++ b/hc32f4a2/inc/hc32_ll_rmu.h
@@ -1,0 +1,131 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_rmu.h
+ * @brief This file contains all the functions prototypes of the RMU driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_RMU_H__
+#define __HC32_LL_RMU_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_RMU
+ * @{
+ */
+#if (LL_RMU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup RMU_Global_Macros RMU Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup RMU_ResetCause Rmu reset cause
+ * @{
+ */
+#define RMU_FLAG_PWR_ON                 (RMU_RSTF0_PORF)        /*!< Power on reset */
+#define RMU_FLAG_PIN                    (RMU_RSTF0_PINRF)       /*!< Reset pin reset */
+#define RMU_FLAG_BROWN_OUT              (RMU_RSTF0_BORF)        /*!< Brown-out reset */
+#define RMU_FLAG_PVD1                   (RMU_RSTF0_PVD1RF)      /*!< Program voltage Detection 1 reset */
+#define RMU_FLAG_PVD2                   (RMU_RSTF0_PVD2RF)      /*!< Program voltage Detection 2 reset */
+#define RMU_FLAG_WDT                    (RMU_RSTF0_WDRF)        /*!< Watchdog timer reset */
+#define RMU_FLAG_SWDT                   (RMU_RSTF0_SWDRF)       /*!< Special watchdog timer reset */
+#define RMU_FLAG_PWR_DOWN               (RMU_RSTF0_PDRF)        /*!< Power down reset */
+#define RMU_FLAG_SW                     (RMU_RSTF0_SWRF)        /*!< Software reset */
+#define RMU_FLAG_MPU_ERR                (RMU_RSTF0_MPUERF)      /*!< Mpu error reset */
+#define RMU_FLAG_RAM_PARITY_ERR         (RMU_RSTF0_RAPERF)      /*!< Ram parity error reset */
+#define RMU_FLAG_RAM_ECC                (RMU_RSTF0_RAECRF)      /*!< Ram ECC reset */
+#define RMU_FLAG_CLK_ERR                (RMU_RSTF0_CKFERF)      /*!< Clk frequency error reset */
+#define RMU_FLAG_XTAL_ERR               (RMU_RSTF0_XTALERF)     /*!< Xtal error reset */
+#define RMU_FLAG_CPU_LOCKUP             (RMU_RSTF0_LKUPRF)      /*!< M4 Lockup reset */
+#define RMU_FLAG_MX                     (RMU_RSTF0_MULTIRF)     /*!< Multiply reset cause */
+#define RMU_FLAG_ALL                    (RMU_FLAG_PWR_ON | RMU_FLAG_PIN | RMU_FLAG_BROWN_OUT | RMU_FLAG_PVD1 | \
+                                        RMU_FLAG_PVD2 | RMU_FLAG_WDT | RMU_FLAG_SWDT | RMU_FLAG_PWR_DOWN | \
+                                        RMU_FLAG_SW | RMU_FLAG_MPU_ERR | RMU_FLAG_RAM_PARITY_ERR | RMU_FLAG_RAM_ECC | \
+                                        RMU_FLAG_CLK_ERR | RMU_FLAG_XTAL_ERR | RMU_FLAG_CPU_LOCKUP | RMU_FLAG_MX)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup RMU_Global_Functions
+ * @{
+ */
+
+en_flag_status_t RMU_GetStatus(uint32_t u32RmuResetCause);
+void RMU_ClearStatus(void);
+
+void RMU_CPULockUpCmd(en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_RMU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_RMU_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/
+

--- a/hc32f4a2/inc/hc32_ll_rtc.h
+++ b/hc32f4a2/inc/hc32_ll_rtc.h
@@ -1,0 +1,458 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_rtc.h
+ * @brief This file contains all the functions prototypes of the RTC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_RTC_H__
+#define __HC32_LL_RTC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_RTC
+ * @{
+ */
+
+#if (LL_RTC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup RTC_Global_Types RTC Global Types
+ * @{
+ */
+
+/**
+ * @brief RTC Init structure definition
+ */
+typedef struct {
+    uint8_t  u8ClockSrc;                /*!< Specifies the RTC clock source.
+                                             This parameter can be a value of @ref RTC_Clock_Source */
+    uint8_t  u8HourFormat;              /*!< Specifies the RTC hour format.
+                                             This parameter can be a value of @ref RTC_Hour_Format */
+    uint8_t  u8IntPeriod;               /*!< Specifies the RTC interrupt period.
+                                             This parameter can be a value of @ref RTC_Interrupt_Period */
+    uint8_t  u8ClockCompen;             /*!< Specifies the validity of RTC clock compensation.
+                                             This parameter can be a value of @ref RTC_Clock_Compensation */
+    uint8_t  u8CompenMode;              /*!< Specifies the mode of RTC clock compensation.
+                                             This parameter can be a value of @ref RTC_Clock_Compensation_Mode */
+    uint16_t u16CompenValue;            /*!< Specifies the value of RTC clock compensation.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 0x1FF */
+} stc_rtc_init_t;
+
+/**
+ * @brief RTC Date structure definition
+ */
+typedef struct {
+    uint8_t u8Year;                     /*!< Specifies the RTC Year.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 99 */
+    uint8_t u8Month;                    /*!< Specifies the RTC Month (in Decimal format).
+                                             This parameter can be a value of @ref RTC_Month */
+    uint8_t u8Day;                      /*!< Specifies the RTC Day.
+                                             This parameter can be a number between Min_Data = 1 and Max_Data = 31 */
+    uint8_t u8Weekday;                  /*!< Specifies the RTC Weekday.
+                                             This parameter can be a value of @ref RTC_Weekday */
+} stc_rtc_date_t;
+
+/**
+ * @brief RTC Time structure definition
+ */
+typedef struct {
+    uint8_t u8Hour;                     /*!< Specifies the RTC Hour.
+                                             This parameter can be a number between Min_Data = 1 and Max_Data = 12 if the RTC_HOUR_FMT_12H is selected.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HOUR_FMT_24H is selected */
+    uint8_t u8Minute;                   /*!< Specifies the RTC Minute.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 59 */
+    uint8_t u8Second;                   /*!< Specifies the RTC Second.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 59 */
+    uint8_t u8AmPm;                     /*!< Specifies the RTC Am/Pm Time (in RTC_HOUR_FMT_12H mode).
+                                             This parameter can be a value of @ref RTC_Hour12_AM_PM */
+} stc_rtc_time_t;
+
+/**
+ * @brief RTC Alarm structure definition
+ */
+typedef struct {
+    uint8_t u8AlarmHour;                /*!< Specifies the RTC Alarm Hour.
+                                           This parameter can be a number between Min_Data = 1 and Max_Data = 12 if the RTC_HOUR_FMT_12H is selected.
+                                           This parameter can be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HOUR_FMT_24H is selected */
+    uint8_t u8AlarmMinute;              /*!< Specifies the RTC Alarm Minute.
+                                             This parameter can be a number between Min_Data = 0 and Max_Data = 59 */
+    uint8_t u8AlarmWeekday;             /*!< Specifies the RTC Alarm Weekday.
+                                             This parameter can be a value of @ref RTC_Alarm_Weekday */
+    uint8_t u8AlarmAmPm;                /*!< Specifies the RTC Alarm Am/Pm Time (in RTC_HOUR_FMT_12H mode).
+                                             This parameter can be a value of @ref RTC_Hour12_AM_PM */
+} stc_rtc_alarm_t;
+
+/**
+ * @brief RTC Intrusion structure definition
+ */
+typedef struct {
+    uint8_t u8Timestamp;                /*!< Specifies the validity of RTC intrusion timestamp.
+                                             This parameter can be a value of @ref RTC_Intrusion_Timestamp */
+    uint8_t u8ResetBackupReg;           /*!< Specifies the validity of RTC intrusion event that trigger backup registers reset.
+                                             This parameter can be a value of @ref RTC_Intrusion_Reset_Backup_Register */
+    uint8_t u8Filter;                   /*!< Specifies the RTC intrusion pin filter.
+                                             This parameter can be a value of @ref RTC_Intrusion_Filter */
+    uint8_t u8TriggerEdge;              /*!< Specifies the RTC intrusion trigger edge.
+                                             This parameter can be a value of @ref RTC_Intrusion_Trigger_Edge */
+} stc_rtc_intrusion_t;
+
+/**
+ * @brief RTC Timestamp structure definition
+ */
+typedef struct {
+    stc_rtc_time_t stcTime;             /*!< Specifies the RTC Intrusion Timestamp Time members */
+    uint8_t u8Month;                    /*!< Specifies the Month of RTC timestamp (in Decimal format).
+                                             This parameter can be a value of @ref RTC_Month */
+    uint8_t u8Day;                      /*!< Specifies the Day of RTC timestamp.
+                                             This parameter can be a number between Min_Data = 1 and Max_Data = 31 */
+} stc_rtc_timestamp_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup RTC_Global_Macros RTC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup RTC_Data_Format RTC Data Format
+ * @{
+ */
+#define RTC_DATA_FMT_DEC                        (0x00U)     /*!< Decimal data format */
+#define RTC_DATA_FMT_BCD                        (0x01U)     /*!< BCD data format     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Decimal_BCD_Conversion RTC Decimal BCD Conversion
+ * @{
+ */
+#define RTC_DEC2BCD(__DATA__)                   ((((__DATA__) / 10U) << 4U) + ((__DATA__) % 10U))
+#define RTC_BCD2DEC(__DATA__)                   ((((__DATA__) >> 4U) * 10U) + ((__DATA__) & 0x0FU))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Clock_Source RTC Clock Source
+ * @{
+ */
+#define RTC_CLK_SRC_XTAL32                      (0U)                                    /*!< XTAL32 Clock   */
+#define RTC_CLK_SRC_LRC                         (RTC_CR3_RCKSEL | RTC_CR3_LRCEN)        /*!< RTC LRC Clock  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Hour_Format RTC Hour Format
+ * @{
+ */
+#define RTC_HOUR_FMT_12H                        (0U)                /*!< 12 hour time system */
+#define RTC_HOUR_FMT_24H                        (RTC_CR1_AMPM)      /*!< 24 hour time system */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Interrupt_Period RTC Interrupt Period
+ * @{
+ */
+#define RTC_INT_PERIOD_INVD                     (0U)                          /*!< Interrupt period invalid         */
+#define RTC_INT_PERIOD_PER_HALF_SEC             (0x01U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per half second */
+#define RTC_INT_PERIOD_PER_SEC                  (0x02U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per second      */
+#define RTC_INT_PERIOD_PER_MINUTE               (0x03U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per minute      */
+#define RTC_INT_PERIOD_PER_HOUR                 (0x04U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per hour        */
+#define RTC_INT_PERIOD_PER_DAY                  (0x05U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per day         */
+#define RTC_INT_PERIOD_PER_MONTH                (0x06U << RTC_CR1_PRDS_POS)   /*!< Interrupt period per month       */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Clock_Compensation RTC Clock Compensation
+ * @{
+ */
+#define RTC_CLK_COMPEN_DISABLE                  (0U)
+#define RTC_CLK_COMPEN_ENABLE                   (RTC_ERRCRH_COMPEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Clock_Compensation_Mode RTC Clock Compensation Mode
+ * @{
+ */
+#define RTC_CLK_COMPEN_MD_DISTRIBUTED           (0U)                    /*!< Distributed compensation 1Hz output */
+#define RTC_CLK_COMPEN_MD_UNIFORM               (RTC_CR1_ONEHZSEL)      /*!< Uniform compensation 1Hz output     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Hour12_AM_PM RTC Hour12 AM/PM
+ * @{
+ */
+#define RTC_HOUR_24H                            (0U)                /*!< 24-hour format */
+#define RTC_HOUR_12H_AM                         (0U)                /*!< AM in 12-hour  */
+#define RTC_HOUR_12H_PM                         (RTC_HOUR_HOURD_1)  /*!< PM in 12-hour  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Month RTC Month
+ * @{
+ */
+#define RTC_MONTH_JANUARY                       (0x01U)
+#define RTC_MONTH_FEBRUARY                      (0x02U)
+#define RTC_MONTH_MARCH                         (0x03U)
+#define RTC_MONTH_APRIL                         (0x04U)
+#define RTC_MONTH_MAY                           (0x05U)
+#define RTC_MONTH_JUNE                          (0x06U)
+#define RTC_MONTH_JULY                          (0x07U)
+#define RTC_MONTH_AUGUST                        (0x08U)
+#define RTC_MONTH_SEPTEMBER                     (0x09U)
+#define RTC_MONTH_OCTOBER                       (0x0AU)
+#define RTC_MONTH_NOVEMBER                      (0x0BU)
+#define RTC_MONTH_DECEMBER                      (0x0CU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Weekday RTC Weekday
+ * @{
+ */
+#define RTC_WEEKDAY_SUNDAY                      (0x00U)
+#define RTC_WEEKDAY_MONDAY                      (0x01U)
+#define RTC_WEEKDAY_TUESDAY                     (0x02U)
+#define RTC_WEEKDAY_WEDNESDAY                   (0x03U)
+#define RTC_WEEKDAY_THURSDAY                    (0x04U)
+#define RTC_WEEKDAY_FRIDAY                      (0x05U)
+#define RTC_WEEKDAY_SATURDAY                    (0x06U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Alarm_Weekday RTC Alarm Weekday
+ * @{
+ */
+#define RTC_ALARM_WEEKDAY_SUNDAY                (0x01U)
+#define RTC_ALARM_WEEKDAY_MONDAY                (0x02U)
+#define RTC_ALARM_WEEKDAY_TUESDAY               (0x04U)
+#define RTC_ALARM_WEEKDAY_WEDNESDAY             (0x08U)
+#define RTC_ALARM_WEEKDAY_THURSDAY              (0x10U)
+#define RTC_ALARM_WEEKDAY_FRIDAY                (0x20U)
+#define RTC_ALARM_WEEKDAY_SATURDAY              (0x40U)
+#define RTC_ALARM_WEEKDAY_EVERYDAY              (0x7FU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Intrusion_Channel RTC Intrusion Channel
+ * @{
+ */
+#define RTC_INTRU_CH0                           (0x00U)
+#define RTC_INTRU_CH1                           (0x04U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Intrusion_Timestamp RTC Intrusion Timestamp
+ * @{
+ */
+#define RTC_INTRU_TS_DISABLE                    (0U)
+#define RTC_INTRU_TS_ENABLE                     (RTC_TPCR0_TSTPE0)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Intrusion_Reset_Backup_Register RTC Intrusion Reset Backup Register
+ * @{
+ */
+#define RTC_INTRU_RST_BACKUP_REG_DISABLE        (0U)
+#define RTC_INTRU_RST_BACKUP_REG_ENABLE         (RTC_TPCR0_TPRSTE0)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Intrusion_Filter RTC Intrusion Filter
+ * @{
+ */
+#define RTC_INTRU_FILTER_INVD                   (0U)                 /*!< Invalid filter function                                                                           */
+#define RTC_INTRU_FILTER_THREE_TIME             (RTC_TPCR0_TPNF0_1)  /*!< The filter detection is consistent with the timing clock for 3 times                              */
+#define RTC_INTRU_FILTER_THREE_TIME_CLK_DIV32   (RTC_TPCR0_TPNF0)    /*!< The filter detection is consistent with the 32 frequency division of the timing clock for 3 times */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Intrusion_Trigger_Edge RTC Intrusion Trigger Edge
+ * @{
+ */
+#define RTC_INTRU_TRIG_EDGE_NONE                (0U)                 /*!< No detect                      */
+#define RTC_INTRU_TRIG_EDGE_RISING              (RTC_TPCR0_TPCT0_0)  /*!< Detect rising edge             */
+#define RTC_INTRU_TRIG_EDGE_FALLING             (RTC_TPCR0_TPCT0_1)  /*!< Detect falling edge            */
+#define RTC_INTRU_TRIG_EDGE_RISING_FALLING      (RTC_TPCR0_TPCT0)    /*!< Detect rising and falling edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Flag RTC Flag
+ * @{
+ */
+#define RTC_FLAG_RD_WR                          (RTC_CR2_RWEN)                      /*!< Read and write permission flag */
+#define RTC_FLAG_ALARM                          (RTC_CR2_ALMF)                      /*!< Alarm flag                     */
+#define RTC_FLAG_PERIOD                         (RTC_CR2_PRDF)                      /*!< Period flag                    */
+#define RTC_FLAG_INTRU_OVF                      ((uint32_t)RTC_TPSR_TPOVF << 16U)   /*!< Intrusion overflow flag        */
+#define RTC_FLAG_INTRU_CH0                      ((uint32_t)RTC_TPSR_TPF0  << 16U)   /*!< RTCIC0 intrusion flag          */
+#define RTC_FLAG_INTRU_CH1                      ((uint32_t)RTC_TPSR_TPF1  << 16U)   /*!< RTCIC1 intrusion flag          */
+#define RTC_FLAG_ALL                            (RTC_FLAG_RD_WR     | RTC_FLAG_ALARM     | RTC_FLAG_PERIOD | \
+                                                 RTC_FLAG_INTRU_OVF | RTC_FLAG_INTRU_CH0 | RTC_FLAG_INTRU_CH1)
+#define RTC_FLAG_CLR_ALL                        (RTC_FLAG_ALARM     | RTC_FLAG_PERIOD    | \
+                                                 RTC_FLAG_INTRU_OVF | RTC_FLAG_INTRU_CH0 | RTC_FLAG_INTRU_CH1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup RTC_Interrupt RTC Interrupt
+ * @{
+ */
+#define RTC_INT_PERIOD                          (RTC_CR2_PRDIE)                     /*!< Period interrupt          */
+#define RTC_INT_ALARM                           (RTC_CR2_ALMIE)                     /*!< Alarm interrupt           */
+#define RTC_INT_INTRU_CH0                       ((uint32_t)RTC_TPCR0_TPIE0 << 8U)   /*!< RTCIC0 intrusion interrupt */
+#define RTC_INT_INTRU_CH1                       ((uint32_t)RTC_TPCR1_TPIE1 << 16U)  /*!< RTCIC1 intrusion interrupt */
+#define RTC_INT_ALL                             (RTC_INT_PERIOD | RTC_INT_ALARM | RTC_INT_INTRU_CH0 | RTC_INT_INTRU_CH1)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup RTC_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration functions */
+int32_t RTC_DeInit(void);
+int32_t RTC_Init(const stc_rtc_init_t *pstcRtcInit);
+int32_t RTC_StructInit(stc_rtc_init_t *pstcRtcInit);
+int32_t RTC_EnterRwMode(void);
+int32_t RTC_ExitRwMode(void);
+
+/* Control configuration */
+int32_t RTC_ConfirmLPMCond(void);
+void RTC_SetIntPeriod(uint8_t u8Period);
+void RTC_SetClockSrc(uint8_t u8Src);
+void RTC_SetClockCompenValue(uint16_t u16Value);
+en_functional_state_t RTC_GetCounterState(void);
+void RTC_Cmd(en_functional_state_t enNewState);
+void RTC_LrcCmd(en_functional_state_t enNewState);
+void RTC_OneHzOutputCmd(en_functional_state_t enNewState);
+void RTC_ClockCompenCmd(en_functional_state_t enNewState);
+
+/* Date and time functions */
+int32_t RTC_SetDate(uint8_t u8Format, stc_rtc_date_t *pstcRtcDate);
+int32_t RTC_GetDate(uint8_t u8Format, stc_rtc_date_t *pstcRtcDate);
+int32_t RTC_SetTime(uint8_t u8Format, stc_rtc_time_t *pstcRtcTime);
+int32_t RTC_GetTime(uint8_t u8Format, stc_rtc_time_t *pstcRtcTime);
+
+/* Alarm configuration functions */
+int32_t RTC_SetAlarm(uint8_t u8Format, stc_rtc_alarm_t *pstcRtcAlarm);
+int32_t RTC_GetAlarm(uint8_t u8Format, stc_rtc_alarm_t *pstcRtcAlarm);
+void RTC_AlarmCmd(en_functional_state_t enNewState);
+
+/* Intrusion timestamp functions */
+void RTC_INTRU_DeInit(uint8_t u8Ch);
+int32_t RTC_INTRU_Init(uint8_t u8Ch, const stc_rtc_intrusion_t *pstcIntru);
+int32_t RTC_INTRU_StructInit(stc_rtc_intrusion_t *pstcIntru);
+int32_t RTC_INTRU_GetTimestamp(uint8_t u8Format, stc_rtc_timestamp_t *pstcTimestamp);
+void RTC_INTRU_Cmd(uint8_t u8Ch, en_functional_state_t enNewState);
+
+/* Interrupt and flag management functions */
+void RTC_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t RTC_GetStatus(uint32_t u32Flag);
+void RTC_ClearStatus(uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_RTC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_RTC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_sdioc.h
+++ b/hc32f4a2/inc/hc32_ll_sdioc.h
@@ -1,0 +1,893 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_sdioc.h
+ * @brief This file contains all the functions prototypes of the SDIOC driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+                                    Rename function SDMMC_CMD1_SendOperatCond to SDMMC_CMD1_SendOperateCond
+                                    Support CMD5/CMD52/CMD53
+                                    Rename macro definition SDIOC_ACMD52_RW_DIRECT to SDIOC_CMD52_IO_RW_DIRECT
+                                    Rename macro definition SDIOC_ACMD53_RW_EXTENDED to SDIOC_CMD53_IO_RW_EXTENDED
+   2024-08-31       CDT             Add parameter for SDMMC_CMD38_Erase
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_SDIOC_H__
+#define __HC32_LL_SDIOC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_SDIOC
+ * @{
+ */
+
+#if (LL_SDIOC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup SDIOC_Global_Types SDIOC Global Types
+ * @{
+ */
+
+/**
+ * @brief SDIOC Init structure definition
+ */
+typedef struct {
+    uint32_t u32Mode;                   /*!< Specifies the SDIOC work mode.
+                                             This parameter can be a value of @ref SDIOC_Mode */
+    uint8_t  u8CardDetect;              /*!< Specifies the SDIOC card detect way.
+                                             This parameter can be a value of @ref SDIOC_Card_Detect_Way */
+    uint8_t  u8SpeedMode;               /*!< Specifies the SDIOC speed mode.
+                                             This parameter can be a value of @ref SDIOC_Speed_Mode */
+    uint8_t  u8BusWidth;                /*!< Specifies the SDIOC bus width.
+                                             This parameter can be a value of @ref SDIOC_Bus_Width */
+    uint16_t u16ClockDiv;               /*!< Specifies the SDIOC clock division.
+                                             This parameter can be a value of @ref SDIOC_Clock_Division */
+} stc_sdioc_init_t;
+
+/**
+ * @brief SDIOC Command Configuration structure definition
+ */
+typedef struct {
+    uint32_t u32Argument;               /*!< Specifies the SDIOC command argument. */
+    uint16_t u16CmdIndex;               /*!< Specifies the SDIOC command index.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 63 */
+    uint16_t u16CmdType;                /*!< Specifies the SDIOC command type.
+                                             This parameter can be a value of @ref SDIOC_Command_Type */
+    uint16_t u16DataLine;               /*!< Specifies whether SDIOC uses data lines in current command.
+                                             This parameter can be a value of @ref SDIOC_Data_Line_Valid */
+    uint16_t u16ResponseType;           /*!< Specifies the SDIOC response type.
+                                             This parameter can be a value of @ref SDIOC_Response_Type */
+} stc_sdioc_cmd_config_t;
+
+/**
+ * @brief SDIOC Data Configuration structure definition
+ */
+typedef struct {
+    uint16_t u16BlockSize;              /*!< Specifies the SDIOC data block size.
+                                             This parameter must be a number between Min_Data = 1 and Max_Data = 512 */
+    uint16_t u16BlockCount;             /*!< Specifies the SDIOC data block count.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 0xFFFF */
+    uint16_t u16TransDir;               /*!< Specifies the SDIOC data transfer direction.
+                                             This parameter can be a value of @ref SDIOC_Transfer_Direction */
+    uint16_t u16AutoCmd12;              /*!< Specifies the validity of the SDIOC Auto Send CMD12.
+                                             This parameter can be a value of @ref SDIOC_Auto_Send_CMD12 */
+    uint16_t u16TransMode;              /*!< Specifies the SDIOC data transfer mode.
+                                             This parameter can be a value of @ref SDIOC_Transfer_Mode */
+    uint8_t  u16DataTimeout;            /*!< Specifies the SDIOC data timeout time.
+                                             This parameter can be a value of @ref SDIOC_Data_Timeout_Time */
+} stc_sdioc_data_config_t;
+
+/**
+ * @brief SDIO CMD52 arguments structure definition
+ */
+typedef struct {
+    uint8_t u8FuncNum;                  /*!< Specifies the number of the function within the I/O card.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 7 */
+    uint32_t u32RwFlag;                 /*!< Specifies the direction of the I/O operation.
+                                             This parameter can be a value of @ref SDIO_CMD52_Arguments_RW_Flag */
+    uint32_t u32RegAddr;                /*!< Specifies the address of the byte of data inside of the selected function.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFF */
+    uint32_t u32RawFlag;                /*!< Specifies the direction of the I/O operation.
+                                             This parameter can be a value of @ref SDIO_CMD52_Arguments_RAW_Flag */
+} stc_sdio_cmd52_arg_t;
+
+/**
+ * @brief SDIO CMD53 arguments structure definition
+ */
+typedef struct {
+    uint8_t u8FuncNum;                  /*!< Specifies the number of the function within the I/O card.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 7 */
+    uint32_t u32RwFlag;                 /*!< Specifies the direction of the I/O operation.
+                                             This parameter can be a value of @ref SDIO_CMD53_Arguments_RW_Flag */
+    uint32_t u32RegAddr;                /*!< Specifies the address of the byte of data inside of the selected function.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FFFF */
+    uint32_t u32OperateCode;            /*!< Specifies the operation code.
+                                             This parameter can be a value of @ref SDIO_CMD53_Arguments_Operate_Code */
+    uint32_t u32BlockMode;              /*!< Specifies the operation code.
+                                             This parameter can be a value of @ref SDIO_CMD53_Arguments_Block_Mode */
+    uint32_t u32Count;                  /*!< Specifies the byte/block count.
+                                             This parameter must be a number between Min_Data = 0 and Max_Data = 0x1FF */
+} stc_sdio_cmd53_arg_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SDIOC_Global_Macros SDIOC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup SDIOC_Mode SDIOC Mode
+ * @{
+ */
+#define SDIOC_MD_SD                             (0x00UL)    /*!< SDIOCx selects SD mode  */
+#define SDIOC_MD_MMC                            (0x01UL)    /*!< SDIOCx selects MMC mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Card_Detect_Way SDIOC Card Detect Way
+ * @{
+ */
+#define SDIOC_CARD_DETECT_CD_PIN_LVL            (0x00U)                 /*!< SDIOCx_CD(x=1~2) line is selected (for normal use)       */
+#define SDIOC_CARD_DETECT_TEST_SIGNAL           (SDIOC_HOSTCON_CDSS)    /*!< The Card Detect Test Level is selected(for test purpose) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Card_Detect_Test_Level SDIOC Card Detect Test Level
+ * @{
+ */
+#define SDIOC_CARD_DETECT_TEST_LVL_LOW          (0x00U)                 /*!< Card identification test signal is low level (with device insertion) */
+#define SDIOC_CARD_DETECT_TEST_LVL_HIGH         (SDIOC_HOSTCON_CDTL)    /*!< Card identification test signal is high level (no device insertion)  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Speed_Mode SDIOC Speed Mode
+ * @{
+ */
+#define SDIOC_SPEED_MD_NORMAL                   (0x00U)                 /*!< Normal speed mode */
+#define SDIOC_SPEED_MD_HIGH                     (SDIOC_HOSTCON_HSEN)    /*!< High speed mode   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Bus_Width SDIOC Bus Width
+ * @{
+ */
+#define SDIOC_BUS_WIDTH_1BIT                    (0x00U)               /*!< The Bus width is 1 bit */
+#define SDIOC_BUS_WIDTH_4BIT                    (SDIOC_HOSTCON_DW)    /*!< The Bus width is 4 bit */
+#define SDIOC_BUS_WIDTH_8BIT                    (SDIOC_HOSTCON_EXDW)  /*!< The Bus width is 8 bit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Clock_Division SDIOC Clock Division
+ * @{
+ */
+#define SDIOC_CLK_DIV1                          (0x00U)               /*!< PCLK/1   */
+#define SDIOC_CLK_DIV2                          (SDIOC_CLKCON_FS_0)   /*!< PCLK/2   */
+#define SDIOC_CLK_DIV4                          (SDIOC_CLKCON_FS_1)   /*!< PCLK/4   */
+#define SDIOC_CLK_DIV8                          (SDIOC_CLKCON_FS_2)   /*!< PCLK/8   */
+#define SDIOC_CLK_DIV16                         (SDIOC_CLKCON_FS_3)   /*!< PCLK/16  */
+#define SDIOC_CLK_DIV32                         (SDIOC_CLKCON_FS_4)   /*!< PCLK/32  */
+#define SDIOC_CLK_DIV64                         (SDIOC_CLKCON_FS_5)   /*!< PCLK/64  */
+#define SDIOC_CLK_DIV128                        (SDIOC_CLKCON_FS_6)   /*!< PCLK/128 */
+#define SDIOC_CLK_DIV256                        (SDIOC_CLKCON_FS_7)   /*!< PCLK/256 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Command_Type SDIOC Command Type
+ * @{
+ */
+#define SDIOC_CMD_TYPE_NORMAL                   (0x00U)               /*!< Other commands                               */
+#define SDIOC_CMD_TYPE_SUSPEND                  (SDIOC_CMD_TYP_0)     /*!< CMD52 for writing "Bus Suspend" in CCCR      */
+#define SDIOC_CMD_TYPE_RESUME                   (SDIOC_CMD_TYP_1)     /*!< CMD52 for writing "Function Select" in CCCR  */
+#define SDIOC_CMD_TYPE_ABORT                    (SDIOC_CMD_TYP)       /*!< CMD12, CMD52 for writing "I/O Abort" in CCCR */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Data_Line_Valid SDIOC Data Line Valid
+ * @{
+ */
+#define SDIOC_DATA_LINE_DISABLE                 (0x00U)               /*!< The current command uses only SDIOCx_CMD(x=1~2) command line       */
+#define SDIOC_DATA_LINE_ENABLE                  (SDIOC_CMD_DAT)       /*!< The current command requires the use of SDIOCx_Dy(x=1~2) data line */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Transfer_Direction SDIOC Transfer Direction
+ * @{
+ */
+#define SDIOC_TRANS_DIR_TO_CARD                 (0x00U)                 /*!< Write (Host to Card) */
+#define SDIOC_TRANS_DIR_TO_HOST                 (SDIOC_TRANSMODE_DDIR)  /*!< Read (Card to Host)  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Auto_Send_CMD12 SDIOC Auto Send CMD12
+ * @{
+ */
+#define SDIOC_AUTO_SEND_CMD12_DISABLE           (0x00U)                    /*!< Do not send autocommands                                   */
+#define SDIOC_AUTO_SEND_CMD12_ENABLE            (SDIOC_TRANSMODE_ATCEN_0)  /*!< CMD12 is automatically sent after multiple block transfers */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Transfer_Mode SDIOC Transfer Mode
+ * @{
+ */
+#define SDIOC_TRANS_MD_SINGLE                   (0x00U)                                         /*!< Single Block transfer        */
+#define SDIOC_TRANS_MD_INFINITE                 (SDIOC_TRANSMODE_MULB)                          /*!< Infinite Block transfer      */
+#define SDIOC_TRANS_MD_MULTI                    (SDIOC_TRANSMODE_MULB | SDIOC_TRANSMODE_BCE)    /*!< Multiple Block transfer      */
+#define SDIOC_TRANS_MD_STOP_MULTI               (0x8000U | SDIOC_TRANS_MD_MULTI)                /*!< Stop Multiple Block transfer */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Data_Timeout_Time SDIOC Data Timeout Time
+ * @{
+ */
+#define SDIOC_DATA_TIMEOUT_CLK_2E13             (0x00U)     /*!< Timeout time: CLK1*2^13 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E14             (0x01U)     /*!< Timeout time: CLK1*2^14 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E15             (0x02U)     /*!< Timeout time: CLK1*2^15 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E16             (0x03U)     /*!< Timeout time: CLK1*2^16 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E17             (0x04U)     /*!< Timeout time: CLK1*2^17 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E18             (0x05U)     /*!< Timeout time: CLK1*2^18 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E19             (0x06U)     /*!< Timeout time: CLK1*2^19 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E20             (0x07U)     /*!< Timeout time: CLK1*2^20 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E21             (0x08U)     /*!< Timeout time: CLK1*2^21 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E22             (0x09U)     /*!< Timeout time: CLK1*2^22 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E23             (0x0AU)     /*!< Timeout time: CLK1*2^23 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E24             (0x0BU)     /*!< Timeout time: CLK1*2^24 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E25             (0x0CU)     /*!< Timeout time: CLK1*2^25 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E26             (0x0DU)     /*!< Timeout time: CLK1*2^26 */
+#define SDIOC_DATA_TIMEOUT_CLK_2E27             (0x0EU)     /*!< Timeout time: CLK1*2^27 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Response_Register SDIOC Response Register
+ * @{
+ */
+#define SDIOC_RESP_REG_BIT0_31                  (0x00U)  /*!< Command Response Register 0-31bit   */
+#define SDIOC_RESP_REG_BIT32_63                 (0x04U)  /*!< Command Response Register 32-63bit  */
+#define SDIOC_RESP_REG_BIT64_95                 (0x08U)  /*!< Command Response Register 64-95bit  */
+#define SDIOC_RESP_REG_BIT96_127                (0x0CU)  /*!< Command Response Register 96-127bit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Software_Reset_Type SDIOC Software Reset Type
+ * @{
+ */
+#define SDIOC_SW_RST_DATA_LINE                  (SDIOC_SFTRST_RSTD)  /*!< Only part of data circuit is reset                                     */
+#define SDIOC_SW_RST_CMD_LINE                   (SDIOC_SFTRST_RSTC)  /*!< Only part of command circuit is reset                                  */
+#define SDIOC_SW_RST_ALL                        (SDIOC_SFTRST_RSTA)  /*!< Reset the entire Host Controller except for the card detection circuit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Output_Clock_Frequency SDIOC Output Clock Frequency
+ * @{
+ */
+#define SDIOC_OUTPUT_CLK_FREQ_400K              (400000UL)    /*!< SDIOC clock: 400KHz */
+#define SDIOC_OUTPUT_CLK_FREQ_25M               (25000000UL)  /*!< SDIOC clock: 25MHz  */
+#define SDIOC_OUTPUT_CLK_FREQ_26M               (26000000UL)  /*!< SDIOC clock: 26MHz  */
+#define SDIOC_OUTPUT_CLK_FREQ_50M               (50000000UL)  /*!< SDIOC clock: 50MHz  */
+#define SDIOC_OUTPUT_CLK_FREQ_52M               (52000000UL)  /*!< SDIOC clock: 52MHz  */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Host_Flag SDIOC Host Flag
+ * @{
+ */
+#define SDIOC_HOST_FLAG_CMDL                    (SDIOC_PSTAT_CMDL)    /*!< CMD Line Level status            */
+#define SDIOC_HOST_FLAG_DATL                    (SDIOC_PSTAT_DATL)    /*!< DAT[3:0] Line Level status       */
+#define SDIOC_HOST_FLAG_DATL_D0                 (SDIOC_PSTAT_DATL_0)  /*!< DAT[0] Line Level status         */
+#define SDIOC_HOST_FLAG_DATL_D1                 (SDIOC_PSTAT_DATL_1)  /*!< DAT[1] Line Level status         */
+#define SDIOC_HOST_FLAG_DATL_D2                 (SDIOC_PSTAT_DATL_2)  /*!< DAT[2] Line Level status         */
+#define SDIOC_HOST_FLAG_DATL_D3                 (SDIOC_PSTAT_DATL_3)  /*!< DAT[3] Line Level status         */
+#define SDIOC_HOST_FLAG_WPL                     (SDIOC_PSTAT_WPL)     /*!< Write Protect Line Level status  */
+#define SDIOC_HOST_FLAG_CDL                     (SDIOC_PSTAT_CDL)     /*!< Card Detect Line Level status    */
+#define SDIOC_HOST_FLAG_CSS                     (SDIOC_PSTAT_CSS)     /*!< Device Stable Status             */
+#define SDIOC_HOST_FLAG_CIN                     (SDIOC_PSTAT_CIN)     /*!< Device Inserted status           */
+#define SDIOC_HOST_FLAG_BRE                     (SDIOC_PSTAT_BRE)     /*!< Data buffer full status          */
+#define SDIOC_HOST_FLAG_BWE                     (SDIOC_PSTAT_BWE)     /*!< Data buffer empty status         */
+#define SDIOC_HOST_FLAG_RTA                     (SDIOC_PSTAT_RTA)     /*!< Read operation status            */
+#define SDIOC_HOST_FLAG_WTA                     (SDIOC_PSTAT_WTA)     /*!< Write operation status           */
+#define SDIOC_HOST_FLAG_DA                      (SDIOC_PSTAT_DA)      /*!< DAT Line transfer status         */
+#define SDIOC_HOST_FLAG_CID                     (SDIOC_PSTAT_CID)     /*!< Command Inhibit with data status */
+#define SDIOC_HOST_FLAG_CIC                     (SDIOC_PSTAT_CIC)     /*!< Command Inhibit status           */
+#define SDIOC_HOST_FLAG_ALL                     (SDIOC_HOST_FLAG_CMDL | SDIOC_HOST_FLAG_DATL | SDIOC_HOST_FLAG_WPL | \
+                                                 SDIOC_HOST_FLAG_CDL  | SDIOC_HOST_FLAG_CSS  | SDIOC_HOST_FLAG_CIN | \
+                                                 SDIOC_HOST_FLAG_BRE  | SDIOC_HOST_FLAG_BWE  | SDIOC_HOST_FLAG_RTA | \
+                                                 SDIOC_HOST_FLAG_WTA  | SDIOC_HOST_FLAG_DA   | SDIOC_HOST_FLAG_CID | \
+                                                 SDIOC_HOST_FLAG_CIC)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Interrupt_Flag SDIOC Interrupt Flag
+ * @{
+ */
+#define SDIOC_INT_FLAG_EI                       (SDIOC_NORINTST_EI)     /*!< Error Interrupt Status     */
+#define SDIOC_INT_FLAG_CINT                     (SDIOC_NORINTST_CINT)   /*!< Card Interrupt status      */
+#define SDIOC_INT_FLAG_CRM                      (SDIOC_NORINTST_CRM)    /*!< Card Removal status        */
+#define SDIOC_INT_FLAG_CIST                     (SDIOC_NORINTST_CIST)   /*!< Card Insertion status      */
+#define SDIOC_INT_FLAG_BRR                      (SDIOC_NORINTST_BRR)    /*!< Buffer Read Ready status   */
+#define SDIOC_INT_FLAG_BWR                      (SDIOC_NORINTST_BWR)    /*!< Buffer Write Ready status  */
+#define SDIOC_INT_FLAG_BGE                      (SDIOC_NORINTST_BGE)    /*!< Block Gap Event status     */
+#define SDIOC_INT_FLAG_TC                       (SDIOC_NORINTST_TC)     /*!< Transfer Complete status   */
+#define SDIOC_INT_FLAG_CC                       (SDIOC_NORINTST_CC)     /*!< Command Complete status    */
+#define SDIOC_INT_FLAG_ACE                      ((uint32_t)SDIOC_ERRINTST_ACE  << 16U)  /*!< Auto CMD12 Error Status      */
+#define SDIOC_INT_FLAG_DEBE                     ((uint32_t)SDIOC_ERRINTST_DEBE << 16U)  /*!< Data End Bit Error status    */
+#define SDIOC_INT_FLAG_DCE                      ((uint32_t)SDIOC_ERRINTST_DCE  << 16U)  /*!< Data CRC Error status        */
+#define SDIOC_INT_FLAG_DTOE                     ((uint32_t)SDIOC_ERRINTST_DTOE << 16U)  /*!< Data Timeout Error status    */
+#define SDIOC_INT_FLAG_CIE                      ((uint32_t)SDIOC_ERRINTST_CIE  << 16U)  /*!< Command Index Error status   */
+#define SDIOC_INT_FLAG_CEBE                     ((uint32_t)SDIOC_ERRINTST_CEBE << 16U)  /*!< Command End Bit Error status */
+#define SDIOC_INT_FLAG_CCE                      ((uint32_t)SDIOC_ERRINTST_CCE  << 16U)  /*!< Command CRC Error status     */
+#define SDIOC_INT_FLAG_CTOE                     ((uint32_t)SDIOC_ERRINTST_CTOE << 16U)  /*!< Command Timeout Error status */
+#define SDIOC_INT_STATIC_FLAGS                  (SDIOC_INT_FLAG_ACE  | SDIOC_INT_FLAG_DEBE | SDIOC_INT_FLAG_DCE  | \
+                                                 SDIOC_INT_FLAG_DTOE | SDIOC_INT_FLAG_CIE  | SDIOC_INT_FLAG_CEBE | \
+                                                 SDIOC_INT_FLAG_CCE  | SDIOC_INT_FLAG_CTOE | SDIOC_INT_FLAG_TC   | \
+                                                 SDIOC_INT_FLAG_CC)
+#define SDIOC_NORMAL_INT_FLAG_ALL               (SDIOC_INT_FLAG_EI   | SDIOC_INT_FLAG_CINT | SDIOC_INT_FLAG_CRM | \
+                                                 SDIOC_INT_FLAG_CIST | SDIOC_INT_FLAG_BRR  | SDIOC_INT_FLAG_BWR | \
+                                                 SDIOC_INT_FLAG_BGE  | SDIOC_INT_FLAG_TC   | SDIOC_INT_FLAG_CC)
+#define SDIOC_ERR_INT_FLAG_ALL                  (SDIOC_INT_FLAG_ACE  | SDIOC_INT_FLAG_DEBE | SDIOC_INT_FLAG_DCE  | \
+                                                 SDIOC_INT_FLAG_DTOE | SDIOC_INT_FLAG_CIE  | SDIOC_INT_FLAG_CEBE | \
+                                                 SDIOC_INT_FLAG_CCE  | SDIOC_INT_FLAG_CTOE)
+#define SDIOC_INT_FLAG_ALL                      (SDIOC_NORMAL_INT_FLAG_ALL | SDIOC_ERR_INT_FLAG_ALL)
+#define SDIOC_INT_FLAG_CLR_ALL                  (SDIOC_INT_FLAG_CRM | SDIOC_INT_FLAG_CIST | SDIOC_INT_FLAG_BRR | \
+                                                 SDIOC_INT_FLAG_BWR | SDIOC_INT_FLAG_BGE  | SDIOC_INT_FLAG_TC  | \
+                                                 SDIOC_INT_FLAG_CC  | SDIOC_ERR_INT_FLAG_ALL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Interrupt SDIOC Interrupt
+ * @{
+ */
+#define SDIOC_INT_CINTSEN                       (SDIOC_NORINTSGEN_CINTSEN)   /*!< Card Interrupt                */
+#define SDIOC_INT_CRMSEN                        (SDIOC_NORINTSGEN_CRMSEN)    /*!< Card Removal Interrupt        */
+#define SDIOC_INT_CISTSEN                       (SDIOC_NORINTSGEN_CISTSEN)   /*!< Card Insertion Interrupt      */
+#define SDIOC_INT_BRRSEN                        (SDIOC_NORINTSGEN_BRRSEN)    /*!< Buffer Read Ready Interrupt   */
+#define SDIOC_INT_BWRSEN                        (SDIOC_NORINTSGEN_BWRSEN)    /*!< Buffer Write Ready Interrupt  */
+#define SDIOC_INT_BGESEN                        (SDIOC_NORINTSGEN_BGESEN)    /*!< Block Gap Event Interrupt     */
+#define SDIOC_INT_TCSEN                         (SDIOC_NORINTSGEN_TCSEN)     /*!< Transfer Complete Interrupt   */
+#define SDIOC_INT_CCSEN                         (SDIOC_NORINTSGEN_CCSEN)     /*!< Command Complete Interrupt    */
+#define SDIOC_INT_ACESEN                        ((uint32_t)SDIOC_ERRINTSGEN_ACESEN  << 16U)   /*!< Auto CMD12 Error Interrupt      */
+#define SDIOC_INT_DEBESEN                       ((uint32_t)SDIOC_ERRINTSGEN_DEBESEN << 16U)   /*!< Data End Bit Error Interrupt    */
+#define SDIOC_INT_DCESEN                        ((uint32_t)SDIOC_ERRINTSGEN_DCESEN  << 16U)   /*!< Data CRC Error Interrupt        */
+#define SDIOC_INT_DTOESEN                       ((uint32_t)SDIOC_ERRINTSGEN_DTOESEN << 16U)   /*!< Data Timeout Error Interrupt    */
+#define SDIOC_INT_CIESEN                        ((uint32_t)SDIOC_ERRINTSGEN_CIESEN  << 16U)   /*!< Command Index Error Interrupt   */
+#define SDIOC_INT_CEBESEN                       ((uint32_t)SDIOC_ERRINTSGEN_CEBESEN << 16U)   /*!< Command End Bit Error Interrupt */
+#define SDIOC_INT_CCESEN                        ((uint32_t)SDIOC_ERRINTSGEN_CCESEN  << 16U)   /*!< Command CRC Error Interrupt     */
+#define SDIOC_INT_CTOESEN                       ((uint32_t)SDIOC_ERRINTSGEN_CTOESEN << 16U)   /*!< Command Timeout Error Interrupt */
+#define SDIOC_NORMAL_INT_ALL                    (SDIOC_INT_CINTSEN | SDIOC_INT_CRMSEN | SDIOC_INT_CISTSEN | \
+                                                 SDIOC_INT_BRRSEN  | SDIOC_INT_BWRSEN | SDIOC_INT_BGESEN  | \
+                                                 SDIOC_INT_TCSEN   | SDIOC_INT_CCSEN)
+#define SDIOC_ERR_INT_ALL                       (SDIOC_INT_ACESEN  | SDIOC_INT_DEBESEN | SDIOC_INT_DCESEN  | \
+                                                 SDIOC_INT_DTOESEN | SDIOC_INT_CIESEN  | SDIOC_INT_CEBESEN | \
+                                                 SDIOC_INT_CCESEN  | SDIOC_INT_CTOESEN)
+#define SDIOC_INT_ALL                           (SDIOC_NORMAL_INT_ALL | SDIOC_ERR_INT_ALL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Auto_CMD_Error_Flag SDIOC Auto CMD Error Flag
+ * @{
+ */
+#define SDIOC_AUTO_CMD_ERR_FLAG_CMDE            (SDIOC_ATCERRST_CMDE)   /*!< Command Not Issued By Auto CMD12 Error Status  */
+#define SDIOC_AUTO_CMD_ERR_FLAG_IE              (SDIOC_ATCERRST_IE)     /*!< Auto CMD12 Index Error status                  */
+#define SDIOC_AUTO_CMD_ERR_FLAG_EBE             (SDIOC_ATCERRST_EBE)    /*!< Auto CMD12 End Bit Error status                */
+#define SDIOC_AUTO_CMD_ERR_FLAG_CE              (SDIOC_ATCERRST_CE)     /*!< Auto CMD12 CRC Error status                    */
+#define SDIOC_AUTO_CMD_ERR_FLAG_TOE             (SDIOC_ATCERRST_TOE)    /*!< Auto CMD12 Timeout Error status                */
+#define SDIOC_AUTO_CMD_ERR_FLAG_NE              (SDIOC_ATCERRST_NE)     /*!< Auto CMD12 Not Executed status                 */
+#define SDIOC_AUTO_CMD_ERR_FLAG_ALL             (SDIOC_AUTO_CMD_ERR_FLAG_CMDE | SDIOC_AUTO_CMD_ERR_FLAG_IE | \
+                                                 SDIOC_AUTO_CMD_ERR_FLAG_EBE  | SDIOC_AUTO_CMD_ERR_FLAG_CE | \
+                                                 SDIOC_AUTO_CMD_ERR_FLAG_TOE  | SDIOC_AUTO_CMD_ERR_FLAG_NE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Force_Auto_CMD_Error SDIOC Force Auto CMD Error
+ * @{
+ */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FCMDE          (SDIOC_FEA_FCMDE)   /*!< Force Event for Command Not Issued By Auto CMD12 Error */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FIE            (SDIOC_FEA_FIE)     /*!< Force Event for Auto CMD12 Index Error                 */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FEBE           (SDIOC_FEA_FEBE)    /*!< Force Event for Auto CMD12 End Bit Error               */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FCE            (SDIOC_FEA_FCE)     /*!< Force Event for Auto CMD12 CRC Error                   */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FTOE           (SDIOC_FEA_FTOE)    /*!< Force Event for Auto CMD12 Timeout Error               */
+#define SDIOC_FORCE_AUTO_CMD_ERR_FNE            (SDIOC_FEA_FNE)     /*!< Force Event for Auto CMD12 Not Executed                */
+#define SDIOC_FORCE_AUTO_CMD_ERR_ALL            (SDIOC_FORCE_AUTO_CMD_ERR_FCMDE | SDIOC_FORCE_AUTO_CMD_ERR_FIE | \
+                                                 SDIOC_FORCE_AUTO_CMD_ERR_FEBE  | SDIOC_FORCE_AUTO_CMD_ERR_FCE | \
+                                                 SDIOC_FORCE_AUTO_CMD_ERR_FTOE  | SDIOC_FORCE_AUTO_CMD_ERR_FNE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Force_Error_Interrupt SDIOC Force Error Interrupt
+ * @{
+ */
+#define SDIOC_FORCE_ERR_INT_FACE                (SDIOC_FEE_FACE)    /*!< Force Event for Auto CMD12 Error       */
+#define SDIOC_FORCE_ERR_INT_FDEBE               (SDIOC_FEE_FDEBE)   /*!< Force Event for Data End Bit Error     */
+#define SDIOC_FORCE_ERR_INT_FDCE                (SDIOC_FEE_FDCE)    /*!< Force Event for Data CRC Error         */
+#define SDIOC_FORCE_ERR_INT_FDTOE               (SDIOC_FEE_FDTOE)   /*!< Force Event for Data Timeout Error     */
+#define SDIOC_FORCE_ERR_INT_FCIE                (SDIOC_FEE_FCIE)    /*!< Force Event for Command Index Error    */
+#define SDIOC_FORCE_ERR_INT_FCEBE               (SDIOC_FEE_FCEBE)   /*!< Force Event for Command End Bit Error  */
+#define SDIOC_FORCE_ERR_INT_FCCE                (SDIOC_FEE_FCCE)    /*!< Force Event for Command CRC Error      */
+#define SDIOC_FORCE_ERR_INT_FCTOE               (SDIOC_FEE_FCTOE)   /*!< Force Event for Command Timeout Error  */
+#define SDIOC_FORCE_ERR_INT_ALL                 (SDIOC_FORCE_ERR_INT_FACE | SDIOC_FORCE_ERR_INT_FDEBE | \
+                                                 SDIOC_FORCE_ERR_INT_FDCE | SDIOC_FORCE_ERR_INT_FDTOE | \
+                                                 SDIOC_FORCE_ERR_INT_FCIE | SDIOC_FORCE_ERR_INT_FCEBE | \
+                                                 SDIOC_FORCE_ERR_INT_FCCE | SDIOC_FORCE_ERR_INT_FCTOE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Response_Type SDIOC Response Type
+ * @{
+ */
+#define SDIOC_RESP_TYPE_NO                      (0x00U)                                               /*!< No Response                        */
+#define SDIOC_RESP_TYPE_R2                      (SDIOC_CMD_RESTYP_0)                                  /*!< Command Response 2                 */
+#define SDIOC_RESP_TYPE_R3_R4                   (SDIOC_CMD_RESTYP_1)                                  /*!< Command Response 3, 4              */
+#define SDIOC_RESP_TYPE_R1_R5_R6_R7             (SDIOC_CMD_RESTYP_1 | SDIOC_CMD_ICE | SDIOC_CMD_CCE)  /*!< Command Response 1, 5, 6, 7        */
+#define SDIOC_RESP_TYPE_R1B_R5B                 (SDIOC_CMD_RESTYP   | SDIOC_CMD_ICE | SDIOC_CMD_CCE)  /*!< Command Response 1 and 5 with busy */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_Command SDIOC Command
+ * @{
+ */
+/**
+ * @defgroup SDIOC_SDMMC_CMD SDIOC SDMMC CMD
+ * @{
+ */
+#define SDIOC_CMD0_GO_IDLE_STATE                (0U)    /*!< Resets the SD memory card. */
+#define SDIOC_CMD1_SEND_OP_COND                 (1U)    /*!< Sends host capacity support information and activates the card's initialization process. */
+#define SDIOC_CMD2_ALL_SEND_CID                 (2U)    /*!< Asks any card connected to the host to send the CID numbers on the CMD line.             */
+#define SDIOC_CMD3_SEND_RELATIVE_ADDR           (3U)    /*!< Asks the card to publish a new relative address (RCA).                                   */
+#define SDIOC_CMD4_SET_DSR                      (4U)    /*!< Programs the DSR of all cards.                                                           */
+#define SDIOC_CMD5_IO_SEND_OP_COND              (5U)    /*!< Sends host capacity support information (HCS) and asks the accessed card to send its \
+                                                            operating condition register (OCR) content in the response on the CMD line.              */
+#define SDIOC_CMD6_SWITCH_FUNC                  (6U)    /*!< Checks switchable function (mode 0) and switch card function (mode 1).                   */
+#define SDIOC_CMD7_SELECT_DESELECT_CARD         (7U)    /*!< Selects the card by its own relative address and gets deselected by any other address    */
+#define SDIOC_CMD8_SEND_IF_COND                 (8U)    /*!< Sends SD Memory Card interface condition, which includes host supply voltage information \
+                                                            and asks the card whether card supports voltage.                                         */
+#define SDIOC_CMD9_SEND_CSD                     (9U)    /*!< Addressed card sends its card specific data (CSD) on the CMD line.                       */
+#define SDIOC_CMD10_SEND_CID                    (10U)   /*!< Addressed card sends its card identification (CID) on the CMD line.                      */
+#define SDIOC_CMD11_READ_DAT_UNTIL_STOP         (11U)   /*!< SD card doesn't support it.                                                              */
+#define SDIOC_CMD12_STOP_TRANSMISSION           (12U)   /*!< Forces the card to stop transmission.                                                    */
+#define SDIOC_CMD13_SEND_STATUS                 (13U)   /*!< Addressed card sends its status register.                                                */
+#define SDIOC_CMD14_HS_BUSTEST_READ             (14U)   /*!< Reserved                                                                                 */
+#define SDIOC_CMD15_GO_INACTIVE_STATE           (15U)   /*!< Sends an addressed card into the inactive state.                                         */
+#define SDIOC_CMD16_SET_BLOCKLEN                (16U)   /*!< Sets the block length (in bytes for SDSC) for all following block commands(read, write).  \
+                                                            Default block length is fixed to 512 Bytes. Not effective for SDHS and SDXC.             */
+#define SDIOC_CMD17_READ_SINGLE_BLOCK           (17U)   /*!< Reads single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of fixed \
+                                                            512 bytes in case of SDHC and SDXC.                                                      */
+#define SDIOC_CMD18_READ_MULTI_BLOCK            (18U)   /*!< Continuously transfers data blocks from card to host until interrupted by                 \
+                                                            STOP_TRANSMISSION command.                                                               */
+#define SDIOC_CMD19_HS_BUSTEST_WRITE            (19U)   /*!< 64 bytes tuning pattern is sent for SDR50 and SDR104.                                    */
+#define SDIOC_CMD20_WRITE_DAT_UNTIL_STOP        (20U)   /*!< Speed class control command.                                                             */
+#define SDIOC_CMD23_SET_BLOCK_COUNT             (23U)   /*!< Specify block count for CMD18 and CMD25.                                                 */
+#define SDIOC_CMD24_WRITE_SINGLE_BLOCK          (24U)   /*!< Writes single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of fixed\
+                                                            512 bytes in case of SDHC and SDXC.                                                      */
+#define SDIOC_CMD25_WRITE_MULTI_BLOCK           (25U)   /*!< Continuously writes blocks of data until a STOP_TRANSMISSION follows.                    */
+#define SDIOC_CMD26_PROGRAM_CID                 (26U)   /*!< Reserved for manufacturers.                                                              */
+#define SDIOC_CMD27_PROGRAM_CSD                 (27U)   /*!< Programming of the programmable bits of the CSD.                                         */
+#define SDIOC_CMD28_SET_WRITE_PROT              (28U)   /*!< Sets the write protection bit of the addressed group.                                    */
+#define SDIOC_CMD29_CLR_WRITE_PROT              (29U)   /*!< Clears the write protection bit of the addressed group.                                  */
+#define SDIOC_CMD30_SEND_WRITE_PROT             (30U)   /*!< Asks the card to send the status of the write protection bits.                           */
+#define SDIOC_CMD32_ERASE_WR_BLK_START          (32U)   /*!< Sets the address of the first write block to be erased. (For SD card only).              */
+#define SDIOC_CMD33_ERASE_WR_BLK_END            (33U)   /*!< Sets the address of the last write block of the continuous range to be erased.           */
+#define SDIOC_CMD35_ERASE_GROUP_START           (35U)   /*!< Sets the address of the first write block to be erased. Reserved for each command system  \
+                                                            set by switch function command (CMD6).                                                   */
+#define SDIOC_CMD36_ERASE_GROUP_END             (36U)   /*!< Sets the address of the last write block of the continuous range to be erased.            \
+                                                            Reserved for each command system set by switch function command (CMD6).                  */
+#define SDIOC_CMD38_ERASE                       (38U)   /*!< Reserved for SD security applications.                                                   */
+#define SDIOC_CMD39_FAST_IO                     (39U)   /*!< SD card doesn't support it (Reserved).                                                   */
+#define SDIOC_CMD40_GO_IRQ_STATE                (40U)   /*!< SD card doesn't support it (Reserved).                                                   */
+#define SDIOC_CMD42_LOCK_UNLOCK                 (42U)   /*!< Sets/resets the password or lock/unlock the card. The size of the data block is set by    \
+                                                            the SET_BLOCK_LEN command.                                                               */
+#define SDIOC_CMD52_IO_RW_DIRECT                (52U)   /*!< For SD I/O card only, access a single I/O register.                                    */
+#define SDIOC_CMD53_IO_RW_EXTENDED              (53U)   /*!< For SD I/O card only, access multiple I/O registers with a single command.              */
+#define SDIOC_CMD55_APP_CMD                     (55U)   /*!< Indicates to the card that the next command is an application specific command rather     \
+                                                            than a standard command.                                                                 */
+#define SDIOC_CMD56_GEN_CMD                     (56U)   /*!< Used either to transfer a data block to the card or to get a data block from the card     \
+                                                            for general purpose/application specific commands.                                       */
+#define SDIOC_CMD64_NO_CMD                      (64U)   /*!< No command                                                                               */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIOC_SDMMC_ACMD SDIOC SDMMC ACMD
+ * @{
+ */
+/* Following commands are SD Card Specific commands. SDIOC_CMD55_APP_CMD should be sent before sending these commands. */
+#define SDIOC_ACMD6_SET_BUS_WIDTH               (6U)    /*!< (ACMD6) Defines the data bus width to be used for data transfer. The allowed data bus     \
+                                                            widths are given in SCR register.                                                        */
+#define SDIOC_ACMD13_SD_STATUS                  (13U)   /*!< (ACMD13) Sends the SD status.                                                            */
+#define SDIOC_ACMD22_SEND_NUM_WR_BLOCKS         (22U)   /*!< (ACMD22) Sends the number of the written (without errors) write blocks. Responds with     \
+                                                            32bit+CRC data block.                                                                    */
+#define SDIOC_ACMD23_SET_WR_BLK_ERASE_COUNT     (23U)   /*!< Set the number of write blocks to be pre-erased before writing (to be used for faster     \
+                                                            Multiple Block WR command). */
+#define SDIOC_ACMD41_SD_APP_OP_COND             (41U)   /*!< (ACMD41) Sends host capacity support information (HCS) and asks the accessed card to      \
+                                                            send its operating condition register (OCR) content in the response on the CMD line.     */
+#define SDIOC_ACMD42_SET_CLR_CARD_DETECT        (42U)   /*!< (ACMD42) Connect/Disconnect the 50 KOhm pull-up resistor on CD/DAT3 (pin 1) of the card  */
+#define SDIOC_ACMD51_SEND_SCR                   (51U)   /*!< Reads the SD Configuration Register (SCR).                                               */
+
+#define SDIOC_ACMD43_GET_MKB                    (43U)
+#define SDIOC_ACMD44_GET_MID                    (44U)
+#define SDIOC_ACMD45_SET_CER_RN1                (45U)
+#define SDIOC_ACMD46_GET_CER_RN2                (46U)
+#define SDIOC_ACMD47_SET_CER_RES2               (47U)
+#define SDIOC_ACMD48_GET_CER_RES1               (48U)
+#define SDIOC_ACMD18_SECURE_READ_MULTI_BLOCK    (18U)
+#define SDIOC_ACMD25_SECURE_WRITE_MULTI_BLOCK   (25U)
+#define SDIOC_ACMD38_SECURE_ERASE               (38U)
+#define SDIOC_ACMD49_CHANGE_SECURE_AREA         (49U)
+#define SDIOC_ACMD48_SECURE_WRITE_MKB           (48U)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_Error_Code SDMMC Error Code
+ * @{
+ */
+#define SDMMC_ERR_NONE                          (0x00000000UL)  /*!< No error                                                      */
+#define SDMMC_ERR_ADDR_OUT_OF_RANGE             (0x80000000UL)  /*!< Error when addressed block is out of range                    */
+#define SDMMC_ERR_ADDR_MISALIGNED               (0x40000000UL)  /*!< Misaligned address                                            */
+#define SDMMC_ERR_BLOCK_LEN_ERR                 (0x20000000UL)  /*!< Transferred block length is not allowed for the card or the    \
+                                                                     number of transferred bytes does not match the block length   */
+#define SDMMC_ERR_ERASE_SEQ_ERR                 (0x10000000UL)  /*!< An error in the sequence of erase command occurs              */
+#define SDMMC_ERR_BAD_ERASE_PARAM               (0x08000000UL)  /*!< An invalid selection for erase groups                         */
+#define SDMMC_ERR_WR_PROT_VIOLATION             (0x04000000UL)  /*!< Attempt to program a write protect block                      */
+#define SDMMC_ERR_LOCK_UNLOCK_FAILED            (0x01000000UL)  /*!< Sequence or password error has been detected in unlock command \
+                                                                     or if there was an attempt to access a locked card            */
+#define SDMMC_ERR_COM_CRC_FAILED                (0x00800000UL)  /*!< CRC check of the previous command failed                      */
+#define SDMMC_ERR_ILLEGAL_CMD                   (0x00400000UL)  /*!< Command is not legal for the card state                       */
+#define SDMMC_ERR_CARD_ECC_FAILED               (0x00200000UL)  /*!< Card internal ECC was applied but failed to correct the data  */
+#define SDMMC_ERR_CC_ERR                        (0x00100000UL)  /*!< Internal card controller error                                */
+#define SDMMC_ERR_GENERAL_UNKNOWN_ERR           (0x00080000UL)  /*!< General or unknown error                                      */
+#define SDMMC_ERR_STREAM_RD_UNDERRUN            (0x00040000UL)  /*!< The card could not sustain data reading in stream mode       */
+#define SDMMC_ERR_STREAM_WR_OVERRUN             (0x00020000UL)  /*!< The card could not sustain data programming in stream mode    */
+#define SDMMC_ERR_CID_CSD_OVERWRITE             (0x00010000UL)  /*!< CID/CSD overwrite error                                       */
+#define SDMMC_ERR_WP_ERASE_SKIP                 (0x00008000UL)  /*!< Only partial address space was erased                         */
+#define SDMMC_ERR_CARD_ECC_DISABLED             (0x00004000UL)  /*!< Command has been executed without using internal ECC          */
+#define SDMMC_ERR_ERASE_RST                     (0x00002000UL)  /*!< Erase sequence was cleared before executing because an out of  \
+                                                                     erase sequence command was received                           */
+#define SDMMC_ERR_CMD_AUTO_SEND                 (0x00001000UL)  /*!< An error occurred in sending the command automatically        */
+#define SDMMC_ERR_CMD_INDEX                     (0x00000800UL)  /*!< The received response contains a command number error         */
+#define SDMMC_ERR_CMD_STOP_BIT                  (0x00000400UL)  /*!< Command line detects low level at stop bit                    */
+#define SDMMC_ERR_CMD_CRC_FAIL                  (0x00000200UL)  /*!< Command response received (but CRC check failed)              */
+#define SDMMC_ERR_CMD_TIMEOUT                   (0x00000100UL)  /*!< Command response timeout                                      */
+#define SDMMC_ERR_SWITCH_ERR                    (0x00000080UL)  /*!< The card did not switch to the expected mode as requested by   \
+                                                                     the SWITCH command                                            */
+#define SDMMC_ERR_DATA_STOP_BIT                 (0x00000040UL)  /*!< Data line detects low level at stop bit                       */
+#define SDMMC_ERR_DATA_CRC_FAIL                 (0x00000020UL)  /*!< Data block sent/received (CRC check failed)                   */
+#define SDMMC_ERR_DATA_TIMEOUT                  (0x00000010UL)  /*!< Data timeout                                                  */
+#define SDMMC_ERR_AKE_SEQ_ERR                   (0x00000008UL)  /*!< Error in sequence of authentication                           */
+#define SDMMC_ERR_INVD_VOLT                     (0x00000004UL)  /*!< Error in case of invalid voltage range                        */
+#define SDMMC_ERR_REQ_NOT_APPLICABLE            (0x00000002UL)  /*!< Error when command request is not applicable                  */
+#define SDMMC_ERR_UNSUPPORT_FEATURE             (0x00000001UL)  /*!< Error when feature is unsupported                         */
+
+#define SDMMC_ERR_BITS_MASK                     (0xFDFFE048UL)  /*!< SD/MMC Error status bits mask                                 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_Card_Status_Bit SDMMC Card Status Bit
+ * @{
+ */
+#define SDMMC_STATUS_CARD_IS_LOCKED_POS         (24U)
+#define SDMMC_STATUS_CARD_IS_LOCKED             (0x02000000UL)  /*!< When set, signals that the card is locked by the host */
+#define SDMMC_STATUS_CURR_STATE_POS             (9U)
+#define SDMMC_STATUS_CURR_STATE                 (0x00001E00UL)  /*!< The state of the card when receiving the command */
+#define SDMMC_STATUS_RDY_FOR_DATA_POS           (8U)
+#define SDMMC_STATUS_RDY_FOR_DATA               (0x00000100UL)  /*!< Corresponds to buffer empty signaling on the bus */
+#define SDMMC_STATUS_APP_CMD_POS                (5U)
+#define SDMMC_STATUS_APP_CMD                    (0x00000020UL)  /*!< The card will expect ACMD, or an indication that the command has been interpreted as ACMD */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_SCR_Register SDMMC SCR Register
+ * @{
+ */
+#define SDMMC_SCR_PHY_SPEC_VER_1P0              (0x00000000UL)
+#define SDMMC_SCR_PHY_SPEC_VER_1P1              (0x01000000UL)
+#define SDMMC_SCR_PHY_SPEC_VER_2P0              (0x02000000UL)
+#define SDMMC_SCR_BUS_WIDTH_4BIT                (0x00040000UL)
+#define SDMMC_SCR_BUS_WIDTH_1BIT                (0x00010000UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_OCR_Register SDMMC OCR Register
+ * @{
+ */
+#define SDMMC_OCR_HIGH_CAPACITY                 (0x40000000UL)
+#define SDMMC_OCR_STD_CAPACITY                  (0x00000000UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_CSD_Register SDMMC CSD Register
+ * @{
+ */
+/* Command Class supported */
+#define SDMMC_CSD_SUPPORT_CLASS5_ERASE          (0x00000020UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_Common_Parameter SDMMC Common Parameter
+ * @{
+ */
+#define SDMMC_DATA_TIMEOUT                      (0x0000FFFFUL)
+#define SDMMC_MAX_VOLT_TRIAL                    (0x0000FFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDMMC_IO_Command_Arguments SDMMC IO Command Arguments
+ * @{
+ */
+/**
+ * @defgroup SDIO_CMD52_Arguments SDIO CMD52 Arguments
+ * @{
+ */
+/**
+ * @defgroup SDIO_CMD52_Arguments_RW_Flag SDIO CMD52 Arguments RW_Flag
+ * @{
+ */
+#define SDIO_CMD52_ARG_RD                       (0UL << 31)
+#define SDIO_CMD52_ARG_WR                       (1UL << 31)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIO_CMD52_Arguments_RAW_Flag SDIO CMD52 Arguments RAW Flag
+ * @{
+ */
+#define SDIO_CMD52_ARG_RAW_FLAG_0               (0UL << 27)
+#define SDIO_CMD52_ARG_RAW_FLAG_1               (1UL << 27)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIO_CMD53_Arguments SDIO CMD53 Arguments
+ * @{
+ */
+/**
+ * @defgroup SDIO_CMD53_Arguments_RW_Flag SDIO CMD53 Arguments RW_Flag
+ * @{
+ */
+#define SDIO_CMD53_ARG_RD                       (0UL << 31)
+#define SDIO_CMD53_ARG_WR                       (1UL << 31)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIO_CMD53_Arguments_Block_Mode SDIO CMD53 Arguments Block Mode
+ * @{
+ */
+#define SDIO_CMD53_ARG_TRANS_MD_BYTE            (0UL << 27)
+#define SDIO_CMD53_ARG_TRANS_MD_BLOCK           (1UL << 27)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SDIO_CMD53_Arguments_Operate_Code SDIO CMD53 Arguments Operate Code
+ * @{
+ */
+#define SDIO_CMD53_ARG_OP_CODE_ADDR_FIX         (0UL << 26)
+#define SDIO_CMD53_ARG_OP_CODE_ADDR_INC         (1UL << 26)
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup SDIOC_Global_Functions
+ * @{
+ */
+int32_t SDIOC_DeInit(CM_SDIOC_TypeDef *SDIOCx);
+int32_t SDIOC_Init(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_init_t *pstcSdiocInit);
+int32_t SDIOC_StructInit(stc_sdioc_init_t *pstcSdiocInit);
+int32_t SDIOC_SWReset(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Type);
+void SDIOC_PowerCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState);
+en_functional_state_t SDIOC_GetPowerState(const CM_SDIOC_TypeDef *SDIOCx);
+uint32_t SDIOC_GetMode(const CM_SDIOC_TypeDef *SDIOCx);
+void SDIOC_ClockCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState);
+void SDIOC_SetClockDiv(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Div);
+int32_t SDIOC_GetOptimumClockDiv(uint32_t u32ClockFreq, uint16_t *pu16Div);
+int32_t SDIOC_VerifyClockDiv(uint32_t u32Mode, uint8_t u8SpeedMode, uint16_t u16ClockDiv);
+en_flag_status_t SDIOC_GetInsertStatus(const CM_SDIOC_TypeDef *SDIOCx);
+void SDIOC_SetSpeedMode(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8SpeedMode);
+void SDIOC_SetBusWidth(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8BusWidth);
+void SDIOC_SetCardDetectSrc(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Src);
+void SDIOC_SetCardDetectTestLevel(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Level);
+
+int32_t SDIOC_SendCommand(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_cmd_config_t *pstcCmdConfig);
+int32_t SDIOC_CommandStructInit(stc_sdioc_cmd_config_t *pstcCmdConfig);
+int32_t SDIOC_GetResponse(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Reg, uint32_t *pu32Value);
+int32_t SDIOC_ConfigData(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_data_config_t *pstcDataConfig);
+int32_t SDIOC_DataStructInit(stc_sdioc_data_config_t *pstcDataConfig);
+int32_t SDIOC_ReadBuffer(CM_SDIOC_TypeDef *SDIOCx, uint8_t au8Data[], uint32_t u32Len);
+int32_t SDIOC_WriteBuffer(CM_SDIOC_TypeDef *SDIOCx, const uint8_t au8Data[], uint32_t u32Len);
+
+void SDIOC_BlockGapStopCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState);
+void SDIOC_RestartTrans(CM_SDIOC_TypeDef *SDIOCx);
+void SDIOC_ReadWaitCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState);
+void SDIOC_BlockGapIntCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState);
+
+void SDIOC_IntCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType, en_functional_state_t enNewState);
+en_functional_state_t SDIOC_GetIntEnableState(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType);
+void SDIOC_IntStatusCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t SDIOC_GetIntStatus(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag);
+void SDIOC_ClearIntStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag);
+en_flag_status_t SDIOC_GetHostStatus(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag);
+en_flag_status_t SDIOC_GetAutoCmdErrorStatus(const CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Flag);
+void SDIOC_ForceAutoCmdErrorEvent(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Event);
+void SDIOC_ForceErrorIntEvent(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Event);
+
+/* SDMMC Commands management functions */
+int32_t SDMMC_CMD0_GoIdleState(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD2_AllSendCID(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD3_SendRelativeAddr(CM_SDIOC_TypeDef *SDIOCx, uint16_t *pu16RCA, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD6_SwitchFunc(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD7_SelectDeselectCard(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD8_SendInterfaceCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD9_SendCSD(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD12_StopTrans(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD13_SendStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD16_SetBlockLength(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32BlockLen, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD17_ReadSingleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32ReadAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD18_ReadMultipleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32ReadAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD24_WriteSingleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32WriteAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD25_WriteMultipleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32WriteAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD32_EraseBlockStartAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32StartAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD33_EraseBlockEndAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32EndAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD38_Erase(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD55_AppCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+
+int32_t SDMMC_ACMD6_SetBusWidth(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32BusWidth, uint32_t *pu32ErrStatus);
+int32_t SDMMC_ACMD13_SendStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+int32_t SDMMC_ACMD41_SendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+int32_t SDMMC_ACMD51_SendSCR(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus);
+
+int32_t SDMMC_CMD1_SendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD35_EraseGroupStartAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32StartAddr, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD36_EraseGroupEndAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32EndAddr, uint32_t *pu32ErrStatus);
+
+int32_t SDMMC_CMD5_IOSendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD52_IORwDirect(CM_SDIOC_TypeDef *SDIOCx, const stc_sdio_cmd52_arg_t *pstcCmdArg,
+                               uint8_t u8In, uint8_t *pu8Out, uint32_t *pu32ErrStatus);
+int32_t SDMMC_CMD53_IORwExtended(CM_SDIOC_TypeDef *SDIOCx, const stc_sdio_cmd53_arg_t *pstcCmdArg,
+                                 uint32_t *pu32ErrStatus);
+
+/**
+ * @}
+ */
+
+#endif /* LL_SDIOC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_SDIOC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_smc.h
+++ b/hc32f4a2/inc/hc32_ll_smc.h
@@ -1,0 +1,399 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_smc.h
+ * @brief This file contains all the functions prototypes of the EXMC_SMC
+ *        (External Memory Controller: Static Memory Controller) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             API EXMC_SMC_DeInit add return value
+   2024-06-30       CDT             Rename macro-define: EXMC_SMC_READ_BURST_CONTINUOUS -> EXMC_SMC_READ_BURST_INFINITE
+                                    Rename macro-define: EXMC_SMC_WRITE_BURST_CONTINUOUS -> EXMC_SMC_WRITE_BURST_INFINITE
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_SMC_H__
+#define __HC32_LL_SMC_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_EXMC
+ * @{
+ */
+
+/**
+ * @addtogroup LL_SMC
+ * @{
+ */
+
+#if (LL_SMC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_SMC_Global_Types EXMC_SMC Global Types
+ * @{
+ */
+
+/**
+ * @brief  EXMC_SMC Chip Configuration Structure definition
+ */
+typedef struct {
+    uint32_t u32ReadMode;       /*!< Defines the read sync enable.
+                                     This parameter can be a value of @ref EXMC_SMC_Memory_Read_Mode */
+    uint32_t u32WriteMode;      /*!< Defines the write sync enable.
+                                     This parameter can be a value of @ref EXMC_SMC_Memory_Write_Mode */
+    uint32_t u32ReadBurstLen;   /*!< Defines the number of read data access.
+                                     This parameter can be a value of @ref EXMC_SMC_Memory_Read_Burst_Length. */
+    uint32_t u32WriteBurstLen;  /*!< Defines the number of write data access.
+                                     This parameter can be a value of @ref EXMC_SMC_Memory_Write_Burst_Length. */
+    uint32_t u32MemoryWidth;    /*!< Defines the SMC memory width.
+                                     This parameter can be a value of @ref EXMC_SMC_Memory_Width. */
+    uint32_t u32BAA;            /*!< Defines the SMC BAA signal enable.
+                                     This parameter can be a value of @ref EXMC_SMC_BAA_Port_Selection. */
+    uint32_t u32ADV;            /*!< Defines the SMC ADVS signal enable.
+                                     This parameter can be a value of @ref EXMC_SMC_ADV_Port_Selection. */
+    uint32_t u32BLS;            /*!< Defines the SMC BLS signal selection.
+                                     This parameter can be a value of @ref EXMC_SMC_BLS_Synchronization_Selection. */
+    uint32_t u32AddrMatch;      /*!< Defines the address match.
+                                     This parameter can be a value between Min_Data = 0x60 and Max_Data = 0x7F */
+    uint32_t u32AddrMask;       /*!< Defines the address mask.
+                                     This parameter can be a value of @ref EXMC_SMC_Mask_Address. */
+} stc_exmc_smc_chip_config_t;
+
+/**
+ * @brief  EXMC_SMC Timing Configuration Structure definition
+ */
+typedef struct {
+    uint8_t u8RC;               /*!< Defines the RC in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F */
+    uint8_t u8WC;               /*!< Defines the WC in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F */
+    uint8_t u8CEOE;             /*!< Defines the CEOE in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+    uint8_t u8WP;               /*!< Defines the WP in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+    uint8_t u8PC;               /*!< Defines the PC in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+    uint8_t u8TR;               /*!< Defines the TR in memory clock cycles.
+                                     This parameter can be a value between Min_Data = 0 and Max_Data = 7 */
+} stc_exmc_smc_timing_config_t;
+
+/**
+ * @brief  EXMC_SMC Initialization Structure definition
+ */
+typedef struct {
+    stc_exmc_smc_chip_config_t   stcChipConfig;     /*!< SMC memory chip configure.
+                                                         This structure details refer @ref stc_exmc_smc_chip_config_t. */
+    stc_exmc_smc_timing_config_t stcTimingConfig;   /*!< SMC memory timing configure.
+                                                         This structure details refer @ref stc_exmc_smc_timing_config_t. */
+} stc_exmc_smc_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_SMC_Global_Macros EXMC_SMC Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_SMC_Chip EXMC_SMC Chip
+ * @{
+ */
+#define EXMC_SMC_CHIP0                          (0UL)     /*!< Chip 0 */
+#define EXMC_SMC_CHIP1                          (1UL)     /*!< Chip 1 */
+#define EXMC_SMC_CHIP2                          (2UL)     /*!< Chip 2 */
+#define EXMC_SMC_CHIP3                          (3UL)     /*!< Chip 3 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Memory_Read_Mode EXMC_SMC Memory Read Mode
+ * @{
+ */
+#define EXMC_SMC_READ_ASYNC                     (0UL)
+#define EXMC_SMC_READ_SYNC                      (SMC_CPCR_RSYN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Memory_Write_Mode EXMC_SMC Memory Write Mode
+ * @{
+ */
+#define EXMC_SMC_WRITE_ASYNC                    (0UL)
+#define EXMC_SMC_WRITE_SYNC                     (SMC_CPCR_WSYN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Memory_Read_Burst_Length EXMC_SMC Memory Read Burst Length
+ * @{
+ */
+#define EXMC_SMC_READ_BURST_1BEAT               (0UL)
+#define EXMC_SMC_READ_BURST_4BEAT               (1UL << SMC_CPCR_RBL_POS)
+#define EXMC_SMC_READ_BURST_8BEAT               (2UL << SMC_CPCR_RBL_POS)
+#define EXMC_SMC_READ_BURST_16BEAT              (3UL << SMC_CPCR_RBL_POS)
+#define EXMC_SMC_READ_BURST_32BEAT              (4UL << SMC_CPCR_RBL_POS)
+#define EXMC_SMC_READ_BURST_INFINITE            (5UL << SMC_CPCR_RBL_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Memory_Write_Burst_Length EXMC_SMC Memory Write Burst Length
+ * @{
+ */
+#define EXMC_SMC_WRITE_BURST_1BEAT              (0UL)
+#define EXMC_SMC_WRITE_BURST_4BEAT              (1UL << SMC_CPCR_WBL_POS)
+#define EXMC_SMC_WRITE_BURST_8BEAT              (2UL << SMC_CPCR_WBL_POS)
+#define EXMC_SMC_WRITE_BURST_16BEAT             (3UL << SMC_CPCR_WBL_POS)
+#define EXMC_SMC_WRITE_BURST_32BEAT             (4UL << SMC_CPCR_WBL_POS)
+#define EXMC_SMC_WRITE_BURST_INFINITE           (5UL << SMC_CPCR_WBL_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Memory_Width EXMC_SMC Memory Width
+ * @{
+ */
+#define EXMC_SMC_MEMORY_WIDTH_16BIT             (SMC_CPCR_MW_0)
+#define EXMC_SMC_MEMORY_WIDTH_32BIT             (SMC_CPCR_MW_1)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_BAA_Port_Selection EXMC_SMC BAA Port Selection
+ * @{
+ */
+#define EXMC_SMC_BAA_PORT_DISABLE               (0UL)
+#define EXMC_SMC_BAA_PORT_ENABLE                (SMC_CPCR_BAAS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_ADV_Port_Selection EXMC_SMC ADV Port Selection
+ * @{
+ */
+#define EXMC_SMC_ADV_PORT_DISABLE               (0UL)
+#define EXMC_SMC_ADV_PORT_ENABLE                (SMC_CPCR_ADVS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_BLS_Synchronization_Selection EXMC_SMC BLS Synchronization Selection
+ * @{
+ */
+#define EXMC_SMC_BLS_SYNC_CS                    (0UL)
+#define EXMC_SMC_BLS_SYNC_WE                    (SMC_CPCR_BLSS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Command EXMC_SMC Command
+ * @{
+ */
+#define EXMC_SMC_CMD_MDREGCONFIG                (SMC_CMDR_CMD_0)    /*!< Command: MdRetConfig */
+#define EXMC_SMC_CMD_UPDATEREGS                 (SMC_CMDR_CMD_1)    /*!< Command: UpdateRegs */
+#define EXMC_SMC_CMD_MDREGCONFIG_AND_UPDATEREGS (SMC_CMDR_CMD)      /*!< Command: MdRetConfig & UpdateRegs */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_CRE_Polarity EXMC_SMC CRE Polarity
+ * @{
+ */
+#define EXMC_SMC_CRE_POLARITY_LOW               (0UL)           /*!< CRE is LOW */
+#define EXMC_SMC_CRE_POLARITY_HIGH              (SMC_CMDR_CRES) /*!< CRE is HIGH when ModeReg write occurs */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Status EXMC_SMC Status
+ * @{
+ */
+#define EXMC_SMC_READY                          (0UL)               /*!< SMC is ready */
+#define EXMC_SMC_LOWPOWER                       (SMC_STSR_STATUS)   /*!< SMC is low power */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Sample_Clock EXMC_SMC Sample Clock
+ * @{
+ */
+#define EXMC_SMC_SAMPLE_CLK_INTERNCLK           (0UL)               /*!< Internal EXCLK */
+#define EXMC_SMC_SAMPLE_CLK_INTERNCLK_INVT      (SMC_BACR_CKSEL_0)  /*!< Invert internal EXCLK */
+#define EXMC_SMC_SAMPLE_CLK_EXTCLK              (SMC_BACR_CKSEL_1)  /*!< External clock from EXMC_CLK port */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Mask_Address EXMC_SMC Mask Address
+ * @{
+ */
+#define EXMC_SMC_ADDR_MASK_16MB                 (0xFFUL)
+#define EXMC_SMC_ADDR_MASK_32MB                 (0xFEUL)
+#define EXMC_SMC_ADDR_MASK_64MB                 (0xFCUL)
+#define EXMC_SMC_ADDR_MASK_128MB                (0xF8UL)
+#define EXMC_SMC_ADDR_MASK_256MB                (0xF0UL)
+#define EXMC_SMC_ADDR_MASK_512MB                (0xE0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Address_Space EXMC_SMC Address Space
+ * @{
+ */
+#define EXMC_SMC_ADDR_MIN                       (0x60000000UL)
+#define EXMC_SMC_ADDR_MAX                       (0x7FFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+  * @brief  SMC device memory address shifting.
+  * @param  [in] mem_base_addr          SMC base address
+  * @param  [in] mem_width              SMC memory width
+  * @param  [in] addr                   SMC device memory address
+  * @retval SMC device shifted address value
+  */
+#define SMC_ADDR_SHIFT(mem_base_addr, mem_width, addr)                  \
+(    ((EXMC_SMC_MEMORY_WIDTH_16BIT == (mem_width))? (((mem_base_addr) + ((addr) << 1U))) : \
+                                (((mem_base_addr) + ((addr) << 2U)))))
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup EXMC_SMC_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  SMC entry low power state
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_SMC_EntryLowPower(void)
+{
+    WRITE_REG32(CM_SMC->STCR0, SMC_STCR0_LPWIR);
+}
+
+/**
+ * @brief  SMC exit low power state
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void EXMC_SMC_ExitLowPower(void)
+{
+    WRITE_REG32(CM_SMC->STCR1, SMC_STCR1_LPWOR);
+}
+
+/**
+ * @brief  Get SMC status
+ * @param  None
+ * @retval Returned value can be one of the macros group @ref EXMC_SMC_Status
+ *           - EXMC_SMC_READY: SMC is ready
+ *           - EXMC_SMC_LOWPOWER: SMC is low power
+ */
+__STATIC_INLINE uint32_t EXMC_SMC_GetStatus(void)
+{
+    return READ_REG32_BIT(CM_SMC->STSR, SMC_STSR_STATUS);
+}
+
+/* Initialization and configuration EXMC_SMC functions */
+int32_t EXMC_SMC_StructInit(stc_exmc_smc_init_t *pstcSmcInit);
+int32_t EXMC_SMC_Init(uint32_t u32Chip, const stc_exmc_smc_init_t *pstcSmcInit);
+int32_t EXMC_SMC_DeInit(void);
+
+void EXMC_SMC_Cmd(en_functional_state_t enNewState);
+void EXMC_SMC_PinMuxCmd(en_functional_state_t enNewState);
+void EXMC_SMC_SetSampleClock(uint32_t u32SampleClock);
+void EXMC_SMC_SetRefreshPeriod(uint8_t u8PeriodVal);
+
+void EXMC_SMC_SetCommand(uint32_t u32Chip, uint32_t u32Cmd, uint32_t u32CrePolarity, uint32_t u32Addr);
+uint32_t EXMC_SMC_GetChipStartAddr(uint32_t u32Chip);
+uint32_t EXMC_SMC_GetChipEndAddr(uint32_t u32Chip);
+int32_t EXMC_SMC_GetChipConfig(uint32_t u32Chip, stc_exmc_smc_chip_config_t *pstcChipConfig);
+int32_t EXMC_SMC_GetTimingConfig(uint32_t u32Chip, stc_exmc_smc_timing_config_t *pstcTimingConfig);
+
+/**
+ * @}
+ */
+
+#endif /* LL_SMC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_SMC_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_spi.h
+++ b/hc32f4a2/inc/hc32_ll_spi.h
@@ -1,0 +1,469 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_spi.h
+ * @brief This file contains all the functions prototypes of the SPI driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add SPI_SetSckPolarity,SPI_SetSckPhase functions
+                                    Add group SPI_SCK_Polarity_Define, SPI_SCK_Phase_Define
+                                    Modify return type of function SPI_DeInit
+   2023-12-15       CDT             Rename SPI_FLAG_OVERLOAD as SPI_FLAG_OVERRUN, SPI_FLAG_UNDERLOAD as SPI_FLAG_UNDERRUN
+                                    Modify API API_xxxConfig() to SPI_Setxxx() and refine SPI_SetSSValidLevel, modify SPI_IRQ_ALL -> SPI_INT_ALL
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_SPI_H__
+#define __HC32_LL_SPI_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_SPI
+ * @{
+ */
+
+#if (LL_SPI_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup SPI_Global_Types SPI Global Types
+ * @{
+ */
+
+/**
+ * @brief Structure definition of SPI initialization.
+ * @note The parameter u32BaudRatePrescaler is invalid while slave mode
+ */
+typedef struct {
+    uint32_t u32WireMode;           /*!< SPI wire mode, 3 wire mode or 4 wire mode.
+                                         This parameter can be a value of @ref SPI_Wire_Mode_Define */
+    uint32_t u32TransMode;          /*!< SPI transfer mode, send only or full duplex.
+                                         This parameter can be a value of @ref SPI_Trans_Mode_Define */
+    uint32_t u32MasterSlave;        /*!< SPI master/slave mode.
+                                         This parameter can be a value of @ref SPI_Master_Slave_Mode_Define */
+    uint32_t u32ModeFaultDetect;    /*!< SPI mode fault detect command.
+                                         This parameter can be a value of @ref SPI_Mode_Fault_Detect_Command_Define */
+    uint32_t u32Parity;             /*!< SPI parity check selection.
+                                         This parameter can be a value of @ref SPI_Parity_Check_Define */
+    uint32_t u32SpiMode;            /*!< SPI mode.
+                                         This parameter can be a value of @ref SPI_Mode_Define */
+    uint32_t u32BaudRatePrescaler;  /*!< SPI baud rate prescaler.
+                                         This parameter can be a value of @ref SPI_Baud_Rate_Prescaler_Define */
+    uint32_t u32DataBits;           /*!< SPI data bits, 4 bits ~ 32 bits.
+                                         This parameter can be a value of @ref SPI_Data_Size_Define */
+    uint32_t u32FirstBit;           /*!< MSB first or LSB first.
+                                         This parameter can be a value of @ref SPI_First_Bit_Define */
+    uint32_t u32SuspendMode;        /*!< SPI communication suspend function.
+                                         This parameter can be a value of @ref SPI_Com_Suspend_Func_Define */
+    uint32_t u32FrameLevel;         /*!< SPI frame level, SPI_1_FRAME ~ SPI_4_FRAME.
+                                         This parameter can be a value of @ref SPI_Frame_Level_Define */
+} stc_spi_init_t;
+
+/**
+ * @brief Structure definition of SPI delay time configuration.
+ */
+typedef struct {
+    uint32_t u32IntervalDelay;      /*!< SPI interval time delay (Next access delay time)
+                                         This parameter can be a value of @ref SPI_Interval_Delay_Time_define */
+    uint32_t u32ReleaseDelay;       /*!< SPI release time delay (SCK invalid delay time)
+                                         This parameter can be a value of @ref SPI_Release_Delay_Time_define */
+    uint32_t u32SetupDelay;         /*!< SPI Setup time delay (SCK valid delay time) define
+                                         This parameter can be a value of @ref SPI_Setup_Delay_Time_define */
+} stc_spi_delay_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SPI_Global_Macros SPI Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup SPI_Wire_Mode_Define SPI Wire Mode Define
+ * @{
+ */
+#define SPI_4_WIRE                  (0UL)
+#define SPI_3_WIRE                  (SPI_CR1_SPIMDS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Trans_Mode_Define SPI Transfer Mode Define
+ * @{
+ */
+#define SPI_FULL_DUPLEX             (0UL)               /*!< Full duplex. */
+#define SPI_SEND_ONLY               (SPI_CR1_TXMDS)     /*!< Send only. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Master_Slave_Mode_Define SPI Master Slave Mode Define
+ * @{
+ */
+#define SPI_SLAVE                   (0UL)
+#define SPI_MASTER                  (SPI_CR1_MSTR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Loopback_Selection_Define SPI Loopback Selection Define
+ * @note Loopback mode is mainly used for parity self-diagnosis in 4-wire full-duplex mode.
+ * @{
+ */
+#define SPI_LOOPBACK_INVD           (0UL)
+#define SPI_LOOPBACK_MOSI_INVT      (SPI_CR1_SPLPBK)    /*!< MISO data is the inverse of the data output by MOSI. */
+#define SPI_LOOPBACK_MOSI           (SPI_CR1_SPLPBK2)   /*!< MISO data is the data output by MOSI. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Int_Type_Define SPI Interrupt Type Define
+ * @{
+ */
+#define SPI_INT_ERR                 (SPI_CR1_EIE)       /*!< Including overload, underload and parity error. */
+#define SPI_INT_TX_BUF_EMPTY        (SPI_CR1_TXIE)
+#define SPI_INT_RX_BUF_FULL         (SPI_CR1_RXIE)
+#define SPI_INT_IDLE                (SPI_CR1_IDIE)
+#define SPI_INT_ALL                 (SPI_INT_ERR | SPI_INT_TX_BUF_EMPTY | SPI_INT_RX_BUF_FULL | SPI_INT_IDLE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Mode_Fault_Detect_Command_Define SPI Mode Fault Detect Command Define
+ * @{
+ */
+#define SPI_MD_FAULT_DETECT_DISABLE (0UL)               /*!< Disable mode fault detection. */
+#define SPI_MD_FAULT_DETECT_ENABLE  (SPI_CR1_MODFE)     /*!< Enable mode fault detection. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Parity_Check_Define SPI Parity Check Mode Define
+ * @{
+ */
+#define SPI_PARITY_INVD             (0UL)                           /*!< Parity check invalid. */
+#define SPI_PARITY_EVEN             (SPI_CR1_PAE)                   /*!< Parity check selection even parity. */
+#define SPI_PARITY_ODD              (SPI_CR1_PAE | SPI_CR1_PAOE)    /*!< Parity check selection odd parity. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_SS_Pin_Define SPI SSx Define
+ * @{
+ */
+#define SPI_PIN_SS0                 (SPI_CFG1_SS0PV)
+#define SPI_PIN_SS1                 (SPI_CFG1_SS1PV)
+#define SPI_PIN_SS2                 (SPI_CFG1_SS2PV)
+#define SPI_PIN_SS3                 (SPI_CFG1_SS3PV)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_SS_Level SPI SS pin valid level
+ * @{
+ */
+#define SPI_SS_VALID_LVL_HIGH       (1UL)
+#define SPI_SS_VALID_LVL_LOW        (0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Read_Target_Buf_Define SPI Read Data Register Target Buffer Define
+ * @{
+ */
+#define SPI_RD_TARGET_RD_BUF        (0UL)               /*!< Read RX buffer. */
+#define SPI_RD_TARGET_WR_BUF        (SPI_CFG1_SPRDTD)   /*!< Read TX buffer. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Frame_Level_Define SPI data frame level define, The Data in the SPI_DR register will be send to TX_BUFF
+ *                                   after enough data frame write to the SPI_DR
+ * @{
+ */
+#define SPI_1_FRAME                 (0UL)                   /*!< Data 1 frame */
+#define SPI_2_FRAME                 (SPI_CFG1_FTHLV_0)      /*!< Data 2 frame.*/
+#define SPI_3_FRAME                 (SPI_CFG1_FTHLV_1)      /*!< Data 3 frame.*/
+#define SPI_4_FRAME                 (SPI_CFG1_FTHLV)        /*!< Data 4 frame.*/
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Interval_Delay_Time_define SPI Interval Time Delay (Next Access Delay Time) define
+ * @{
+ */
+#define SPI_INTERVAL_TIME_1SCK      (0UL << SPI_CFG1_MIDI_POS)    /*!< 1 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_2SCK      (1UL << SPI_CFG1_MIDI_POS)    /*!< 2 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_3SCK      (2UL << SPI_CFG1_MIDI_POS)    /*!< 3 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_4SCK      (3UL << SPI_CFG1_MIDI_POS)    /*!< 4 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_5SCK      (4UL << SPI_CFG1_MIDI_POS)    /*!< 5 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_6SCK      (5UL << SPI_CFG1_MIDI_POS)    /*!< 6 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_7SCK      (6UL << SPI_CFG1_MIDI_POS)    /*!< 7 SCK + 2 PCLK1 */
+#define SPI_INTERVAL_TIME_8SCK      (7UL << SPI_CFG1_MIDI_POS)    /*!< 8 SCK + 2 PCLK1 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Release_Delay_Time_define SPI Release Time Delay (SCK Invalid Delay Time) Define
+ * @{
+ */
+#define SPI_RELEASE_TIME_1SCK       (0UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_2SCK       (1UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_3SCK       (2UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_4SCK       (3UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_5SCK       (4UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_6SCK       (5UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_7SCK       (6UL << SPI_CFG1_MSSDL_POS)
+#define SPI_RELEASE_TIME_8SCK       (7UL << SPI_CFG1_MSSDL_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Setup_Delay_Time_define SPI Setup Time Delay (SCK Valid Delay Time) Define
+ * @{
+ */
+#define SPI_SETUP_TIME_1SCK         (0UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_2SCK         (1UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_3SCK         (2UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_4SCK         (3UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_5SCK         (4UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_6SCK         (5UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_7SCK         (6UL << SPI_CFG1_MSSI_POS)
+#define SPI_SETUP_TIME_8SCK         (7UL << SPI_CFG1_MSSI_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Com_Suspend_Func_Define SPI Communication Suspend Function Define
+ * @{
+ */
+#define SPI_COM_SUSP_FUNC_OFF       (0UL)
+#define SPI_COM_SUSP_FUNC_ON        (SPI_CR1_CSUSPE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Mode_Define SPI Mode Define
+ * @{
+ */
+#define SPI_MD_0                    (0UL)                           /*!< SCK pin output low in idle state; \
+                                                                         MOSI/MISO pin data valid in odd edge, \
+                                                                         MOSI/MISO pin data change in even edge */
+#define SPI_MD_1                    (SPI_CFG2_CPHA)                 /*!< SCK pin output low in idle state; \
+                                                                         MOSI/MISO pin data valid in even edge, \
+                                                                         MOSI/MISO pin data change in odd edge */
+#define SPI_MD_2                    (SPI_CFG2_CPOL)                 /*!< SCK pin output high in idle state; \
+                                                                         MOSI/MISO pin data valid in odd edge, \
+                                                                         MOSI/MISO pin data change in even edge */
+#define SPI_MD_3                    (SPI_CFG2_CPOL | SPI_CFG2_CPHA) /*!< SCK pin output high in idle state; \
+                                                                         MOSI/MISO pin data valid in even edge, \
+                                                                         MOSI/MISO pin data change in odd edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_SCK_Polarity_Define SPI SCK Polarity Define
+ * @{
+ */
+#define SPI_SCK_POLARITY_LOW        (0UL)                   /*!< SCK pin output low in idle state  */
+#define SPI_SCK_POLARITY_HIGH       (SPI_CFG2_CPOL)         /*!< SCK pin output high in idle state */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_SCK_Phase_Define SPI SCK Phase Define
+ * @{
+ */
+#define SPI_SCK_PHASE_ODD_EDGE_SAMPLE   (0UL)               /*!< MOSI/MISO pin data sample in odd edge, MOSI/MISO pin data change in even edge */
+#define SPI_SCK_PHASE_EVEN_EDGE_SAMPLE  (SPI_CFG2_CPHA)     /*!< MOSI/MISO pin data sample in even edge, MOSI/MISO pin data change in odd edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Baud_Rate_Prescaler_Define SPI Baudrate Prescaler Define
+ * @{
+ */
+#define SPI_BR_CLK_DIV2             (0UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 2. */
+#define SPI_BR_CLK_DIV4             (1UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 4. */
+#define SPI_BR_CLK_DIV8             (2UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 8. */
+#define SPI_BR_CLK_DIV16            (3UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 16. */
+#define SPI_BR_CLK_DIV32            (4UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 32. */
+#define SPI_BR_CLK_DIV64            (5UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 64. */
+#define SPI_BR_CLK_DIV128           (6UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 128. */
+#define SPI_BR_CLK_DIV256           (7UL << SPI_CFG2_MBR_POS)   /*!< PCLK1 / 256. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Data_Size_Define SPI Data Size Define
+ * @{
+ */
+#define SPI_DATA_SIZE_4BIT          (0UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_5BIT          (1UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_6BIT          (2UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_7BIT          (3UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_8BIT          (4UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_9BIT          (5UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_10BIT         (6UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_11BIT         (7UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_12BIT         (8UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_13BIT         (9UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_14BIT         (10UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_15BIT         (11UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_16BIT         (12UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_20BIT         (13UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_24BIT         (14UL << SPI_CFG2_DSIZE_POS)
+#define SPI_DATA_SIZE_32BIT         (15UL << SPI_CFG2_DSIZE_POS)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_First_Bit_Define SPI First Bit Define
+ * @{
+ */
+#define SPI_FIRST_MSB               (0UL)
+#define SPI_FIRST_LSB               (SPI_CFG2_LSBF)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_State_Flag_Define SPI State Flag Define
+ * @{
+ */
+#define SPI_FLAG_OVERRUN            (SPI_SR_OVRERF)
+#define SPI_FLAG_IDLE               (SPI_SR_IDLNF)
+#define SPI_FLAG_MD_FAULT           (SPI_SR_MODFERF)
+#define SPI_FLAG_PARITY_ERR         (SPI_SR_PERF)
+#define SPI_FLAG_UNDERRUN           (SPI_SR_UDRERF)
+#define SPI_FLAG_TX_BUF_EMPTY       (SPI_SR_TDEF)       /*!< This flag is set when the data in the data register     \
+                                                             is copied into the shift register, but the transmission \
+                                                             of the data bit may not have been completed. */
+#define SPI_FLAG_RX_BUF_FULL        (SPI_SR_RDFF)       /*!< Indicates that a data was received. */
+#define SPI_FLAG_CLR_ALL            (SPI_FLAG_OVERRUN  | SPI_FLAG_MD_FAULT | SPI_FLAG_PARITY_ERR | SPI_FLAG_UNDERRUN)
+#define SPI_FLAG_ALL                (SPI_FLAG_OVERRUN  | SPI_FLAG_IDLE | SPI_FLAG_MD_FAULT | SPI_FLAG_PARITY_ERR | \
+                                     SPI_FLAG_UNDERRUN | SPI_FLAG_TX_BUF_EMPTY | SPI_FLAG_RX_BUF_FULL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup SPI_Global_Functions
+ * @{
+ */
+int32_t SPI_StructInit(stc_spi_init_t *pstcSpiInit);
+int32_t SPI_Init(CM_SPI_TypeDef *SPIx, const stc_spi_init_t *pstcSpiInit);
+int32_t SPI_DeInit(CM_SPI_TypeDef *SPIx);
+
+void SPI_IntCmd(CM_SPI_TypeDef *SPIx, uint32_t u32IntType, en_functional_state_t enNewState);
+void SPI_Cmd(CM_SPI_TypeDef *SPIx, en_functional_state_t enNewState);
+void SPI_WriteData(CM_SPI_TypeDef *SPIx, uint32_t u32Data);
+uint32_t SPI_ReadData(const CM_SPI_TypeDef *SPIx);
+
+en_flag_status_t SPI_GetStatus(const CM_SPI_TypeDef *SPIx, uint32_t u32Flag);
+void SPI_ClearStatus(CM_SPI_TypeDef *SPIx, uint32_t u32Flag);
+void SPI_SetLoopbackMode(CM_SPI_TypeDef *SPIx, uint32_t u32Mode);
+void SPI_ParityCheckCmd(CM_SPI_TypeDef *SPIx, en_functional_state_t enNewState);
+void SPI_SetSSValidLevel(CM_SPI_TypeDef *SPIx, uint32_t u32SSPin, uint32_t u32SSLevel);
+void SPI_SetSckPolarity(CM_SPI_TypeDef *SPIx, uint32_t u32Polarity);
+void SPI_SetSckPhase(CM_SPI_TypeDef *SPIx, uint32_t u32Phase);
+
+int32_t SPI_DelayTimeConfig(CM_SPI_TypeDef *SPIx, const stc_spi_delay_t *pstcDelayConfig);
+void SPI_SSPinSelect(CM_SPI_TypeDef *SPIx, uint32_t u32SSPin);
+void SPI_SetReadBuf(CM_SPI_TypeDef *SPIx, uint32_t u32ReadBuf);
+int32_t SPI_DelayStructInit(stc_spi_delay_t *pstcDelayConfig);
+
+int32_t SPI_Trans(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, uint32_t u32TxLen, uint32_t u32Timeout);
+int32_t SPI_Receive(CM_SPI_TypeDef *SPIx, void *pvRxBuf, uint32_t u32RxLen, uint32_t u32Timeout);
+int32_t SPI_TransReceive(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout);
+
+/**
+ * @}
+ */
+
+#endif /* LL_SPI_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_SPI_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_sram.h
+++ b/hc32f4a2/inc/hc32_ll_sram.h
@@ -1,0 +1,256 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_sram.h
+ * @brief This file contains all the functions prototypes of the SRAM driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Deleted redundant comments
+   2023-06-30       CDT             Modify typo
+   2023-12-15       CDT             Refine def group SRAM_ECC_Mode, and refine def group SRAM_Err_Mode as SRAM_Exception_Type
+                                    Add macro SRAM_ECC_SRAM_ALL and group SRAM_Check_SRAM
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_SRAM_H__
+#define __HC32_LL_SRAM_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_SRAM
+ * @{
+ */
+
+#if (LL_SRAM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SRAM_Global_Macros SRAM Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup SRAM_Sel SRAM Selection
+ * @{
+ */
+#define SRAM_SRAMH              (1UL << 2U)                 /*!< SRAMH: 0x1FFE0000~0x1FFFFFFF, 128KB */
+#define SRAM_SRAM123            (1UL << 0U)                 /*!< SRAM1: 0x20000000~0x2001FFFF, 128KB
+                                                                 SRAM2: 0x20020000~0x2003FFFF, 128KB
+                                                                 SRAM3: 0x20040000~0x20057FFF, 96KB */
+#define SRAM_SRAM4              (1UL << 1U)                 /*!< SRAM4: 0x20058000~0x2005FFFF, 32KB */
+#define SRAM_SRAMB              (1UL << 3U)                 /*!< SRAMB: 0x200F0000~0x200F0FFF, 4KB */
+#define SRAM_SRAM_ALL           (SRAM_SRAMH | SRAM_SRAM123 | SRAM_SRAM4 | SRAM_SRAMB)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_ECC_SRAM ECC SRAM Definition
+ * @{
+ */
+#define SRAM_ECC_SRAM4          (1UL << 0U)
+#define SRAM_ECC_SRAMB          (1UL << 1U)
+#define SRAM_ECC_SRAM_ALL       (SRAM_ECC_SRAM4 | SRAM_ECC_SRAMB)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Access_Wait_Cycle SRAM Access Wait Cycle
+ * @{
+ */
+#define SRAM_WAIT_CYCLE0        (0U)                        /*!< Wait 0 CPU cycle. */
+#define SRAM_WAIT_CYCLE1        (1U)                        /*!< Wait 1 CPU cycle. */
+#define SRAM_WAIT_CYCLE2        (2U)                        /*!< Wait 2 CPU cycles. */
+#define SRAM_WAIT_CYCLE3        (3U)                        /*!< Wait 3 CPU cycles. */
+#define SRAM_WAIT_CYCLE4        (4U)                        /*!< Wait 4 CPU cycles. */
+#define SRAM_WAIT_CYCLE5        (5U)                        /*!< Wait 5 CPU cycles. */
+#define SRAM_WAIT_CYCLE6        (6U)                        /*!< Wait 6 CPU cycles. */
+#define SRAM_WAIT_CYCLE7        (7U)                        /*!< Wait 7 CPU cycles. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Exception_Type SRAM exception type
+ * @note Even-parity check error, ECC check error.
+ * @{
+ */
+#define SRAM_EXP_TYPE_NMI               (0UL)
+#define SRAM_EXP_TYPE_RST               (1UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Check_SRAM SRAM check sram
+ * @{
+ */
+#define SRAM_CHECK_SRAM4                (SRAMC_CKCR_ECCOAD)
+#define SRAM_CHECK_SRAMB                (SRAMC_CKCR_BECCOAD)
+#define SRAM_CHECK_SRAMH_1_2_3          (SRAMC_CKCR_PYOAD)
+#define SRAM_CHECK_SRAM_ALL             (SRAM_CHECK_SRAM4 | SRAM_CHECK_SRAMB | SRAM_CHECK_SRAMH_1_2_3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_ECC_Mode SRAM ECC Mode
+ * @note     XX_INVD: The ECC mode is invalid
+ *           XX_MD1:  When 1-bit error occurs, ECC error corrects. No 1-bit-error status flag setting, no interrupt or reset.
+ *                    When 2-bit error occurs, ECC error detects. 2-bit-error status flag sets and interrupt or reset occurs.
+ *           XX_MD2:  When 1-bit error occurs, ECC error corrects. 1-bit-error status flag sets, no interrupt or reset.
+ *                    When 2-bit error occurs, ECC error detects. 2-bit-error status flag sets and interrupt or reset occurs.
+ *           XX_MD3:  When 1-bit error occurs, ECC error corrects. 1-bit-error status flag sets and interrupt or reset occurs.
+ *                    When 2-bit error occurs, ECC error detects. 2-bit-error status flag sets and interrupt or reset occurs.
+ * @{
+ */
+#define SRAM_SRAM4_ECC_INVD             (0x0UL)
+#define SRAM_SRAM4_ECC_MD1              (SRAMC_CKCR_ECCMOD_0)
+#define SRAM_SRAM4_ECC_MD2              (SRAMC_CKCR_ECCMOD_1)
+#define SRAM_SRAM4_ECC_MD3              (SRAMC_CKCR_ECCMOD)
+#define SRAM_SRAMB_ECC_INVD             (0x0UL)
+#define SRAM_SRAMB_ECC_MD1              (SRAMC_CKCR_BECCMOD_0)
+#define SRAM_SRAMB_ECC_MD2              (SRAMC_CKCR_BECCMOD_1)
+#define SRAM_SRAMB_ECC_MD3              (SRAMC_CKCR_BECCMOD)
+#define SRAM_ECC_MD_INVD                (SRAM_SRAM4_ECC_INVD & SRAM_SRAMB_ECC_INVD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Err_Status_Flag SRAM Error Status Flag
+ * @{
+ */
+#define SRAM_FLAG_SRAM1_PYERR           (SRAMC_CKSR_SRAM1_PYERR)    /*!< SRAM1 parity error. */
+#define SRAM_FLAG_SRAM2_PYERR           (SRAMC_CKSR_SRAM2_PYERR)    /*!< SRAM2 parity error. */
+#define SRAM_FLAG_SRAM3_PYERR           (SRAMC_CKSR_SRAM3_PYERR)    /*!< SRAM3 parity error. */
+#define SRAM_FLAG_SRAMH_PYERR           (SRAMC_CKSR_SRAMH_PYERR)    /*!< SRAMH parity error. */
+#define SRAM_FLAG_SRAM4_1ERR            (SRAMC_CKSR_SRAM4_1ERR)     /*!< SRAM4 ECC 1-bit error. */
+#define SRAM_FLAG_SRAM4_2ERR            (SRAMC_CKSR_SRAM4_2ERR)     /*!< SRAM4 ECC 2-bit error. */
+#define SRAM_FLAG_SRAMB_1ERR            (SRAMC_CKSR_SRAMB_1ERR)     /*!< SRAMB ECC 1-bit error. */
+#define SRAM_FLAG_SRAMB_2ERR            (SRAMC_CKSR_SRAMB_2ERR)     /*!< SRAMB ECC 2-bit error. */
+#define SRAM_FLAG_CACHE_PYERR           (SRAMC_CKSR_CACHE_PYERR)    /*!< Cache RAM parity error. */
+#define SRAM_FLAG_ALL                   (0x1FFUL)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Reg_Protect_Key SRAM Register Protect Key
+ * @{
+ */
+#define SRAM_REG_LOCK_KEY               (0x76U)
+#define SRAM_REG_UNLOCK_KEY             (0x77U)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup SRAM_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Lock SRAM registers, write protect.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void SRAM_REG_Lock(void)
+{
+    WRITE_REG32(CM_SRAMC->WTPR, SRAM_REG_LOCK_KEY);
+    WRITE_REG32(CM_SRAMC->CKPR, SRAM_REG_LOCK_KEY);
+}
+
+/**
+ * @brief  Unlock SRAM registers, write enable.
+ * @param  None
+ * @retval None
+ */
+__STATIC_INLINE void SRAM_REG_Unlock(void)
+{
+    WRITE_REG32(CM_SRAMC->WTPR, SRAM_REG_UNLOCK_KEY);
+    WRITE_REG32(CM_SRAMC->CKPR, SRAM_REG_UNLOCK_KEY);
+}
+
+void SRAM_Init(void);
+void SRAM_DeInit(void);
+
+void SRAM_REG_Lock(void);
+void SRAM_REG_Unlock(void);
+
+void SRAM_SetWaitCycle(uint32_t u32SramSel, uint32_t u32WriteCycle, uint32_t u32ReadCycle);
+void SRAM_SetEccMode(uint32_t u32EccSram, uint32_t u32EccMode);
+void SRAM_SetExceptionType(uint32_t u32CheckSram, uint32_t u32ExceptionType);
+
+en_flag_status_t SRAM_GetStatus(uint32_t u32Flag);
+void SRAM_ClearStatus(uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_SRAM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_SRAM_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_swdt.h
+++ b/hc32f4a2/inc/hc32_ll_swdt.h
@@ -1,0 +1,227 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_swdt.h
+ * @brief This file contains all the functions prototypes of the SWDT driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-12-15       CDT             Modify macro define: SWDT_LPM_CNT_CONTINUE -> SWDT_LPM_CNT_CONT
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_SWDT_H__
+#define __HC32_LL_SWDT_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_SWDT
+ * @{
+ */
+
+#if (LL_SWDT_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup SWDT_Global_Types SWDT Global Types
+ * @{
+ */
+
+/**
+ * @brief SWDT Init structure definition
+ */
+typedef struct {
+    uint32_t u32CountPeriod;            /*!< Specifies the counting period of SWDT.
+                                             This parameter can be a value of @ref SWDT_Count_Period */
+    uint32_t u32ClockDiv;               /*!< Specifies the clock division factor of SWDT.
+                                             This parameter can be a value of @ref SWDT_Clock_Division */
+    uint32_t u32RefreshRange;           /*!< Specifies the allow refresh range of SWDT.
+                                             This parameter can be a value of @ref SWDT_Refresh_Range */
+    uint32_t u32LPMCount;               /*!< Specifies the count state in Low Power Mode (Sleep/Stop Mode).
+                                             This parameter can be a value of @ref SWDT_LPM_Count */
+    uint32_t u32ExceptionType;          /*!< Specifies the type of exception response for SWDT.
+                                             This parameter can be a value of @ref SWDT_Exception_Type */
+} stc_swdt_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SWDT_Global_Macros SWDT Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup SWDT_Count_Period SWDT Count Period
+ * @{
+ */
+#define SWDT_CNT_PERIOD256                      (0UL)               /*!< 256 clock cycle   */
+#define SWDT_CNT_PERIOD4096                     (SWDT_CR_PERI_0)    /*!< 4096 clock cycle  */
+#define SWDT_CNT_PERIOD16384                    (SWDT_CR_PERI_1)    /*!< 16384 clock cycle */
+#define SWDT_CNT_PERIOD65536                    (SWDT_CR_PERI)      /*!< 65536 clock cycle */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWDT_Clock_Division SWDT Clock Division
+ * @{
+ */
+#define SWDT_CLK_DIV1                           (0UL)                       /*!< SWDTCLK/1    */
+#define SWDT_CLK_DIV16                          (0x04UL << SWDT_CR_CKS_POS) /*!< SWDTCLK/16   */
+#define SWDT_CLK_DIV32                          (0x05UL << SWDT_CR_CKS_POS) /*!< SWDTCLK/32   */
+#define SWDT_CLK_DIV64                          (0x06UL << SWDT_CR_CKS_POS) /*!< SWDTCLK/64   */
+#define SWDT_CLK_DIV128                         (0x07UL << SWDT_CR_CKS_POS) /*!< SWDTCLK/128  */
+#define SWDT_CLK_DIV256                         (0x08UL << SWDT_CR_CKS_POS) /*!< SWDTCLK/256  */
+#define SWDT_CLK_DIV2048                        (0x0BUL << SWDT_CR_CKS_POS) /*!< SWDTCLK/2048 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWDT_Refresh_Range SWDT Refresh Range
+ * @{
+ */
+#define SWDT_RANGE_0TO25PCT                     (0x01UL << SWDT_CR_WDPT_POS)    /*!< 0%~25%             */
+#define SWDT_RANGE_25TO50PCT                    (0x02UL << SWDT_CR_WDPT_POS)    /*!< 25%~50%            */
+#define SWDT_RANGE_0TO50PCT                     (0x03UL << SWDT_CR_WDPT_POS)    /*!< 0%~50%             */
+#define SWDT_RANGE_50TO75PCT                    (0x04UL << SWDT_CR_WDPT_POS)    /*!< 50%~75%            */
+#define SWDT_RANGE_0TO25PCT_50TO75PCT           (0x05UL << SWDT_CR_WDPT_POS)    /*!< 0%~25% & 50%~75%   */
+#define SWDT_RANGE_25TO75PCT                    (0x06UL << SWDT_CR_WDPT_POS)    /*!< 25%~75%            */
+#define SWDT_RANGE_0TO75PCT                     (0x07UL << SWDT_CR_WDPT_POS)    /*!< 0%~75%             */
+#define SWDT_RANGE_75TO100PCT                   (0x08UL << SWDT_CR_WDPT_POS)    /*!< 75%~100%           */
+#define SWDT_RANGE_0TO25PCT_75TO100PCT          (0x09UL << SWDT_CR_WDPT_POS)    /*!< 0%~25% & 75%~100%  */
+#define SWDT_RANGE_25TO50PCT_75TO100PCT         (0x0AUL << SWDT_CR_WDPT_POS)    /*!< 25%~50% & 75%~100% */
+#define SWDT_RANGE_0TO50PCT_75TO100PCT          (0x0BUL << SWDT_CR_WDPT_POS)    /*!< 0%~50% & 75%~100%  */
+#define SWDT_RANGE_50TO100PCT                   (0x0CUL << SWDT_CR_WDPT_POS)    /*!< 50%~100%           */
+#define SWDT_RANGE_0TO25PCT_50TO100PCT          (0x0DUL << SWDT_CR_WDPT_POS)    /*!< 0%~25% & 50%~100%  */
+#define SWDT_RANGE_25TO100PCT                   (0x0EUL << SWDT_CR_WDPT_POS)    /*!< 25%~100%           */
+#define SWDT_RANGE_0TO100PCT                    (0x0FUL << SWDT_CR_WDPT_POS)    /*!< 0%~100%            */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWDT_LPM_Count SWDT Low Power Mode Count
+ * @brief    Counting control of SWDT in sleep/stop mode.
+ * @{
+ */
+#define SWDT_LPM_CNT_CONT                       (0UL)               /*!< Continue counting in sleep/stop mode */
+#define SWDT_LPM_CNT_STOP                       (SWDT_CR_SLPOFF)    /*!< Stop counting in sleep/stop mode     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWDT_Exception_Type SWDT Exception Type
+ * @brief    Specifies the exception response when a refresh error or count overflow occurs.
+ * @{
+ */
+#define SWDT_EXP_TYPE_INT                       (0UL)           /*!< SWDT trigger interrupt */
+#define SWDT_EXP_TYPE_RST                       (SWDT_CR_ITS)   /*!< SWDT trigger reset     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SWDT_Flag SWDT Flag
+ * @{
+ */
+#define SWDT_FLAG_UDF                           (SWDT_SR_UDF)   /*!< Count underflow flag */
+#define SWDT_FLAG_REFRESH                       (SWDT_SR_REF)   /*!< Refresh error flag   */
+#define SWDT_FLAG_ALL                           (SWDT_SR_UDF | SWDT_SR_REF)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup SWDT_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Get SWDT count value.
+ * @param  None
+ * @retval uint16_t                     Count value
+ */
+__STATIC_INLINE uint16_t SWDT_GetCountValue(void)
+{
+    return (uint16_t)(READ_REG32(CM_SWDT->SR) & SWDT_SR_CNT);
+}
+
+/* Initialization and configuration functions */
+int32_t SWDT_Init(const stc_swdt_init_t *pstcSwdtInit);
+void SWDT_FeedDog(void);
+uint16_t SWDT_GetCountValue(void);
+
+/* Flags management functions */
+en_flag_status_t SWDT_GetStatus(uint32_t u32Flag);
+int32_t SWDT_ClearStatus(uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_SWDT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_SWDT_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_tmr0.h
+++ b/hc32f4a2/inc/hc32_ll_tmr0.h
@@ -1,0 +1,226 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr0.h
+ * @brief This file contains all the functions prototypes of the TMR0 driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+   2024-06-30       CDT             Modify API of TMR0_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TMR0_H__
+#define __HC32_LL_TMR0_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TMR0
+ * @{
+ */
+
+#if (LL_TMR0_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup TMR0_Global_Types TMR0 Global Types
+ * @{
+ */
+
+/**
+ * @brief TMR0 initialization structure definition
+ * @note  The 'u32ClockDiv' is invalid when the value of 'u32ClockSrc' is "TMR0_CLK_SRC_SPEC_EVT".
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Specifies the clock source of TMR0 channel.
+                                             This parameter can be a value of @ref TMR0_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Specifies the clock division of TMR0 channel.
+                                             This parameter can be a value of @ref TMR0_Clock_Division */
+    uint32_t u32Func;                   /*!< Specifies the function of TMR0 channel.
+                                             This parameter can be a value of @ref TMR0_Function */
+    uint16_t u16CompareValue;           /*!< Specifies the compare value of TMR0 channel.
+                                             This parameter can be a value of half-word */
+} stc_tmr0_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR0_Global_Macros TMR0 Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR0_Channel TMR0 Channel
+ * @{
+ */
+#define TMR0_CH_A                       (0UL)
+#define TMR0_CH_B                       (1UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR0_Clock_Source TMR0 Clock Source
+ * @note In asynchronous clock, continuous operation of the BCONR register requires waiting for 6 asynchronous clocks.
+ * @{
+ */
+#define TMR0_CLK_SRC_INTERN_CLK         (0UL)                                       /*!< Internal clock (Synchronous clock)  */
+#define TMR0_CLK_SRC_SPEC_EVT           (TMR0_BCONR_SYNCLKA)                        /*!< Specified event (Synchronous clock) */
+#define TMR0_CLK_SRC_LRC                (TMR0_BCONR_SYNSA)                          /*!< LRC (Asynchronous clock)            */
+#define TMR0_CLK_SRC_XTAL32             (TMR0_BCONR_ASYNCLKA | TMR0_BCONR_SYNSA)    /*!< XTAL32 (Asynchronous clock)         */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR0_Clock_Division TMR0 Clock Division
+ * @{
+ */
+#define TMR0_CLK_DIV1                   (0UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK      */
+#define TMR0_CLK_DIV2                   (1UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/2    */
+#define TMR0_CLK_DIV4                   (2UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/4    */
+#define TMR0_CLK_DIV8                   (3UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/8    */
+#define TMR0_CLK_DIV16                  (4UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/16   */
+#define TMR0_CLK_DIV32                  (5UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/32   */
+#define TMR0_CLK_DIV64                  (6UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/64   */
+#define TMR0_CLK_DIV128                 (7UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/128  */
+#define TMR0_CLK_DIV256                 (8UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/256  */
+#define TMR0_CLK_DIV512                 (9UL  << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/512  */
+#define TMR0_CLK_DIV1024                (10UL << TMR0_BCONR_CKDIVA_POS)     /*!< CLK/1024 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR0_Function TMR0 Function
+ * @{
+ */
+#define TMR0_FUNC_CMP                   (0UL)                                   /*!< Output compare function */
+#define TMR0_FUNC_CAPT                  (TMR0_BCONR_CAPMDA | TMR0_BCONR_HICPA)  /*!< Input capture function */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR0_Interrupt TMR0 Interrupt
+ * @{
+ */
+#define TMR0_INT_CMP_A                  (TMR0_BCONR_INTENA)
+#define TMR0_INT_CMP_B                  (TMR0_BCONR_INTENB)
+#define TMR0_INT_ALL                    (TMR0_INT_CMP_A | TMR0_INT_CMP_B)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR0_FLAG TMR0 Flag
+ * @{
+ */
+#define TMR0_FLAG_CMP_A                 (TMR0_STFLR_CMFA)
+#define TMR0_FLAG_CMP_B                 (TMR0_STFLR_CMFB)
+#define TMR0_FLAG_ALL                   (TMR0_FLAG_CMP_A | TMR0_FLAG_CMP_B)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TMR0_Global_Functions
+ * @{
+ */
+
+/* Initialization functions */
+int32_t TMR0_DeInit(CM_TMR0_TypeDef *TMR0x);
+int32_t TMR0_Init(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, const stc_tmr0_init_t *pstcTmr0Init);
+int32_t TMR0_StructInit(stc_tmr0_init_t *pstcTmr0Init);
+void TMR0_Start(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch);
+void TMR0_Stop(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch);
+
+/* Control configuration functions */
+void TMR0_SetCountValue(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint16_t u16Value);
+uint16_t TMR0_GetCountValue(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch);
+void TMR0_SetCompareValue(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint16_t u16Value);
+uint16_t TMR0_GetCompareValue(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch);
+void TMR0_SetClockSrc(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Src);
+void TMR0_SetClockDiv(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Div);
+void TMR0_SetFunc(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Func);
+
+/* Hardware trigger Functions */
+void TMR0_HWCaptureCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR0_HWStartCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR0_HWStopCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR0_HWClearCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState);
+
+/* Interrupt and flag management functions */
+void TMR0_IntCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t TMR0_GetStatus(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Flag);
+void TMR0_ClearStatus(CM_TMR0_TypeDef *TMR0x, uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR0_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TMR0_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_tmr2.h
+++ b/hc32f4a2/inc/hc32_ll_tmr2.h
@@ -1,0 +1,354 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr2.h
+ * @brief This file contains all the functions prototypes of the TMR2(Timer2)
+ *        driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+   2024-06-30       CDT             API TMR2_DeInit() added return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TMR2_H__
+#define __HC32_LL_TMR2_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TMR2
+ * @{
+ */
+#if (LL_TMR2_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup TMR2_Global_Types TMR2 Global Types
+ * @{
+ */
+
+/**
+ * @brief TMR2 PWM configuration structure.
+ */
+typedef struct {
+    uint32_t u32StartPolarity;          /*!< Specifies the polarity of PWM output when TMR2 counting start.
+                                             This parameter can be a value of @ref TMR2_PWM_Polarity */
+    uint32_t u32StopPolarity;           /*!< Specifies the polarity of PWM output when TMR2 counting stop.
+                                             This parameter can be a value of @ref TMR2_PWM_Polarity */
+    uint32_t u32CompareMatchPolarity;   /*!< Specifies the polarity of PWM output when TMR2 counter matches the compare value.
+                                             This parameter can be a value of @ref TMR2_PWM_Polarity */
+} stc_tmr2_pwm_init_t;
+
+/**
+ * @brief TMR2 initialization structure.
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Specifies the clock source for TMR2 channel.
+                                             This parameter can be a value of @ref TMR2_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Specifies the division of the clock source.
+                                             This parameter can be a value of @ref TMR2_Clock_Divider */
+    uint32_t u32Func;                   /*!< Specifies the function mode for TMR2 channel.
+                                             This parameter can be a value of @ref TMR2_Function */
+    uint32_t u32CompareValue;           /*!< Specifies the compare value.
+                                             This parameter can be a number between 0U and 0xFFFFU, inclusive. */
+} stc_tmr2_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR2_Global_Macros TMR2 Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR2_Channel TMR2 Channel
+ * @{
+ */
+#define TMR2_CH_A                       (0U)                            /*!< Channel A of TMR2. */
+#define TMR2_CH_B                       (1U)                            /*!< Channel B of TMR2. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Function TMR2 Function
+ * @{
+ */
+#define TMR2_FUNC_CMP                   (0x0U)                          /*!< The function of TMR2 channel is output compare. */
+#define TMR2_FUNC_CAPT                  (TMR2_BCONR_CAPMDA)             /*!< The function of TMR2 channel is input capture. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Clock_Source TMR2 Clock Source
+ * @{
+ */
+#define TMR2_CLK_PCLK1                  (0x0U)                          /*!< Synchronous clock source, PCLK1. */
+#define TMR2_CLK_TRIG_RISING            (TMR2_BCONR_SYNCLKA_0)          /*!< Synchronous clock source, rising edge of TIM2_<t>_TRIGA/B.
+                                                                             One rising edge causes one count. */
+#define TMR2_CLK_TRIG_FALLING           (TMR2_BCONR_SYNCLKA_1)          /*!< Synchronous clock source, falling edge of TIM2_<t>_TRIGA/B.
+                                                                             One falling edge causes one count. */
+#define TMR2_CLK_EVT                    (TMR2_BCONR_SYNCLKA)            /*!< Synchronous clock source, peripheral event. The event is specified by register TMR2_TRGSEL.
+                                                                             One event causes one count. */
+#define TMR2_CLK_TMR6_OVF               (TMR2_BCONR_SYNCLKAT_0)         /*!< Synchronous clock source, the event of counting overflow of TIMER6.
+                                                                             It is NOT need to set register TMR2_TRGSEL. */
+#define TMR2_CLK_TMR6_UDF               (TMR2_BCONR_SYNCLKAT_1)         /*!< Synchronous clock source, the event of counting underflow of TIMER6.
+                                                                             It is NOT need to set register TMR2_TRGSEL. */
+#define TMR2_CLK_TMR6_OVF_UDF           (TMR2_BCONR_SYNCLKAT_0 | \
+                                         TMR2_BCONR_SYNCLKAT_1)         /*!< Synchronous clock source, both overflow and underflow of TIMER6. */
+#define TMR2_CLK_LRC                    (TMR2_BCONR_SYNSA)              /*!< Asynchronous clock source, LRC(32.768KHz). */
+#define TMR2_CLK_XTAL32                 (TMR2_BCONR_ASYNCLKA_0 | \
+                                         TMR2_BCONR_SYNSA)              /*!< Asynchronous clock source, XTAL32(32.768KHz). */
+#define TMR2_CLK_PIN_CLK                (TMR2_BCONR_ASYNCLKA_1 | \
+                                         TMR2_BCONR_SYNSA)              /*!< Asynchronous clock source, input from pin TIM2_<t>_CLKA/B. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Clock_Divider TMR2 Clock Divider
+ * @{
+ */
+#define TMR2_CLK_DIV1                   (0x0U)                              /*!< Clock source. */
+#define TMR2_CLK_DIV2                   (0x1UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 2. */
+#define TMR2_CLK_DIV4                   (0x2UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 4. */
+#define TMR2_CLK_DIV8                   (0x3UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 8. */
+#define TMR2_CLK_DIV16                  (0x4UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 16. */
+#define TMR2_CLK_DIV32                  (0x5UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 32. */
+#define TMR2_CLK_DIV64                  (0x6UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 64. */
+#define TMR2_CLK_DIV128                 (0x7UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 128. */
+#define TMR2_CLK_DIV256                 (0x8UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 256. */
+#define TMR2_CLK_DIV512                 (0x9UL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 512. */
+#define TMR2_CLK_DIV1024                (0xAUL << TMR2_BCONR_CKDIVA_POS)    /*!< Clock source / 1024. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Interrupt_Type TMR2 Interrupt Type
+ * @{
+ */
+#define TMR2_INT_MATCH_CH_A             (TMR2_ICONR_CMENA)              /*!< TMR2 count match interrupt. */
+#define TMR2_INT_OVF_CH_A               (TMR2_ICONR_OVENA)              /*!< TMR2 count overflow interrupt. */
+#define TMR2_INT_MATCH_CH_B             (TMR2_ICONR_CMENB)              /*!< TMR2 count match interrupt. */
+#define TMR2_INT_OVF_CH_B               (TMR2_ICONR_OVENB)              /*!< TMR2 count overflow interrupt. */
+#define TMR2_INT_ALL                    (TMR2_INT_MATCH_CH_A | TMR2_INT_OVF_CH_A | \
+                                         TMR2_INT_MATCH_CH_B | TMR2_INT_OVF_CH_B)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Status_Flag TMR2 Status Flag
+ * @{
+ */
+#define TMR2_FLAG_MATCH_CH_A            (TMR2_STFLR_CMFA)               /*!< Counter match flag of channel A. */
+#define TMR2_FLAG_OVF_CH_A              (TMR2_STFLR_OVFA)               /*!< Counter overflow flag channel A. */
+#define TMR2_FLAG_MATCH_CH_B            (TMR2_STFLR_CMFB)               /*!< Counter match flag channel B. */
+#define TMR2_FLAG_OVF_CH_B              (TMR2_STFLR_OVFB)               /*!< Counter overflow flag channel B. */
+#define TMR2_FLAG_ALL                   (TMR2_FLAG_MATCH_CH_A | TMR2_FLAG_OVF_CH_A | \
+                                         TMR2_FLAG_MATCH_CH_B | TMR2_FLAG_OVF_CH_B)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Counter_State TMR2 Counter State
+ * @{
+ */
+#define TMR2_CNT_STAT_START             (0U)                            /*!< Counter start counting. */
+#define TMR2_CNT_STAT_STOP              (1U)                            /*!< Counter stop counting. */
+#define TMR2_CNT_STAT_MATCH_CMP         (2U)                            /*!< Counter value matches the compare value. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_PWM_Polarity TMR2 PWM Polarity
+ * @{
+ */
+#define TMR2_PWM_LOW                    (0x0U)                          /*!< PWM output low. */
+#define TMR2_PWM_HIGH                   (0x1U)                          /*!< PWM output high. */
+#define TMR2_PWM_HOLD                   (0x2U)                          /*!< PWM output keeps the current polarity. */
+#define TMR2_PWM_INVT                   (0x3U)                          /*!< PWM output reverses the current polarity. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Start_Condition TMR2 Start Condition
+ * @{
+ */
+#define TMR2_START_COND_INVD            (0x0U)                          /*!< The start condition of TMR2 is INVALID. */
+#define TMR2_START_COND_TRIG_RISING     (TMR2_HCONR_HSTAA0)             /*!< The start condition of TMR2 is the rising edge of TIM2_x_PWMA/B. */
+#define TMR2_START_COND_TRIG_FALLING    (TMR2_HCONR_HSTAA1)             /*!< The start condition of TMR2 is the falling edge of TIM2_x_PWMA/B. */
+#define TMR2_START_COND_EVT             (TMR2_HCONR_HSTAA2)             /*!< The start condition of TMR2 is the specified event occurred. */
+#define TMR2_START_COND_ALL             (TMR2_START_COND_TRIG_RISING | TMR2_START_COND_TRIG_FALLING | \
+                                         TMR2_START_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Stop_Condition TMR2 Stop Condition
+ * @{
+ */
+#define TMR2_STOP_COND_INVD             (0x0U)                          /*!< The stop condition of TMR2 is INVALID. */
+#define TMR2_STOP_COND_TRIG_RISING      (TMR2_HCONR_HSTPA0)             /*!< The stop condition of TMR2 is the rising edge of TIM2_x_PWMA/B. */
+#define TMR2_STOP_COND_TRIG_FALLING     (TMR2_HCONR_HSTPA1)             /*!< The stop condition of TMR2 is the falling edge of TIM2_x_PWMA/B. */
+#define TMR2_STOP_COND_EVT              (TMR2_HCONR_HSTPA2)             /*!< The stop condition of TMR2 is the specified event occurred. */
+#define TMR2_STOP_COND_ALL              (TMR2_STOP_COND_TRIG_RISING | TMR2_STOP_COND_TRIG_FALLING | \
+                                         TMR2_STOP_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Clear_Condition TMR2 Clear Condition
+ * @{
+ */
+#define TMR2_CLR_COND_INVD              (0x0U)                          /*!< The clear condition of TMR2 is INVALID. */
+#define TMR2_CLR_COND_TRIG_RISING       (TMR2_HCONR_HCLEA0)             /*!< The clear(clear CNTAR/CNTBR) condition of TMR2 is the rising edge of TIM2_x_PWMA/B. */
+#define TMR2_CLR_COND_TRIG_FALLING      (TMR2_HCONR_HCLEA1)             /*!< The clear(clear CNTAR/CNTBR) condition of TMR2 is the falling edge of TIM2_x_PWMA/B. */
+#define TMR2_CLR_COND_EVT               (TMR2_HCONR_HCLEA2)             /*!< The clear(clear CNTAR/CNTBR) condition of TMR2 is the specified event occurred. */
+#define TMR2_CLR_COND_ALL               (TMR2_CLR_COND_TRIG_RISING | TMR2_CLR_COND_TRIG_FALLING | \
+                                         TMR2_CLR_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Capture_Condition TMR2 Capture Condition
+ * @{
+ */
+#define TMR2_CAPT_COND_INVD             (0x0U)                          /*!< The capture condition of TMR2 is INVALID. */
+#define TMR2_CAPT_COND_TRIG_RISING      (TMR2_HCONR_HICPA0)             /*!< The capture condition of TMR2 is the rising edge of TIM2_x_PWMA/B. */
+#define TMR2_CAPT_COND_TRIG_FALLING     (TMR2_HCONR_HICPA1)             /*!< The capture condition of TMR2 is the falling edge of TIM2_x_PWMA/B. */
+#define TMR2_CAPT_COND_EVT              (TMR2_HCONR_HICPA2)             /*!< The capture condition of TMR2 is the specified event occurred. */
+#define TMR2_CAPT_COND_ALL              (TMR2_CAPT_COND_TRIG_RISING | TMR2_CAPT_COND_TRIG_FALLING | \
+                                         TMR2_CAPT_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Filter_Clock_Divider TMR2 Filter Clock Divider
+ * @{
+ */
+#define TMR2_FILTER_CLK_DIV1            (0x0U)                          /*!< The filter clock is the clock of timer2 / 1 */
+#define TMR2_FILTER_CLK_DIV4            (TMR2_PCONR_NOFICKA_0)          /*!< The filter clock is the clock of timer2 / 4 */
+#define TMR2_FILTER_CLK_DIV16           (TMR2_PCONR_NOFICKA_1)          /*!< The filter clock is the clock of timer2 / 16 */
+#define TMR2_FILTER_CLK_DIV64           (TMR2_PCONR_NOFICKA)            /*!< The filter clock is the clock of timer2 / 64 */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TMR2_Global_Functions
+ * @{
+ */
+int32_t TMR2_Init(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, const stc_tmr2_init_t *pstcTmr2Init);
+int32_t TMR2_StructInit(stc_tmr2_init_t *pstcTmr2Init);
+int32_t TMR2_DeInit(CM_TMR2_TypeDef *TMR2x);
+
+void TMR2_SetFunc(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Func);
+void TMR2_SetClockSrc(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Src);
+void TMR2_SetClockDiv(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Div);
+
+int32_t TMR2_PWM_StructInit(stc_tmr2_pwm_init_t *pstcPwmInit);
+int32_t TMR2_PWM_Init(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, const stc_tmr2_pwm_init_t *pstcPwmInit);
+void TMR2_PWM_OutputCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, en_functional_state_t enNewState);
+
+void TMR2_HWCaptureCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState);
+
+void TMR2_HWStartCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR2_HWStopCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR2_HWClearCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState);
+
+void TMR2_SetFilterClockDiv(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Div);
+void TMR2_FilterCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, en_functional_state_t enNewState);
+
+void TMR2_IntCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32IntType, en_functional_state_t enNewState);
+
+void TMR2_Start(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch);
+void TMR2_Stop(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch);
+
+en_flag_status_t TMR2_GetStatus(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Flag);
+void TMR2_ClearStatus(CM_TMR2_TypeDef *TMR2x, uint32_t u32Flag);
+
+void TMR2_SetCompareValue(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Value);
+uint32_t TMR2_GetCompareValue(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch);
+
+void TMR2_SetCountValue(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Value);
+uint32_t TMR2_GetCountValue(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch);
+
+void TMR2_PWM_SetPolarity(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint8_t u8CountState, uint32_t u32Polarity);
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR2_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TMR2_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_tmr4.h
+++ b/hc32f4a2/inc/hc32_ll_tmr4.h
@@ -1,0 +1,813 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr4.h
+ * @brief This file contains all the functions prototypes of the TMR4
+ *        driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Update API parameter u16IntType to u32IntType
+   2023-06-30       CDT             Add the macros group @ref TMR4_OC_Output_Polarity
+                                    Modify typo
+                                    TMR4_OC_Buffer_Object group add macro-definition: TMR4_OC_BUF_NONE
+   2023-09-30       CDT             Modify API TMR4_DeInit
+                                    Fix spell error about "response" that in function name
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TMR4_H__
+#define __HC32_LL_TMR4_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TMR4
+ * @{
+ */
+
+#if (LL_TMR4_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup TMR4_Global_Types TMR4 Global Types
+ * @{
+ */
+
+/**
+ * @brief TMR4 Counter function initialization configuration
+ * @note The TMR4 division(u16ClockDiv) is valid when clock source is the internal clock.
+ */
+typedef struct {
+    uint16_t u16ClockSrc;       /*!< TMR4 counter clock source.
+                                     This parameter can be a value of @ref TMR4_Count_Clock_Source */
+    uint16_t u16ClockDiv;       /*!< TMR4 counter internal clock division.
+                                     This parameter can be a value of @ref TMR4_Count_Clock_Division. */
+    uint16_t u16CountMode;      /*!< TMR4 counter mode.
+                                     This parameter can be a value of @ref TMR4_Count_Mode */
+    uint16_t u16PeriodValue;    /*!< TMR4 counter period value.
+                                     This parameter can be a value of half-word */
+} stc_tmr4_init_t;
+
+/**
+ * @brief The configuration of Output-Compare high channel(OUH/OVH/OWH)
+ */
+typedef union {
+    uint16_t OCMRx;             /*!< OCMRxH(x=U/V/W) register */
+
+    struct {                    /*!< OCMRxH(x=U/V/W) register struct field bit */
+        uint16_t OCFDCH : 1;    /*!< OCMRxh b0 High channel's OCF status when high channel match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint16_t OCFPKH : 1;    /*!< OCMRxh b1 High channel's OCF status when high channel match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint16_t OCFUCH : 1;    /*!< OCMRxh b2 High channel's OCF status when high channel match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint16_t OCFZRH : 1;    /*!< OCMRxh b3 High channel's OCF status when high channel match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint16_t OPDCH  : 2;    /*!< OCMRxh b5~b4 High channel's OP output status when high channel match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint16_t OPPKH  : 2;    /*!< OCMRxh b7~b6 High channel's OP output status when high channel match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint16_t OPUCH  : 2;    /*!< OCMRxh b9~b8 High channel's OP output status when high channel match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint16_t OPZRH  : 2;    /*!< OCMRxh b11~b10 High channel's OP output status when high channel match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint16_t OPNPKH : 2;    /*!< OCMRxh b13~b12 High channel's OP output status when high channel match doesn't occur at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint16_t OPNZRH : 2;    /*!< OCMRxh b15~b14 High channel's OP output status when high channel match doesn't occur at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+    } OCMRx_f;
+} un_tmr4_oc_ocmrh_t;
+
+/**
+ * @brief The configuration of Output-Compare low channel(OUL/OVL/OWL)
+ */
+typedef union {
+    uint32_t OCMRx;             /*!< OCMRxL(x=U/V/W) register */
+
+    struct {                    /*!< OCMRxL(x=U/V/W) register struct field bit*/
+        uint32_t OCFDCL  : 1;   /*!< OCMRxl b0 Low channel's OCF status when low channel match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint32_t OCFPKL  : 1;   /*!< OCMRxl b1 Low channel's OCF status when low channel match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint32_t OCFUCL  : 1;   /*!< OCMRxl b2 Low channel's OCF status when low channel match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint32_t OCFZRL  : 1;   /*!< OCMRxl b3 Low channel's OCF status when low channel match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_OCF_State */
+        uint32_t OPDCL   : 2;   /*!< OCMRxl b5~b4 Low channel's OP output status when high channel not match and low channel match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t OPPKL   : 2;   /*!< OCMRxl b7~b6 Low channel's OP output status when high channel not match and low channel match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t OPUCL   : 2;   /*!< OCMRxl b9~b8 Low channel's OP output status when high channel not match and low channel match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t OPZRL   : 2;   /*!< OCMRxl b11~b10 Low channel's OP output status when high channel not match and low channel match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t OPNPKL  : 2;   /*!< OCMRxl b13~b12 Low channel's OP output status when high channel not match and low channel not match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t OPNZRL  : 2;   /*!< OCMRxl b15~b14 Low channel's OP output status when high channel not match and low channel not match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPNDCL : 2;   /*!< OCMRxl b17~b16 Low channel's OP output status when high channel match and low channel not match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPNUCL : 2;   /*!< OCMRxl b19~b18 Low channel's OP output status when high channel match and low channel not match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPDCL  : 2;   /*!< OCMRxl b21~b20 Low channel's OP output status when high channel and low channel match occurs at the condition that counter is counting down
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPPKL  : 2;   /*!< OCMRxl b23~b22 Low channel's OP output status when high channel and low channel match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPUCL  : 2;   /*!< OCMRxl b25~b24 Low channel's OP output status when high channel and low channel match occurs at the condition that counter is counting up
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPZRL  : 2;   /*!< OCMRxl b27~b26 Low channel's OP output status when high channel and low channel match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPNPKL : 2;   /*!< OCMRxl b29~b28 Low channel's OP output status when high channel match and low channel not match occurs at the condition that counter count=Peak
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+        uint32_t EOPNZRL : 2;   /*!< OCMRxl b31~b30 Low channel's OP output status when high channel match and low channel not match occurs at the condition that counter count=0x0000
+                                     This parameter can be a value of @ref TMR4_OC_Count_Match_Output_Polarity */
+    } OCMRx_f;
+} un_tmr4_oc_ocmrl_t;
+
+/**
+ * @brief TMR4 Output-Compare(OC) initialization configuration
+ */
+typedef struct {
+    uint16_t u16CompareValue;           /*!< TMR4 OC compare match value.
+                                             This parameter can be a value of half-word. */
+    uint16_t u16OcInvalidPolarity;      /*!< Port output polarity when OC is disabled.
+                                             This parameter can be a value of @ref TMR4_OC_Invalid_Output_Polarity. */
+    uint16_t u16CompareModeBufCond;     /*!< Register OCMR buffer transfer condition.
+                                             This parameter can be a value of @ref TMR4_OC_Buffer_Transfer_Condition. */
+    uint16_t u16CompareValueBufCond;    /*!< Register OCCR buffer transfer condition.
+                                             This parameter can be a value of @ref TMR4_OC_Buffer_Transfer_Condition. */
+    uint16_t u16BufLinkTransObject;     /*!< Enable the specified object(OCMR/OCCR) register buffer linked transfer with the counter interrupt mask.
+                                             This parameter can be a value of @ref TMR4_OC_Buffer_Object. */
+} stc_tmr4_oc_init_t;
+
+/**
+ * @brief TMR4 PWM initialization configuration
+ * @note The clock division(u16ClockDiv) is valid when TMR4 clock source is the internal clock.
+ */
+typedef struct {
+    uint16_t u16Mode;                   /*!< Select PWM mode
+                                             This parameter can be a value of @ref TMR4_PWM_Mode */
+    uint16_t u16ClockDiv;               /*!< The internal clock division of PWM timer.
+                                             This parameter can be a value of @ref TMR4_PWM_Clock_Division. */
+    uint16_t u16Polarity;               /*!< TMR4 PWM polarity
+                                             This parameter can be a value of @ref TMR4_PWM_Polarity */
+} stc_tmr4_pwm_init_t;
+
+/**
+ * @brief TMR4 Special-Event(EVT) initialization configuration
+ */
+typedef struct {
+    uint16_t u16Mode;                   /*!< TMR4 event mode
+                                             This parameter can be a value of @ref TMR4_Event_Mode */
+    uint16_t u16CompareValue;           /*!< TMR4 event compare match value.
+                                             This parameter can be a value of half-word */
+    uint16_t u16OutputEvent;            /*!< TMR4 event output event when match count compare condition.
+                                             This parameter can be a value of @ref TMR4_Event_Output_Event */
+    uint16_t u16MatchCond;              /*!< Enable the specified count compare type with counter count to generate event.
+                                             This parameter can be a value of @ref TMR4_Event_Match_Condition */
+} stc_tmr4_evt_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR4_Global_Macros TMR4 Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_Counter_Macros TMR4 Counter Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_Count_Clock_Source TMR4 Count Clock Source
+ * @{
+ */
+#define TMR4_CLK_SRC_INTERNCLK          (0U)
+#define TMR4_CLK_SRC_EXTCLK             (TMR4_CCSR_ECKEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Count_Clock_Division TMR4 Count Clock Division
+ * @{
+ */
+#define TMR4_CLK_DIV1                   (0U << TMR4_CCSR_CKDIV_POS)  /*!< CLK      */
+#define TMR4_CLK_DIV2                   (1U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/2    */
+#define TMR4_CLK_DIV4                   (2U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/4    */
+#define TMR4_CLK_DIV8                   (3U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/8    */
+#define TMR4_CLK_DIV16                  (4U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/16   */
+#define TMR4_CLK_DIV32                  (5U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/32   */
+#define TMR4_CLK_DIV64                  (6U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/64   */
+#define TMR4_CLK_DIV128                 (7U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/128  */
+#define TMR4_CLK_DIV256                 (8U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/256  */
+#define TMR4_CLK_DIV512                 (9U << TMR4_CCSR_CKDIV_POS)  /*!< CLK/512  */
+#define TMR4_CLK_DIV1024                (10U << TMR4_CCSR_CKDIV_POS) /*!< CLK/1024 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Count_Mode TMR4 Count Mode
+ * @{
+ */
+#define TMR4_MD_SAWTOOTH                (0U)
+#define TMR4_MD_TRIANGLE                (TMR4_CCSR_MODE)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Flag TMR4 Flag
+ * @{
+ */
+#define TMR4_FLAG_CNT_PEAK              ((uint32_t)TMR4_CCSR_IRQPF)     /*!< Count peak flag */
+#define TMR4_FLAG_CNT_VALLEY            ((uint32_t)TMR4_CCSR_IRQZF)     /*!< Count valley flag */
+#define TMR4_FLAG_RELOAD_TMR_U          (1UL << 0U)                     /*!< TMR4 PWM reload-timer flag - channel U */
+#define TMR4_FLAG_RELOAD_TMR_V          (1UL << 4U)                     /*!< TMR4 PWM reload-timer flag - channel V */
+#define TMR4_FLAG_RELOAD_TMR_W          (1UL << 8U)                     /*!< TMR4 PWM reload-timer flag - channel W */
+#define TMR4_FLAG_OC_CMP_UH             (1UL << 16U)                    /*!< TMR4 output-compare compare flag - channel UH */
+#define TMR4_FLAG_OC_CMP_UL             (1UL << 17U)                    /*!< TMR4 output-compare compare flag - channel UL */
+#define TMR4_FLAG_OC_CMP_VH             (1UL << 18U)                    /*!< TMR4 output-compare compare flag - channel VH */
+#define TMR4_FLAG_OC_CMP_VL             (1UL << 19U)                    /*!< TMR4 output-compare compare flag - channel VL */
+#define TMR4_FLAG_OC_CMP_WH             (1UL << 20U)                    /*!< TMR4 output-compare compare flag - channel WH */
+#define TMR4_FLAG_OC_CMP_WL             (1UL << 21U)                    /*!< TMR4 output-compare compare flag - channel WL */
+
+#define TMR4_FLAG_ALL                   (TMR4_FLAG_CNT_PEAK     | TMR4_FLAG_CNT_VALLEY   | TMR4_FLAG_RELOAD_TMR_U | \
+                                         TMR4_FLAG_RELOAD_TMR_V | TMR4_FLAG_RELOAD_TMR_W | TMR4_FLAG_OC_CMP_UH    | \
+                                         TMR4_FLAG_OC_CMP_UL    | TMR4_FLAG_OC_CMP_VH    | TMR4_FLAG_OC_CMP_VL    | \
+                                         TMR4_FLAG_OC_CMP_WH    | TMR4_FLAG_OC_CMP_WL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Interrupt TMR4 Interrupt
+ * @{
+ */
+#define TMR4_INT_CNT_PEAK               ((uint32_t)TMR4_CCSR_IRQPEN)    /*!< Count peak interrupt */
+#define TMR4_INT_CNT_VALLEY             ((uint32_t)TMR4_CCSR_IRQZEN)    /*!< Count valley interrupt */
+#define TMR4_INT_RELOAD_TMR_U           (1UL << 0U)                     /*!< TMR4 PWM reload-timer interrupt - channel U */
+#define TMR4_INT_RELOAD_TMR_V           (1UL << 1U)                     /*!< TMR4 PWM reload-timer interrupt - channel W */
+#define TMR4_INT_RELOAD_TMR_W           (1UL << 2U)                     /*!< TMR4 PWM reload-timer interrupt - channel V */
+#define TMR4_INT_OC_CMP_UH              (1UL << 16U)                    /*!< TMR4 output-compare compare interrupt - channel UH */
+#define TMR4_INT_OC_CMP_UL              (1UL << 17U)                    /*!< TMR4 output-compare compare interrupt - channel UL */
+#define TMR4_INT_OC_CMP_VH              (1UL << 18U)                    /*!< TMR4 output-compare compare interrupt - channel VH */
+#define TMR4_INT_OC_CMP_VL              (1UL << 19U)                    /*!< TMR4 output-compare compare interrupt - channel VL */
+#define TMR4_INT_OC_CMP_WH              (1UL << 20U)                    /*!< TMR4 output-compare compare interrupt - channel WH */
+#define TMR4_INT_OC_CMP_WL              (1UL << 21U)                    /*!< TMR4 output-compare compare interrupt - channel WL */
+
+#define TMR4_INT_ALL                    (TMR4_INT_CNT_PEAK     | TMR4_INT_CNT_VALLEY   | TMR4_INT_RELOAD_TMR_U | \
+                                         TMR4_INT_RELOAD_TMR_V | TMR4_INT_RELOAD_TMR_W | TMR4_INT_OC_CMP_UH    | \
+                                         TMR4_INT_OC_CMP_UL    | TMR4_INT_OC_CMP_VH    | TMR4_INT_OC_CMP_VL    | \
+                                         TMR4_INT_OC_CMP_WH    | TMR4_INT_OC_CMP_WL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Count_Interrupt_Mask_Time TMR4 Count Interrupt Mask Time
+ * @{
+ */
+#define TMR4_INT_CNT_MASK0              (0U)    /*!< Counter interrupt flag is always set(not masked) for counter count every time at "0x0000" or peak */
+#define TMR4_INT_CNT_MASK1              (1U)    /*!< Counter interrupt flag is set once when counter counts 2 times at "0x0000" or peak (skipping 1 count) */
+#define TMR4_INT_CNT_MASK2              (2U)    /*!< Counter interrupt flag is set once when counter counts 3 times at "0x0000" or peak (skipping 2 count) */
+#define TMR4_INT_CNT_MASK3              (3U)    /*!< Counter interrupt flag is set once when counter counts 4 times at "0x0000" or peak (skipping 3 count) */
+#define TMR4_INT_CNT_MASK4              (4U)    /*!< Counter interrupt flag is set once when counter counts 5 times at "0x0000" or peak (skipping 4 count) */
+#define TMR4_INT_CNT_MASK5              (5U)    /*!< Counter interrupt flag is set once when counter counts 6 times at "0x0000" or peak (skipping 5 count) */
+#define TMR4_INT_CNT_MASK6              (6U)    /*!< Counter interrupt flag is set once when counter counts 7 times at "0x0000" or peak (skipping 6 count) */
+#define TMR4_INT_CNT_MASK7              (7U)    /*!< Counter interrupt flag is set once when counter counts 8 times at "0x0000" or peak (skipping 7 count) */
+#define TMR4_INT_CNT_MASK8              (8U)    /*!< Counter interrupt flag is set once when counter counts 9 times at "0x0000" or peak (skipping 8 count) */
+#define TMR4_INT_CNT_MASK9              (9U)    /*!< Counter interrupt flag is set once when counter counts 10 times at "0x0000" or peak (skipping 9 count) */
+#define TMR4_INT_CNT_MASK10             (10U)   /*!< Counter interrupt flag is set once when counter counts 11 times at "0x0000" or peak (skipping 10 count) */
+#define TMR4_INT_CNT_MASK11             (11U)   /*!< Counter interrupt flag is set once when counter counts 12 times at "0x0000" or peak (skipping 11 count) */
+#define TMR4_INT_CNT_MASK12             (12U)   /*!< Counter interrupt flag is set once when counter counts 13 times at "0x0000" or peak (skipping 12 count) */
+#define TMR4_INT_CNT_MASK13             (13U)   /*!< Counter interrupt flag is set once when counter counts 14 times at "0x0000" or peak (skipping 13 count) */
+#define TMR4_INT_CNT_MASK14             (14U)   /*!< Counter interrupt flag is set once when counter counts 15 times at "0x0000" or peak (skipping 14 count) */
+#define TMR4_INT_CNT_MASK15             (15U)   /*!< Counter interrupt flag is set once when counter counts 16 times at "0x0000" or peak (skipping 15 count) */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Output_Compare_Macros TMR4 Output-Compare Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_OC_Channel TMR4 OC Channel
+ * @{
+ */
+#define TMR4_OC_CH_UH                   (0UL)   /*!< TMR4 OC channel:UH */
+#define TMR4_OC_CH_UL                   (1UL)   /*!< TMR4 OC channel:UL */
+#define TMR4_OC_CH_VH                   (2UL)   /*!< TMR4 OC channel:VH */
+#define TMR4_OC_CH_VL                   (3UL)   /*!< TMR4 OC channel:VL */
+#define TMR4_OC_CH_WH                   (4UL)   /*!< TMR4 OC channel:WH */
+#define TMR4_OC_CH_WL                   (5UL)   /*!< TMR4 OC channel:WL */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Invalid_Output_Polarity TMR4 OC Invalid Output Polarity
+ * @{
+ */
+#define TMR4_OC_INVD_LOW                (0U)              /*!< TMR4 OC Output low level when OC is invalid */
+#define TMR4_OC_INVD_HIGH               (TMR4_OCSR_OCPH)  /*!< TMR4 OC Output high level when OC is invalid */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Output_Polarity TMR4 OC Output Polarity
+ * @{
+ */
+#define TMR4_OC_PORT_LOW                (0U)              /*!< TMR4 OC Output low level */
+#define TMR4_OC_PORT_HIGH               (TMR4_OCSR_OCPH)  /*!< TMR4 OC Output high level */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Buffer_Object TMR4 OC Buffer Object
+ * @{
+ */
+#define TMR4_OC_BUF_NONE                (0x00U) /*!< Disable the buffer function of OCCR/OCMR */
+#define TMR4_OC_BUF_CMP_VALUE           (0x01U) /*!< The register OCCR buffer function */
+#define TMR4_OC_BUF_CMP_MD              (0x02U) /*!< The register OCMR buffer function */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Buffer_Transfer_Condition TMR4 OC OCCR Buffer Transfer Condition
+ * @{
+ */
+#define TMR4_OC_BUF_COND_IMMED          (0U)    /*!< Buffer transfer is made when writing to the OCCR/OCMR register. */
+#define TMR4_OC_BUF_COND_VALLEY         (1U)    /*!< Buffer transfer is made when counter count valley */
+#define TMR4_OC_BUF_COND_PEAK           (2U)    /*!< Buffer transfer is made when counter count peak */
+#define TMR4_OC_BUF_COND_PEAK_VALLEY    (3U)    /*!< Buffer transfer is made when counter count peak or valley */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Count_Match_OCF_State TMR4 OC Count Match OCF State
+ * @{
+ */
+#define TMR4_OC_OCF_HOLD                (0U)                /*!< Hold OCF when the TMR4 OC count match */
+#define TMR4_OC_OCF_SET                 (TMR4_OCMRH_OCFDCH) /*!< Set OCF when the TMR4 OC count match */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Count_Match_Output_Polarity TMR4 OC Count Match Output Polarity
+ * @{
+ */
+#define TMR4_OC_HOLD                    (0U)    /*!< Hold output when the TMR4 OC count match */
+#define TMR4_OC_HIGH                    (1U)    /*!< Output high when the TMR4 OC count match */
+#define TMR4_OC_LOW                     (2U)    /*!< Output low when the TMR4 OC count match */
+#define TMR4_OC_INVT                    (3U)    /*!< Invert output when the TMR4 OC count match */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Macros TMR4 PWM Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_PWM_Channel TMR4 PWM Channel
+ * @{
+ */
+#define TMR4_PWM_CH_U                   (0UL)   /*!< TMR4 PWM couple channel: U */
+#define TMR4_PWM_CH_V                   (1UL)   /*!< TMR4 PWM couple channel: V */
+#define TMR4_PWM_CH_W                   (2UL)   /*!< TMR4 PWM couple channel: W */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Pin TMR4 PWM Pin
+ * @{
+ */
+#define TMR4_PWM_PIN_OUH                (0UL)   /*!< TMR4 PWM port: TIM4_<t>_OUH */
+#define TMR4_PWM_PIN_OUL                (1UL)   /*!< TMR4 PWM port: TIM4_<t>_OUL */
+#define TMR4_PWM_PIN_OVH                (2UL)   /*!< TMR4 PWM port: TIM4_<t>_OVH */
+#define TMR4_PWM_PIN_OVL                (3UL)   /*!< TMR4 PWM port: TIM4_<t>_OVL */
+#define TMR4_PWM_PIN_OWH                (4UL)   /*!< TMR4 PWM port: TIM4_<t>_OWH */
+#define TMR4_PWM_PIN_OWL                (5UL)   /*!< TMR4 PWM port: TIM4_<t>_OWL */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Clock_Division TMR4 PWM Clock Division
+ * @{
+ */
+#define TMR4_PWM_CLK_DIV1               (0U)                        /*!< CLK     */
+#define TMR4_PWM_CLK_DIV2               (1U << TMR4_POCR_DIVCK_POS) /*!< CLK/2   */
+#define TMR4_PWM_CLK_DIV4               (2U << TMR4_POCR_DIVCK_POS) /*!< CLK/8   */
+#define TMR4_PWM_CLK_DIV8               (3U << TMR4_POCR_DIVCK_POS) /*!< CLK/8   */
+#define TMR4_PWM_CLK_DIV16              (4U << TMR4_POCR_DIVCK_POS) /*!< CLK/16  */
+#define TMR4_PWM_CLK_DIV32              (5U << TMR4_POCR_DIVCK_POS) /*!< CLK/32  */
+#define TMR4_PWM_CLK_DIV64              (6U << TMR4_POCR_DIVCK_POS) /*!< CLK/64  */
+#define TMR4_PWM_CLK_DIV128             (7U << TMR4_POCR_DIVCK_POS) /*!< CLK/128 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Mode TMR4 PWM Mode
+ * @{
+ */
+#define TMR4_PWM_MD_THROUGH             (0U)                /*!< Through mode */
+#define TMR4_PWM_MD_DEAD_TMR            (TMR4_POCR_PWMMD_0) /*!< Dead timer mode */
+#define TMR4_PWM_MD_DEAD_TMR_FILTER     (TMR4_POCR_PWMMD_1) /*!< Dead timer filter mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Polarity TMR4 PWM Polarity
+ * @{
+ */
+#define TMR4_PWM_OXH_HOLD_OXL_HOLD      (0U)                /*!< Output PWML and PWMH signals without changing the level */
+#define TMR4_PWM_OXH_INVT_OXL_INVT      (TMR4_POCR_LVLS_0)  /*!< Output both PWML and PWMH signals reversed */
+#define TMR4_PWM_OXH_INVT_OXL_HOLD      (TMR4_POCR_LVLS_1)  /*!< Output the PWMH signal reversed, outputs the PWML signal without changing the level. */
+#define TMR4_PWM_OXH_HOLD_OXL_INVT      (TMR4_POCR_LVLS)    /*!< Output the PWMH signal without changing the level, Outputs the PWML signal reversed. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Dead_Time_Register_Index TMR4 PWM Dead Time Register Index
+ * @{
+ */
+#define TMR4_PWM_PDAR_IDX               (0UL)               /*!< TMR4_PDARn(n=U/V/W) */
+#define TMR4_PWM_PDBR_IDX               (1UL)               /*!< TMR4_PDBRn(n=U/V/W) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Abnormal_Pin_Status TMR4 PWM Abnormal Pin Status
+ * @{
+ */
+#define TMR4_PWM_ABNORMAL_PIN_NORMAL    (0UL)           /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) output normal */
+#define TMR4_PWM_ABNORMAL_PIN_HIZ       (1UL)           /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) to Hi-z */
+#define TMR4_PWM_ABNORMAL_PIN_LOW       (2UL)           /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) output low level */
+#define TMR4_PWM_ABNORMAL_PIN_HIGH      (3UL)           /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) output high level */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Pin_Output_Mode TMR4 PWM Pin Mode
+ * @{
+ */
+#define TMR4_PWM_PIN_OUTPUT_OS          (0UL)               /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) output polarity by specified register TMR4_PSCR.OSxy */
+#define TMR4_PWM_PIN_OUTPUT_NORMAL      (TMR4_PSCR_OEUH)    /*!< TIM4_<t>_Oxy(x=U/V/W, y=H/L) output normal PWM */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_OE_Bit_Effect_Time TMR4 PWM Register TMR4_PSCR.OE Bit Effect Time
+ * @{
+ */
+#define TMR4_PWM_OE_EFFECT_IMMED        (TMR4_PSCR_ODT_0)   /*!< TMR4 PWM register TMR4_PSCR.OE bit immediate effect. */
+#define TMR4_PWM_OE_EFFECT_COUNT_PEAK   (TMR4_PSCR_ODT)     /*!< TMR4 PWM register TMR4_PSCR.OE bit effect when TMR4 counter count peak. */
+#define TMR4_PWM_OE_EFFECT_COUNT_VALLEY (TMR4_PSCR_ODT_1)   /*!< TMR4 PWM register TMR4_PSCR.OE bit effect when TMR4 counter count valley. */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Macros TMR4 Event Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_Event_Channel TMR4 Event Channel
+ * @{
+ */
+#define TMR4_EVT_CH_UH                  (0UL)               /*!< TMR4 EVT channel:UH */
+#define TMR4_EVT_CH_UL                  (1UL)               /*!< TMR4 EVT channel:UL */
+#define TMR4_EVT_CH_VH                  (2UL)               /*!< TMR4 EVT channel:VH */
+#define TMR4_EVT_CH_VL                  (3UL)               /*!< TMR4 EVT channel:VL */
+#define TMR4_EVT_CH_WH                  (4UL)               /*!< TMR4 EVT channel:WH */
+#define TMR4_EVT_CH_WL                  (5UL)               /*!< TMR4 EVT channel:WL */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Match_Condition TMR4 Event Match Condition
+ * @{
+ */
+#define TMR4_EVT_MATCH_CNT_UP           (TMR4_SCSR_UEN)     /*!< Start event operation when match with SCCR&SCMR and TMR4 counter count up */
+#define TMR4_EVT_MATCH_CNT_DOWN         (TMR4_SCSR_DEN)     /*!< Start event operation when match with SCCR&SCMR and TMR4 counter count down */
+#define TMR4_EVT_MATCH_CNT_PEAK         (TMR4_SCSR_PEN)     /*!< Start event operation when match with SCCR&SCMR and TMR4 counter count peak */
+#define TMR4_EVT_MATCH_CNT_VALLEY       (TMR4_SCSR_ZEN)     /*!< Start event operation when match with SCCR&SCMR and TMR4 counter count valley */
+#define TMR4_EVT_MATCH_CNT_ALL          (TMR4_EVT_MATCH_CNT_DOWN | TMR4_EVT_MATCH_CNT_UP | \
+                                         TMR4_EVT_MATCH_CNT_PEAK | TMR4_EVT_MATCH_CNT_VALLEY)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Mask TMR4 Event Mask
+ * @{
+ */
+#define TMR4_EVT_MASK_PEAK              (TMR4_SCMR_MPCE)    /*!< Match with the count peak interrupt mask of the counter  */
+#define TMR4_EVT_MASK_VALLEY            (TMR4_SCMR_MZCE)    /*!< Match with the count valley interrupt mask  of the counter */
+#define TMR4_EVT_MASK_TYPE_ALL          (TMR4_EVT_MASK_PEAK | TMR4_EVT_MASK_VALLEY)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Buffer_Transfer_Condition TMR4 Event Buffer Transfer Condition
+ * @{
+ */
+#define TMR4_EVT_BUF_COND_IMMED         (0U)                /*!< Register SCCR&SCMR buffer transfer when writing to the SCCR&SCMR register */
+#define TMR4_EVT_BUF_COND_VALLEY        (TMR4_SCSR_BUFEN_0) /*!< Register SCCR&SCMR buffer transfer when counter count valley */
+#define TMR4_EVT_BUF_COND_PEAK          (TMR4_SCSR_BUFEN_1) /*!< Register SCCR&SCMR buffer transfer when counter count peak */
+#define TMR4_EVT_BUF_COND_PEAK_VALLEY   (TMR4_SCSR_BUFEN)   /*!< Register SCCR&SCMR buffer transfer when counter count peak or valley */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Mode TMR4 Event Mode
+ * @{
+ */
+#define TMR4_EVT_MD_CMP                 (0U)                /*!< TMR4 EVT compare mode */
+#define TMR4_EVT_MD_DELAY               (TMR4_SCSR_EVTMS)   /*!< TMR4 EVT delay mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Delay_Object TMR4 Event Delay Object
+ * @{
+ */
+#define TMR4_EVT_DELAY_OCCRXH           (0U)                /*!< TMR4 EVT delay object: OCCRxh(x=u/v/w) */
+#define TMR4_EVT_DELAY_OCCRXL           (TMR4_SCSR_EVTDS)   /*!< TMR4 EVT delay object: OCCRxl(x=u/v/w) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Mask_Times TMR4 Event Mask Times
+ * @{
+ */
+#define TMR4_EVT_MASK0                  (0U << TMR4_SCMR_AMC_POS)   /*!< Mask 0 time */
+#define TMR4_EVT_MASK1                  (1U << TMR4_SCMR_AMC_POS)   /*!< Mask 1 times */
+#define TMR4_EVT_MASK2                  (2U << TMR4_SCMR_AMC_POS)   /*!< Mask 2 times */
+#define TMR4_EVT_MASK3                  (3U << TMR4_SCMR_AMC_POS)   /*!< Mask 3 times */
+#define TMR4_EVT_MASK4                  (4U << TMR4_SCMR_AMC_POS)   /*!< Mask 4 times */
+#define TMR4_EVT_MASK5                  (5U << TMR4_SCMR_AMC_POS)   /*!< Mask 5 times */
+#define TMR4_EVT_MASK6                  (6U << TMR4_SCMR_AMC_POS)   /*!< Mask 6 times */
+#define TMR4_EVT_MASK7                  (7U << TMR4_SCMR_AMC_POS)   /*!< Mask 7 times */
+#define TMR4_EVT_MASK8                  (8U << TMR4_SCMR_AMC_POS)   /*!< Mask 8 times */
+#define TMR4_EVT_MASK9                  (9U << TMR4_SCMR_AMC_POS)   /*!< Mask 9 times */
+#define TMR4_EVT_MASK10                 (10U << TMR4_SCMR_AMC_POS)  /*!< Mask 10 times */
+#define TMR4_EVT_MASK11                 (11U << TMR4_SCMR_AMC_POS)  /*!< Mask 11 times */
+#define TMR4_EVT_MASK12                 (12U << TMR4_SCMR_AMC_POS)  /*!< Mask 12 times */
+#define TMR4_EVT_MASK13                 (13U << TMR4_SCMR_AMC_POS)  /*!< Mask 13 times */
+#define TMR4_EVT_MASK14                 (14U << TMR4_SCMR_AMC_POS)  /*!< Mask 14 times */
+#define TMR4_EVT_MASK15                 (15U << TMR4_SCMR_AMC_POS)  /*!< Mask 15 times */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Output_Event TMR4 Event Output Event
+ * @{
+ */
+#define TMR4_EVT_OUTPUT_EVT0            (0U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 0 */
+#define TMR4_EVT_OUTPUT_EVT1            (1U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 1 */
+#define TMR4_EVT_OUTPUT_EVT2            (2U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 2 */
+#define TMR4_EVT_OUTPUT_EVT3            (3U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 3 */
+#define TMR4_EVT_OUTPUT_EVT4            (4U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 4 */
+#define TMR4_EVT_OUTPUT_EVT5            (5U << TMR4_SCSR_EVTOS_POS) /*!< TMR4 event output special event 5 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Output_Signal TMR4 Event Output Signal
+ * @{
+ */
+#define TMR4_EVT_OUTPUT_NONE            (0U)    /*!< Disable output event signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT0_SIGNAL     (1U)    /*!< Output the specified event 0 signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT1_SIGNAL     (2U)    /*!< Output the specified event 1 signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT2_SIGNAL     (3U)    /*!< Output the specified event 2 signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT3_SIGNAL     (4U)    /*!< Output the specified event 3 signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT4_SIGNAL     (5U)    /*!< Output the specified event 4 signal of TMR4 Special-EVT */
+#define TMR4_EVT_OUTPUT_EVT5_SIGNAL     (6U)    /*!< Output the specified event 5 signal of TMR4 Special-EVT */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TMR4_Global_Functions
+ * @{
+ */
+
+/**
+ * @addtogroup TMR4_Counter_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration TMR4 counter functions */
+int32_t TMR4_StructInit(stc_tmr4_init_t *pstcTmr4Init);
+int32_t TMR4_Init(CM_TMR4_TypeDef *TMR4x, const stc_tmr4_init_t *pstcTmr4Init);
+int32_t TMR4_DeInit(CM_TMR4_TypeDef *TMR4x);
+void TMR4_SetClockSrc(CM_TMR4_TypeDef *TMR4x, uint16_t u16Src);
+void TMR4_SetClockDiv(CM_TMR4_TypeDef *TMR4x, uint16_t u16Div);
+void TMR4_SetCountMode(CM_TMR4_TypeDef *TMR4x, uint16_t u16Mode);
+uint16_t TMR4_GetPeriodValue(const CM_TMR4_TypeDef *TMR4x);
+void TMR4_SetPeriodValue(CM_TMR4_TypeDef *TMR4x, uint16_t u16Value);
+uint16_t TMR4_GetCountValue(const CM_TMR4_TypeDef *TMR4x);
+void TMR4_SetCountValue(CM_TMR4_TypeDef *TMR4x, uint16_t u16Value);
+void TMR4_ClearCountValue(CM_TMR4_TypeDef *TMR4x);
+void TMR4_Start(CM_TMR4_TypeDef *TMR4x);
+void TMR4_Stop(CM_TMR4_TypeDef *TMR4x);
+void TMR4_ClearStatus(CM_TMR4_TypeDef *TMR4x, uint32_t u32Flag);
+en_flag_status_t TMR4_GetStatus(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Flag);
+void TMR4_IntCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType, en_functional_state_t enNewState);
+void TMR4_PeriodBufCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState);
+uint16_t TMR4_GetCountIntMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType);
+void TMR4_SetCountIntMaskTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType, uint16_t u16MaskTime);
+uint16_t TMR4_GetCurrentCountIntMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType);
+void TMR4_PortOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState);
+/**
+ * @}
+ */
+
+/**
+ * @addtogroup TMR4_Output_Compare_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration TMR4 Output-Compare functions */
+int32_t TMR4_OC_StructInit(stc_tmr4_oc_init_t *pstcTmr4OcInit);
+int32_t TMR4_OC_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_oc_init_t *pstcTmr4OcInit);
+void TMR4_OC_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+uint16_t TMR4_OC_GetCompareValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_OC_SetCompareValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value);
+void TMR4_OC_Cmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR4_OC_ExtendControlCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR4_OC_BufIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch,
+                                    uint16_t u16Object, en_functional_state_t enNewState);
+uint16_t TMR4_OC_GetPolarity(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_OC_SetOcInvalidPolarity(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Polarity);
+void TMR4_OC_SetCompareBufCond(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Object, uint16_t u16BufCond);
+uint16_t TMR4_OC_GetHighChCompareMode(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_OC_SetHighChCompareMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, un_tmr4_oc_ocmrh_t unTmr4Ocmrh);
+uint32_t TMR4_OC_GetLowChCompareMode(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_OC_SetLowChCompareMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, un_tmr4_oc_ocmrl_t unTmr4Ocmrl);
+/**
+ * @}
+ */
+
+/**
+ * @addtogroup TMR4_PWM_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration TMR4 PWM functions */
+int32_t TMR4_PWM_StructInit(stc_tmr4_pwm_init_t *pstcTmr4PwmInit);
+int32_t TMR4_PWM_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_pwm_init_t *pstcTmr4PwmInit);
+void TMR4_PWM_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_PWM_SetClockDiv(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Div);
+void TMR4_PWM_SetPolarity(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Polarity);
+void TMR4_PWM_StartReloadTimer(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_PWM_StopReloadTimer(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_PWM_SetFilterCountValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value);
+void TMR4_PWM_SetDeadTimeValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint32_t u32DeadTimeIndex, uint16_t u16Value);
+uint16_t TMR4_PWM_GetDeadTimeValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint32_t u32DeadTimeIndex);
+void TMR4_PWM_SetAbnormalPinStatus(CM_TMR4_TypeDef *TMR4x, uint32_t u32PwmPin, uint32_t u32PinStatus);
+void TMR4_PWM_SetOEEffectTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32Time);
+void TMR4_PWM_EmbHWMainOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState);
+void TMR4_PWM_MainOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState);
+void TMR4_PWM_SetPortOutputMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32PwmPin, uint32_t u32Mode);
+
+/**
+ * @}
+ */
+
+/**
+ * @addtogroup TMR4_Event_Global_Functions
+ * @{
+ */
+
+/* Initialization and configuration TMR4 event functions */
+int32_t TMR4_EVT_StructInit(stc_tmr4_evt_init_t *pstcTmr4EventInit);
+int32_t TMR4_EVT_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_evt_init_t *pstcTmr4EventInit);
+void TMR4_EVT_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_EVT_SetDelayObject(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Object);
+void TMR4_EVT_SetMaskTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16MaskTime);
+uint16_t TMR4_EVT_GetMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_EVT_SetCompareValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value);
+uint16_t TMR4_EVT_GetCompareValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch);
+void TMR4_EVT_SetOutputEvent(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Event);
+void TMR4_EVT_SetCompareBufCond(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16BufCond);
+void TMR4_EVT_BufIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR4_EVT_EventIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch,
+                                       uint16_t u16MaskType, en_functional_state_t enNewState);
+void TMR4_EVT_MatchCondCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Cond, en_functional_state_t enNewState);
+void TMR4_EVT_SetOutputEventSignal(CM_TMR4_TypeDef *TMR4x, uint16_t u16Signal);
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR4_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TMR4_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_tmr6.h
+++ b/hc32f4a2/inc/hc32_ll_tmr6.h
@@ -1,0 +1,927 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr6.h
+ * @brief This file contains all the functions prototypes of the TMR6 driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify structure stc_tmr6_deadtime_config_t
+   2023-01-15       CDT             Modify structure stc_timer6_init_t to stc_tmr6_init_t
+                                    Modify macro define for group TMR6_Emb_Ch_Define
+                                    Modify macro define for group TMR6_hardware_xxx_condition_Define
+                                    Modify macro define for group TMR6_HW_Count_xx_Cond_Define
+                                    Modify macro define for group TMR6_Valid_Period_Count_Cond_Define
+                                    Modify API TMR6_SetFilterClockDiv()
+   2023-06-30       CDT             Delete union in stc_tmr6_init_t structure
+   2023-09-30       CDT             Modify macro define for group TMR6_Emb_Ch_Define
+                                    Add macro define for TMR6_Count_Dir_Status_Define
+                                    Modify typo
+   2023-12-15       CDT             Modify for headfile update: CM_TMR6CR -> CM_TMR6_COMMON
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TMR6_H__
+#define __HC32_LL_TMR6_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TMR6
+ * @{
+ */
+
+#if (LL_TMR6_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup TMR6_Global_Types TMR6 Global Types
+ * @{
+ */
+
+/**
+ * @brief Timer6 count function structure definition
+ */
+typedef struct {
+    uint8_t u8CountSrc;             /*!< Specifies the count source @ref TMR6_Count_Src_Define */
+    struct {
+        uint32_t u32ClockDiv;   /*!< Count clock division select, @ref TMR6_Count_Clock_Define */
+        uint32_t u32CountMode;  /*!< Count mode, @ref TMR6_Count_Mode_Define */
+        uint32_t u32CountDir;   /*!< Count direction, @ref TMR6_Count_Dir_Define */
+    } sw_count;
+    struct {
+        uint32_t u32CountUpCond;   /*!< Hardware count up condition. @ref TMR6_HW_Count_Up_Cond_Define */
+        uint32_t u32CountDownCond; /*!< Hardware count down condition. @ref TMR6_HW_Count_Down_Cond_Define */
+    } hw_count;
+    uint32_t u32PeriodValue;        /*!< The period reference value. (0x00 ~ 0xFFFF) or (0x00 ~ 0xFFFFFFFF) */
+    uint32_t u32CountReload;        /*!< Count reload after overflow @ref TMR6_Count_Reload_Define */
+} stc_tmr6_init_t;
+
+/**
+ * @brief Timer6 pwm output function structure definition
+ */
+typedef struct {
+    uint32_t u32CompareValue;               /*!< Range (0 ~ 0xFFFF) or (0 ~ 0xFFFFFFFF) */
+    uint32_t u32StartPolarity;              /*!< Pin polarity when count start @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32StopPolarity;               /*!< Pin polarity when count stop @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32CountUpMatchAPolarity;      /*!< Port state when match compare register A(GCMAR) at count-up mode \
+                                                 @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32CountDownMatchAPolarity;    /*!< Port state when match compare register A(GCMAR) at count-down mode \
+                                                 @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32CountUpMatchBPolarity;      /*!< Port state when match compare register B(GCMBR) at count-up mode \
+                                                 @ref TMR6_Pin_Polarity_Define*/
+    uint32_t u32CountDownMatchBPolarity;    /*!< Port state when match compare register B(GCMBR) at count-down mode\
+                                                 @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32UdfPolarity;                /*!< Pin polarity when underflow @ref TMR6_Pin_Polarity_Define */
+    uint32_t u32OvfPolarity;                /*!< Pin polarity when overflow @ref TMR6_Pin_Polarity_Define */
+} stc_tmr6_pwm_init_t;
+
+/**
+ * @brief Timer6 buffer function configuration structure definition
+ */
+typedef struct {
+    uint32_t u32BufNum;             /*!< The buffer number, and this parameter can be a value of \
+                                         @ref TMR6_Buf_Num_Define */
+    uint32_t u32BufTransCond;       /*!< The buffer send time, and this parameter can be a value of \
+                                         @ref TMR6_Buf_Trans_Cond_Define */
+} stc_tmr6_buf_config_t;
+
+/**
+ * @brief Timer6 Valid period function configuration structure definition
+ */
+typedef struct {
+    uint32_t u32CountCond;          /*!< The count condition, and this parameter can be a value of \
+                                          @ref TMR6_Valid_Period_Count_Cond_Define */
+    uint32_t u32PeriodInterval;     /*!< The interval of the valid period @ref TMR6_Valid_Period_Count_Define */
+} stc_tmr6_valid_period_config_t;
+
+/**
+ * @brief Timer6 EMB configuration structure definition
+ */
+typedef struct {
+    uint32_t u32ValidCh;            /*!< Valid EMB event channel @ref TMR6_Emb_Ch_Define */
+    uint32_t u32ReleaseMode;        /*!< Pin release mode when EMB event invalid @ref TMR6_Emb_Release_Mode_Define */
+    uint32_t u32PinStatus;          /*!< Pin output status when EMB event valid @ref TMR6_Emb_Pin_Status_Define */
+} stc_tmr6_emb_config_t;
+
+/**
+ * @brief Timer6 Dead time function configuration structure definition
+ */
+typedef struct {
+    uint32_t u32EqualUpDown;        /*!< Enable down count dead time register equal to up count DT register \
+                                         @ref TMR6_DeadTime_Reg_Equal_Func_Define */
+    uint32_t u32BufUp;              /*!< Enable buffer transfer for up count dead time register (DTUBR-->DTUAR) \
+                                         @ref TMR6_DeadTime_CountUp_Buf_Func_Define*/
+    uint32_t u32BufDown;            /*!< Enable buffer transfer for down count dead time register (DTDBR-->DTDAR) \
+                                         @ref TMR6_DeadTime_CountDown_Buf_Func_Define*/
+    uint32_t u32BufTransCond;       /*!< Buffer transfer condition for triangular wave mode \
+                                         @ref TMR6_DeadTime_Buf_Trans_Cond_Define */
+} stc_tmr6_deadtime_config_t;
+
+/**
+ * @brief Timer6 Dead time function configuration structure definition
+ */
+typedef struct {
+    uint32_t u32ZMaskCycle;         /*!< Z phase input mask periods selection @ref TMR6_Zmask_Cycle_Define */
+    uint32_t u32PosCountMaskFunc;   /*!< As position count timer, clear function enable(TRUE) or disable(FALSE) during \
+                                         the time of Z phase input mask @ref TMR6_Zmask_Pos_Unit_Clear_Func_Define */
+    uint32_t u32RevoCountMaskFunc;  /*!< As revolution count timer, the counter function enable(TRUE) or disable(FALSE) \
+                                         during the time of Z phase input mask \
+                                         @ref TMR6_Zmask_Revo_Unit_Count_Func_Define*/
+} stc_tmr6_zmask_config_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR6_Global_Macros TMR6 Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR6_Count_Src_Define TMR6 Count Source Define
+ * @{
+ */
+#define TMR6_CNT_SRC_SW                     (0U)                    /*!< Timer6 normal count function */
+#define TMR6_CNT_SRC_HW                     (1U)                    /*!< Timer6 hardware count function */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Stat_Flag_Define TMR6 Status Flag Define
+ * @{
+ */
+#define TMR6_FLAG_MATCH_A                   (TMR6_STFLR_CMAF)       /*!< GCMAR match counter */
+#define TMR6_FLAG_MATCH_B                   (TMR6_STFLR_CMBF)       /*!< GCMBR match counter */
+#define TMR6_FLAG_MATCH_C                   (TMR6_STFLR_CMCF)       /*!< GCMCR match counter */
+#define TMR6_FLAG_MATCH_D                   (TMR6_STFLR_CMDF)       /*!< GCMDR match counter */
+#define TMR6_FLAG_MATCH_E                   (TMR6_STFLR_CMEF)       /*!< GCMER match counter */
+#define TMR6_FLAG_MATCH_F                   (TMR6_STFLR_CMFF)       /*!< GCMFR match counter */
+#define TMR6_FLAG_OVF                       (TMR6_STFLR_OVFF)       /*!< Sawtooth wave counter overflow, \
+                                                                         Triangular wave peak point */
+#define TMR6_FLAG_UDF                       (TMR6_STFLR_UDFF)       /*!< Sawtooth wave counter underflow, \
+                                                                         Triangular wave valley point */
+#define TMR6_FLAG_DEAD_TIME_ERR             (TMR6_STFLR_DTEF)       /*!< Dead time error */
+#define TMR6_FLAG_UP_CNT_SPECIAL_MATCH_A    (TMR6_STFLR_CMSAUF)     /*!< SCMAR match counter when count-up */
+#define TMR6_FLAG_DOWN_CNT_SPECIAL_MATCH_A  (TMR6_STFLR_CMSADF)     /*!< SCMAR match counter when count-down */
+#define TMR6_FLAG_UP_CNT_SPECIAL_MATCH_B    (TMR6_STFLR_CMSBUF)     /*!< SCMBR match counter when count-up */
+#define TMR6_FLAG_DOWN_CNT_SPECIAL_MATCH_B  (TMR6_STFLR_CMSBDF)     /*!< SCMBR match counter when count-down */
+#define TMR6_FLAG_CNT_DIR                   (TMR6_STFLR_DIRF)       /*!< Count direction flag */
+
+#define TMR6_FLAG_CLR_ALL                   (0x00001EFFUL)          /*!< Clear all flag */
+#define TMR6_FLAG_ALL                       (TMR6_FLAG_MATCH_A | TMR6_FLAG_MATCH_B | TMR6_FLAG_MATCH_C | \
+                                            TMR6_FLAG_MATCH_D | TMR6_FLAG_MATCH_E | TMR6_FLAG_MATCH_F | \
+                                            TMR6_FLAG_OVF | TMR6_FLAG_UDF | TMR6_FLAG_DEAD_TIME_ERR | \
+                                            TMR6_FLAG_UP_CNT_SPECIAL_MATCH_A | TMR6_FLAG_DOWN_CNT_SPECIAL_MATCH_A | \
+                                            TMR6_FLAG_UP_CNT_SPECIAL_MATCH_B | TMR6_FLAG_DOWN_CNT_SPECIAL_MATCH_B | \
+                                            TMR6_FLAG_CNT_DIR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Int_Flag_Define TMR6 Interrupt Flag Define
+ * @{
+ */
+#define TMR6_INT_MATCH_A                    (TMR6_ICONR_INTENA)     /*!< GCMAR register matched */
+#define TMR6_INT_MATCH_B                    (TMR6_ICONR_INTENB)     /*!< GCMBR register matched */
+#define TMR6_INT_MATCH_C                    (TMR6_ICONR_INTENC)     /*!< GCMCR register matched */
+#define TMR6_INT_MATCH_D                    (TMR6_ICONR_INTEND)     /*!< GCMDR register matched */
+#define TMR6_INT_MATCH_E                    (TMR6_ICONR_INTENE)     /*!< GCMER register matched */
+#define TMR6_INT_MATCH_F                    (TMR6_ICONR_INTENF)     /*!< GCMFR register matched */
+#define TMR6_INT_OVF                        (TMR6_ICONR_INTENOVF)   /*!< Counter register overflow */
+#define TMR6_INT_UDF                        (TMR6_ICONR_INTENUDF)   /*!< Counter register underflow */
+#define TMR6_INT_DEAD_TIME_ERR              (TMR6_ICONR_INTENDTE)   /*!< Dead time error */
+#define TMR6_INT_UP_CNT_SPECIAL_MATCH_A     (TMR6_ICONR_INTENSAU)   /*!< SCMAR register matched when count-up */
+#define TMR6_INT_DOWN_CNT_SPECIAL_MATCH_A   (TMR6_ICONR_INTENSAD)   /*!< SCMAR register matched when count-down */
+#define TMR6_INT_UP_CNT_SPECIAL_MATCH_B     (TMR6_ICONR_INTENSBU)   /*!< SCMBR register matched when count-up */
+#define TMR6_INT_DOWN_CNT_SPECIAL_MATCH_B   (TMR6_ICONR_INTENSBD)   /*!< SCMBR register matched when count-down */
+#define TMR6_INT_ALL                        (TMR6_INT_MATCH_A | TMR6_INT_MATCH_B | TMR6_INT_MATCH_C | TMR6_INT_MATCH_D |\
+                                             TMR6_INT_MATCH_E | TMR6_INT_MATCH_F | TMR6_INT_OVF | TMR6_INT_UDF | \
+                                             TMR6_INT_DEAD_TIME_ERR | TMR6_INT_UP_CNT_SPECIAL_MATCH_A | \
+                                             TMR6_INT_DOWN_CNT_SPECIAL_MATCH_A | TMR6_INT_UP_CNT_SPECIAL_MATCH_B | \
+                                             TMR6_INT_DOWN_CNT_SPECIAL_MATCH_B)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Period_Reg_Index_Define TMR6 Period Register Index Define
+ * @{
+ */
+#define TMR6_PERIOD_REG_A                   (0x00UL)
+#define TMR6_PERIOD_REG_B                   (0x01UL)
+#define TMR6_PERIOD_REG_C                   (0x02UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Compare_Reg_Index_Define TMR6 Compare Register Index Define
+ * @{
+ */
+#define TMR6_CMP_REG_A                      (0x00UL)
+#define TMR6_CMP_REG_B                      (0x01UL)
+#define TMR6_CMP_REG_C                      (0x02UL)
+#define TMR6_CMP_REG_D                      (0x03UL)
+#define TMR6_CMP_REG_E                      (0x04UL)
+#define TMR6_CMP_REG_F                      (0x05UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Ch_Define TMR6 General/Special Compare Channel Define
+ * @{
+ */
+#define TMR6_CH_A                           (0x00UL)
+#define TMR6_CH_B                           (0x01UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Buf_Num_Define TMR6 Buffer Number Define
+ * @{
+ */
+#define TMR6_BUF_SINGLE                     (0x00UL)
+#define TMR6_BUF_DUAL                       (TMR6_BCONR_BSEA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Buf_Trans_Cond_Define TMR6 Buffer Transfer Time Configuration Define
+ * @{
+ */
+#define TMR6_BUF_TRANS_INVD                 (0x00UL)
+#define TMR6_BUF_TRANS_OVF                  (0x00000004UL)
+#define TMR6_BUF_TRANS_UDF                  (0x00000008UL)
+#define TMR6_BUF_TRANS_OVF_UDF              (0x0000000CUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Valid_Period_Count_Cond_Define TMR6 Valid Period Function Count Condition Define
+ * @{
+ */
+#define TMR6_VALID_PERIOD_INVD                  (0x00UL)             /*!< Valid period function off */
+#define TMR6_VALID_PERIOD_CNT_COND_VALLEY       (TMR6_VPERR_PCNTE_0) /*!< Count when Sawtooth waveform overflow and underflow, \
+                                                                        triangular wave valley */
+#define TMR6_VALID_PERIOD_CNT_COND_PEAK         (TMR6_VPERR_PCNTE_1) /*!< Count when Sawtooth waveform overflow and underflow, \
+                                                                        triangular wave peak */
+#define TMR6_VALID_PERIOD_CNT_COND_VALLEY_PEAK  (TMR6_VPERR_PCNTE)   /*!< Count when Sawtooth waveform overflow and underflow, \
+                                                                        triangular wave valley and peak */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Valid_Period_Count_Define TMR6 Valid Period Function Count Define
+ * @{
+ */
+#define TMR6_VALID_PERIOD_CNT_INVD          (0x00UL)
+#define TMR6_VALID_PERIOD_CNT1              (1UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT2              (2UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT3              (3UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT4              (4UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT5              (5UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT6              (6UL << TMR6_VPERR_PCNTS_POS)
+#define TMR6_VALID_PERIOD_CNT7              (7UL << TMR6_VPERR_PCNTS_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_DeadTime_Reg_Define TMR6 Dead Time Register Define
+ * @{
+ */
+#define TMR6_DEADTIME_REG_UP_A              (0x00U)         /*!< Register DTUAR */
+#define TMR6_DEADTIME_REG_DOWN_A            (0x01U)         /*!< Register DTDAR */
+#define TMR6_DEADTIME_REG_UP_B              (0x02U)         /*!< Register DTUBR */
+#define TMR6_DEADTIME_REG_DOWN_B            (0x03U)         /*!< Register DTDBR */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Pin_Define TMR6 Input And Output Pin Define
+ * @{
+ */
+#define TMR6_IO_PWMA                        (0x00U)         /*!< Pin TIM6_<t>_PWMA */
+#define TMR6_IO_PWMB                        (0x01U)         /*!< Pin TIM6_<t>_PWMB */
+#define TMR6_INPUT_TRIGA                    (0x02U)         /*!< Input pin TIM6_TRIGA */
+#define TMR6_INPUT_TRIGB                    (0x03U)         /*!< Input pin TIM6_TRIGB */
+#define TMR6_INPUT_TRIGC                    (0x04U)         /*!< Input pin TIM6_TRIGC */
+#define TMR6_INPUT_TRIGD                    (0x05U)         /*!< Input pin TIM6_TRIGD */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Input_Filter_Clock TMR6 Input Pin Filter Clock Divider Define
+ * @{
+ */
+#define TMR6_FILTER_CLK_DIV1                (0x00U)
+#define TMR6_FILTER_CLK_DIV4                (0x01U)
+#define TMR6_FILTER_CLK_DIV16               (0x02U)
+#define TMR6_FILTER_CLK_DIV64               (0x03U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Pin_Mode_Define TMR6 Pin Function Mode Selection
+ * @{
+ */
+#define TMR6_PIN_CMP_OUTPUT                 (0x00UL)
+#define TMR6_PIN_CAPT_INPUT                 (TMR6_PCNAR_CAPMDA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_State_Define TMR6 Count State
+ * @{
+ */
+#define TMR6_STAT_START                     (0U)    /*!< Count start */
+#define TMR6_STAT_STOP                      (1U)    /*!< Count stop */
+#define TMR6_STAT_OVF                       (2U)    /*!< Count overflow */
+#define TMR6_STAT_UDF                       (3U)    /*!< Count underflow */
+#define TMR6_STAT_UP_CNT_MATCH_A            (4U)    /*!< Count up match compare register A */
+#define TMR6_STAT_DOWN_CNT_MATCH_A          (5U)    /*!< Count down match compare register A */
+#define TMR6_STAT_UP_CNT_MATCH_B            (6U)    /*!< Count up match compare register B */
+#define TMR6_STAT_DOWN_CNT_MATCH_B          (7U)    /*!< Count down match compare register B */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Pin_Polarity_Define TMR6 Pin Output Polarity
+ * @{
+ */
+#define TMR6_PWM_LOW                        (0x00U)
+#define TMR6_PWM_HIGH                       (0x01U)
+#define TMR6_PWM_HOLD                       (0x02U)
+#define TMR6_PWM_INVT                       (0x03U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Force_Output_Polarity_Define TMR6 Force Output Polarity Next Period
+ * @{
+ */
+#define TMR6_PWM_FORCE_INVD                 (0x00U)
+#define TMR6_PWM_FORCE_LOW                  (0x02U)
+#define TMR6_PWM_FORCE_HIGH                 (0x03U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Emb_Ch_Define TMR6 EMB Event Channel
+ * @{
+ */
+#define TMR6_EMB_EVT_CH0                    (0x00UL)                            /* EMB group 0 */
+#define TMR6_EMB_EVT_CH1                    (0x01UL << TMR6_PCNAR_EMBSA_POS)    /* EMB group 1 */
+#define TMR6_EMB_EVT_CH2                    (0x02UL << TMR6_PCNAR_EMBSA_POS)    /* EMB group 2 */
+#define TMR6_EMB_EVT_CH3                    (0x03UL << TMR6_PCNAR_EMBSA_POS)    /* EMB group 3 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Emb_Release_Mode_Define TMR6 EMB Function Release Mode When EMB Event Invalid
+ * @{
+ */
+#define TMR6_EMB_RELEASE_IMMED              (0x00UL)
+#define TMR6_EMB_RELEASE_OVF                (TMR6_PCNAR_EMBRA_0)
+#define TMR6_EMB_RELEASE_UDF                (TMR6_PCNAR_EMBRA_1)
+#define TMR6_EMB_RELEASE_OVF_UDF            (TMR6_PCNAR_EMBRA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Emb_Pin_Status_Define TMR6 Pin Output Status When EMB Event Valid
+ * @{
+ */
+#define TMR6_EMB_PIN_NORMAL                 (0x00UL)
+#define TMR6_EMB_PIN_HIZ                    (TMR6_PCNAR_EMBCA_0)
+#define TMR6_EMB_PIN_LOW                    (TMR6_PCNAR_EMBCA_1)
+#define TMR6_EMB_PIN_HIGH                   (TMR6_PCNAR_EMBCA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_DeadTime_CountUp_Buf_Func_Define TMR6 Dead Time Buffer Function For Count Up Stage
+ * @{
+ */
+#define TMR6_DEADTIME_CNT_UP_BUF_OFF        (0x00UL)
+#define TMR6_DEADTIME_CNT_UP_BUF_ON         (TMR6_DCONR_DTBENU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_DeadTime_CountDown_Buf_Func_Define TMR6 Dead Time Buffer Function For Count Down Stage
+ * @{
+ */
+#define TMR6_DEADTIME_CNT_DOWN_BUF_OFF      (0x00UL)
+#define TMR6_DEADTIME_CNT_DOWN_BUF_ON       (TMR6_DCONR_DTBEND)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_DeadTime_Buf_Trans_Cond_Define TMR6 Dead Time Buffer Transfer Condition Define For Triangular Count Mode
+ * @{
+ */
+#define TMR6_DEADTIME_BUF_COND_INVD         (0x00U)
+#define TMR6_DEADTIME_BUF_COND_OVF          (TMR6_DCONR_DTBTRU)
+#define TMR6_DEADTIME_BUF_COND_UDF          (TMR6_DCONR_DTBTRD)
+#define TMR6_DEADTIME_BUF_COND_OVF_UDF      (TMR6_DCONR_DTBTRU | TMR6_DCONR_DTBTRD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_DeadTime_Reg_Equal_Func_Define TMR6 Dead Time Function DTDAR Equal DTUAR
+ * @{
+ */
+#define TMR6_DEADTIME_EQUAL_OFF             (0x00UL)
+#define TMR6_DEADTIME_EQUAL_ON              (TMR6_DCONR_SEPA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_SW_Sync_Unit_define TMR6 Software Synchronization Start/Stop/Clear/Update Unit Number Define
+ * @{
+ */
+#define TMR6_SW_SYNC_U1                     (TMR6_COMMON_SSTAR_SSTA1)
+#define TMR6_SW_SYNC_U2                     (TMR6_COMMON_SSTAR_SSTA2)
+#define TMR6_SW_SYNC_U3                     (TMR6_COMMON_SSTAR_SSTA3)
+#define TMR6_SW_SYNC_U4                     (TMR6_COMMON_SSTAR_SSTA4)
+#define TMR6_SW_SYNC_U5                     (TMR6_COMMON_SSTAR_SSTA5)
+#define TMR6_SW_SYNC_U6                     (TMR6_COMMON_SSTAR_SSTA6)
+#define TMR6_SW_SYNC_U7                     (TMR6_COMMON_SSTAR_SSTA7)
+#define TMR6_SW_SYNC_U8                     (TMR6_COMMON_SSTAR_SSTA8)
+#define TMR6_SW_SYNC_ALL                    (0xFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_hardware_start_condition_Define TMR6 Hardware Start Condition Define
+ * @{
+ */
+#define TMR6_START_COND_PWMA_RISING         (TMR6_HSTAR_HSTA0)
+#define TMR6_START_COND_PWMA_FALLING        (TMR6_HSTAR_HSTA1)
+#define TMR6_START_COND_PWMB_RISING         (TMR6_HSTAR_HSTA2)
+#define TMR6_START_COND_PWMB_FALLING        (TMR6_HSTAR_HSTA3)
+#define TMR6_START_COND_EVT0                (TMR6_HSTAR_HSTA8)
+#define TMR6_START_COND_EVT1                (TMR6_HSTAR_HSTA9)
+#define TMR6_START_COND_EVT2                (TMR6_HSTAR_HSTA10)
+#define TMR6_START_COND_EVT3                (TMR6_HSTAR_HSTA11)
+#define TMR6_START_COND_TRIGA_RISING        (TMR6_HSTAR_HSTA16)
+#define TMR6_START_COND_TRIGA_FALLING       (TMR6_HSTAR_HSTA17)
+#define TMR6_START_COND_TRIGB_RISING        (TMR6_HSTAR_HSTA18)
+#define TMR6_START_COND_TRIGB_FALLING       (TMR6_HSTAR_HSTA19)
+#define TMR6_START_COND_TRIGC_RISING        (TMR6_HSTAR_HSTA20)
+#define TMR6_START_COND_TRIGC_FALLING       (TMR6_HSTAR_HSTA21)
+#define TMR6_START_COND_TRIGD_RISING        (TMR6_HSTAR_HSTA22)
+#define TMR6_START_COND_TRIGD_FALLING       (TMR6_HSTAR_HSTA23)
+#define TMR6_START_COND_ALL                 (0x00FF0F0FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_hardware_stop_condition_Define TMR6 Hardware Stop Condition Define
+ * @{
+ */
+#define TMR6_STOP_COND_PWMA_RISING          (TMR6_HSTPR_HSTP0)
+#define TMR6_STOP_COND_PWMA_FALLING         (TMR6_HSTPR_HSTP1)
+#define TMR6_STOP_COND_PWMB_RISING          (TMR6_HSTPR_HSTP2)
+#define TMR6_STOP_COND_PWMB_FALLING         (TMR6_HSTPR_HSTP3)
+#define TMR6_STOP_COND_EVT0                 (TMR6_HSTPR_HSTP8)
+#define TMR6_STOP_COND_EVT1                 (TMR6_HSTPR_HSTP9)
+#define TMR6_STOP_COND_EVT2                 (TMR6_HSTPR_HSTP10)
+#define TMR6_STOP_COND_EVT3                 (TMR6_HSTPR_HSTP11)
+#define TMR6_STOP_COND_TRIGA_RISING         (TMR6_HSTPR_HSTP16)
+#define TMR6_STOP_COND_TRIGA_FALLING        (TMR6_HSTPR_HSTP17)
+#define TMR6_STOP_COND_TRIGB_RISING         (TMR6_HSTPR_HSTP18)
+#define TMR6_STOP_COND_TRIGB_FALLING        (TMR6_HSTPR_HSTP19)
+#define TMR6_STOP_COND_TRIGC_RISING         (TMR6_HSTPR_HSTP20)
+#define TMR6_STOP_COND_TRIGC_FALLING        (TMR6_HSTPR_HSTP21)
+#define TMR6_STOP_COND_TRIGD_RISING         (TMR6_HSTPR_HSTP22)
+#define TMR6_STOP_COND_TRIGD_FALLING        (TMR6_HSTPR_HSTP23)
+#define TMR6_STOP_COND_ALL                  (0x00FF0F0FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_hardware_clear_condition_Define TMR6 Hardware Clear Condition Define
+ * @{
+ */
+#define TMR6_CLR_COND_PWMA_RISING           (TMR6_HCLRR_HCLE0)
+#define TMR6_CLR_COND_PWMA_FALLING          (TMR6_HCLRR_HCLE1)
+#define TMR6_CLR_COND_PWMB_RISING           (TMR6_HCLRR_HCLE2)
+#define TMR6_CLR_COND_PWMB_FALLING          (TMR6_HCLRR_HCLE3)
+#define TMR6_CLR_COND_EVT0                  (TMR6_HCLRR_HCLE8)
+#define TMR6_CLR_COND_EVT1                  (TMR6_HCLRR_HCLE9)
+#define TMR6_CLR_COND_EVT2                  (TMR6_HCLRR_HCLE10)
+#define TMR6_CLR_COND_EVT3                  (TMR6_HCLRR_HCLE11)
+#define TMR6_CLR_COND_TRIGA_RISING          (TMR6_HCLRR_HCLE16)
+#define TMR6_CLR_COND_TRIGA_FALLING         (TMR6_HCLRR_HCLE17)
+#define TMR6_CLR_COND_TRIGB_RISING          (TMR6_HCLRR_HCLE18)
+#define TMR6_CLR_COND_TRIGB_FALLING         (TMR6_HCLRR_HCLE19)
+#define TMR6_CLR_COND_TRIGC_RISING          (TMR6_HCLRR_HCLE20)
+#define TMR6_CLR_COND_TRIGC_FALLING         (TMR6_HCLRR_HCLE21)
+#define TMR6_CLR_COND_TRIGD_RISING          (TMR6_HCLRR_HCLE22)
+#define TMR6_CLR_COND_TRIGD_FALLING         (TMR6_HCLRR_HCLE23)
+#define TMR6_CLR_COND_ALL                   (0x00FF0F0FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_hardware_update_condition_Define TMR6 Hardware Update Condition Define
+ * @{
+ */
+#define TMR6_UPD_COND_PWMA_RISING           (TMR6_HUPDR_HUPD0)
+#define TMR6_UPD_COND_PWMA_FALLING          (TMR6_HUPDR_HUPD1)
+#define TMR6_UPD_COND_PWMB_RISING           (TMR6_HUPDR_HUPD2)
+#define TMR6_UPD_COND_PWMB_FALLING          (TMR6_HUPDR_HUPD3)
+#define TMR6_UPD_COND_EVT0                  (TMR6_HUPDR_HUPD8)
+#define TMR6_UPD_COND_EVT1                  (TMR6_HUPDR_HUPD9)
+#define TMR6_UPD_COND_EVT2                  (TMR6_HUPDR_HUPD10)
+#define TMR6_UPD_COND_EVT3                  (TMR6_HUPDR_HUPD11)
+#define TMR6_UPD_COND_TRIGA_RISING          (TMR6_HUPDR_HUPD16)
+#define TMR6_UPD_COND_TRIGA_FALLING         (TMR6_HUPDR_HUPD17)
+#define TMR6_UPD_COND_TRIGB_RISING          (TMR6_HUPDR_HUPD18)
+#define TMR6_UPD_COND_TRIGB_FALLING         (TMR6_HUPDR_HUPD19)
+#define TMR6_UPD_COND_TRIGC_RISING          (TMR6_HUPDR_HUPD20)
+#define TMR6_UPD_COND_TRIGC_FALLING         (TMR6_HUPDR_HUPD21)
+#define TMR6_UPD_COND_TRIGD_RISING          (TMR6_HUPDR_HUPD22)
+#define TMR6_UPD_COND_TRIGD_FALLING         (TMR6_HUPDR_HUPD23)
+#define TMR6_UPD_COND_ALL                   (0x00FF0F0FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_hardware_capture_condition_Define TMR6 Hardware Capture Condition Define
+ * @{
+ */
+#define TMR6_CAPT_COND_PWMA_RISING          (TMR6_HCPAR_HCPA0)
+#define TMR6_CAPT_COND_PWMA_FALLING         (TMR6_HCPAR_HCPA1)
+#define TMR6_CAPT_COND_PWMB_RISING          (TMR6_HCPAR_HCPA2)
+#define TMR6_CAPT_COND_PWMB_FALLING         (TMR6_HCPAR_HCPA3)
+#define TMR6_CAPT_COND_EVT0                 (TMR6_HCPAR_HCPA8)
+#define TMR6_CAPT_COND_EVT1                 (TMR6_HCPAR_HCPA9)
+#define TMR6_CAPT_COND_EVT2                 (TMR6_HCPAR_HCPA10)
+#define TMR6_CAPT_COND_EVT3                 (TMR6_HCPAR_HCPA11)
+#define TMR6_CAPT_COND_TRIGA_RISING         (TMR6_HCPAR_HCPA16)
+#define TMR6_CAPT_COND_TRIGA_FALLING        (TMR6_HCPAR_HCPA17)
+#define TMR6_CAPT_COND_TRIGB_RISING         (TMR6_HCPAR_HCPA18)
+#define TMR6_CAPT_COND_TRIGB_FALLING        (TMR6_HCPAR_HCPA19)
+#define TMR6_CAPT_COND_TRIGC_RISING         (TMR6_HCPAR_HCPA20)
+#define TMR6_CAPT_COND_TRIGC_FALLING        (TMR6_HCPAR_HCPA21)
+#define TMR6_CAPT_COND_TRIGD_RISING         (TMR6_HCPAR_HCPA22)
+#define TMR6_CAPT_COND_TRIGD_FALLING        (TMR6_HCPAR_HCPA23)
+#define TMR6_CAPT_COND_ALL                  (0x00FF0F0FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_HW_Count_Up_Cond_Define TMR6 Hardware Count Up Condition Define
+ * @{
+ */
+#define TMR6_CNT_UP_COND_INVD                       (0U)
+#define TMR6_CNT_UP_COND_PWMA_LOW_PWMB_RISING       (TMR6_HCUPR_HCUP0)
+#define TMR6_CNT_UP_COND_PWMA_LOW_PWMB_FALLING      (TMR6_HCUPR_HCUP1)
+#define TMR6_CNT_UP_COND_PWMA_HIGH_PWMB_RISING      (TMR6_HCUPR_HCUP2)
+#define TMR6_CNT_UP_COND_PWMA_HIGH_PWMB_FALLING     (TMR6_HCUPR_HCUP3)
+#define TMR6_CNT_UP_COND_PWMB_LOW_PWMA_RISING       (TMR6_HCUPR_HCUP4)
+#define TMR6_CNT_UP_COND_PWMB_LOW_PWMA_FALLING      (TMR6_HCUPR_HCUP5)
+#define TMR6_CNT_UP_COND_PWMB_HIGH_PWMA_RISING      (TMR6_HCUPR_HCUP6)
+#define TMR6_CNT_UP_COND_PWMB_HIGH_PWMA_FALLING     (TMR6_HCUPR_HCUP7)
+#define TMR6_CNT_UP_COND_EVT0                       (TMR6_HCUPR_HCUP8)
+#define TMR6_CNT_UP_COND_EVT1                       (TMR6_HCUPR_HCUP9)
+#define TMR6_CNT_UP_COND_EVT2                       (TMR6_HCUPR_HCUP10)
+#define TMR6_CNT_UP_COND_EVT3                       (TMR6_HCUPR_HCUP11)
+#define TMR6_CNT_UP_COND_TRIGA_RISING               (TMR6_HCUPR_HCUP16)
+#define TMR6_CNT_UP_COND_TRIGA_FALLING              (TMR6_HCUPR_HCUP17)
+#define TMR6_CNT_UP_COND_TRIGB_RISING               (TMR6_HCUPR_HCUP18)
+#define TMR6_CNT_UP_COND_TRIGB_FALLING              (TMR6_HCUPR_HCUP19)
+#define TMR6_CNT_UP_COND_TRIGC_RISING               (TMR6_HCUPR_HCUP20)
+#define TMR6_CNT_UP_COND_TRIGC_FALLING              (TMR6_HCUPR_HCUP21)
+#define TMR6_CNT_UP_COND_TRIGD_RISING               (TMR6_HCUPR_HCUP22)
+#define TMR6_CNT_UP_COND_TRIGD_FALLING              (TMR6_HCUPR_HCUP23)
+#define TMR6_CNT_UP_COND_ALL                        (0x00FF0FFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_HW_Count_Down_Cond_Define TMR6 Hardware Count Down Condition Define
+ * @{
+ */
+#define TMR6_CNT_DOWN_COND_INVD                     (0U)
+#define TMR6_CNT_DOWN_COND_PWMA_LOW_PWMB_RISING     (TMR6_HCDOR_HCDO0)
+#define TMR6_CNT_DOWN_COND_PWMA_LOW_PWMB_FALLING    (TMR6_HCDOR_HCDO1)
+#define TMR6_CNT_DOWN_COND_PWMA_HIGH_PWMB_RISING    (TMR6_HCDOR_HCDO2)
+#define TMR6_CNT_DOWN_COND_PWMA_HIGH_PWMB_FALLING   (TMR6_HCDOR_HCDO3)
+#define TMR6_CNT_DOWN_COND_PWMB_LOW_PWMA_RISING     (TMR6_HCDOR_HCDO4)
+#define TMR6_CNT_DOWN_COND_PWMB_LOW_PWMA_FALLING    (TMR6_HCDOR_HCDO5)
+#define TMR6_CNT_DOWN_COND_PWMB_HIGH_PWMA_RISING    (TMR6_HCDOR_HCDO6)
+#define TMR6_CNT_DOWN_COND_PWMB_HIGH_PWMA_FALLING   (TMR6_HCDOR_HCDO7)
+#define TMR6_CNT_DOWN_COND_EVT0                     (TMR6_HCDOR_HCDO8)
+#define TMR6_CNT_DOWN_COND_EVT1                     (TMR6_HCDOR_HCDO9)
+#define TMR6_CNT_DOWN_COND_EVT2                     (TMR6_HCDOR_HCDO10)
+#define TMR6_CNT_DOWN_COND_EVT3                     (TMR6_HCDOR_HCDO11)
+#define TMR6_CNT_DOWN_COND_TRIGA_RISING             (TMR6_HCDOR_HCDO16)
+#define TMR6_CNT_DOWN_COND_TRIGA_FALLING            (TMR6_HCDOR_HCDO17)
+#define TMR6_CNT_DOWN_COND_TRIGB_RISING             (TMR6_HCDOR_HCDO18)
+#define TMR6_CNT_DOWN_COND_TRIGB_FALLING            (TMR6_HCDOR_HCDO19)
+#define TMR6_CNT_DOWN_COND_TRIGC_RISING             (TMR6_HCDOR_HCDO20)
+#define TMR6_CNT_DOWN_COND_TRIGC_FALLING            (TMR6_HCDOR_HCDO21)
+#define TMR6_CNT_DOWN_COND_TRIGD_RISING             (TMR6_HCDOR_HCDO22)
+#define TMR6_CNT_DOWN_COND_TRIGD_FALLING            (TMR6_HCDOR_HCDO23)
+#define TMR6_CNT_DOWN_COND_ALL                      (0x00FF0FFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Dir_Define TMR6 Base Counter Function Direction Define
+ * @{
+ */
+#define TMR6_CNT_UP                         (TMR6_GCONR_DIR)
+#define TMR6_CNT_DOWN                       (0x00UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Dir_Status_Define TMR6 Count Direction Status Define
+ * @{
+ */
+#define TMR6_STAT_CNT_UP                    (TMR6_STFLR_DIRF)
+#define TMR6_STAT_CNT_DOWN                  (0x00UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Mode_Define TMR6 Base Counter Function Mode Define
+ * @{
+ */
+#define TMR6_MD_SAWTOOTH                    (0x00UL)
+#define TMR6_MD_TRIANGLE                    (TMR6_GCONR_MODE)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Clock_Define TMR6 Base Counter Clock Source Define
+ * @{
+ */
+#define TMR6_CLK_DIV1                       (0x00UL)
+#define TMR6_CLK_DIV2                       (0x01UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV4                       (0x02UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV8                       (0x03UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV16                      (0x04UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV32                      (0x05UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV64                      (0x06UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV128                     (0x07UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV256                     (0x08UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV512                     (0x09UL << TMR6_GCONR_CKDIV_POS)
+#define TMR6_CLK_DIV1024                    (0x0AUL << TMR6_GCONR_CKDIV_POS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Count_Reload_Define TMR6 Count Stop After Overflow Function Define
+ * @{
+ */
+#define TMR6_CNT_RELOAD_ON                  (0x00UL)
+#define TMR6_CNT_RELOAD_OFF                 (TMR6_GCONR_OVSTP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Zmask_Cycle_Define TMR6 Z Mask Input Function Mask Cycles Number Define
+ * @{
+ */
+#define TMR6_ZMASK_FUNC_INVD                (0x00UL)
+#define TMR6_ZMASK_CYCLE_4                  (TMR6_GCONR_ZMSKVAL_0)
+#define TMR6_ZMASK_CYCLE_8                  (TMR6_GCONR_ZMSKVAL_1)
+#define TMR6_ZMASK_CYCLE_16                 (TMR6_GCONR_ZMSKVAL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Zmask_Pos_Unit_Clear_Func_Define TMR6 Unit As Position Timer, Z Phase Input Mask Function Define For Clear Action
+ * @{
+ */
+#define TMR6_POS_CLR_ZMASK_FUNC_OFF         (0x00UL)
+#define TMR6_POS_CLR_ZMASK_FUNC_ON          (TMR6_GCONR_ZMSKPOS)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR6_Zmask_Revo_Unit_Count_Func_Define TMR6 Unit As Revolution Timer, Z Phase Input Mask Function Define For Count Action
+ * @{
+ */
+#define TMR6_REVO_CNT_ZMASK_FUNC_OFF        (0x00UL)
+#define TMR6_REVO_CNT_ZMASK_FUNC_ON         (TMR6_GCONR_ZMSKREV)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TMR6_Global_Functions
+ * @{
+ */
+/**
+ * @brief  Get Software Sync start status
+ * @param  None
+ * @retval uint32_t                 Data indicate the read status.
+ */
+__STATIC_INLINE uint32_t TMR6_GetSWSyncStartStatus(void)
+{
+    return READ_REG32(CM_TMR6_COMMON->SSTAR);
+}
+
+/* Base count */
+int32_t TMR6_StructInit(stc_tmr6_init_t *pstcTmr6Init);
+int32_t TMR6_Init(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_init_t *pstcTmr6Init);
+
+void TMR6_SetCountMode(CM_TMR6_TypeDef *TMR6x, uint32_t u32Mode);
+void TMR6_SetCountDir(CM_TMR6_TypeDef *TMR6x, uint32_t u32Dir);
+uint32_t TMR6_GetCountDir(CM_TMR6_TypeDef *TMR6x);
+void TMR6_SetClockDiv(CM_TMR6_TypeDef *TMR6x, uint32_t u32Div);
+void TMR6_CountReloadCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+
+/* Hardware count */
+void TMR6_HWCountUpCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR6_HWCountDownCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+
+/* PWM output */
+int32_t TMR6_PWM_StructInit(stc_tmr6_pwm_init_t *pstcPwmInit);
+int32_t TMR6_PWM_Init(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_pwm_init_t *pstcPwmInit);
+void TMR6_PWM_OutputCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR6_PWM_SetPolarity(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32CountState, uint32_t u32Polarity);
+void TMR6_PWM_SetForcePolarity(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Polarity);
+
+/* Input capture */
+void TMR6_HWCaptureCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState);
+
+/* Pin config */
+void TMR6_SetFilterClockDiv(CM_TMR6_TypeDef *TMR6x, uint32_t u32Pin, uint32_t u32Div);
+void TMR6_FilterCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Pin, en_functional_state_t enNewState);
+void TMR6_SetFunc(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Func);
+
+/* Universal */
+void TMR6_IntCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32IntType, en_functional_state_t enNewState);
+en_flag_status_t TMR6_GetStatus(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Flag);
+void TMR6_ClearStatus(CM_TMR6_TypeDef *TMR6x, uint32_t u32Flag);
+uint32_t TMR6_GetPeriodNum(const CM_TMR6_TypeDef *TMR6x);
+void TMR6_DeInit(CM_TMR6_TypeDef *TMR6x);
+void TMR6_Start(CM_TMR6_TypeDef *TMR6x);
+void TMR6_Stop(CM_TMR6_TypeDef *TMR6x);
+
+/* Register write */
+void TMR6_SetCountValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Value);
+void TMR6_SetUpdateValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Value);
+void TMR6_SetPeriodValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value);
+void TMR6_SetCompareValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value);
+void TMR6_SetSpecialCompareValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value);
+void TMR6_SetDeadTimeValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value);
+
+/* Register read */
+uint32_t TMR6_GetCountValue(const CM_TMR6_TypeDef *TMR6x);
+uint32_t TMR6_GetUpdateValue(const CM_TMR6_TypeDef *TMR6x);
+uint32_t TMR6_GetPeriodValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index);
+uint32_t TMR6_GetCompareValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index);
+uint32_t TMR6_GetSpecialCompareValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index);
+uint32_t TMR6_GetDeadTimeValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index);
+
+/* Buffer function */
+int32_t TMR6_GeneralBufConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_buf_config_t *pstcBufConfig);
+int32_t TMR6_PeriodBufConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_buf_config_t *pstcBufConfig);
+
+int32_t TMR6_SpecialBufConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_buf_config_t *pstcBufConfig);
+void TMR6_GeneralBufCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR6_SpecialBufCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR6_PeriodBufCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+
+/* Extend function */
+int32_t TMR6_ValidPeriodConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_valid_period_config_t *pstcValidperiodConfig);
+void TMR6_ValidPeriodCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMR6_DeadTimeFuncCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+int32_t TMR6_DeadTimeConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_deadtime_config_t *pstcDeadTimeConfig);
+int32_t TMR6_ZMaskConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_zmask_config_t *pstcZMaskConfig);
+int32_t TMR6_EMBConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_emb_config_t *pstcEmbConfig);
+int32_t TMR6_BufFuncStructInit(stc_tmr6_buf_config_t *pstcBufConfig);
+int32_t TMR6_ValidPeriodStructInit(stc_tmr6_valid_period_config_t *pstcValidperiodConfig);
+int32_t TMR6_EMBConfigStructInit(stc_tmr6_emb_config_t *pstcEmbConfig);
+int32_t TMR6_DeadTimeStructInit(stc_tmr6_deadtime_config_t *pstcDeadTimeConfig);
+int32_t TMR6_ZMaskConfigStructInit(stc_tmr6_zmask_config_t *pstcZMaskConfig);
+
+/* Software synchronous control */
+void TMR6_SWSyncStart(uint32_t u32Unit);
+void TMR6_SWSyncStop(uint32_t u32Unit);
+void TMR6_SWSyncClear(uint32_t u32Unit);
+void TMR6_SWSyncUpdate(uint32_t u32Unit);
+
+/* Hardware control */
+void TMR6_HWStartCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR6_HWStartCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+void TMR6_HWStopCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR6_HWStopCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+void TMR6_HWClearCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR6_HWClearCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+void TMR6_HWUpdateCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState);
+void TMR6_HWUpdateCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState);
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR6_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TMR6_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_tmra.h
+++ b/hc32f4a2/inc/hc32_ll_tmra.h
@@ -1,0 +1,546 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmra.h
+ * @brief This file contains all the functions prototypes of the TMRA(TimerA)
+ *        driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Comments optimization
+   2023-06-30       CDT             Modify typo
+                                    Update about split 16bit register TMRA_BCSTR into two 8bit registers TMRA_BCSTRH and TMRA_BCSTRL
+                                    Delete union in stc_tmra_init_t structure
+   2023-09-30       CDT             Modify some of member type of struct stc_tmra_init_t and relate function about these member
+                                    Modify macro-definition value for group TMRA_Interrupt_Type/TMRA_Status_Flag
+   2024-06-30       CDT             API TMRA_DeInit() added return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TMRA_H__
+#define __HC32_LL_TMRA_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TMRA
+ * @{
+ */
+
+#if (LL_TMRA_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup TMRA_Global_Types TMRA Global Types
+ * @{
+ */
+/**
+ * @brief TMRA initialization structure.
+ */
+typedef struct {
+    uint8_t u8CountSrc;                     /*!< Specifies the count source of TMRA.
+                                                 This parameter can be a value of @ref TMRA_Count_Src */
+    struct {
+        uint8_t u8ClockDiv;                 /*!< Specifies the divider of software clock source.
+                                                 This parameter can be a value of @ref TMRA_Clock_Divider */
+        uint8_t u8CountMode;                /*!< Specifies count mode.
+                                                 This parameter can be a value of @ref TMRA_Count_Mode */
+        uint8_t u8CountDir;                 /*!< Specifies count direction.
+                                                    This parameter can be a value of @ref TMRA_Count_Dir */
+    } sw_count;
+    struct {
+        uint16_t u16CountUpCond;            /*!< Hardware count up condition.
+                                                 This parameter can be a value of @ref TMRA_Hard_Count_Up_Condition */
+        uint16_t u16CountDownCond;          /*!< Hardware count down condition.
+                                                 This parameter can be a value of @ref TMRA_Hard_Count_Down_Condition */
+    } hw_count;
+    uint32_t u32PeriodValue;                /*!< Specifies the period reference value.
+                                                 This parameter can be a number between 0U and 0xFFFFU, inclusive. */
+    uint8_t u8CountReload;                  /*!< Continue counting or stop when counter overflow/underflow.
+                                                 This parameter can be a value of @ref TMRA_Count_Reload_En */
+} stc_tmra_init_t;
+
+/**
+ * @brief TMRA PWM configuration structure.
+ */
+typedef struct {
+    uint32_t u32CompareValue;               /*!< Specifies compare value of the TMRA channel.
+                                                 This parameter can be a number between:
+                                                 0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+                                                 0UL and 0xFFFFUL for 16-bit TimerA units. */
+    uint16_t u16StartPolarity;              /*!< Specifies the polarity when the counter start counting.
+                                                 This parameter can be a value of @ref TMRA_PWM_Polarity
+                                                 NOTE: CAN NOT be specified as TMRA_PWM_LOW or TMRA_PWM_HIGH when
+                                                       sw_count.u16ClockDiv of @ref stc_tmra_init_t is NOT specified
+                                                       as @ref TMRA_CLK_DIV1 */
+    uint16_t u16StopPolarity;               /*!< Specifies the polarity when the counter stop counting.
+                                                 This parameter can be a value of @ref TMRA_PWM_Polarity */
+    uint16_t u16CompareMatchPolarity;       /*!< Specifies the polarity when the counter matches the compare register.
+                                                 This parameter can be a value of @ref TMRA_PWM_Polarity */
+    uint16_t u16PeriodMatchPolarity;        /*!< Specifies the polarity when the counter matches the period register.
+                                                 This parameter can be a value of @ref TMRA_PWM_Polarity */
+} stc_tmra_pwm_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMRA_Global_Macros TMRA Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMRA_Count_Src TMRA Count Source
+ * @{
+ */
+#define TMRA_CNT_SRC_SW                     (0U)                        /*!< Clock source is PCLK. */
+#define TMRA_CNT_SRC_HW                     (1U)                        /*!< Clock source is from external pin or peripheral event. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Channel TMRA Channel
+ * @{
+ */
+#define TMRA_CH1                            (0U)                        /*!< Channel 1 of TMRA. */
+#define TMRA_CH2                            (1U)                        /*!< Channel 2 of TMRA. */
+#define TMRA_CH3                            (2U)                        /*!< Channel 3 of TMRA. */
+#define TMRA_CH4                            (3U)                        /*!< Channel 4 of TMRA. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Count_Dir TMRA Count Direction
+ * @{
+ */
+#define TMRA_DIR_DOWN                       (0x0U)                      /*!< TMRA count down. */
+#define TMRA_DIR_UP                         (TMRA_BCSTRL_DIR)           /*!< TMRA count up. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Count_Mode TMRA Count Mode
+ * @{
+ */
+#define TMRA_MD_SAWTOOTH                    (0x0U)                      /*!< Count mode is sawtooth wave. */
+#define TMRA_MD_TRIANGLE                    (TMRA_BCSTRL_MODE)          /*!< Count mode is triangle wave. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Function_Mode TMRA TMRA Function Mode
+ * @{
+ */
+#define TMRA_FUNC_CMP                       (0x0U)                      /*!< Function mode of TMRA channel is output compare. */
+#define TMRA_FUNC_CAPT                      (TMRA_CCONR_CAPMD)          /*!< Function mode of TMRA channel is input capture. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Count_Reload_En TMRA Count Reload
+ * @{
+ */
+#define TMRA_CNT_RELOAD_DISABLE             (TMRA_BCSTRH_OVSTP)         /*!< Stop when counter overflow/underflow. */
+#define TMRA_CNT_RELOAD_ENABLE              (0U)                        /*!< When counter overflow/underflow, counter reload to continue counting. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Clock_Divider TMRA Clock Divider
+ * @{
+ */
+#define TMRA_CLK_DIV1                       (0x0U)                              /*!< The clock source of TMRA is PCLK. */
+#define TMRA_CLK_DIV2                       (0x1U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 2. */
+#define TMRA_CLK_DIV4                       (0x2U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 4. */
+#define TMRA_CLK_DIV8                       (0x3U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 8. */
+#define TMRA_CLK_DIV16                      (0x4U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 16. */
+#define TMRA_CLK_DIV32                      (0x5U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 32. */
+#define TMRA_CLK_DIV64                      (0x6U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 64. */
+#define TMRA_CLK_DIV128                     (0x7U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 128. */
+#define TMRA_CLK_DIV256                     (0x8U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 256. */
+#define TMRA_CLK_DIV512                     (0x9U << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 512. */
+#define TMRA_CLK_DIV1024                    (0xAU << TMRA_BCSTRL_CKDIV_POS)     /*!< The clock source of TMRA is PCLK / 1024. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Filter_Pin TMRA Pin With Filter
+ * @{
+ */
+#define TMRA_PIN_TRIG                       (0U)                        /*!< Pin TIMA_<t>_TRIG. */
+#define TMRA_PIN_CLKA                       (1U)                        /*!< Pin TIMA_<t>_CLKA. */
+#define TMRA_PIN_CLKB                       (2U)                        /*!< Pin TIMA_<t>_CLKB. */
+#define TMRA_PIN_PWM1                       (3U)                        /*!< Pin TIMA_<t>_PWM1. */
+#define TMRA_PIN_PWM2                       (4U)                        /*!< Pin TIMA_<t>_PWM2. */
+#define TMRA_PIN_PWM3                       (5U)                        /*!< Pin TIMA_<t>_PWM3. */
+#define TMRA_PIN_PWM4                       (6U)                        /*!< Pin TIMA_<t>_PWM4. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Hard_Count_Up_Condition TMRA Hardware Count Up Condition
+ * @note Symmetric units: unit 1 and 2; unit 3 and 4; ...; unit 11 and 12.
+ * @{
+ */
+#define TMRA_CNT_UP_COND_INVD                        (0U)                    /*!< TMRA hardware count up condition is INVALID. */
+#define TMRA_CNT_UP_COND_CLKA_LOW_CLKB_RISING        (TMRA_HCUPR_HCUP0)      /*!< When CLKA is low, a rising edge is sampled on CLKB, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKA_LOW_CLKB_FALLING       (TMRA_HCUPR_HCUP1)      /*!< When CLKA is low, a falling edge is sampled on CLKB, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKA_HIGH_CLKB_RISING       (TMRA_HCUPR_HCUP2)      /*!< When CLKA is high, a rising edge is sampled on CLKB, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKA_HIGH_CLKB_FALLING      (TMRA_HCUPR_HCUP3)      /*!< When CLKA is high, a falling edge is sampled on CLKB, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKB_LOW_CLKA_RISING        (TMRA_HCUPR_HCUP4)      /*!< When CLKB is low, a rising edge is sampled on CLKA, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKB_LOW_CLKA_FALLING       (TMRA_HCUPR_HCUP5)      /*!< When CLKB is low, a falling edge is sampled on CLKA, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKB_HIGH_CLKA_RISING       (TMRA_HCUPR_HCUP6)      /*!< When CLKB is high, a rising edge is sampled on CLKA, the counter register counts up. */
+#define TMRA_CNT_UP_COND_CLKB_HIGH_CLKA_FALLING      (TMRA_HCUPR_HCUP7)      /*!< When CLKB is high, a falling edge is sampled on CLKA, the counter register counts up. */
+#define TMRA_CNT_UP_COND_TRIG_RISING                 (TMRA_HCUPR_HCUP8)      /*!< When a rising edge occurred on TRIG, the counter register counts up. */
+#define TMRA_CNT_UP_COND_TRIG_FALLING                (TMRA_HCUPR_HCUP9)      /*!< When a falling edge occurred on TRIG, the counter register counts up. */
+#define TMRA_CNT_UP_COND_EVT                         (TMRA_HCUPR_HCUP10)     /*!< When the TMRA common trigger event occurred, the counter register counts up. */
+#define TMRA_CNT_UP_COND_SYM_OVF                     (TMRA_HCUPR_HCUP11)     /*!< When the symmetric unit overflow, the counter register counts up. */
+#define TMRA_CNT_UP_COND_SYM_UDF                     (TMRA_HCUPR_HCUP12)     /*!< When the symmetric unit underflow, the counter register counts up. */
+#define TMRA_CNT_UP_COND_ALL                         (0x1FFFU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Hard_Count_Down_Condition TMRA Hardware Count Down Condition
+ * @note Symmetric units: unit 1 and 2; unit 3 and 4; ...; unit 11 and 12.
+ * @{
+ */
+#define TMRA_CNT_DOWN_COND_INVD                      (0U)                    /*!< TMRA hardware count down condition is INVALID. */
+#define TMRA_CNT_DOWN_COND_CLKA_LOW_CLKB_RISING      (TMRA_HCDOR_HCDO0)      /*!< When CLKA is low, a rising edge is sampled on CLKB, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKA_LOW_CLKB_FALLING     (TMRA_HCDOR_HCDO1)      /*!< When CLKA is low, a falling edge is sampled on CLKB, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKA_HIGH_CLKB_RISING     (TMRA_HCDOR_HCDO2)      /*!< When CLKA is high, a rising edge is sampled on CLKB, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKA_HIGH_CLKB_FALLING    (TMRA_HCDOR_HCDO3)      /*!< When CLKA is high, a falling edge is sampled on CLKB, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKB_LOW_CLKA_RISING      (TMRA_HCDOR_HCDO4)      /*!< When CLKB is low, a rising edge is sampled on CLKA, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKB_LOW_CLKA_FALLING     (TMRA_HCDOR_HCDO5)      /*!< When CLKB is low, a falling edge is sampled on CLKA, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKB_HIGH_CLKA_RISING     (TMRA_HCDOR_HCDO6)      /*!< When CLKB is high, a rising edge is sampled on CLKA, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_CLKB_HIGH_CLKA_FALLING    (TMRA_HCDOR_HCDO7)      /*!< When CLKB is high, a falling edge is sampled on CLKA, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_TRIG_RISING               (TMRA_HCDOR_HCDO8)      /*!< When a rising edge occurred on TRIG, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_TRIG_FALLING              (TMRA_HCDOR_HCDO9)      /*!< When a falling edge occurred on TRIG, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_EVT                       (TMRA_HCDOR_HCDO10)     /*!< When the TMRA common trigger event occurred, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_SYM_OVF                   (TMRA_HCDOR_HCDO11)     /*!< When the symmetric unit overflow, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_SYM_UDF                   (TMRA_HCDOR_HCDO12)     /*!< When the symmetric unit underflow, the counter register counts down. */
+#define TMRA_CNT_DOWN_COND_ALL                       (0x1FFFU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Interrupt_Type TMRA Interrupt Type
+ * @{
+ */
+#define TMRA_INT_OVF                        (1UL << 4U)                 /*!< The interrupt of counting overflow. */
+#define TMRA_INT_UDF                        (1UL << 5U)                 /*!< The interrupt of counting underflow. */
+#define TMRA_INT_CMP_CH1                    (1UL << 16U)                /*!< The interrupt of compare-match of channel 1. */
+#define TMRA_INT_CMP_CH2                    (1UL << 17U)                /*!< The interrupt of compare-match of channel 2. */
+#define TMRA_INT_CMP_CH3                    (1UL << 18U)                /*!< The interrupt of compare-match of channel 3. */
+#define TMRA_INT_CMP_CH4                    (1UL << 19U)                /*!< The interrupt of compare-match of channel 4. */
+#define TMRA_INT_ALL                        (0xF0030UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Event_Type TMRA Event Type
+ * @{
+ */
+#define TMRA_EVT_CMP_CH1                    (TMRA_ECONR_ETEN1)          /*!< The event of compare-match of channel 1. */
+#define TMRA_EVT_CMP_CH2                    (TMRA_ECONR_ETEN2)          /*!< The event of compare-match of channel 2. */
+#define TMRA_EVT_CMP_CH3                    (TMRA_ECONR_ETEN3)          /*!< The event of compare-match of channel 3. */
+#define TMRA_EVT_CMP_CH4                    (TMRA_ECONR_ETEN4)          /*!< The event of compare-match of channel 4. */
+#define TMRA_EVT_ALL                        (TMRA_EVT_CMP_CH1 | TMRA_EVT_CMP_CH2 | \
+                                             TMRA_EVT_CMP_CH3 | TMRA_EVT_CMP_CH4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Status_Flag TMRA Status Flag
+ * @{
+ */
+#define TMRA_FLAG_OVF                       (1UL << 6U)                 /*!< The flag of counting overflow. */
+#define TMRA_FLAG_UDF                       (1UL << 7U)                 /*!< The flag of counting underflow. */
+#define TMRA_FLAG_CMP_CH1                   (1UL << 16U)                /*!< The flag of compare-match of channel 1. */
+#define TMRA_FLAG_CMP_CH2                   (1UL << 17U)                /*!< The flag of compare-match of channel 2. */
+#define TMRA_FLAG_CMP_CH3                   (1UL << 18U)                /*!< The flag of compare-match of channel 3. */
+#define TMRA_FLAG_CMP_CH4                   (1UL << 19U)                /*!< The flag of compare-match of channel 4. */
+#define TMRA_FLAG_ALL                       (0xF00C0UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Capture_Cond TMRA Capture Condition
+ * @note 'TMRA_CAPT_COND_TRIG_RISING' and 'TMRA_CAPT_COND_TRIG_FALLING' are only valid for channel 4.
+ * @{
+ */
+#define TMRA_CAPT_COND_INVD                 (0x0U)                      /*!< The condition of capture is INVALID. */
+#define TMRA_CAPT_COND_PWM_RISING           (TMRA_CCONR_HICP0)          /*!< The condition of capture is a rising edge is sampled on pin TIMA_<t>_PWMn. */
+#define TMRA_CAPT_COND_PWM_FALLING          (TMRA_CCONR_HICP1)          /*!< The condition of capture is a falling edge is sampled on pin TIMA_<t>_PWMn. */
+#define TMRA_CAPT_COND_EVT                  (TMRA_CCONR_HICP2)          /*!< The condition of capture is the specified event occurred. */
+#define TMRA_CAPT_COND_TRIG_RISING          (TMRA_CCONR_HICP3)          /*!< The condition of capture is a rising edge is sampled on pin TIMA_<t>_TRIG.
+                                                                            This condition is only valid for channel 4. */
+#define TMRA_CAPT_COND_TRIG_FALLING         (TMRA_CCONR_HICP4)          /*!< The condition of capture is a falling edge is sampled on pin TIMA_<t>_TRIG.
+                                                                            This condition is only valid for channel 4. */
+#define TMRA_CAPT_COND_ALL                  (TMRA_CAPT_COND_PWM_RISING | TMRA_CAPT_COND_PWM_FALLING | \
+                                             TMRA_CAPT_COND_EVT | TMRA_CAPT_COND_TRIG_RISING | \
+                                             TMRA_CAPT_COND_TRIG_FALLING)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Cmp_Value_Buf_Trans_Cond TMRA Compare Value Buffer Transmission Condition
+ * @{
+ */
+#define TMRA_BUF_TRANS_COND_OVF_UDF_CLR     (0x0U)                      /*!< This configuration value applies to non-triangular wave counting mode.
+                                                                             When counting overflow or underflow or counting register was cleared,
+                                                                             transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,...). */
+#define TMRA_BUF_TRANS_COND_PEAK            (TMRA_BCONR_BSE0)           /*!< In triangle wave count mode, when count reached peak,
+                                                                             transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,...). */
+#define TMRA_BUF_TRANS_COND_VALLEY          (TMRA_BCONR_BSE1)           /*!< In triangle wave count mode, when count reached valley,
+                                                                             transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,.... */
+#define TMRA_BUF_TRANS_COND_PEAK_VALLEY     (TMRA_BCONR_BSE1 | \
+                                             TMRA_BCONR_BSE0)           /*!< In triangle wave count mode, when count reached peak or valley,
+                                                                             transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,...). */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Filter_Clock_Divider TMRA Filter Clock Divider
+ * @{
+ */
+#define TMRA_FILTER_CLK_DIV1                (0x0U)                      /*!< The filter clock is the clock of TimerA / 1 */
+#define TMRA_FILTER_CLK_DIV4                (0x1U)                      /*!< The filter clock is the clock of TimerA / 4 */
+#define TMRA_FILTER_CLK_DIV16               (0x2U)                      /*!< The filter clock is the clock of TimerA / 16 */
+#define TMRA_FILTER_CLK_DIV64               (0x3U)                      /*!< The filter clock is the clock of TimerA / 64 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Counter_State TMRA Counter State
+ * @{
+ */
+#define TMRA_CNT_STAT_START                 (0U)                        /*!< Counter start counting. */
+#define TMRA_CNT_STAT_STOP                  (1U)                        /*!< Counter stop counting. */
+#define TMRA_CNT_STAT_MATCH_CMP             (2U)                        /*!< Counter value matches the compare value. */
+#define TMRA_CNT_STAT_MATCH_PERIOD          (3U)                        /*!< Counter value matches the period value. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_PWM_Polarity TMRA PWM Polarity
+ * @{
+ */
+#define TMRA_PWM_LOW                        (0x0U)                      /*!< PWM output low. */
+#define TMRA_PWM_HIGH                       (0x1U)                      /*!< PWM output high. */
+#define TMRA_PWM_HOLD                       (0x2U)                      /*!< PWM output holds the current polarity. */
+#define TMRA_PWM_INVT                       (0x3U)                      /*!< PWM output reverses the current polarity. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_PWM_Force_Polarity TMRA PWM Force Polarity
+ * @{
+ */
+#define TMRA_PWM_FORCE_INVD                 (0x0U)                      /*!< Force polarity is invalid. */
+#define TMRA_PWM_FORCE_LOW                  (TMRA_PCONR_FORC_1)         /*!< Force the PWM output low at the beginning of the next cycle.
+                                                                             The beginning of the next cycle: overflow position or underflow position
+                                                                             of sawtooth wave; valley position of triangle wave. */
+#define TMRA_PWM_FORCE_HIGH                 (TMRA_PCONR_FORC)           /*!< Force the PWM output high at the beginning of the next cycle.
+                                                                             The beginning of the next cycle: overflow position or underflow position
+                                                                             of sawtooth wave; valley position of triangle wave. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Hardware_Start_Condition TMRA Hardware Start Condition
+ * @{
+ */
+#define TMRA_START_COND_INVD                (0x0U)                      /*!< The condition of start is INVALID. */
+#define TMRA_START_COND_TRIG_RISING         (TMRA_HCONR_HSTA0)          /*!< 1. Sync start is invalid: The condition is that a rising edge is sampled on TRIG of the current TMRA unit.
+                                                                             2. Sync start is valid: The condition is that a rising edge is sampled on TRIG of the symmetric TMRA unit. */
+#define TMRA_START_COND_TRIG_FALLING        (TMRA_HCONR_HSTA1)          /*!< 1. Sync start is invalid: The condition is that a falling edge is sampled on TRIG of the current TMRA unit.
+                                                                             2. Sync start is valid: The condition is that a falling edge is sampled on TRIG of the symmetric TMRA unit. */
+#define TMRA_START_COND_EVT                 (TMRA_HCONR_HSTA2)          /*!< The condition is that the TMRA common trigger event has occurred. */
+#define TMRA_START_COND_ALL                 (TMRA_START_COND_TRIG_RISING | TMRA_START_COND_TRIG_FALLING | \
+                                             TMRA_START_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Hardware_Stop_Condition TMRA Hardware Stop Condition
+ * @{
+ */
+#define TMRA_STOP_COND_INVD                 (0x0U)                      /*!< The condition of stop is INVALID. */
+#define TMRA_STOP_COND_TRIG_RISING          (TMRA_HCONR_HSTP0)          /*!< The condition is that a rising edge is sampled on pin TRIG of the current TMRA unit. */
+#define TMRA_STOP_COND_TRIG_FALLING         (TMRA_HCONR_HSTP1)          /*!< The condition is that a falling edge is sampled on pin TRIG of the current TMRA unit. */
+#define TMRA_STOP_COND_EVT                  (TMRA_HCONR_HSTP2)          /*!< The condition is that the TMRA common trigger event has occurred. */
+#define TMRA_STOP_COND_ALL                  (TMRA_STOP_COND_TRIG_RISING | TMRA_STOP_COND_TRIG_FALLING | \
+                                             TMRA_STOP_COND_EVT)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Hardware_Clear_Condition TMRA Hardware Clear Condition
+ * @note Symmetric units: unit 1 and 2; unit 3 and 4; ... ; unit 11 and 12.
+ * @{
+ */
+#define TMRA_CLR_COND_INVD                  (0x0U)                      /*!< The condition of clear is INVALID. */
+#define TMRA_CLR_COND_TRIG_RISING           (TMRA_HCONR_HCLE0)          /*!< The condition is that a rising edge is sampled on TRIG of the current TMRA unit. */
+#define TMRA_CLR_COND_TRIG_FALLING          (TMRA_HCONR_HCLE1)          /*!< The condition is that a falling edge is sampled on TRIG of the current TMRA unit. */
+#define TMRA_CLR_COND_EVT                   (TMRA_HCONR_HCLE2)          /*!< The condition is that the TMRA common trigger event has occurred. */
+#define TMRA_CLR_COND_SYM_TRIG_RISING       (TMRA_HCONR_HCLE3)          /*!< The condition is that a rising edge is sampled on TRIG of the symmetric unit. */
+#define TMRA_CLR_COND_SYM_TRIG_FALLING      (TMRA_HCONR_HCLE4)          /*!< The condition is that a falling edge is sampled on TRIG of the symmetric unit. */
+#define TMRA_CLR_COND_PWM3_RISING           (TMRA_HCONR_HCLE5)          /*!< The condition is that a rising edge is sampled on PWM3 of the current TMRA unit. */
+#define TMRA_CLR_COND_PWM3_FALLING          (TMRA_HCONR_HCLE6)          /*!< The condition is that a falling edge is sampled on PWM3 of the current TMRA unit. */
+#define TMRA_CLR_COND_ALL                   (TMRA_CLR_COND_TRIG_RISING | TMRA_CLR_COND_TRIG_FALLING | \
+                                             TMRA_CLR_COND_EVT| TMRA_CLR_COND_SYM_TRIG_RISING | \
+                                             TMRA_CLR_COND_SYM_TRIG_FALLING | TMRA_CLR_COND_PWM3_RISING| \
+                                             TMRA_CLR_COND_PWM3_FALLING)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TMRA_Global_Functions
+ * @{
+ */
+/* Base count(use software clock PCLK/HCLK) */
+int32_t TMRA_Init(CM_TMRA_TypeDef *TMRAx, const stc_tmra_init_t *pstcTmraInit);
+int32_t TMRA_StructInit(stc_tmra_init_t *pstcTmraInit);
+void TMRA_SetCountMode(CM_TMRA_TypeDef *TMRAx, uint8_t u8Mode);
+void TMRA_SetCountDir(CM_TMRA_TypeDef *TMRAx, uint8_t u8Dir);
+void TMRA_SetClockDiv(CM_TMRA_TypeDef *TMRAx, uint8_t u8Div);
+
+/* Hardware count */
+void TMRA_HWCountUpCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState);
+void TMRA_HWCountDownCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState);
+/* Set function mode */
+void TMRA_SetFunc(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Func);
+
+/* Output compare */
+int32_t TMRA_PWM_Init(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, const stc_tmra_pwm_init_t *pstcPwmInit);
+int32_t TMRA_PWM_StructInit(stc_tmra_pwm_init_t *pstcPwmInit);
+void TMRA_PWM_OutputCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, en_functional_state_t enNewState);
+void TMRA_PWM_SetPolarity(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint8_t u8CountState, uint16_t u16Polarity);
+void TMRA_PWM_SetForcePolarity(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Polarity);
+/* Input capture */
+void TMRA_HWCaptureCondCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Cond, en_functional_state_t enNewState);
+
+/* Trigger: hardware trigger to start/stop/clear the counter */
+void TMRA_HWStartCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState);
+void TMRA_HWStopCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState);
+void TMRA_HWClearCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState);
+
+/* Filter */
+void TMRA_SetFilterClockDiv(CM_TMRA_TypeDef *TMRAx, uint32_t u32Pin, uint16_t u16Div);
+void TMRA_FilterCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Pin, en_functional_state_t enNewState);
+
+/* Global */
+int32_t TMRA_DeInit(CM_TMRA_TypeDef *TMRAx);
+/* Counting direction, period value, counter value, compare value */
+uint8_t TMRA_GetCountDir(const CM_TMRA_TypeDef *TMRAx);
+
+void TMRA_SetPeriodValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Value);
+uint32_t TMRA_GetPeriodValue(const CM_TMRA_TypeDef *TMRAx);
+void TMRA_SetCountValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Value);
+uint32_t TMRA_GetCountValue(const CM_TMRA_TypeDef *TMRAx);
+void TMRA_SetCompareValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint32_t u32Value);
+uint32_t TMRA_GetCompareValue(const CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch);
+
+/* Sync start */
+void TMRA_SyncStartCmd(CM_TMRA_TypeDef *TMRAx, en_functional_state_t enNewState);
+/* Reload and continue counting when overflow/underflow */
+void TMRA_CountReloadCmd(CM_TMRA_TypeDef *TMRAx, en_functional_state_t enNewState);
+
+void TMRA_SetCompareBufCond(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Cond);
+void TMRA_CompareBufCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, en_functional_state_t enNewState);
+
+en_flag_status_t TMRA_GetStatus(const CM_TMRA_TypeDef *TMRAx, uint32_t u32Flag);
+void TMRA_ClearStatus(CM_TMRA_TypeDef *TMRAx, uint32_t u32Flag);
+void TMRA_IntCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32IntType, en_functional_state_t enNewState);
+void TMRA_EventCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32EventType, en_functional_state_t enNewState);
+void TMRA_Start(CM_TMRA_TypeDef *TMRAx);
+void TMRA_Stop(CM_TMRA_TypeDef *TMRAx);
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMRA_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TMRA_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_trng.h
+++ b/hc32f4a2/inc/hc32_ll_trng.h
@@ -1,0 +1,130 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_trng.h
+ * @brief This file contains all the functions prototypes of the TRNG driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add TRNG_Cmd,TRNG_DeInit functions
+                                    API optimized for better random numbers: TRNG_GenerateRandom()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_TRNG_H__
+#define __HC32_LL_TRNG_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_TRNG
+ * @{
+ */
+
+#if (LL_TRNG_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup TRNG_Global_Macros TRNG Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup TRNG_Reload_Init_Value TRNG Reload Initial Value
+ * @{
+ */
+#define TRNG_RELOAD_INIT_VAL_ENABLE     (TRNG_MR_LOAD)                /* Enable reload new initial value. */
+#define TRNG_RELOAD_INIT_VAL_DISABLE    (0x0U)                        /* Disable reload new initial value. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TRNG_Shift_Ctrl TRNG Shift Control
+ * @{
+ */
+#define TRNG_SHIFT_CNT32                (0x3UL << TRNG_MR_CNT_POS)    /* Shift 32 times when capturing random noise. */
+#define TRNG_SHIFT_CNT64                (0x4UL << TRNG_MR_CNT_POS)    /* Shift 64 times when capturing random noise. */
+#define TRNG_SHIFT_CNT128               (0x5UL << TRNG_MR_CNT_POS)    /* Shift 128 times when capturing random noise. */
+#define TRNG_SHIFT_CNT256               (0x6UL << TRNG_MR_CNT_POS)    /* Shift 256 times when capturing random noise. */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup TRNG_Global_Functions
+ * @{
+ */
+int32_t TRNG_DeInit(void);
+void TRNG_Init(uint32_t u32ShiftCount, uint32_t u32ReloadInitValueEn);
+int32_t TRNG_GenerateRandom(uint32_t *pu32Random, uint32_t u32RandomLen);
+
+void TRNG_Start(void);
+void TRNG_Cmd(en_functional_state_t enNewState);
+int32_t TRNG_GetRandom(uint32_t *pu32Random, uint8_t u8RandomLen);
+/**
+ * @}
+ */
+
+#endif /* LL_TRNG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_TRNG_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_usart.h
+++ b/hc32f4a2/inc/hc32_ll_usart.h
@@ -1,0 +1,547 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_usart.h
+ * @brief This file contains all the functions prototypes of the USART(Universal
+ *        Synchronous/Asynchronous Receiver Transmitter) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+                                    Change macro-definition: USART_DR_MPID -> USART_TDR_MPID
+                                    Modify USART_SetTransType parameter: u32Type -> u16Type
+                                    Modify USART_SC_ETU_CLK128/256 value
+                                    Modify return type of function USART_DeInit
+   2023-09-30       CDT             Remove u32StopBit param from stc_usart_smartcard_init_t structure
+   2023-12-15       CDT             Add the declaration of API USART_GetFuncState()
+   2024-06-30       CDT             Add interfaces for getting USART configuration status
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_USART_H__
+#define __HC32_LL_USART_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_USART
+ * @{
+ */
+
+#if (LL_USART_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup USART_Global_Types USART Global Types
+ * @{
+ */
+
+/**
+ * @brief clock synchronization mode initialization structure definition
+ * @note The parameter(u32ClockDiv/u32CKOutput/u32Baudrate) is valid when clock source is the internal clock.
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Clock Source.
+                                             This parameter can be a value of @ref USART_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Clock division.
+                                             This parameter can be a value of @ref USART_Clock_Division. */
+    uint32_t u32Baudrate;               /*!< USART baudrate.
+                                             This parameter is valid when clock source is the internal clock. */
+    uint32_t u32FirstBit;               /*!< Significant bit.
+                                             This parameter can be a value of @ref USART_First_Bit */
+    uint32_t u32HWFlowControl;          /*!< Hardware flow control.
+                                             This parameter can be a value of @ref USART_Hardware_Flow_Control */
+} stc_usart_clocksync_init_t;
+
+/**
+ * @brief UART multiple-processor initialization structure definition
+ * @note The parameter(u32ClockDiv/u32CKOutput/u32Baudrate) is valid when clock source is the internal clock.
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Clock Source.
+                                             This parameter can be a value of @ref USART_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Clock division.
+                                             This parameter can be a value of @ref USART_Clock_Division. */
+    uint32_t u32CKOutput;               /*!< USART_CK output selection.
+                                             This parameter can be a value of @ref USART_CK_Output_Selection. */
+    uint32_t u32Baudrate;               /*!< USART baudrate.
+                                             This parameter is valid when clock source is the internal clock. */
+    uint32_t u32DataWidth;              /*!< Data width.
+                                             This parameter can be a value of @ref USART_Data_Width_Bit */
+    uint32_t u32StopBit;                /*!< Stop Bits.
+                                             This parameter can be a value of @ref USART_Stop_Bit */
+    uint32_t u32OverSampleBit;          /*!< Oversampling Bits.
+                                             This parameter can be a value of @ref USART_Over_Sample_Bit */
+    uint32_t u32FirstBit;               /*!< Significant bit.
+                                             This parameter can be a value of @ref USART_First_Bit */
+    uint32_t u32StartBitPolarity;       /*!< Start Bit Detect Polarity.
+                                             This parameter can be a value of @ref USART_Start_Bit_Polarity */
+    uint32_t u32HWFlowControl;          /*!< Hardware flow control.
+                                             This parameter can be a value of @ref USART_Hardware_Flow_Control */
+} stc_usart_multiprocessor_init_t;
+
+/**
+ * @brief UART mode initialization structure definition
+ * @note The parameter(u32ClockDiv/u32CKOutput/u32Baudrate) is valid when clock source is the internal clock.
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Clock Source.
+                                             This parameter can be a value of @ref USART_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Clock division.
+                                             This parameter can be a value of @ref USART_Clock_Division. */
+    uint32_t u32CKOutput;               /*!< USART_CK output selection.
+                                             This parameter can be a value of @ref USART_CK_Output_Selection. */
+    uint32_t u32Baudrate;               /*!< USART baudrate.
+                                             This parameter is valid when clock source is the internal clock. */
+    uint32_t u32DataWidth;              /*!< Data width.
+                                             This parameter can be a value of @ref USART_Data_Width_Bit */
+    uint32_t u32StopBit;                /*!< Stop Bits.
+                                             This parameter can be a value of @ref USART_Stop_Bit */
+    uint32_t u32Parity;                 /*!< Parity format.
+                                             This parameter can be a value of @ref USART_Parity_Control */
+    uint32_t u32OverSampleBit;          /*!< Oversampling Bits.
+                                             This parameter can be a value of @ref USART_Over_Sample_Bit */
+    uint32_t u32FirstBit;               /*!< Significant bit.
+                                             This parameter can be a value of @ref USART_First_Bit */
+    uint32_t u32StartBitPolarity;       /*!< Start Bit Detect Polarity.
+                                             This parameter can be a value of @ref USART_Start_Bit_Polarity */
+    uint32_t u32HWFlowControl;          /*!< Hardware flow control.
+                                             This parameter can be a value of @ref USART_Hardware_Flow_Control */
+} stc_usart_uart_init_t;
+
+/**
+ * @brief LIN mode initialization structure definition
+ * @note The parameter(u32ClockDiv/u32CKOutput/u32Baudrate) is valid when clock source is the internal clock.
+ */
+typedef struct {
+    uint32_t u32ClockSrc;               /*!< Clock Source.
+                                             This parameter can be a value of @ref USART_Clock_Source */
+    uint32_t u32ClockDiv;               /*!< Clock division.
+                                             This parameter can be a value of @ref USART_Clock_Division. */
+    uint32_t u32CKOutput;               /*!< USART_CK output selection.
+                                             This parameter can be a value of @ref USART_CK_Output_Selection. */
+    uint32_t u32Baudrate;               /*!< USART baudrate.
+                                             This parameter is valid when clock source is the internal clock. */
+    uint32_t u32OverSampleBit;          /*!< Oversampling Bits.
+                                             This parameter can be a value of @ref USART_Over_Sample_Bit */
+    uint32_t u32BmcClockDiv;            /*!< BMC clock division.
+                                             This parameter can be a value of @ref USART_LIN_BMC_Clock_Division.
+                                             @note The clock division is valid when clock source is the internal clock. */
+    uint32_t u32DetectBreakLen;         /*!< Detect break length.
+                                             This parameter can be a value of @ref USART_LIN_Detect_Break_Length */
+    uint32_t u32SendBreakLen;           /*!< Send break length.
+                                             This parameter can be a value of @ref USART_LIN_Send_Break_Length */
+    uint32_t u32SendBreakMode;          /*!< Send break mode.
+                                             This parameter can be a value of @ref USART_LIN_Send_Break_Mode */
+} stc_usart_lin_init_t;
+
+/**
+ * @brief Smartcard mode initialization structure definition
+ */
+typedef struct {
+    uint32_t u32ClockDiv;               /*!< Clock division. This parameter can be a value of @ref USART_Clock_Division.
+                                             @note This parameter is valid when clock source is the internal clock. */
+    uint32_t u32CKOutput;               /*!< USART_CK output selection. This parameter can be a value of @ref USART_CK_Output_Selection.
+                                             @note This parameter is valid when clock source is the internal clock. */
+    uint32_t u32Baudrate;               /*!< USART baudrate.
+                                             This parameter is calculated according with smartcard default ETU and clock. */
+    uint32_t u32FirstBit;               /*!< Significant bit.
+                                             This parameter can be a value of @ref USART_First_Bit */
+} stc_usart_smartcard_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup USART_Global_Macros USART Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup USART_Flag USART Flag
+ * @{
+ */
+#define USART_FLAG_RX_FULL              (USART_SR_RXNE)     /*!< Receive data register not empty flag */
+#define USART_FLAG_OVERRUN              (USART_SR_ORE)      /*!< Overrun error flag */
+#define USART_FLAG_TX_CPLT              (USART_SR_TC)       /*!< Transmission complete flag */
+#define USART_FLAG_TX_EMPTY             (USART_SR_TXE)      /*!< Transmit data register empty flag */
+#define USART_FLAG_FRAME_ERR            (USART_SR_FE)       /*!< Framing error flag */
+#define USART_FLAG_PARITY_ERR           (USART_SR_PE)       /*!< Parity error flag */
+#define USART_FLAG_MX_PROCESSOR         (USART_SR_MPB)      /*!< Receive processor ID flag */
+#define USART_FLAG_RX_TIMEOUT           (USART_SR_RTOF)     /*!< Receive timeout flag */
+#define USART_FLAG_LIN_ERR              (USART_SR_BE)       /*!< LIN bus error flag */
+#define USART_FLAG_LIN_WKUP             (USART_SR_WKUP)     /*!< LIN wakeup signal detection flag */
+#define USART_FLAG_LIN_BREAK            (USART_SR_LBD)      /*!< LIN break signal detection flag */
+
+#define USART_FLAG_ALL                  (USART_FLAG_RX_FULL | USART_FLAG_FRAME_ERR  | USART_FLAG_TX_EMPTY   | \
+                                         USART_FLAG_OVERRUN | USART_FLAG_PARITY_ERR | USART_FLAG_RX_TIMEOUT | \
+                                         USART_FLAG_TX_CPLT | USART_FLAG_LIN_BREAK  | USART_FLAG_LIN_WKUP   | \
+                                         USART_FLAG_LIN_ERR | USART_FLAG_MX_PROCESSOR)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Transmission_Type USART Transmission Type
+ * @{
+ */
+#define USART_TRANS_DATA                (0UL)
+#define USART_TRANS_ID                  (USART_TDR_MPID)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Function USART Function
+ * @{
+ */
+#define USART_TX                        (USART_CR1_TE)      /*!< USART TX function */
+#define USART_RX                        (USART_CR1_RE)      /*!< USART RX function */
+#define USART_INT_RX                    (USART_CR1_RIE)     /*!< USART receive data register not empty && receive error interrupt */
+#define USART_INT_TX_CPLT               (USART_CR1_TCIE)    /*!< USART transmission complete interrupt */
+#define USART_INT_TX_EMPTY              (USART_CR1_TXEIE)   /*!< USART transmit data register empty interrupt */
+#define USART_RX_TIMEOUT                (USART_CR1_RTOE)    /*!< USART RX timeout function */
+#define USART_INT_RX_TIMEOUT            (USART_CR1_RTOIE)   /*!< USART RX timeout interrupt */
+#define USART_LIN                       (USART_CR2_LINEN  << 16UL)  /*!< USART LIN function */
+#define USART_LIN_WKUP                  (USART_CR2_WKUPE  << 16UL)  /*!< USART LIN wakeup signal detect function */
+#define USART_LIN_ERR                   (USART_CR2_BEE    << 16UL)  /*!< USART LIN bus error detect function */
+#define USART_LIN_BREAK                 (USART_CR2_LBDL   << 16UL)  /*!< USART LIN bus break field detect function */
+#define USART_LIN_INT_ERR               (USART_CR2_BEIE   << 16UL)  /*!< USART LIN bus error detect interrupt function */
+#define USART_LIN_INT_BREAK             (USART_CR2_LBDIE  << 16UL)  /*!< USART LIN bus break field detect interrupt function */
+#define USART_LIN_INT_WKUP              (USART_CR2_WKUPIE << 16UL)  /*!< USART LIN bus wakeup signal detect interrupt function */
+
+#define USART_FUNC_ALL                  (USART_TX | USART_RX  | USART_INT_RX | USART_INT_TX_CPLT | USART_RX_TIMEOUT | \
+                                         USART_INT_RX_TIMEOUT | USART_INT_TX_EMPTY | USART_LIN | USART_LIN_WKUP | \
+                                         USART_LIN_ERR | USART_LIN_BREAK | USART_LIN_INT_ERR | USART_LIN_INT_BREAK | \
+                                         USART_LIN_INT_WKUP)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Parity_Control USART Parity Control
+ * @{
+ */
+#define USART_PARITY_NONE               (0UL)               /*!< Parity control disabled */
+#define USART_PARITY_EVEN               (USART_CR1_PCE)     /*!< Parity control enabled and Even Parity is selected */
+#define USART_PARITY_ODD                (USART_CR1_PCE | \
+                                         USART_CR1_PS)      /*!< Parity control enabled and Odd Parity is selected */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Data_Width_Bit USART Data Width Bit
+ * @{
+ */
+#define USART_DATA_WIDTH_8BIT           (0UL)               /*!< 8 bits */
+#define USART_DATA_WIDTH_9BIT           (USART_CR1_M)       /*!< 9 bits */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Over_Sample_Bit USART Over Sample Bit
+ * @{
+ */
+#define USART_OVER_SAMPLE_16BIT         (0UL)               /*!< Oversampling by 16 bits */
+#define USART_OVER_SAMPLE_8BIT          (USART_CR1_OVER8)   /*!< Oversampling by 8 bits */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_First_Bit USART First Bit
+ * @{
+ */
+#define USART_FIRST_BIT_LSB             (0UL)               /*!< LSB(Least Significant Bit) */
+#define USART_FIRST_BIT_MSB             (USART_CR1_ML)      /*!< MSB(Most Significant Bit) */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Start_Bit_Polarity USART Start Bit Polarity
+ * @{
+ */
+#define USART_START_BIT_LOW             (0UL)               /*!< Detect RX pin low level */
+#define USART_START_BIT_FALLING         (USART_CR1_SBS)     /*!< Detect RX pin falling edge */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Clock_Source USART Clock Source
+ * @{
+ */
+#define USART_CLK_SRC_INTERNCLK         (0UL)               /*!< Select internal clock source and don't output clock */
+#define USART_CLK_SRC_EXTCLK            (USART_CR2_CLKC_1)  /*!< Select external clock source. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_CK_Output_Selection USART_CK Output Selection
+ * @{
+ */
+#define USART_CK_OUTPUT_DISABLE         (0UL)               /*!< Disable USART_CK output */
+#define USART_CK_OUTPUT_ENABLE          (USART_CR2_CLKC_0)  /*!< Enable USART_CK output. */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Stop_Bit USART Stop Bit
+ * @{
+ */
+#define USART_STOPBIT_1BIT              (0UL)               /*!< 1 stop bit */
+#define USART_STOPBIT_2BIT              (USART_CR2_STOP)    /*!< 2 stop bit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Hardware_Flow_Control USART Hardware Flow Control
+ * @{
+ */
+#define USART_HW_FLOWCTRL_CTS           (USART_CR3_CTSE)        /*!< USART hardware flow control CTS mode */
+#define USART_HW_FLOWCTRL_RTS           (USART_CR3_CTSE >> 1U)  /*!< USART hardware flow control RTS mode */
+#define USART_HW_FLOWCTRL_NONE          (0UL)                   /*!< Disable USART hardware flow control */
+#define USART_HW_FLOWCTRL_RTS_CTS       (USART_HW_FLOWCTRL_CTS | \
+                                         USART_HW_FLOWCTRL_RTS) /*!< USART hardware flow control RTS and CTS mode */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Clock_Division USART Clock Division
+ * @{
+ */
+#define USART_CLK_DIV1                  (0UL)   /*!< CLK      */
+#define USART_CLK_DIV4                  (1UL)   /*!< CLK/4    */
+#define USART_CLK_DIV16                 (2UL)   /*!< CLK/16   */
+#define USART_CLK_DIV64                 (3UL)   /*!< CLK/64   */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Max_Timeout USART Max Timeout
+ * @{
+ */
+#define USART_MAX_TIMEOUT               (0xFFFFFFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Smartcard_ETU_Clock USART Smartcard ETU Clock
+ * @{
+ */
+#define USART_SC_ETU_CLK32              (0UL << USART_CR3_BCN_POS)  /*!< 1 etu = 32/f */
+#define USART_SC_ETU_CLK64              (1UL << USART_CR3_BCN_POS)  /*!< 1 etu = 64/f */
+#define USART_SC_ETU_CLK128             (3UL << USART_CR3_BCN_POS)  /*!< 1 etu = 128/f */
+#define USART_SC_ETU_CLK256             (5UL << USART_CR3_BCN_POS)  /*!< 1 etu = 256/f */
+#define USART_SC_ETU_CLK372             (6UL << USART_CR3_BCN_POS)  /*!< 1 etu = 372/f */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Stop_Mode_Noise_Filter_Width_Level USART Stop Mode Noise Filter Width Level
+ * @{
+ */
+#define USART_STOP_MD_FILTER_LVL1       (0UL)                               /*!< Filter width level 1 */
+#define USART_STOP_MD_FILTER_LVL2       (PERIC_USART1_NFC_USASRT1_NFS_0)    /*!< Filter width level 2 */
+#define USART_STOP_MD_FILTER_LVL3       (PERIC_USART1_NFC_USASRT1_NFS_1)    /*!< Filter width level 3 */
+#define USART_STOP_MD_FILTER_LVL4       (PERIC_USART1_NFC_USASRT1_NFS)      /*!< Filter width level 4 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_LIN_BMC_Clock_Division USART LIN Baudrate Measure Counter Clock Division
+ * @{
+ */
+#define USART_LIN_BMC_CLK_DIV1          (0UL)               /*!< CLK */
+#define USART_LIN_BMC_CLK_DIV2          (USART_PR_LBMPSC_0) /*!< CLK/2 */
+#define USART_LIN_BMC_CLK_DIV4          (USART_PR_LBMPSC_1) /*!< CLK/4 */
+#define USART_LIN_BMC_CLK_DIV8          (USART_PR_LBMPSC)   /*!< CLK/8 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_LIN_Send_Break_Mode USART LIN Send Break Mode
+ * @{
+ */
+#define USART_LIN_SEND_BREAK_MD_SBK     (0UL)               /*!< Start send break after USART_CR2 SBK bit set 1 value */
+#define USART_LIN_SEND_BREAK_MD_TDR     (USART_CR2_SBKM)    /*!< Start send break after USART_DR TDR write 0x00 value */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_LIN_Detect_Break_Length USART LIN Detect Break Length
+ * @{
+ */
+#define USART_LIN_DETECT_BREAK_10BIT    (0UL)               /*!< Detect break 10-bit */
+#define USART_LIN_DETECT_BREAK_11BIT    (USART_CR2_LBDL)    /*!< Detect break 11-bit */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_LIN_Send_Break_Length USART LIN Send Break Length
+ * @{
+ */
+#define USART_LIN_SEND_BREAK_10BIT      (0UL)               /*!< Send break 10-bit */
+#define USART_LIN_SEND_BREAK_11BIT      (USART_CR2_SBKL_0)  /*!< Send break 11-bit */
+#define USART_LIN_SEND_BREAK_13BIT      (USART_CR2_SBKL_1)  /*!< Send break 13-bit */
+#define USART_LIN_SEND_BREAK_14BIT      (USART_CR2_SBKL)    /*!< Send break 14-bit */
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup USART_Global_Functions
+ * @{
+ */
+int32_t USART_ClockSync_StructInit(stc_usart_clocksync_init_t *pstcClockSyncInit);
+int32_t USART_ClockSync_Init(CM_USART_TypeDef *USARTx,
+                             const stc_usart_clocksync_init_t *pstcClockSyncInit, float32_t *pf32Error);
+int32_t USART_MultiProcessor_StructInit(stc_usart_multiprocessor_init_t *pstcMultiProcessorInit);
+int32_t USART_MultiProcessor_Init(CM_USART_TypeDef *USARTx,
+                                  const stc_usart_multiprocessor_init_t *pstcMultiProcessorInit, float32_t *pf32Error);
+int32_t USART_UART_StructInit(stc_usart_uart_init_t *pstcUartInit);
+int32_t USART_UART_Init(CM_USART_TypeDef *USARTx, const stc_usart_uart_init_t *pstcUartInit, float32_t *pf32Error);
+
+int32_t USART_HalfDuplex_Init(CM_USART_TypeDef *USARTx,
+                              const stc_usart_uart_init_t *pstcUartInit, float32_t *pf32Error);
+
+int32_t USART_LIN_StructInit(stc_usart_lin_init_t *pstcLinInit);
+int32_t USART_LIN_Init(CM_USART_TypeDef *USARTx, const stc_usart_lin_init_t *pstcLinInit, float32_t *pf32Error);
+
+int32_t USART_SmartCard_StructInit(stc_usart_smartcard_init_t *pstcSmartCardInit);
+int32_t USART_SmartCard_Init(CM_USART_TypeDef *USARTx,
+                             const stc_usart_smartcard_init_t *pstcSmartCardInit, float32_t *pf32Error);
+
+int32_t USART_DeInit(CM_USART_TypeDef *USARTx);
+void USART_FuncCmd(CM_USART_TypeDef *USARTx, uint32_t u32Func, en_functional_state_t enNewState);
+en_functional_state_t USART_GetFuncState(CM_USART_TypeDef *USARTx, uint32_t u32Func);
+en_flag_status_t USART_GetStatus(const CM_USART_TypeDef *USARTx, uint32_t u32Flag);
+void USART_ClearStatus(CM_USART_TypeDef *USARTx, uint32_t u32Flag);
+void USART_SetParity(CM_USART_TypeDef *USARTx, uint32_t u32Parity);
+uint32_t USART_GetParity(CM_USART_TypeDef *USARTx);
+void USART_SetFirstBit(CM_USART_TypeDef *USARTx, uint32_t u32FirstBit);
+void USART_SetStopBit(CM_USART_TypeDef *USARTx, uint32_t u32StopBit);
+uint32_t USART_GetStopBit(CM_USART_TypeDef *USARTx);
+void USART_SetDataWidth(CM_USART_TypeDef *USARTx, uint32_t u32DataWidth);
+uint32_t USART_GetDataWidth(CM_USART_TypeDef *USARTx);
+void USART_SetOverSampleBit(CM_USART_TypeDef *USARTx, uint32_t u32OverSampleBit);
+void USART_SetStartBitPolarity(CM_USART_TypeDef *USARTx, uint32_t u32Polarity);
+void USART_SetTransType(CM_USART_TypeDef *USARTx, uint16_t u16Type);
+void USART_SetClockDiv(CM_USART_TypeDef *USARTx, uint32_t u32ClockDiv);
+uint32_t USART_GetClockDiv(const CM_USART_TypeDef *USARTx);
+void USART_SetClockSrc(CM_USART_TypeDef *USARTx, uint32_t u32ClockSrc);
+uint32_t USART_GetClockSrc(const CM_USART_TypeDef *USARTx);
+void USART_FilterCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState);
+void USART_SilenceCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState);
+void USART_SetHWFlowControl(CM_USART_TypeDef *USARTx, uint32_t u32HWFlowControl);
+uint32_t USART_GetHWFlowControl(CM_USART_TypeDef *USARTx);
+uint16_t USART_ReadData(const CM_USART_TypeDef *USARTx);
+void USART_WriteData(CM_USART_TypeDef *USARTx, uint16_t u16Data);
+void USART_WriteID(CM_USART_TypeDef *USARTx, uint16_t u16ID);
+
+int32_t USART_SetBaudrate(CM_USART_TypeDef *USARTx, uint32_t u32Baudrate, float32_t *pf32Error);
+
+void USART_SmartCard_SetEtuClock(CM_USART_TypeDef *USARTx, uint32_t u32EtuClock);
+
+void USART_StopModeNoiseFilterCmd(const CM_USART_TypeDef *USARTx, en_functional_state_t enNewState);
+void USART_SetStopModeNoiseFilter(const CM_USART_TypeDef *USARTx, uint32_t u32Level);
+
+void USART_LIN_LoopbackCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState);
+void USART_LIN_SetBmcClockDiv(CM_USART_TypeDef *USARTx, uint32_t u32ClockDiv);
+void USART_LIN_RequestBreakSending(CM_USART_TypeDef *USARTx);
+en_flag_status_t USART_LIN_GetRequestBreakStatus(const CM_USART_TypeDef *USARTx);
+void USART_LIN_SetBreakMode(CM_USART_TypeDef *USARTx, uint32_t u32Mode);
+uint32_t USART_LIN_GetBreakMode(const CM_USART_TypeDef *USARTx);
+uint32_t USART_LIN_GetMeasureCount(const CM_USART_TypeDef *USARTx);
+uint32_t USART_LIN_GetMeasureBaudrate(const CM_USART_TypeDef *USARTx);
+void USART_LIN_SetDetectBreakLen(CM_USART_TypeDef *USARTx, uint32_t u32Len);
+void USART_LIN_SetSendBreakLen(CM_USART_TypeDef *USARTx, uint32_t u32Len);
+
+int32_t USART_UART_Trans(CM_USART_TypeDef *USARTx, const void *pvBuf, uint32_t u32Len, uint32_t u32Timeout);
+int32_t USART_UART_Receive(const CM_USART_TypeDef *USARTx, void *pvBuf, uint32_t u32Len, uint32_t u32Timeout);
+int32_t USART_ClockSync_Trans(CM_USART_TypeDef *USARTx, const uint8_t au8Buf[], uint32_t u32Len, uint32_t u32Timeout);
+int32_t USART_ClockSync_Receive(CM_USART_TypeDef *USARTx, uint8_t au8Buf[], uint32_t u32Len, uint32_t u32Timeout);
+int32_t USART_ClockSync_TransReceive(CM_USART_TypeDef *USARTx, const uint8_t au8TxBuf[], uint8_t au8RxBuf[],
+                                     uint32_t u32Len, uint32_t u32Timeout);
+
+/**
+ * @}
+ */
+
+#endif /* LL_USART_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_USART_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_usb.h
+++ b/hc32f4a2/inc/hc32_ll_usb.h
@@ -1,0 +1,707 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_usb.h
+ * @brief A detailed description is available at hardware registers.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add USB core ID select function
+                                    Delete comment
+   2023-06-30       CDT             Modify typo
+   2024-06-30       CDT             Modify for macro define USB_MAX_TX_FIFOS
+                                    Modify parameter type in function usb_FrameIntervalConfig():uint8_t -> uint32_t
+   2024-11-08       CDT             Modify API usb_wrpkt & usb_rdpkt for C-STAT
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_USB_H__
+#define __HC32_LL_USB_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+#include "usb_app_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_USB
+ * @{
+ */
+
+#if (LL_USB_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup USB_Global_Macros USB Global Macros
+ * @{
+ */
+#define USB_MAX_TX_FIFOS                       (16U)
+#define USB_MAX_CH_NUM                         (16U)
+#define USB_MAX_EP_NUM                         (USB_MAX_TX_FIFOS)
+
+/* USB Core ID define */
+#define USBFS_CORE_ID                          (0U)
+#define USBHS_CORE_ID                          (1U)
+
+/* USB PHY type define for USBHS core */
+#define USBHS_PHY_EMBED                        (0U)
+#define USBHS_PHY_EXT                          (1U)
+
+#define USB_MAX_EP0_SIZE                       (64U)
+/* working mode of the USB core */
+#define DEVICE_MODE                            (0U)
+#define HOST_MODE                              (1U)
+
+/* Macro definitions for device mode*/
+#define DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ     (0U << USBFS_DSTS_ENUMSPD_POS)
+#define DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ     (1U << USBFS_DSTS_ENUMSPD_POS)
+#define DSTS_ENUMSPD_LS_PHY_6MHZ               (2U << USBFS_DSTS_ENUMSPD_POS)
+#define DSTS_ENUMSPD_FS_PHY_48MHZ              (3U << USBFS_DSTS_ENUMSPD_POS)
+
+/* EP type */
+#define EP_TYPE_CTRL                           (0U)
+#define EP_TYPE_ISOC                           (1U)
+#define EP_TYPE_BULK                           (2U)
+#define EP_TYPE_INTR                           (3U)
+#define EP_TYPE_MSK                            (3U)
+
+/* USB port speed */
+#define PRTSPD_FULL_SPEED                      (1U)
+#define PRTSPD_LOW_SPEED                       (2U)
+
+/* PHY clock */
+#define HCFG_30_60_MHZ                         (0U)
+#define HCFG_48_MHZ                            (1U)
+#define HCFG_6_MHZ                             (2U)
+
+#define USB_EP_TX_DIS                          (0x0000U)
+#define USB_EP_TX_STALL                        (0x0010U)
+#define USB_EP_TX_NAK                          (0x0020U)
+#define USB_EP_TX_VALID                        (0x0030U)
+
+#define USB_EP_RX_DIS                          (0x0000U)
+#define USB_EP_RX_STALL                        (0x1000U)
+#define USB_EP_RX_NAK                          (0x2000U)
+#define USB_EP_RX_VALID                        (0x3000U)
+
+#define USB_OK                              (0U)
+#define USB_ERROR                           (1U)
+
+#define USB_FRAME_INTERVAL_80                  (0UL << USBFS_DCFG_PFIVL_POS)
+#define USB_FRAME_INTERVAL_85                  (1UL << USBFS_DCFG_PFIVL_POS)
+#define USB_FRAME_INTERVAL_90                  (2UL << USBFS_DCFG_PFIVL_POS)
+#define USB_FRAME_INTERVAL_95                  (3UL << USBFS_DCFG_PFIVL_POS)
+
+#define SWAPBYTE(addr)          (((uint16_t)(*((uint8_t *)(addr)))) + \
+                                (uint16_t)(((uint16_t)(*(((uint8_t *)(addr)) + 1U))) << 8U))
+#define LOBYTE(x)               ((uint8_t)((uint16_t)(x) & 0x00FFU))
+#define HIBYTE(x)               ((uint8_t)(((uint16_t)(x) & 0xFF00U) >>8U))
+
+#ifdef USB_INTERNAL_DMA_ENABLED
+#define __USB_ALIGN_END
+#if defined   (__GNUC__)      /* GNU Compiler */
+#define __USB_ALIGN_BEGIN       __attribute__ ((aligned (4)))
+#elif defined   (__CC_ARM)    /* ARM Compiler */
+#define __USB_ALIGN_BEGIN       __align(4)
+#elif defined (__ICCARM__)    /* IAR Compiler */
+#define __USB_ALIGN_BEGIN
+#elif defined  (__TASKING__)  /* TASKING Compiler */
+#define __USB_ALIGN_BEGIN       __align(4)
+#endif
+#else
+#define __USB_ALIGN_BEGIN
+#define __USB_ALIGN_END
+#endif
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup USB_Global_Types USB Global Types
+ * @{
+ */
+
+typedef struct {
+    __IO uint32_t GVBUSCFG;                   /* VBUS Configuration Register                      000h */
+    uint32_t Reserved04;                      /* Reserved                                         004h */
+    __IO uint32_t GAHBCFG;                    /* AHB Configuration Register                       008h */
+    __IO uint32_t GUSBCFG;                    /* USB Configuration Register                       00Ch */
+    __IO uint32_t GRSTCTL;                    /* Reset Register                                   010h */
+    __IO uint32_t GINTSTS;                    /* Interrupt Register                               014h */
+    __IO uint32_t GINTMSK;                    /* Interrupt Mask Register                          018h */
+    __IO uint32_t GRXSTSR;                    /* Receive Sts Q Read Register                      01Ch */
+    __IO uint32_t GRXSTSP;                    /* Receive Sts Q Read & POP Register                020h */
+    __IO uint32_t GRXFSIZ;                    /* Receive FIFO Size Register                       024h */
+    __IO uint32_t HNPTXFSIZ;                  /* HNPTXFSIZ: Host Non-Periodic Transmit FIFO Size Register 028h
+                                                 DIEPTXF0: Device IN EP0 Transmit FIFO size register      028h */
+    __IO uint32_t HNPTXSTS;                   /* Host Non Periodic Transmit FIFO/Queue Status Register    02Ch */
+    uint32_t Reserved30[3];                   /* Reserved                                    030h-038h */
+    __IO uint32_t CID;                        /* User ID Register                                 03Ch */
+    uint32_t  Reserved40[5];                  /* Reserved                                    040h-050h */
+    __IO uint32_t GLPMCFG;                    /* Low Power Mode Configuration Register            054h */
+    uint32_t  Reserved58[42];                 /* Reserved                                    058h-0FCh */
+    __IO uint32_t HPTXFSIZ;                   /* Host Periodic Transmit FIFO Size Register        100h */
+    __IO uint32_t DIEPTXF[USB_MAX_TX_FIFOS];  /* Device Periodic Transmit FIFO Size Register           */
+} USB_CORE_GREGS;
+
+typedef struct {
+    __IO uint32_t DCFG;         /* Device Configuration Register                     800h */
+    __IO uint32_t DCTL;         /* Device Control Register                           804h */
+    __IO uint32_t DSTS;         /* Device Status Register (RO)                       808h */
+    uint32_t Reserved0C;        /* Reserved                                          80Ch */
+    __IO uint32_t DIEPMSK;      /* Device IN EP Common Interrupt Mask Register       810h */
+    __IO uint32_t DOEPMSK;      /* Device OUT EP Common Interrupt Mask Register      814h */
+    __IO uint32_t DAINT;        /* Device All EP Interrupt Register                  818h */
+    __IO uint32_t DAINTMSK;     /* Device All EP Interrupt Mask Register             81Ch */
+    uint32_t Reserved20[4];     /* Reserved                                     820h-82Ch */
+    __IO uint32_t DTHRCTL;      /* Device Threshold Control Register                 830h */
+    __IO uint32_t DIEPEMPMSK;   /* Device IN EP FIFO Empty Interrupt Mask Register   834h */
+    __IO uint32_t DEACHINT;     /* Device Each EP Interrupt Register                 838h */
+    __IO uint32_t DEACHINTMSK;  /* Device Each EP Interrupt Mask Register            83Ch */
+    uint32_t Reserved40;        /* Reserved                                          840h */
+    __IO uint32_t DIEPEACHMSK1; /* Device IN EP1 Interrupt Mask Register             844h */
+    uint32_t Reserved48[15];    /* Reserved                                      848-880h */
+    __IO uint32_t DOEPEACHMSK1; /* Device OUT EP1 Interrupt Mask Register            884h */
+} USB_CORE_DREGS;
+
+typedef struct {
+    __IO uint32_t DIEPCTL;  /* dev IN Endpoint Control Reg 900h + (ep_num * 20h) + 00h     */
+    uint32_t Reserved04;        /* Reserved                    900h + (ep_num * 20h) + 04h */
+    __IO uint32_t DIEPINT;  /* dev IN Endpoint Itr Reg     900h + (ep_num * 20h) + 08h     */
+    uint32_t Reserved0C;        /* Reserved                    900h + (ep_num * 20h) + 0Ch */
+    __IO uint32_t DIEPTSIZ; /* IN Endpoint Txfer Size      900h + (ep_num * 20h) + 10h     */
+    __IO uint32_t DIEPDMA;  /* IN Endpoint DMA Address Reg 900h + (ep_num * 20h) + 14h     */
+    __IO uint32_t DTXFSTS;  /* IN Endpoint Tx FIFO Status  900h + (ep_num * 20h) + 18h     */
+    uint32_t Reserved18;        /* Reserved                    900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch*/
+} USB_CORE_INEPREGS;
+
+typedef struct {
+    __IO uint32_t DOEPCTL;   /* dev OUT Endpoint Control Reg  B00h + (ep_num * 20h) + 00h */
+    uint32_t Reserved04;     /* Reserved                      B00h + (ep_num * 20h) + 04h */
+    __IO uint32_t DOEPINT;   /* dev OUT Endpoint Itr Reg      B00h + (ep_num * 20h) + 08h */
+    uint32_t Reserved0C;     /* Reserved                      B00h + (ep_num * 20h) + 0Ch */
+    __IO uint32_t DOEPTSIZ;  /* dev OUT Endpoint Txfer Size   B00h + (ep_num * 20h) + 10h */
+    __IO uint32_t DOEPDMA;   /* dev OUT Endpoint DMA Address  B00h + (ep_num * 20h) + 14h */
+    uint32_t Reserved18[2];  /* Reserved                B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
+} USB_CORE_OUTEPREGS;
+
+typedef struct {
+    __IO uint32_t HCFG;      /* Host Configuration Register    400h*/
+    __IO uint32_t HFIR;      /* Host Frame Interval Register   404h*/
+    __IO uint32_t HFNUM;     /* Host Frame Nbr/Frame Remaining 408h*/
+    uint32_t Reserved40C;    /* Reserved                       40Ch*/
+    __IO uint32_t HPTXSTS;   /* Host Periodic Tx FIFO/ Queue Status 410h*/
+    __IO uint32_t HAINT;     /* Host All Channels Interrupt Register 414h*/
+    __IO uint32_t HAINTMSK;  /* Host All Channels Interrupt Mask 418h*/
+} USB_CORE_HREGS;
+
+typedef struct {
+    __IO uint32_t HCCHAR;
+    __IO uint32_t HCSPLT;
+    __IO uint32_t HCINT;
+    __IO uint32_t HCINTMSK;
+    __IO uint32_t HCTSIZ;
+    __IO uint32_t HCDMA;
+    uint32_t Reserved[2];
+} USB_CORE_HC_REGS;
+
+typedef struct { /* 000h */
+    USB_CORE_GREGS     *GREGS;
+    USB_CORE_DREGS     *DREGS;
+    USB_CORE_HREGS     *HREGS;
+    USB_CORE_INEPREGS  *INEP_REGS[USB_MAX_TX_FIFOS];
+    USB_CORE_OUTEPREGS *OUTEP_REGS[USB_MAX_TX_FIFOS];
+    USB_CORE_HC_REGS   *HC_REGS[USB_MAX_CH_NUM];
+    __IO uint32_t  *HPRT;
+    __IO uint32_t  *DFIFO[USB_MAX_TX_FIFOS];
+    __IO uint32_t  *GCCTL;
+} LL_USB_TypeDef;
+
+typedef struct {
+    uint8_t       host_chnum;
+    uint8_t       dev_epnum;
+    uint8_t       dmaen;
+    uint8_t       low_power;
+    uint8_t       phy_type;
+    uint8_t       core_type;
+} USB_CORE_BASIC_CFGS;
+
+typedef struct {
+    uint8_t       dev_addr;
+    uint8_t       ep_idx;
+    uint8_t       is_epin;
+    uint8_t       ch_speed;
+    uint8_t       do_ping;
+    uint8_t       ep_type;
+    uint16_t      max_packet;
+    uint8_t       pid_type;
+    uint8_t       in_toggle;
+    uint8_t       out_toggle;
+    /* transaction level variables*/
+    uint32_t      dma_addr;
+    uint32_t      xfer_len;
+    uint32_t      xfer_count;
+    uint8_t       *xfer_buff;
+} USB_HOST_CH;
+
+typedef struct {
+    uint8_t        epidx;
+    uint8_t        ep_dir;
+    uint8_t        trans_type;
+    uint8_t        ep_stall;
+    uint8_t        data_pid_start;
+    uint8_t        datax_pid;
+    uint16_t       tx_fifo_num;
+    uint32_t       maxpacket;
+    /* Transfer level variables */
+    uint32_t       rem_data_len;
+    uint32_t       total_data_len;
+    uint32_t       ctl_data_len;
+    /* transaction level variables*/
+    uint32_t       dma_addr;
+    uint32_t       xfer_len;
+    uint32_t       xfer_count;
+    uint8_t        *xfer_buff;
+} USB_DEV_EP;
+
+typedef struct {
+    uint8_t        u8CoreID;     /* USBFS_CORE_ID or USBHS_CORE_ID */
+    uint8_t        u8PhyType;    /* USBHS_PHY_EMBED or USBHS_PHY_EXT */
+} stc_usb_port_identify;
+
+/**
+ * @}
+ */
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+
+/**
+ * @addtogroup USB_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  get the current mode of the usb core from the corresponding register
+ * @param  [in] USBx        usb instance
+ * @retval current mode     1: host mode   0: device mode
+ */
+__STATIC_INLINE uint8_t usb_getcurmod(LL_USB_TypeDef *USBx)
+{
+    if (0UL != READ_REG32_BIT(USBx->GREGS->GINTSTS, USBFS_GINTSTS_CMOD)) {
+        return 1U;
+    } else {
+        return 0U;
+    }
+}
+
+/**
+ * @brief  Initializes the normal interrupts
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_normalinten(LL_USB_TypeDef *USBx)
+{
+    WRITE_REG32(USBx->GREGS->GINTSTS, 0xBFFFFFFFUL);
+    WRITE_REG32(USBx->GREGS->GINTMSK, USBFS_GINTMSK_WKUIM | USBFS_GINTMSK_USBSUSPM);
+}
+
+/**
+ * @brief  clear all the pending device interrupt bits and mask the IN and OUT
+ *         endpoint interrupts.
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_clrandmskepint(LL_USB_TypeDef *USBx)
+{
+    WRITE_REG32(USBx->DREGS->DIEPMSK, 0UL);
+    WRITE_REG32(USBx->DREGS->DOEPMSK, 0UL);
+    WRITE_REG32(USBx->DREGS->DAINT, 0xFFFFFFFFUL);
+    WRITE_REG32(USBx->DREGS->DAINTMSK, 0UL);
+}
+
+/**
+ * @brief  generate a device connect signal to the USB host
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_coreconn(LL_USB_TypeDef *USBx)
+{
+    CLR_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_SDIS);
+}
+
+/**
+ * @brief  test of mode processing
+ * @param  [in] USBx        usb instance
+ * @param  [in] reg         Register write
+ * @retval None
+ */
+__STATIC_INLINE void usb_runtestmode(LL_USB_TypeDef *USBx, uint32_t reg)
+{
+    WRITE_REG32(USBx->DREGS->DCTL, reg);
+}
+
+/**
+ * @brief  Enables the controller's Global interrupts in the AHB Configuration
+ *         registers.
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_ginten(LL_USB_TypeDef *USBx)
+{
+    SET_REG32_BIT(USBx->GREGS->GAHBCFG, USBFS_GAHBCFG_GINTMSK);
+}
+
+/**
+ * @brief  Disable the controller's Global interrupt in the AHB Configuration
+ *         register.
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_gintdis(LL_USB_TypeDef *USBx)
+{
+    CLR_REG32_BIT(USBx->GREGS->GAHBCFG, USBFS_GAHBCFG_GINTMSK);
+}
+
+/**
+ * @brief  Get the Core Interrupt bits from the interrupt register not including
+ *         the bits that are masked.
+ * @param  [in] USBx        usb instance
+ * @retval status[32bits]
+ */
+__STATIC_INLINE uint32_t usb_getcoreintr(LL_USB_TypeDef *USBx)
+{
+    uint32_t v;
+    v  = READ_REG32(USBx->GREGS->GINTSTS);
+    v &= READ_REG32(USBx->GREGS->GINTMSK);
+    return v;
+}
+
+/**
+ * @brief  Get the out endpoint interrupt bits from the all endpoint interrupt
+ *         register not including the bits masked.
+ * @param  [in] USBx        usb instance
+ * @retval The status that shows which OUT EP have interrupted.
+ */
+__STATIC_INLINE uint32_t usb_getalloepintr(LL_USB_TypeDef *USBx)
+{
+    uint32_t v;
+    v  = READ_REG32(USBx->DREGS->DAINT);
+    v &= READ_REG32(USBx->DREGS->DAINTMSK);
+    return ((v & 0xFFFF0000UL) >> 16U);
+}
+
+/**
+ * @brief  Get the Device OUT EP Interrupt register(DOEPINT) not including the
+ *         interrupt bits that are masked.
+ * @param  [in] USBx        usb instance
+ * @param  [in] epnum       end point index
+ * @retval all the interrupt bits on DOEPINTn while n = epnum
+ */
+__STATIC_INLINE uint32_t usb_getoepintbit(LL_USB_TypeDef *USBx, uint8_t epnum)
+{
+    uint32_t v;
+    v  = READ_REG32(USBx->OUTEP_REGS[epnum]->DOEPINT);
+    v &= READ_REG32(USBx->DREGS->DOEPMSK);
+    return v;
+}
+
+/**
+ * @brief  Get the IN endpoint interrupt bits from the all endpoint interrupt
+ *         register not including the bits masked.
+ * @param  [in] USBx        usb instance
+ * @retval The status that shows which IN EP have interrupted.
+ */
+__STATIC_INLINE uint32_t usb_getalliepintr(LL_USB_TypeDef *USBx)
+{
+    uint32_t v;
+    v  = READ_REG32(USBx->DREGS->DAINT);
+    v &= READ_REG32(USBx->DREGS->DAINTMSK);
+    return (v & 0xFFFFUL);
+}
+
+/**
+ * @brief  Set the device a new address.
+ * @param  [in] USBx        usb instance
+ * @param  [in] address     device address which will be set to the corresponding register.
+ * @retval None
+ */
+__STATIC_INLINE void usb_devaddrset(LL_USB_TypeDef *USBx, uint8_t address)
+{
+    MODIFY_REG32(USBx->DREGS->DCFG, USBFS_DCFG_DAD, (uint32_t)address << USBFS_DCFG_DAD_POS);
+}
+
+/**
+ * @brief  Select the USB PHY.
+ * @param  [in] USBx        usb instance
+ * @param  [in] PhyType      USB phy, 1 select external ULPI PHY, 0 select internal FS PHY
+ * @retval None
+ */
+__STATIC_INLINE void usb_PhySelect(LL_USB_TypeDef *USBx, uint8_t PhyType)
+{
+    if (USBHS_PHY_EXT == PhyType) {
+        CLR_REG32_BIT(USBx->GREGS->GUSBCFG, USBFS_GUSBCFG_PHYSEL);
+        //SET_REG32_BIT(USBx->GREGS->GUSBCFG, 1UL<<4);
+    } else {
+        SET_REG32_BIT(USBx->GREGS->GUSBCFG, USBFS_GUSBCFG_PHYSEL);
+    }
+}
+
+/**
+ * @brief  Select the USB device PHY.
+ * @param  [in] USBx        usb instance
+ * @param  [in] PhyType      USB phy, 1 select external ULPI PHY, 0 select internal FS PHY
+ * @retval None
+ */
+__STATIC_INLINE void usb_DevPhySelect(LL_USB_TypeDef *USBx, uint8_t PhyType)
+{
+    if (1U == PhyType) {
+        CLR_REG32_BIT(USBx->DREGS->DCFG, USBFS_DCFG_DSPD);
+    } else {
+        SET_REG32_BIT(USBx->DREGS->DCFG, USBFS_DCFG_DSPD);
+    }
+
+}
+
+/**
+ * @brief  USB DMA function command.
+ * @param  [in] USBx        usb instance
+ * @param  [in] DmaCmd       USB DMA command status, 0 disable, 1 enable
+ * @retval None
+ */
+__STATIC_INLINE void usb_DmaCmd(LL_USB_TypeDef *USBx, uint8_t DmaCmd)
+{
+    MODIFY_REG32(USBx->GREGS->GAHBCFG, USBFS_GAHBCFG_DMAEN, (uint32_t)DmaCmd << USBFS_GAHBCFG_DMAEN_POS);
+}
+
+/**
+ * @brief  USB burst length config.
+ * @param  [in] USBx        usb instance
+ * @param  [in] len         Burst length
+ * @retval None
+ */
+__STATIC_INLINE void usb_BurstLenConfig(LL_USB_TypeDef *USBx, uint8_t len)
+{
+    MODIFY_REG32(USBx->GREGS->GAHBCFG, USBFS_GAHBCFG_HBSTLEN, (uint32_t)len << USBFS_GAHBCFG_HBSTLEN_POS);
+}
+
+/**
+ * @brief  USB frame interval config
+ * @param  [in] USBx        usb instance
+ * @param  [in] interval    Frame interval
+ * @retval None
+ */
+__STATIC_INLINE void usb_FrameIntervalConfig(LL_USB_TypeDef *USBx, uint32_t interval)
+{
+    MODIFY_REG32(USBx->DREGS->DCFG, USBFS_DCFG_PFIVL, interval);
+}
+
+#ifdef USE_HOST_MODE
+/**
+ * @brief  Read the register HPRT and reset the following bits.
+ * @param  [in] USBx        usb instance
+ * @retval value of HPRT
+ */
+//#define USBFS_HPRT_PRTOVRCURRCHNG                            (0x00000020UL)
+__STATIC_INLINE uint32_t usb_rdhprt(LL_USB_TypeDef *USBx)
+{
+    return (READ_REG32(*USBx->HPRT) & ~(USBFS_HPRT_PENA | USBFS_HPRT_PCDET | USBFS_HPRT_PENCHNG));
+}
+
+/**
+ * @brief  Issues a ping token
+ * @param  [in] USBx        usb instance
+ * @param  [in] hc_num      the host channel index
+ * @retval None
+ */
+//#define USBFS_HCTSIZ_DOPNG (0x80000000UL)
+__STATIC_INLINE void usb_pingtokenissue(LL_USB_TypeDef *USBx, uint8_t hc_num)
+{
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCTSIZ, 1UL << USBFS_HCTSIZ_PKTCNT_POS);
+    MODIFY_REG32(USBx->HC_REGS[hc_num]->HCCHAR, USBFS_HCCHAR_CHENA | USBFS_HCCHAR_CHDIS, USBFS_HCCHAR_CHENA);
+}
+
+/**
+ * @brief  This function returns the frame number for sof packet
+ * @param  [in] USBx        usb instance
+ * @retval Frame number
+ */
+__STATIC_INLINE uint32_t usb_ifevenframe(LL_USB_TypeDef *USBx)
+{
+    return ((READ_REG32(USBx->HREGS->HFNUM) + 1UL) & 0x1UL);
+}
+
+/**
+ * @brief  Initializes the FSLSPClkSel field of the HCFG register on the PHY type
+ * @param  [in] USBx        usb instance
+ * @param  [in] freq        clock frequency
+ * @retval None
+ */
+__STATIC_INLINE void usb_fslspclkselset(LL_USB_TypeDef *USBx, uint8_t freq)
+{
+    MODIFY_REG32(USBx->HREGS->HCFG, USBFS_HCFG_FSLSPCS, (uint32_t)freq << USBFS_HCFG_FSLSPCS_POS);
+}
+
+/**
+ * @brief  suspend the port
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_prtsusp(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32hprt;
+    u32hprt = usb_rdhprt(USBx);
+    u32hprt |= USBFS_HPRT_PSUSP;
+    u32hprt &= ~USBFS_HPRT_PRES;
+    WRITE_REG32(*USBx->HPRT, u32hprt);
+}
+
+/**
+ * @brief  control the enumeration speed of the core, this function make sure that
+ *         the maximum speed supported by the connected device.
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_enumspeed(LL_USB_TypeDef *USBx)
+{
+    CLR_REG32_BIT(USBx->HREGS->HCFG, USBFS_HCFG_FSLSS);
+}
+
+/**
+ * @brief  set the TXFIFO and depth for non-periodic and periodic and RXFIFO size
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+__STATIC_INLINE void usb_sethostfifo(LL_USB_TypeDef *USBx, uint8_t u8CoreID)
+{
+    if (USBFS_CORE_ID == u8CoreID) {
+#ifdef USB_FS_MODE
+        /* USBFS Core*/
+        WRITE_REG32(USBx->GREGS->GRXFSIZ, RX_FIFO_FS_SIZE);   /* set the RxFIFO Depth */
+        /* non-periodic transmit RAM start address, set the non-periodic TxFIFO depth */
+        WRITE_REG32(USBx->GREGS->HNPTXFSIZ,
+                    (RX_FIFO_FS_SIZE << USBFS_HNPTXFSIZ_NPTXFSA_POS)
+                    | (TXH_NP_FS_FIFOSIZ << USBFS_HNPTXFSIZ_NPTXFD_POS));
+        /* set the host periodic TxFIFO start address, set the host periodic TxFIFO depth */
+        WRITE_REG32(USBx->GREGS->HPTXFSIZ,
+                    ((RX_FIFO_FS_SIZE + TXH_NP_FS_FIFOSIZ) << USBFS_HPTXFSIZ_PTXSA_POS)
+                    | (TXH_P_FS_FIFOSIZ << USBFS_HPTXFSIZ_PTXFD_POS));
+#endif
+    } else {
+#ifdef USB_HS_MODE
+        /* USBHS Core */
+        WRITE_REG32(USBx->GREGS->GRXFSIZ, RX_FIFO_HS_SIZE);
+        WRITE_REG32(USBx->GREGS->HNPTXFSIZ,
+                    (RX_FIFO_HS_SIZE << USBFS_HNPTXFSIZ_NPTXFSA_POS)
+                    | (TXH_NP_HS_FIFOSIZ << USBFS_HNPTXFSIZ_NPTXFD_POS));
+        WRITE_REG32(USBx->GREGS->HPTXFSIZ,
+                    ((RX_FIFO_HS_SIZE + TXH_NP_HS_FIFOSIZ) << USBFS_HPTXFSIZ_PTXSA_POS)
+                    | (TXH_P_HS_FIFOSIZ << USBFS_HPTXFSIZ_PTXFD_POS));
+#endif
+    }
+}
+
+/**
+ * @brief  reset the channel whose channel number is ch_idx
+ * @param  [in] USBx        usb instance
+ * @param  [in] ch_idx      channel number
+ * @retval None
+ */
+__STATIC_INLINE void usb_chrst(LL_USB_TypeDef *USBx, uint8_t ch_idx)
+{
+    MODIFY_REG32(USBx->HC_REGS[ch_idx]->HCCHAR,
+                 USBFS_HCCHAR_CHENA | USBFS_HCCHAR_CHDIS | USBFS_HCCHAR_EPDIR,
+                 USBFS_HCCHAR_CHDIS);
+}
+#endif /* end of USE_HOST_MODE */
+
+extern void usb_initusbcore(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs);
+extern void usb_setregaddr(LL_USB_TypeDef *USBx, stc_usb_port_identify *pstcPortIdentify, USB_CORE_BASIC_CFGS *basic_cfgs);
+extern void usb_rdpkt(LL_USB_TypeDef *USBx, uint8_t *pu8dest, uint16_t len);
+extern void usb_wrpkt(LL_USB_TypeDef *USBx, const uint8_t *pu8src, uint8_t ch_ep_num, uint16_t len, uint8_t u8DmaEn);
+extern void usb_txfifoflush(LL_USB_TypeDef *USBx, uint32_t num);
+extern void usb_rxfifoflush(LL_USB_TypeDef *USBx);
+extern void usb_modeset(LL_USB_TypeDef *USBx, uint8_t mode);
+extern void usb_coresoftrst(LL_USB_TypeDef *USBx);
+
+#ifdef USE_HOST_MODE
+extern void usb_hostmodeinit(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs);
+extern void usb_hostinten(LL_USB_TypeDef *USBx, uint8_t u8DmaEn);
+extern uint8_t usb_inithch(LL_USB_TypeDef *USBx, uint8_t hc_num, USB_HOST_CH *pCh, uint8_t u8DmaEn);
+extern void usb_hoststop(LL_USB_TypeDef *USBx, uint8_t u8ChNum);
+extern void usb_hchstop(LL_USB_TypeDef *USBx, uint8_t hc_num);
+extern uint8_t usb_hchtransbegin(LL_USB_TypeDef *USBx, uint8_t hc_num, USB_HOST_CH *pCh, uint8_t u8DmaEn);
+extern void usb_hprtrst(LL_USB_TypeDef *USBx);
+extern void usb_vbusctrl(LL_USB_TypeDef *USBx, uint8_t u8State);
+#endif
+
+#ifdef USE_DEVICE_MODE
+extern void usb_devmodeinit(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs);
+extern void usb_devinten(LL_USB_TypeDef *USBx, uint8_t u8DmaEn);
+extern void usb_ep0activate(LL_USB_TypeDef *USBx);
+extern void usb_epactive(LL_USB_TypeDef *USBx, USB_DEV_EP *ep);
+extern void usb_epdeactive(LL_USB_TypeDef *USBx, USB_DEV_EP *ep);
+extern void usb_epntransbegin(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint8_t u8DmaEn);
+extern void usb_ep0transbegin(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint8_t u8DmaEn);
+extern void usb_setepstall(LL_USB_TypeDef *USBx, USB_DEV_EP *ep);
+extern void usb_clearepstall(LL_USB_TypeDef *USBx, USB_DEV_EP *ep);
+extern void usb_ep0revcfg(LL_USB_TypeDef *USBx, uint8_t u8DmaEn, uint8_t *u8RevBuf);
+extern void usb_remotewakeupen(LL_USB_TypeDef *USBx);
+extern void usb_epstatusset(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint32_t Status);
+extern uint32_t usb_epstatusget(LL_USB_TypeDef *USBx, USB_DEV_EP *ep);
+extern void usb_devepdis(LL_USB_TypeDef *USBx, uint8_t u8EpNum);
+extern void usb_ctrldevconnect(LL_USB_TypeDef *USBx, uint8_t link);
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* LL_USB_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_USB_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_utility.h
+++ b/hc32f4a2/inc/hc32_ll_utility.h
@@ -1,0 +1,131 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_utility.h
+ * @brief This file contains all the functions prototypes of the DDL utility.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_UTILITY_H__
+#define __HC32_LL_UTILITY_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_UTILITY
+ * @{
+ */
+
+#if (LL_UTILITY_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup UTILITY_Global_Functions
+ * @{
+ */
+
+/* Imprecise delay */
+void DDL_DelayMS(uint32_t u32Count);
+void DDL_DelayUS(uint32_t u32Count);
+
+/* SysTick functions */
+int32_t SysTick_Init(uint32_t u32Freq);
+void SysTick_Delay(uint32_t u32Delay);
+void SysTick_IncTick(void);
+uint32_t SysTick_GetTick(void);
+void SysTick_Suspend(void);
+void SysTick_Resume(void);
+
+#if (LL_PRINT_ENABLE == DDL_ON)
+int32_t LL_PrintfInit(void *vpDevice, uint32_t u32Param, int32_t (*pfnPreinit)(void *vpDevice, uint32_t u32Param));
+#endif
+
+/* You can add your own assert functions by implement the function DDL_AssertHandler
+   definition follow the function DDL_AssertHandler declaration */
+#ifdef __DEBUG
+#define DDL_ASSERT(x)                                                          \
+do {                                                                           \
+    ((x) ? (void)0 : DDL_AssertHandler(__FILE__, __LINE__));                   \
+} while (0)
+/* Exported function */
+void DDL_AssertHandler(const char *file, int line);
+#else
+#define DDL_ASSERT(x)                   ((void)0U)
+#endif /* __DEBUG */
+
+#if (LL_PRINT_ENABLE == DDL_ON)
+#include <stdio.h>
+__WEAKDEF int32_t DDL_ConsoleOutputChar(char cData);
+
+#define DDL_PrintfInit                  (void)LL_PrintfInit
+#define DDL_Printf                      (void)printf
+#else
+#define DDL_PrintfInit(vpDevice, u32Param, pfnPreinit)
+#define DDL_Printf(...)
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* LL_UTILITY_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_UTILITY_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32_ll_wdt.h
+++ b/hc32f4a2/inc/hc32_ll_wdt.h
@@ -1,0 +1,228 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_wdt.h
+ * @brief This file contains all the functions prototypes of the WDT driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-12-15       CDT             Modify macro define: WDT_LPM_CNT_CONTINUE -> WDT_LPM_CNT_CONT
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32_LL_WDT_H__
+#define __HC32_LL_WDT_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_WDT
+ * @{
+ */
+
+#if (LL_WDT_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup WDT_Global_Types WDT Global Types
+ * @{
+ */
+
+/**
+ * @brief WDT Init structure definition
+ */
+typedef struct {
+    uint32_t u32CountPeriod;            /*!< Specifies the counting period of WDT.
+                                             This parameter can be a value of @ref WDT_Count_Period */
+    uint32_t u32ClockDiv;               /*!< Specifies the clock division factor of WDT.
+                                             This parameter can be a value of @ref WDT_Clock_Division */
+    uint32_t u32RefreshRange;           /*!< Specifies the allow refresh range of WDT.
+                                             This parameter can be a value of @ref WDT_Refresh_Range */
+    uint32_t u32LPMCount;               /*!< Specifies the count state in Low Power Mode (Sleep Mode).
+                                             This parameter can be a value of @ref WDT_LPM_Count */
+    uint32_t u32ExceptionType;          /*!< Specifies the type of exception response for WDT.
+                                             This parameter can be a value of @ref WDT_Exception_Type */
+} stc_wdt_init_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup WDT_Global_Macros WDT Global Macros
+ * @{
+ */
+
+/**
+ * @defgroup WDT_Count_Period WDT Count Period
+ * @{
+ */
+#define WDT_CNT_PERIOD256                       (0UL)               /*!< 256 clock cycle   */
+#define WDT_CNT_PERIOD4096                      (WDT_CR_PERI_0)     /*!< 4096 clock cycle  */
+#define WDT_CNT_PERIOD16384                     (WDT_CR_PERI_1)     /*!< 16384 clock cycle */
+#define WDT_CNT_PERIOD65536                     (WDT_CR_PERI)       /*!< 65536 clock cycle */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup WDT_Clock_Division WDT Clock Division
+ * @{
+ */
+#define WDT_CLK_DIV4                            (0x02UL << WDT_CR_CKS_POS)  /*!< PLCKx/4    */
+#define WDT_CLK_DIV64                           (0x06UL << WDT_CR_CKS_POS)  /*!< PLCKx/64   */
+#define WDT_CLK_DIV128                          (0x07UL << WDT_CR_CKS_POS)  /*!< PLCKx/128  */
+#define WDT_CLK_DIV256                          (0x08UL << WDT_CR_CKS_POS)  /*!< PLCKx/256  */
+#define WDT_CLK_DIV512                          (0x09UL << WDT_CR_CKS_POS)  /*!< PLCKx/512  */
+#define WDT_CLK_DIV1024                         (0x0AUL << WDT_CR_CKS_POS)  /*!< PLCKx/1024 */
+#define WDT_CLK_DIV2048                         (0x0BUL << WDT_CR_CKS_POS)  /*!< PLCKx/2048 */
+#define WDT_CLK_DIV8192                         (0x0DUL << WDT_CR_CKS_POS)  /*!< PLCKx/8192 */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup WDT_Refresh_Range WDT Refresh Range
+ * @{
+ */
+#define WDT_RANGE_0TO25PCT                      (0x01UL << WDT_CR_WDPT_POS)     /*!< 0%~25%             */
+#define WDT_RANGE_25TO50PCT                     (0x02UL << WDT_CR_WDPT_POS)     /*!< 25%~50%            */
+#define WDT_RANGE_0TO50PCT                      (0x03UL << WDT_CR_WDPT_POS)     /*!< 0%~50%             */
+#define WDT_RANGE_50TO75PCT                     (0x04UL << WDT_CR_WDPT_POS)     /*!< 50%~75%            */
+#define WDT_RANGE_0TO25PCT_50TO75PCT            (0x05UL << WDT_CR_WDPT_POS)     /*!< 0%~25% & 50%~75%   */
+#define WDT_RANGE_25TO75PCT                     (0x06UL << WDT_CR_WDPT_POS)     /*!< 25%~75%            */
+#define WDT_RANGE_0TO75PCT                      (0x07UL << WDT_CR_WDPT_POS)     /*!< 0%~75%             */
+#define WDT_RANGE_75TO100PCT                    (0x08UL << WDT_CR_WDPT_POS)     /*!< 75%~100%           */
+#define WDT_RANGE_0TO25PCT_75TO100PCT           (0x09UL << WDT_CR_WDPT_POS)     /*!< 0%~25% & 75%~100%  */
+#define WDT_RANGE_25TO50PCT_75TO100PCT          (0x0AUL << WDT_CR_WDPT_POS)     /*!< 25%~50% & 75%~100% */
+#define WDT_RANGE_0TO50PCT_75TO100PCT           (0x0BUL << WDT_CR_WDPT_POS)     /*!< 0%~50% & 75%~100%  */
+#define WDT_RANGE_50TO100PCT                    (0x0CUL << WDT_CR_WDPT_POS)     /*!< 50%~100%           */
+#define WDT_RANGE_0TO25PCT_50TO100PCT           (0x0DUL << WDT_CR_WDPT_POS)     /*!< 0%~25% & 50%~100%  */
+#define WDT_RANGE_25TO100PCT                    (0x0EUL << WDT_CR_WDPT_POS)     /*!< 25%~100%           */
+#define WDT_RANGE_0TO100PCT                     (0x0FUL << WDT_CR_WDPT_POS)     /*!< 0%~100%            */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup WDT_LPM_Count WDT Low Power Mode Count
+ * @brief    Counting control of WDT in sleep mode.
+ * @{
+ */
+#define WDT_LPM_CNT_CONT                        (0UL)               /*!< Continue counting in sleep mode */
+#define WDT_LPM_CNT_STOP                        (WDT_CR_SLPOFF)     /*!< Stop counting in sleep mode     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup WDT_Exception_Type WDT Exception Type
+ * @brief    Specifies the exception response when a refresh error or count overflow occurs.
+ * @{
+ */
+#define WDT_EXP_TYPE_INT                        (0UL)           /*!< WDT trigger interrupt */
+#define WDT_EXP_TYPE_RST                        (WDT_CR_ITS)    /*!< WDT trigger reset     */
+/**
+ * @}
+ */
+
+/**
+ * @defgroup WDT_Flag WDT Flag
+ * @{
+ */
+#define WDT_FLAG_UDF                            (WDT_SR_UDF)    /*!< Count underflow flag */
+#define WDT_FLAG_REFRESH                        (WDT_SR_REF)    /*!< Refresh error flag   */
+#define WDT_FLAG_ALL                            (WDT_SR_UDF | WDT_SR_REF)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup WDT_Global_Functions
+ * @{
+ */
+
+/**
+ * @brief  Get WDT count value.
+ * @param  None
+ * @retval uint16_t                     Count value
+ */
+__STATIC_INLINE uint16_t WDT_GetCountValue(void)
+{
+    return (uint16_t)(READ_REG32(CM_WDT->SR) & WDT_SR_CNT);
+}
+
+/* Initialization and configuration functions */
+int32_t WDT_Init(const stc_wdt_init_t *pstcWdtInit);
+void WDT_FeedDog(void);
+uint16_t WDT_GetCountValue(void);
+
+/* Flags management functions */
+en_flag_status_t WDT_GetStatus(uint32_t u32Flag);
+int32_t WDT_ClearStatus(uint32_t u32Flag);
+
+/**
+ * @}
+ */
+
+#endif /* LL_WDT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32_LL_WDT_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/inc/hc32f4a2_ll_interrupts_share.h
+++ b/hc32f4a2/inc/hc32f4a2_ll_interrupts_share.h
@@ -1,0 +1,554 @@
+/**
+ *******************************************************************************
+ * @file  hc32f4a2_ll_interrupts_share.h
+ * @brief This file contains all the functions prototypes of the interrupt driver
+ *        library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Rename I2Cx_Error_IrqHandler as I2Cx_EE_IrqHandler
+   2024-06-30       CDT             Add handler for USB
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+#ifndef __HC32F4A2_LL_SHARE_INTERRUPTS_H__
+#define __HC32F4A2_LL_SHARE_INTERRUPTS_H__
+
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_def.h"
+
+#include "hc32f4xx.h"
+#include "hc32f4xx_conf.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @addtogroup LL_HC32F4A2_SHARE_INTERRUPTS
+ * @{
+ */
+
+#if (LL_INTERRUPTS_SHARE_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Global type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global variable definitions ('extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+  Global function prototypes (definition in C source)
+ ******************************************************************************/
+/**
+ * @addtogroup Share_Interrupts_Global_Functions
+ * @{
+ */
+
+int32_t INTC_ShareIrqCmd(en_int_src_t enIntSrc, en_functional_state_t enNewState);
+
+void IRQ128_Handler(void);
+void IRQ129_Handler(void);
+void IRQ130_Handler(void);
+void IRQ131_Handler(void);
+void IRQ132_Handler(void);
+void IRQ133_Handler(void);
+void IRQ134_Handler(void);
+void IRQ135_Handler(void);
+void IRQ136_Handler(void);
+void IRQ137_Handler(void);
+void IRQ138_Handler(void);
+void IRQ139_Handler(void);
+void IRQ140_Handler(void);
+void IRQ141_Handler(void);
+void IRQ142_Handler(void);
+void IRQ143_Handler(void);
+
+void EXTINT00_IrqHandler(void);
+void EXTINT01_IrqHandler(void);
+void EXTINT02_IrqHandler(void);
+void EXTINT03_IrqHandler(void);
+void EXTINT04_IrqHandler(void);
+void EXTINT05_IrqHandler(void);
+void EXTINT06_IrqHandler(void);
+void EXTINT07_IrqHandler(void);
+void EXTINT08_IrqHandler(void);
+void EXTINT09_IrqHandler(void);
+void EXTINT10_IrqHandler(void);
+void EXTINT11_IrqHandler(void);
+void EXTINT12_IrqHandler(void);
+void EXTINT13_IrqHandler(void);
+void EXTINT14_IrqHandler(void);
+void EXTINT15_IrqHandler(void);
+void DMA1_TC0_IrqHandler(void);
+void DMA1_TC1_IrqHandler(void);
+void DMA1_TC2_IrqHandler(void);
+void DMA1_TC3_IrqHandler(void);
+void DMA1_TC4_IrqHandler(void);
+void DMA1_TC5_IrqHandler(void);
+void DMA1_TC6_IrqHandler(void);
+void DMA1_TC7_IrqHandler(void);
+void DMA1_BTC0_IrqHandler(void);
+void DMA1_BTC1_IrqHandler(void);
+void DMA1_BTC2_IrqHandler(void);
+void DMA1_BTC3_IrqHandler(void);
+void DMA1_BTC4_IrqHandler(void);
+void DMA1_BTC5_IrqHandler(void);
+void DMA1_BTC6_IrqHandler(void);
+void DMA1_BTC7_IrqHandler(void);
+void DMA1_Error0_IrqHandler(void);
+void DMA1_Error1_IrqHandler(void);
+void DMA1_Error2_IrqHandler(void);
+void DMA1_Error3_IrqHandler(void);
+void DMA1_Error4_IrqHandler(void);
+void DMA1_Error5_IrqHandler(void);
+void DMA1_Error6_IrqHandler(void);
+void DMA1_Error7_IrqHandler(void);
+void DMA2_TC0_IrqHandler(void);
+void DMA2_TC1_IrqHandler(void);
+void DMA2_TC2_IrqHandler(void);
+void DMA2_TC3_IrqHandler(void);
+void DMA2_TC4_IrqHandler(void);
+void DMA2_TC5_IrqHandler(void);
+void DMA2_TC6_IrqHandler(void);
+void DMA2_TC7_IrqHandler(void);
+void DMA2_BTC0_IrqHandler(void);
+void DMA2_BTC1_IrqHandler(void);
+void DMA2_BTC2_IrqHandler(void);
+void DMA2_BTC3_IrqHandler(void);
+void DMA2_BTC4_IrqHandler(void);
+void DMA2_BTC5_IrqHandler(void);
+void DMA2_BTC6_IrqHandler(void);
+void DMA2_BTC7_IrqHandler(void);
+void DMA2_Error0_IrqHandler(void);
+void DMA2_Error1_IrqHandler(void);
+void DMA2_Error2_IrqHandler(void);
+void DMA2_Error3_IrqHandler(void);
+void DMA2_Error4_IrqHandler(void);
+void DMA2_Error5_IrqHandler(void);
+void DMA2_Error6_IrqHandler(void);
+void DMA2_Error7_IrqHandler(void);
+void EFM_ProgramEraseError_IrqHandler(void);
+void EFM_ColError_IrqHandler(void);
+void EFM_OpEnd_IrqHandler(void);
+void QSPI_Error_IrqHandler(void);
+void MAU_Sqrt_IrqHandler(void);
+void DVP_FrameStart_IrqHandler(void);
+void DVP_FrameEnd_IrqHandler(void);
+void DVP_LineStart_IrqHandler(void);
+void DVP_LineEnd_IrqHandler(void);
+void DVP_SWSyncError_IrqHandler(void);
+void DVP_FifoError_IrqHandler(void);
+void FMAC1_IrqHandler(void);
+void FMAC2_IrqHandler(void);
+void FMAC3_IrqHandler(void);
+void FMAC4_IrqHandler(void);
+void DCU1_IrqHandler(void);
+void DCU2_IrqHandler(void);
+void DCU3_IrqHandler(void);
+void DCU4_IrqHandler(void);
+void DCU5_IrqHandler(void);
+void DCU6_IrqHandler(void);
+void DCU7_IrqHandler(void);
+void DCU8_IrqHandler(void);
+void TMR0_1_CmpA_IrqHandler(void);
+void TMR0_1_CmpB_IrqHandler(void);
+void TMR0_2_CmpA_IrqHandler(void);
+void TMR0_2_CmpB_IrqHandler(void);
+void TMR2_1_CmpA_IrqHandler(void);
+void TMR2_1_CmpB_IrqHandler(void);
+void TMR2_1_OvfA_IrqHandler(void);
+void TMR2_1_OvfB_IrqHandler(void);
+void TMR2_2_CmpA_IrqHandler(void);
+void TMR2_2_CmpB_IrqHandler(void);
+void TMR2_2_OvfA_IrqHandler(void);
+void TMR2_2_OvfB_IrqHandler(void);
+void TMR2_3_CmpA_IrqHandler(void);
+void TMR2_3_CmpB_IrqHandler(void);
+void TMR2_3_OvfA_IrqHandler(void);
+void TMR2_3_OvfB_IrqHandler(void);
+void TMR2_4_CmpA_IrqHandler(void);
+void TMR2_4_CmpB_IrqHandler(void);
+void TMR2_4_OvfA_IrqHandler(void);
+void TMR2_4_OvfB_IrqHandler(void);
+void RTC_TimeStamp0_IrqHandler(void);
+void RTC_TimeStamp1_IrqHandler(void);
+void RTC_Alarm_IrqHandler(void);
+void RTC_Period_IrqHandler(void);
+void CLK_XtalStop_IrqHandler(void);
+void SWDT_IrqHandler(void);
+void WDT_IrqHandler(void);
+void PWC_WakeupTimer_IrqHandler(void);
+void TMR6_1_GCmpA_IrqHandler(void);
+void TMR6_1_GCmpB_IrqHandler(void);
+void TMR6_1_GCmpC_IrqHandler(void);
+void TMR6_1_GCmpD_IrqHandler(void);
+void TMR6_1_GCmpE_IrqHandler(void);
+void TMR6_1_GCmpF_IrqHandler(void);
+void TMR6_1_GOvf_IrqHandler(void);
+void TMR6_1_GUdf_IrqHandler(void);
+void TMR6_1_GDte_IrqHandler(void);
+void TMR6_1_SCmpUpA_IrqHandler(void);
+void TMR6_1_SCmpDownA_IrqHandler(void);
+void TMR6_1_SCmpUpB_IrqHandler(void);
+void TMR6_1_SCmpDownB_IrqHandler(void);
+void TMR6_2_GCmpA_IrqHandler(void);
+void TMR6_2_GCmpB_IrqHandler(void);
+void TMR6_2_GCmpC_IrqHandler(void);
+void TMR6_2_GCmpD_IrqHandler(void);
+void TMR6_2_GCmpE_IrqHandler(void);
+void TMR6_2_GCmpF_IrqHandler(void);
+void TMR6_2_GOvf_IrqHandler(void);
+void TMR6_2_GUdf_IrqHandler(void);
+void TMR6_2_GDte_IrqHandler(void);
+void TMR6_2_SCmpUpA_IrqHandler(void);
+void TMR6_2_SCmpDownA_IrqHandler(void);
+void TMR6_2_SCmpUpB_IrqHandler(void);
+void TMR6_2_SCmpDownB_IrqHandler(void);
+void TMR6_3_GCmpA_IrqHandler(void);
+void TMR6_3_GCmpB_IrqHandler(void);
+void TMR6_3_GCmpC_IrqHandler(void);
+void TMR6_3_GCmpD_IrqHandler(void);
+void TMR6_3_GCmpE_IrqHandler(void);
+void TMR6_3_GCmpF_IrqHandler(void);
+void TMR6_3_GOvf_IrqHandler(void);
+void TMR6_3_GUdf_IrqHandler(void);
+void TMR6_3_GDte_IrqHandler(void);
+void TMR6_3_SCmpUpA_IrqHandler(void);
+void TMR6_3_SCmpDownA_IrqHandler(void);
+void TMR6_3_SCmpUpB_IrqHandler(void);
+void TMR6_3_SCmpDownB_IrqHandler(void);
+void TMR6_4_GCmpA_IrqHandler(void);
+void TMR6_4_GCmpB_IrqHandler(void);
+void TMR6_4_GCmpC_IrqHandler(void);
+void TMR6_4_GCmpD_IrqHandler(void);
+void TMR6_4_GCmpE_IrqHandler(void);
+void TMR6_4_GCmpF_IrqHandler(void);
+void TMR6_4_GOvf_IrqHandler(void);
+void TMR6_4_GUdf_IrqHandler(void);
+void TMR6_4_Gdte_IrqHandler(void);
+void TMR6_4_SCmpUpA_IrqHandler(void);
+void TMR6_4_SCmpDownA_IrqHandler(void);
+void TMR6_4_SCmpUpB_IrqHandler(void);
+void TMR6_4_SCmpDownB_IrqHandler(void);
+void TMR6_5_GCmpA_IrqHandler(void);
+void TMR6_5_GCmpB_IrqHandler(void);
+void TMR6_5_GCmpC_IrqHandler(void);
+void TMR6_5_GCmpD_IrqHandler(void);
+void TMR6_5_GCmpE_IrqHandler(void);
+void TMR6_5_GCmpF_IrqHandler(void);
+void TMR6_5_GOvf_IrqHandler(void);
+void TMR6_5_GUdf_IrqHandler(void);
+void TMR6_5_Gdte_IrqHandler(void);
+void TMR6_5_SCmpUpA_IrqHandler(void);
+void TMR6_5_SCmpDownA_IrqHandler(void);
+void TMR6_5_SCmpUpB_IrqHandler(void);
+void TMR6_5_SCmpDownB_IrqHandler(void);
+void TMR6_6_GCmpA_IrqHandler(void);
+void TMR6_6_GCmpB_IrqHandler(void);
+void TMR6_6_GCmpC_IrqHandler(void);
+void TMR6_6_GCmpD_IrqHandler(void);
+void TMR6_6_GCmpE_IrqHandler(void);
+void TMR6_6_GCmpF_IrqHandler(void);
+void TMR6_6_GOvf_IrqHandler(void);
+void TMR6_6_GUdf_IrqHandler(void);
+void TMR6_6_Gdte_IrqHandler(void);
+void TMR6_6_SCmpUpA_IrqHandler(void);
+void TMR6_6_SCmpDownA_IrqHandler(void);
+void TMR6_6_SCmpUpB_IrqHandler(void);
+void TMR6_6_SCmpDownB_IrqHandler(void);
+void TMR6_7_GCmpA_IrqHandler(void);
+void TMR6_7_GCmpB_IrqHandler(void);
+void TMR6_7_GCmpC_IrqHandler(void);
+void TMR6_7_GCmpD_IrqHandler(void);
+void TMR6_7_GCmpE_IrqHandler(void);
+void TMR6_7_GCmpF_IrqHandler(void);
+void TMR6_7_GOvf_IrqHandler(void);
+void TMR6_7_GUdf_IrqHandler(void);
+void TMR6_7_Gdte_IrqHandler(void);
+void TMR6_7_SCmpUpA_IrqHandler(void);
+void TMR6_7_SCmpDownA_IrqHandler(void);
+void TMR6_7_SCmpUpB_IrqHandler(void);
+void TMR6_7_SCmpDownB_IrqHandler(void);
+void TMR6_8_GCmpA_IrqHandler(void);
+void TMR6_8_GCmpB_IrqHandler(void);
+void TMR6_8_GCmpC_IrqHandler(void);
+void TMR6_8_GCmpD_IrqHandler(void);
+void TMR6_8_GCmpE_IrqHandler(void);
+void TMR6_8_GCmpF_IrqHandler(void);
+void TMR6_8_GOvf_IrqHandler(void);
+void TMR6_8_GUdf_IrqHandler(void);
+void TMR6_8_Gdte_IrqHandler(void);
+void TMR6_8_SCmpUpA_IrqHandler(void);
+void TMR6_8_SCmpDownA_IrqHandler(void);
+void TMR6_8_SCmpUpB_IrqHandler(void);
+void TMR6_8_SCmpDownB_IrqHandler(void);
+void TMR4_1_GCmpUH_IrqHandler(void);
+void TMR4_1_GCmpUL_IrqHandler(void);
+void TMR4_1_GCmpVH_IrqHandler(void);
+void TMR4_1_GCmpVL_IrqHandler(void);
+void TMR4_1_GCmpWH_IrqHandler(void);
+void TMR4_1_GCmpWL_IrqHandler(void);
+void TMR4_1_Ovf_IrqHandler(void);
+void TMR4_1_Udf_IrqHandler(void);
+void TMR4_1_ReloadU_IrqHandler(void);
+void TMR4_1_ReloadV_IrqHandler(void);
+void TMR4_1_ReloadW_IrqHandler(void);
+void TMR4_2_GCmpUH_IrqHandler(void);
+void TMR4_2_GCmpUL_IrqHandler(void);
+void TMR4_2_GCmpVH_IrqHandler(void);
+void TMR4_2_GCmpVL_IrqHandler(void);
+void TMR4_2_GCmpWH_IrqHandler(void);
+void TMR4_2_GCmpWL_IrqHandler(void);
+void TMR4_2_Ovf_IrqHandler(void);
+void TMR4_2_Udf_IrqHandler(void);
+void TMR4_2_ReloadU_IrqHandler(void);
+void TMR4_2_ReloadV_IrqHandler(void);
+void TMR4_2_ReloadW_IrqHandler(void);
+void TMR4_3_GCmpUH_IrqHandler(void);
+void TMR4_3_GCmpUL_IrqHandler(void);
+void TMR4_3_GCmpVH_IrqHandler(void);
+void TMR4_3_GCmpVL_IrqHandler(void);
+void TMR4_3_GCmpWH_IrqHandler(void);
+void TMR4_3_GCmpWL_IrqHandler(void);
+void TMR4_3_Ovf_IrqHandler(void);
+void TMR4_3_Udf_IrqHandler(void);
+void TMR4_3_ReloadU_IrqHandler(void);
+void TMR4_3_ReloadV_IrqHandler(void);
+void TMR4_3_ReloadW_IrqHandler(void);
+void TMRA_1_Ovf_IrqHandler(void);
+void TMRA_1_Udf_IrqHandler(void);
+void TMRA_1_Cmp_IrqHandler(void);
+void TMRA_2_Ovf_IrqHandler(void);
+void TMRA_2_Udf_IrqHandler(void);
+void TMRA_2_Cmp_IrqHandler(void);
+void TMRA_3_Ovf_IrqHandler(void);
+void TMRA_3_Udf_IrqHandler(void);
+void TMRA_3_Cmp_IrqHandler(void);
+void TMRA_4_Ovf_IrqHandler(void);
+void TMRA_4_Udf_IrqHandler(void);
+void TMRA_4_Cmp_IrqHandler(void);
+void TMRA_5_Ovf_IrqHandler(void);
+void TMRA_5_Udf_IrqHandler(void);
+void TMRA_5_Cmp_IrqHandler(void);
+void TMRA_6_Ovf_IrqHandler(void);
+void TMRA_6_Udf_IrqHandler(void);
+void TMRA_6_Cmp_IrqHandler(void);
+void TMRA_7_Ovf_IrqHandler(void);
+void TMRA_7_Udf_IrqHandler(void);
+void TMRA_7_Cmp_IrqHandler(void);
+void TMRA_8_Ovf_IrqHandler(void);
+void TMRA_8_Udf_IrqHandler(void);
+void TMRA_8_Cmp_IrqHandler(void);
+void TMRA_9_Ovf_IrqHandler(void);
+void TMRA_9_Udf_IrqHandler(void);
+void TMRA_9_Cmp_IrqHandler(void);
+void TMRA_10_Ovf_IrqHandler(void);
+void TMRA_10_Udf_IrqHandler(void);
+void TMRA_10_Cmp_IrqHandler(void);
+void TMRA_11_Ovf_IrqHandler(void);
+void TMRA_11_Udf_IrqHandler(void);
+void TMRA_11_Cmp_IrqHandler(void);
+void TMRA_12_Ovf_IrqHandler(void);
+void TMRA_12_Udf_IrqHandler(void);
+void TMRA_12_Cmp_IrqHandler(void);
+void EMB_GR0_IrqHandler(void);
+void EMB_GR1_IrqHandler(void);
+void EMB_GR2_IrqHandler(void);
+void EMB_GR3_IrqHandler(void);
+void EMB_GR4_IrqHandler(void);
+void EMB_GR5_IrqHandler(void);
+void EMB_GR6_IrqHandler(void);
+void USBHS_EP1Out_IrqHandler(void);
+void USBHS_EP1In_IrqHandler(void);
+void USBHS_Global_IrqHandler(void);
+void USBHS_Wakeup_IrqHandler(void);
+void USART1_RxError_IrqHandler(void);
+void USART1_RxFull_IrqHandler(void);
+void USART1_TxEmpty_IrqHandler(void);
+void USART1_TxComplete_IrqHandler(void);
+void USART1_RxTO_IrqHandler(void);
+void USART2_RxError_IrqHandler(void);
+void USART2_RxFull_IrqHandler(void);
+void USART2_TxEmpty_IrqHandler(void);
+void USART2_TxComplete_IrqHandler(void);
+void USART2_RxTO_IrqHandler(void);
+void USART3_RxError_IrqHandler(void);
+void USART3_RxFull_IrqHandler(void);
+void USART3_TxEmpty_IrqHandler(void);
+void USART3_TxComplete_IrqHandler(void);
+void USART4_RxError_IrqHandler(void);
+void USART4_RxFull_IrqHandler(void);
+void USART4_TxEmpty_IrqHandler(void);
+void USART4_TxComplete_IrqHandler(void);
+void USART5_LinBreakField_IrqHandler(void);
+void USART5_LinWakeup_IrqHandler(void);
+void USART5_RxError_IrqHandler(void);
+void USART5_RxFull_IrqHandler(void);
+void USART5_TxEmpty_IrqHandler(void);
+void USART5_TxComplete_IrqHandler(void);
+void USART6_RxError_IrqHandler(void);
+void USART6_RxFull_IrqHandler(void);
+void USART6_TxEmpty_IrqHandler(void);
+void USART6_TxComplete_IrqHandler(void);
+void USART6_RxTO_IrqHandler(void);
+void USART7_RxError_IrqHandler(void);
+void USART7_RxFull_IrqHandler(void);
+void USART7_TxEmpty_IrqHandler(void);
+void USART7_TxComplete_IrqHandler(void);
+void USART7_RxTO_IrqHandler(void);
+void USART8_RxError_IrqHandler(void);
+void USART8_RxFull_IrqHandler(void);
+void USART8_TxEmpty_IrqHandler(void);
+void USART8_TxComplete_IrqHandler(void);
+void USART9_RxError_IrqHandler(void);
+void USART9_RxFull_IrqHandler(void);
+void USART9_TxEmpty_IrqHandler(void);
+void USART9_TxComplete_IrqHandler(void);
+void USART10_LinBreakField_IrqHandler(void);
+void USART10_LinWakeup_IrqHandler(void);
+void USART10_RxError_IrqHandler(void);
+void USART10_RxFull_IrqHandler(void);
+void USART10_TxEmpty_IrqHandler(void);
+void USART10_TxComplete_IrqHandler(void);
+void SPI1_RxFull_IrqHandler(void);
+void SPI1_TxEmpty_IrqHandler(void);
+void SPI1_Error_IrqHandler(void);
+void SPI1_Idle_IrqHandler(void);
+void SPI2_RxFull_IrqHandler(void);
+void SPI2_TxEmpty_IrqHandler(void);
+void SPI2_Error_IrqHandler(void);
+void SPI2_Idle_IrqHandler(void);
+void SPI3_RxFull_IrqHandler(void);
+void SPI3_TxEmpty_IrqHandler(void);
+void SPI3_Error_IrqHandler(void);
+void SPI3_Idle_IrqHandler(void);
+void SPI4_RxFull_IrqHandler(void);
+void SPI4_TxEmpty_IrqHandler(void);
+void SPI4_Error_IrqHandler(void);
+void SPI4_Idle_IrqHandler(void);
+void SPI5_RxFull_IrqHandler(void);
+void SPI5_TxEmpty_IrqHandler(void);
+void SPI5_Error_IrqHandler(void);
+void SPI5_Idle_IrqHandler(void);
+void SPI6_RxFull_IrqHandler(void);
+void SPI6_TxEmpty_IrqHandler(void);
+void SPI6_Error_IrqHandler(void);
+void SPI6_Idle_IrqHandler(void);
+void CAN1_IrqHandler(void);
+void CAN2_IrqHandler(void);
+void I2S1_Tx_IrqHandler(void);
+void I2S1_Rx_IrqHandler(void);
+void I2S1_Error_IrqHandler(void);
+void I2S2_Tx_IrqHandler(void);
+void I2S2_Rx_IrqHandler(void);
+void I2S2_Error_IrqHandler(void);
+void I2S3_Tx_IrqHandler(void);
+void I2S3_Rx_IrqHandler(void);
+void I2S3_Error_IrqHandler(void);
+void I2S4_Tx_IrqHandler(void);
+void I2S4_Rx_IrqHandler(void);
+void I2S4_Error_IrqHandler(void);
+void USBFS_Global_IrqHandler(void);
+void USBFS_Wakeup_IrqHandler(void);
+void SDIOC1_Normal_IrqHandler(void);
+void SDIOC1_Error_IrqHandler(void);
+void SDIOC2_Normal_IrqHandler(void);
+void SDIOC2_Error_IrqHandler(void);
+void ETH_Global_IrqHandler(void);
+void ETH_Wakeup_IrqHandler(void);
+void I2C1_RxFull_IrqHandler(void);
+void I2C1_TxComplete_IrqHandler(void);
+void I2C1_TxEmpty_IrqHandler(void);
+void I2C1_EE_IrqHandler(void);
+void I2C2_RxFull_IrqHandler(void);
+void I2C2_TxComplete_IrqHandler(void);
+void I2C2_TxEmpty_IrqHandler(void);
+void I2C2_EE_IrqHandler(void);
+void I2C3_RxFull_IrqHandler(void);
+void I2C3_TxComplete_IrqHandler(void);
+void I2C3_TxEmpty_IrqHandler(void);
+void I2C3_EE_IrqHandler(void);
+void I2C4_RxFull_IrqHandler(void);
+void I2C4_TxComplete_IrqHandler(void);
+void I2C4_TxEmpty_IrqHandler(void);
+void I2C4_EE_IrqHandler(void);
+void I2C5_RxFull_IrqHandler(void);
+void I2C5_TxComplete_IrqHandler(void);
+void I2C5_TxEmpty_IrqHandler(void);
+void I2C5_EE_IrqHandler(void);
+void I2C6_RxFull_IrqHandler(void);
+void I2C6_TxComplete_IrqHandler(void);
+void I2C6_TxEmpty_IrqHandler(void);
+void I2C6_EE_IrqHandler(void);
+void PWC_LVD1_IrqHandler(void);
+void PWC_LVD2_IrqHandler(void);
+void FCM_Error_IrqHandler(void);
+void FCM_End_IrqHandler(void);
+void FCM_Ovf_IrqHandler(void);
+void CTC_Udf_IrqHandler(void);
+void CTC_Ovf_IrqHandler(void);
+void ADC1_SeqA_IrqHandler(void);
+void ADC1_SeqB_IrqHandler(void);
+void ADC1_Cmp0_IrqHandler(void);
+void ADC1_Cmp1_IrqHandler(void);
+void ADC1_CmpComb_IrqHandler(void);
+void ADC2_SeqA_IrqHandler(void);
+void ADC2_SeqB_IrqHandler(void);
+void ADC2_Cmp0_IrqHandler(void);
+void ADC2_Cmp1_IrqHandler(void);
+void ADC2_CmpComb_IrqHandler(void);
+void ADC3_SeqA_IrqHandler(void);
+void ADC3_SeqB_IrqHandler(void);
+void ADC3_Cmp0_IrqHandler(void);
+void ADC3_Cmp1_IrqHandler(void);
+void ADC3_CmpComb_IrqHandler(void);
+void NFC_IrqHandler(void);
+
+/**
+ * @}
+ */
+
+#endif /* LL_INTERRUPTS_SHARE_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HC32F4A2_LL_SHARE_INTERRUPTS_H__ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/src/hc32_ll.c
+++ b/hc32f4a2/src/hc32_ll.c
@@ -1,0 +1,170 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll.c
+ * @brief This file provides firmware functions to low-level drivers (LL).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @defgroup LL_Driver LL Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_Global Global
+ * @{
+ */
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup LL_Global_Functions LL Global Functions
+ * @{
+ */
+void LL_PERIPH_WE(uint32_t u32Peripheral)
+{
+#if (LL_EFM_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_EFM) != 0UL) {
+        /* Unlock all EFM registers */
+        EFM_REG_Unlock();
+    }
+#endif
+#if (LL_FCG_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_FCG) != 0UL) {
+        /* Unlock FCG register */
+        PWC_FCG0_REG_Unlock();
+    }
+#endif
+#if (LL_GPIO_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_GPIO) != 0UL) {
+        /* Unlock GPIO register: PSPCR, PCCR, PINAER, PCRxy, PFSRxy */
+        GPIO_REG_Unlock();
+    }
+#endif
+#if (LL_MPU_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_MPU) != 0UL) {
+        /* Unlock all MPU registers */
+        MPU_REG_Unlock();
+    }
+#endif
+#if (LL_PWC_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_LVD) != 0UL) {
+        /* Unlock LVD registers, @ref PWC_REG_Write_Unlock_Code for details */
+        PWC_REG_Unlock(PWC_UNLOCK_CODE2);
+    }
+#endif
+#if (LL_PWC_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_PWC_CLK_RMU) != 0UL) {
+        /* Unlock PWC, CLK, RMU registers, @ref PWC_REG_Write_Unlock_Code for details */
+        PWC_REG_Unlock(PWC_UNLOCK_CODE0 | PWC_UNLOCK_CODE1);
+    }
+#endif
+#if (LL_SRAM_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_SRAM) != 0UL) {
+        /* Unlock SRAM register: WTCR, CKCR */
+        SRAM_REG_Unlock();
+    }
+#endif
+}
+
+void LL_PERIPH_WP(uint32_t u32Peripheral)
+{
+#if (LL_EFM_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_EFM) != 0UL) {
+        /* Lock all EFM registers */
+        EFM_REG_Lock();
+    }
+#endif
+#if (LL_FCG_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_FCG) != 0UL) {
+        /* Lock FCG register */
+        PWC_FCG0_REG_Lock();
+    }
+#endif
+#if (LL_GPIO_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_GPIO) != 0UL) {
+        /* Unlock GPIO register: PSPCR, PCCR, PINAER, PCRxy, PFSRxy */
+        GPIO_REG_Lock();
+    }
+#endif
+#if (LL_MPU_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_MPU) != 0UL) {
+        /* Lock all MPU registers */
+        MPU_REG_Lock();
+    }
+#endif
+#if (LL_PWC_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_LVD) != 0UL) {
+        /* Lock LVD registers, @ref PWC_REG_Write_Unlock_Code for details */
+        PWC_REG_Lock(PWC_UNLOCK_CODE2);
+    }
+#endif
+#if (LL_PWC_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_PWC_CLK_RMU) != 0UL) {
+        /* Lock PWC, CLK, RMU registers, @ref PWC_REG_Write_Unlock_Code for details */
+        PWC_REG_Lock(PWC_UNLOCK_CODE0 | PWC_UNLOCK_CODE1);
+    }
+#endif
+#if (LL_SRAM_ENABLE == DDL_ON)
+    if ((u32Peripheral & LL_PERIPH_SRAM) != 0UL) {
+        /* Lock SRAM register: WTCR, CKCR */
+        SRAM_REG_Lock();
+    }
+#endif
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_adc.c
+++ b/hc32f4a2/src/hc32_ll_adc.c
@@ -1,0 +1,1257 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_adc.c
+ * @brief This file provides firmware functions to manage the Analog-to-Digital
+ *        Converter(ADC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             API fixed: ADC_DeInit()
+   2023-06-30       CDT             Modify typo
+                                    API fixed: ADC_DeInit()
+   2023-12-15       CDT             Add API ADC_MxChCmd(),ADC_ConvDataAverageMxChCmd
+                                    Add API ADC_GetResolution()
+   2024-06-30       CDT             Optimized access code for some registers to improve readability
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_adc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_ADC ADC
+ * @brief Analog-to-Digital Converter Driver Library
+ * @{
+ */
+
+#if (LL_ADC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ADC_Local_Macros ADC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup ADC_PGA_En ADC PGA Function Control
+ * @{
+ */
+#define ADC_PGA_DISABLE                 (0x0U)
+#define ADC_PGA_ENABLE                  (0xEU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_AWD_DR_CHSR ADC AWD DR CHSR
+ * @{
+ */
+#define ADC_AWDx_DR(awd, reg_base)      (*(__IO uint16_t *)((uint32_t)(reg_base) + ((uint32_t)(awd) * 8U)))
+#define ADC_AWDx_CHSR(awd, reg_base)    (*(__IO uint8_t *)((uint32_t)(reg_base) + ((uint32_t)(awd) * 8U)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Channel_Max ADC Channel Max
+ * @{
+ */
+#define ADC1_CH_MAX                     (ADC_CH15)
+#define ADC2_CH_MAX                     (ADC_CH15)
+#define ADC3_CH_MAX                     (ADC_CH19)
+#define ADC_REMAP_CH_MAX                (ADC_CH15)
+#define ADC_REMAP_PIN_MAX               (ADC12_PIN_PC5)
+#define ADC_SSTR_NUM                    (16U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ADC_Check_Parameters_Validity ADC check parameters validity
+ * @{
+ */
+#define IS_ADC_1BIT_MASK(x)             (((x) != 0U) && (((x) & ((x) - 1U)) == 0U))
+#define IS_ADC_BIT_MASK(x, mask)        (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+/* ADC unit check */
+#define IS_ADC_UNIT(x)                                                         \
+(   ((x) == CM_ADC1)                        ||                                 \
+    ((x) == CM_ADC2)                        ||                                 \
+    ((x) == CM_ADC3))
+
+/* ADC sequence check */
+#define IS_ADC_SEQ(x)                   (((x) == ADC_SEQ_A) || ((x) == ADC_SEQ_B))
+
+/* ADC channel check */
+#define IS_ADC_CH(adc, ch)                                                     \
+(   (((adc) == CM_ADC1) && ((ch) <= ADC1_CH_MAX))   ||                         \
+    (((adc) == CM_ADC2) && ((ch) <= ADC2_CH_MAX))   ||                         \
+    (((adc) == CM_ADC3) && ((ch) <= ADC3_CH_MAX)))
+
+/* ADC MX channel check */
+#define IS_ADC_MX_CH(adc, ch)                                                  \
+(   (((adc) == CM_ADC1) && IS_ADC_BIT_MASK(ch, ADC1_MX_CH_ALL))   ||           \
+    (((adc) == CM_ADC2) && IS_ADC_BIT_MASK(ch, ADC2_MX_CH_ALL))   ||           \
+    (((adc) == CM_ADC3) && IS_ADC_BIT_MASK(ch, ADC3_MX_CH_ALL)))
+
+#define IS_ADC_SCAN_MD(x)                                                      \
+(   ((x) == ADC_MD_SEQA_SINGLESHOT)         ||                                 \
+    ((x) == ADC_MD_SEQA_CONT)               ||                                 \
+    ((x) == ADC_MD_SEQA_SEQB_SINGLESHOT)    ||                                 \
+    ((x) == ADC_MD_SEQA_CONT_SEQB_SINGLESHOT))
+
+#define IS_ADC_RESOLUTION(x)                                                   \
+(   ((x) == ADC_RESOLUTION_8BIT)            ||                                 \
+    ((x) == ADC_RESOLUTION_10BIT)           ||                                 \
+    ((x) == ADC_RESOLUTION_12BIT))
+
+#define IS_ADC_HARDTRIG(x)                                                     \
+(   ((x) == ADC_HARDTRIG_ADTRG_PIN)         ||                                 \
+    ((x) == ADC_HARDTRIG_EVT0)              ||                                 \
+    ((x) == ADC_HARDTRIG_EVT1)              ||                                 \
+    ((x) == ADC_HARDTRIG_EVT0_EVT1))
+
+#define IS_ADC_DATAALIGN(x)                                                    \
+(   ((x) == ADC_DATAALIGN_RIGHT)            ||                                 \
+    ((x) == ADC_DATAALIGN_LEFT))
+
+#define IS_ADC_SEQA_RESUME_MD(x)                                               \
+(   ((x) == ADC_SEQA_RESUME_SCAN_CONT)      ||                                 \
+    ((x) == ADC_SEQA_RESUME_SCAN_RESTART))
+
+#define IS_ADC_SAMPLE_TIME(x)           ((x) >= 5U)
+
+#define IS_ADC_INT(x)                   IS_ADC_BIT_MASK(x, ADC_INT_ALL)
+#define IS_ADC_FLAG(x)                  IS_ADC_BIT_MASK(x, ADC_FLAG_ALL)
+
+/* Scan-average. */
+#define IS_ADC_AVG_CNT(x)               (((x) | ADC_AVG_CNT256) == ADC_AVG_CNT256)
+
+/* Extended channel. */
+#define IS_ADC_EXTCH_SRC(x)                                                    \
+(   ((x) == ADC_EXTCH_EXTERN_ANALOG_PIN)    ||                                 \
+    ((x) == ADC_EXTCH_INTERN_ANALOG_SRC))
+
+/* Channel remapping. */
+#define IS_ADC_REMAP_PIN(adc, pin)      (IS_ADC_UNIT(adc) && ((pin) <= ADC_REMAP_PIN_MAX))
+#define IS_ADC_REMAP_CH(adc, ch)        (IS_ADC_UNIT(adc) && ((ch) <= ADC_REMAP_CH_MAX))
+
+/* Sync mode. */
+#define IS_ADC_SYNC_MD(x)                                                      \
+(   ((x) == ADC_SYNC_SINGLE_DELAY_TRIG)     ||                                 \
+    ((x) == ADC_SYNC_SINGLE_PARALLEL_TRIG)  ||                                 \
+    ((x) == ADC_SYNC_CYCLIC_DELAY_TRIG)     ||                                 \
+    ((x) == ADC_SYNC_CYCLIC_PARALLEL_TRIG))
+
+#define IS_ADC_SYNC(x)                                                         \
+(   ((x) == ADC_SYNC_ADC1_ADC2)             ||                                 \
+    ((x) == ADC_SYNC_ADC1_ADC2_ADC3))
+
+/* Analog watchdog. */
+#define IS_ADC_AWD_MD(x)                                                       \
+(   ((x) == ADC_AWD_MD_CMP_OUT)             ||                                 \
+    ((x) == ADC_AWD_MD_CMP_IN))
+
+#define IS_ADC_AWD(x)                   ((x) <= ADC_AWD1)
+
+/* AWD flag check */
+#define IS_ADC_AWD_FLAG(x)              IS_ADC_BIT_MASK(x, ADC_AWD_FLAG_ALL)
+
+/* Two AWD units */
+#define IS_ADC_AWD_COMB_MD(x)                                                  \
+(   ((x) == ADC_AWD_COMB_INVD)              ||                                 \
+    ((x) == ADC_AWD_COMB_OR)                ||                                 \
+    ((x) == ADC_AWD_COMB_AND)               ||                                 \
+    ((x) == ADC_AWD_COMB_XOR))
+
+#define IS_ADC_AWD_INT(x)               IS_ADC_BIT_MASK(x, ADC_AWD_INT_ALL)
+
+/* Sample hold. */
+#define IS_ADC_SPLHOLD_SPLTIME(x)       ((x) >= 4U)
+
+#define IS_ADC_SH_UNIT(x)               ((x) == CM_ADC1)
+
+#define IS_ADC_SH_CH(x)                 ((x) <= ADC_CH2)
+
+/* PGA */
+#define IS_ADC_PGA_GAIN(x)              ((x) <= ADC_PGA_GAIN_32)
+
+#define IS_ADC_PGA_VSS(x)               (((x) == ADC_PGA_VSS_PGAVSS) || ((x) == ADC_PGA_VSS_AVSS))
+
+/* PGA unit */
+#define IS_ADC_PGA(adc, pga)                                                   \
+(   (((adc) == CM_ADC1) && ((pga) <= ADC_PGA3))         ||                     \
+    (((adc) == CM_ADC2) && ((pga) == ADC_PGA4)))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup ADC_Global_Functions ADC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes the specified ADC peripheral according to the specified parameters
+ *         in the structure pstcAdcInit.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  pstcAdcInit            Pointer to a @ref stc_adc_init_t structure that contains the
+ *                                      configuration information for the specified ADC.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcAdcInit == NULL.
+ */
+int32_t ADC_Init(CM_ADC_TypeDef *ADCx, const stc_adc_init_t *pstcAdcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+
+    if (pstcAdcInit != NULL) {
+        DDL_ASSERT(IS_ADC_SCAN_MD(pstcAdcInit->u16ScanMode));
+        DDL_ASSERT(IS_ADC_RESOLUTION(pstcAdcInit->u16Resolution));
+        DDL_ASSERT(IS_ADC_DATAALIGN(pstcAdcInit->u16DataAlign));
+        /* Configures scan mode, resolution, data align. */
+        WRITE_REG16(ADCx->CR0, pstcAdcInit->u16ScanMode | pstcAdcInit->u16Resolution | pstcAdcInit->u16DataAlign);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Deinitialize the specified ADC peripheral registers to their default reset values.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t ADC_DeInit(CM_ADC_TypeDef *ADCx)
+{
+    uint8_t i;
+    __IO uint8_t *reg8SSTR;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+
+    /* Stop the ADC. */
+    WRITE_REG8(ADCx->STR, 0U);
+    /* Set the registers to reset value. */
+    WRITE_REG16(ADCx->CR0, 0x0U);
+    WRITE_REG16(ADCx->CR1, 0x0U);
+    WRITE_REG16(ADCx->TRGSR, 0x0U);
+    WRITE_REG32(ADCx->CHSELRA, 0x0U);
+    WRITE_REG32(ADCx->CHSELRB, 0x0U);
+    WRITE_REG8(ADCx->ICR, 0x03U);
+    WRITE_REG32(ADCx->AVCHSELR, 0x0U);
+
+    /* SSTRx */
+    reg8SSTR = (__IO uint8_t *)((uint32_t)&ADCx->SSTR0);
+    for (i = 0U; i < ADC_SSTR_NUM; i++) {
+        reg8SSTR[i] = 0x0BU;
+    }
+
+    /* SSTRL */
+    if (ADCx == CM_ADC3) {
+        WRITE_REG8(ADCx->SSTRL, 0x0BU);
+    }
+
+    /* CHMUXRx */
+    WRITE_REG16(ADCx->CHMUXR0, 0x3210U);
+    WRITE_REG16(ADCx->CHMUXR1, 0x7654U);
+    WRITE_REG16(ADCx->CHMUXR2, 0xBA98U);
+    WRITE_REG16(ADCx->CHMUXR3, 0xFEDCU);
+
+    /* ISR clearing */
+    WRITE_REG8(ADCx->ISCLRR, 0x13U);
+
+    /* Sync mode */
+    WRITE_REG16(ADCx->SYNCCR, 0x0C00U);
+
+    /* Analog watchdog */
+    WRITE_REG16(ADCx->AWDCR, 0x0U);
+    WRITE_REG8(ADCx->AWDSCLRR, 0x13U);
+    WRITE_REG16(ADCx->AWD0DR0, 0x0U);
+    WRITE_REG16(ADCx->AWD0DR1, 0xFFFFU);
+    WRITE_REG16(ADCx->AWD1DR0, 0x0U);
+    WRITE_REG16(ADCx->AWD1DR1, 0xFFFFU);
+    WRITE_REG8(ADCx->AWD0CHSR, 0x0U);
+    WRITE_REG8(ADCx->AWD1CHSR, 0x0U);
+
+    /* Sample hold */
+    WRITE_REG16(ADCx->SHCR, 0x0U);
+
+    /* PGA and OPA */
+    if (ADCx == CM_ADC1) {
+        WRITE_REG8(ADCx->PGACR1, 0x0U);
+        WRITE_REG8(ADCx->PGACR2, 0x0U);
+        WRITE_REG8(ADCx->PGACR3, 0x0U);
+        WRITE_REG8(ADCx->PGAVSSENR, 0x0U);
+    } else if (ADCx == CM_ADC2) {
+        WRITE_REG8(ADCx->PGACR1, 0x0U);
+        WRITE_REG8(ADCx->PGAVSSENR, 0x0U);
+    } else {
+        /* rsvd */
+    }
+    return LL_OK;
+}
+
+/**
+ * @brief  Set each @ref stc_adc_init_t field to default value.
+ * @param  [in]  pstcAdcInit            Pointer to a @ref stc_adc_init_t structure
+ *                                      whose fields will be set to default values.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcAdcInit == NULL.
+ */
+int32_t ADC_StructInit(stc_adc_init_t *pstcAdcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcAdcInit != NULL) {
+        pstcAdcInit->u16ScanMode   = ADC_MD_SEQA_SINGLESHOT;
+        pstcAdcInit->u16Resolution = ADC_RESOLUTION_12BIT;
+        pstcAdcInit->u16DataAlign  = ADC_DATAALIGN_RIGHT;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the specified ADC channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Seq                  The sequence whose channel specified by 'u8Ch' will be enabled or disabled.
+ *                                      This parameter can be a value of @ref ADC_Sequence
+ *   @arg  ADC_SEQ_A:                   ADC sequence A.
+ *   @arg  ADC_SEQ_B:                   ADC sequence B.
+ * @param  [in]  u8Ch                   The ADC channel.
+ *                                      This parameter can be values of @ref ADC_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @note   Sequence A and Sequence B CAN NOT include the same channel!
+ * @note   Sequence A can always started by software(by calling @ref ADC_Start()),
+ *         regardless of whether the hardware trigger source is valid or not.
+ * @note   Sequence B must be specified a valid hard trigger by calling functions @ref ADC_TriggerConfig()
+ *         and @ref ADC_TriggerCmd().
+ */
+void ADC_ChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CHSELRx;
+
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+    DDL_ASSERT(IS_ADC_SEQ(u8Seq));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CHSELRx = (__IO uint32_t *)((uint32_t)(&ADCx->CHSELRA) + (u8Seq * 4UL));
+    if (enNewState == ENABLE) {
+        /* Enable the specified channel. */
+        SET_REG32_BIT(*CHSELRx, 1UL << u8Ch);
+    } else {
+        /* Disable the specified channel. */
+        CLR_REG32_BIT(*CHSELRx, 1UL << u8Ch);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified ADC channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Seq                  The sequence whose channel specified by 'u32MxCh' will be enabled or disabled.
+ *                                      This parameter can be a value of @ref ADC_Sequence
+ *   @arg  ADC_SEQ_A:                   ADC sequence A.
+ *   @arg  ADC_SEQ_B:                   ADC sequence B.
+ * @param  [in]  u32MxCh                The ADC channel.
+ *                                      This parameter can be any component of @ref ADC_Mx_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @note   Sequence A and Sequence B CAN NOT include the same channel!
+ * @note   Sequence A can always started by software(by calling @ref ADC_Start()),
+ *         regardless of whether the hardware trigger source is valid or not.
+ * @note   Sequence B must be specified a valid hard trigger by calling functions @ref ADC_TriggerConfig()
+ *         and @ref ADC_TriggerCmd().
+ */
+void ADC_MxChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint32_t u32MxCh, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CHSELRx;
+
+    DDL_ASSERT(IS_ADC_MX_CH(ADCx, u32MxCh));
+    DDL_ASSERT(IS_ADC_SEQ(u8Seq));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CHSELRx = (__IO uint32_t *)((uint32_t)(&ADCx->CHSELRA) + (u8Seq * 4UL));
+    if (enNewState == ENABLE) {
+        /* Enable the specified channel. */
+        SET_REG32_BIT(*CHSELRx, u32MxCh);
+    } else {
+        /* Disable the specified channel. */
+        CLR_REG32_BIT(*CHSELRx, u32MxCh);
+    }
+}
+
+/**
+ * @brief  Set sampling time for the specified channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   The channel to be set sampling time.
+ *                                      This parameter can be values of @ref ADC_Channel
+ * @param  [in]  u8SampleTime           Sampling time for the channel that specified by 'u8Ch'.
+ * @retval None
+ */
+void ADC_SetSampleTime(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, uint8_t u8SampleTime)
+{
+    __IO uint8_t *SSTRx;
+
+    DDL_ASSERT(IS_ADC_SAMPLE_TIME(u8SampleTime));
+
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+    SSTRx = (__IO uint8_t *)((uint32_t)&ADCx->SSTR0 + u8Ch);
+    if (u8Ch < ADC_SSTR_NUM) {
+        WRITE_REG8(*SSTRx, u8SampleTime);
+    } else {
+        WRITE_REG8(ADCx->SSTRL, u8SampleTime);
+    }
+}
+
+/**
+ * @brief  Set scan-average count.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u16AverageCount        Scan-average count.
+ *                                      This parameter can be a value of @ref ADC_Average_Count
+ *   @arg  ADC_AVG_CNT2:                2 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT4:                4 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT8:                8 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT16:               16 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT32:               32 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT64:               64 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT128:              128 consecutive average conversions.
+ *   @arg  ADC_AVG_CNT256:              256 consecutive average conversions.
+ * @retval None
+ */
+void ADC_ConvDataAverageConfig(CM_ADC_TypeDef *ADCx, uint16_t u16AverageCount)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AVG_CNT(u16AverageCount));
+    MODIFY_REG16(ADCx->CR0, ADC_CR0_AVCNT, u16AverageCount);
+}
+
+/**
+ * @brief  Enable or disable conversion data average calculation channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   The ADC channel.
+ *                                      This parameter can be values of @ref ADC_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_ConvDataAverageChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(ADCx->AVCHSELR, 1UL << u8Ch);
+    } else {
+        CLR_REG32_BIT(ADCx->AVCHSELR, 1UL << u8Ch);
+    }
+}
+
+/**
+ * @brief  Enable or disable conversion data average calculation channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u32MxCh                The ADC channel.
+ *                                      This parameter can be any component of @ref ADC_Mx_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_ConvDataAverageMxChCmd(CM_ADC_TypeDef *ADCx, uint32_t u32MxCh, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_MX_CH(ADCx, u32MxCh));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(ADCx->AVCHSELR, u32MxCh);
+    } else {
+        CLR_REG32_BIT(ADCx->AVCHSELR, u32MxCh);
+    }
+}
+
+/**
+ * @brief  Specifies the analog input source of extended channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8ExtChSrc             The analog input source of extended channel.
+ *                                      This parameter can be a value of @ref ADC_Ext_Ch_Analog_Src
+ * @retval None
+ */
+void ADC_SetExtChSrc(CM_ADC_TypeDef *ADCx, uint8_t u8ExtChSrc)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_EXTCH_SRC(u8ExtChSrc));
+    WRITE_REG8(ADCx->EXCHSELR, u8ExtChSrc);
+}
+
+/**
+ * @brief  Specifies the hard trigger for the specified ADC sequence.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADCx or CM_ADC
+ * @param  [in]  u8Seq                  The sequence to be configured.
+ *                                      This parameter can be a value of @ref ADC_Sequence
+ *   @arg  ADC_SEQ_A:                   Sequence A.
+ *   @arg  ADC_SEQ_B:                   Sequence B.
+ * @param  [in]  u16TriggerSel          Hard trigger selection. This parameter can be a value of @ref ADC_Hard_Trigger_Sel
+ *   @arg  ADC_HARDTRIG_ADTRG_PIN:      Selects the following edge of pin ADTRG as the trigger of ADC sequence.
+ *   @arg  ADC_HARDTRIG_EVT0:           Selects an internal event as the trigger of ADC sequence.
+                                        This event is specified by register ADCx_TRGSEL0(x=(null), 1, 2, 3).
+ *   @arg  ADC_HARDTRIG_EVT1:           Selects an internal event as the trigger of ADC sequence.
+                                        This event is specified by register ADCx_TRGSEL1(x=(null), 1, 2, 3).
+ *   @arg  ADC_HARDTRIG_EVT0_EVT1:      Selects two internal events as the trigger of ADC sequence.
+                                        The two events are specified by register ADCx_TRGSEL0 and register ADCx_TRGSEL1.
+ * @retval None
+ * @note   ADC must be stopped while calling this function.
+ * @note   The trigger source CANNOT be an event that generated by the sequence itself.
+ */
+void ADC_TriggerConfig(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, uint16_t u16TriggerSel)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_SEQ(u8Seq));
+    DDL_ASSERT(IS_ADC_HARDTRIG(u16TriggerSel));
+
+    u8Seq *= ADC_TRGSR_TRGSELB_POS;
+    MODIFY_REG16(ADCx->TRGSR, (uint32_t)ADC_TRGSR_TRGSELA << u8Seq, (uint32_t)u16TriggerSel << u8Seq);
+}
+
+/**
+ * @brief  Enable or disable the hard trigger of the specified ADC sequence.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADCx or CM_ADC
+ * @param  [in]  u8Seq                  The sequence to be configured.
+ *                                      This parameter can be a value of @ref ADC_Sequence
+ *   @arg  ADC_SEQ_A:                   Sequence A.
+ *   @arg  ADC_SEQ_B:                   Sequence B.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   ADC must be stopped while calling this function.
+ */
+void ADC_TriggerCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Seq, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_SEQ(u8Seq));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(ADCx->TRGSR, (uint32_t)ADC_TRGSR_TRGENA << (u8Seq * ADC_TRGSR_TRGSELB_POS));
+    } else {
+        CLR_REG16_BIT(ADCx->TRGSR, (uint32_t)ADC_TRGSR_TRGENA << (u8Seq * ADC_TRGSR_TRGSELB_POS));
+    }
+}
+
+/**
+ * @brief  Enable or disable ADC interrupts.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8IntType              ADC interrupt.
+ *                                      This parameter can be values of @ref ADC_Int_Type
+ *   @arg  ADC_INT_EOCA:                Interrupt of the end of conversion of sequence A.
+ *   @arg  ADC_INT_EOCB:                Interrupt of the end of conversion of sequence B.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_IntCmd(CM_ADC_TypeDef *ADCx, uint8_t u8IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_INT(u8IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG8_BIT(ADCx->ICR, u8IntType);
+    } else {
+        CLR_REG8_BIT(ADCx->ICR, u8IntType);
+    }
+}
+
+/**
+ * @brief  Start sequence A conversion.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @retval int32_t
+ *           - LL_OK:                   Start success.
+ *           - LL_ERR_BUSY:             ADC is busy.
+ */
+int32_t ADC_Start(CM_ADC_TypeDef *ADCx)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+
+    if (1U == READ_REG8(ADCx->STR)) {
+        i32Ret = LL_ERR_BUSY;
+    } else {
+        WRITE_REG8(ADCx->STR, ADC_STR_STRT);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Stop ADC conversion, both sequence A and sequence B.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @retval None
+ */
+void ADC_Stop(CM_ADC_TypeDef *ADCx)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    WRITE_REG8(ADCx->STR, 0U);
+}
+
+/**
+ * @brief  Get the ADC value of the specified channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   The ADC channel.
+ *                                      This parameter can be values of @ref ADC_Channel
+ * @retval An uint16_t type value of ADC value.
+ */
+uint16_t ADC_GetValue(const CM_ADC_TypeDef *ADCx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+
+    return RW_MEM16((uint32_t)&ADCx->DR0 + u8Ch * 2UL);
+}
+
+/**
+ * @brief  Get the ADC resolution.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @retval An uint16_t type value of ADC resolution. @ref ADC_Resolution
+ */
+uint16_t ADC_GetResolution(const CM_ADC_TypeDef *ADCx)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+
+    return READ_REG16_BIT(ADCx->CR0, ADC_CR0_ACCSEL);
+}
+
+/**
+ * @brief  Get the status of the specified ADC flag.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Flag                 ADC status flag.
+ *                                      This parameter can be a value of @ref ADC_Status_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ADC_GetStatus(const CM_ADC_TypeDef *ADCx, uint8_t u8Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_FLAG(u8Flag));
+
+    if (READ_REG8_BIT(ADCx->ISR, u8Flag) != 0U) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified ADC flag.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Flag                 ADC status flag.
+ *                                      This parameter can be values of @ref ADC_Status_Flag
+ * @retval None
+ */
+void ADC_ClearStatus(CM_ADC_TypeDef *ADCx, uint8_t u8Flag)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_FLAG(u8Flag));
+
+    WRITE_REG8(ADCx->ISCLRR, u8Flag);
+}
+
+/**
+ * @brief  Remap the correspondence between ADC channel and analog input pins.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   This parameter can be values of @ref ADC_Channel
+ * @param  [in]  u8AdcPin               This parameter can be a value of @ref ADC_Remap_Pin
+ * @retval None
+ */
+void ADC_ChRemap(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, uint8_t u8AdcPin)
+{
+    uint8_t u8FieldOfs;
+    __IO uint16_t *CHMUXRx;
+
+    DDL_ASSERT(IS_ADC_REMAP_CH(ADCx, u8Ch));
+    DDL_ASSERT(IS_ADC_REMAP_PIN(ADCx, u8AdcPin));
+
+    CHMUXRx    = (__IO uint16_t *)(((uint32_t)&ADCx->CHMUXR0) + (u8Ch / 4UL) * 2UL);
+    u8FieldOfs = (u8Ch % 4U) * 4U;
+    MODIFY_REG16(*CHMUXRx, ((uint32_t)ADC_CHMUXR0_CH00MUX << u8FieldOfs), ((uint32_t)u8AdcPin << u8FieldOfs));
+}
+
+/**
+ * @brief  Get the ADC pin corresponding to the specified ADC channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   ADC channel.
+ *                                      This parameter can be one of the following values of @ref ADC_Channel
+ * @retval An uint8_t type value of ADC pin. @ref ADC_Remap_Pin
+ */
+uint8_t ADC_GetChPin(const CM_ADC_TypeDef *ADCx, uint8_t u8Ch)
+{
+    uint8_t u8RetPin;
+    uint8_t u8FieldOfs;
+    __IO uint16_t *CHMUXRx;
+
+    DDL_ASSERT(IS_ADC_REMAP_CH(ADCx, u8Ch));
+
+    CHMUXRx    = (__IO uint16_t *)(((uint32_t)&ADCx->CHMUXR0) + (u8Ch / 4UL) * 2UL);
+    u8FieldOfs = (u8Ch % 4U) * 4U;
+    u8RetPin   = ((uint8_t)(*CHMUXRx >> u8FieldOfs)) & 0xFU;
+
+    return u8RetPin;
+}
+
+/**
+ * @brief  Reset channel-pin mapping.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @retval None
+ */
+void ADC_ResetChMapping(CM_ADC_TypeDef *ADCx)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+
+    WRITE_REG16(ADCx->CHMUXR0, 0x3210U);
+    WRITE_REG16(ADCx->CHMUXR1, 0x7654U);
+    WRITE_REG16(ADCx->CHMUXR2, 0xBA98U);
+    WRITE_REG16(ADCx->CHMUXR3, 0xFEDCU);
+}
+
+/**
+ * @brief  Configures synchronous mode.
+ * @param  [in]  u16SyncUnit            Specify the ADC units which work synchronously.
+ *                                      This parameter can be a value of @ref ADC_Sync_Unit
+ * @param  [in]  u16SyncMode            Synchronous mode.
+ *                                      This parameter can be a value of @ref ADC_Sync_Mode
+ *   @arg  ADC_SYNC_SINGLE_DELAY_TRIG:  Single shot delayed trigger mode.
+ *                                      When the trigger condition occurs, ADC1 starts first, then ADC2, last ADC3(if has).
+ *                                      All ADCs scan once.
+ *   @arg  ADC_SYNC_SINGLE_PARALLEL_TRIG: Single shot parallel trigger mode.
+ *                                        When the trigger condition occurs, all ADCs start at the same time.
+ *                                        All ADCs scan once.
+ *   @arg  ADC_SYNC_CYCLIC_DELAY_TRIG:  Cyclic delayed trigger mode.
+ *                                      When the trigger condition occurs, ADC1 starts first, then ADC2, last ADC3(if has).
+ *                                      All ADCs scan cyclically(keep scanning till you stop them).
+ *   @arg  ADC_SYNC_CYCLIC_PARALLEL_TRIG: Single shot parallel trigger mode.
+ *                                        When the trigger condition occurs, all ADCs start at the same time.
+ *                                        All ADCs scan cyclically(keep scanning till you stop them).
+ * @param  [in]  u8TriggerDelay         Trigger delay time(ADCLK cycle), range is [1, 255].
+ * @retval None
+ */
+void ADC_SyncModeConfig(uint16_t u16SyncUnit, uint16_t u16SyncMode, uint8_t u8TriggerDelay)
+{
+    DDL_ASSERT(IS_ADC_SYNC(u16SyncUnit));
+    DDL_ASSERT(IS_ADC_SYNC_MD(u16SyncMode));
+
+    u16SyncMode |= ((uint16_t)((uint32_t)u8TriggerDelay << ADC_SYNCCR_SYNCDLY_POS)) | u16SyncUnit;
+    MODIFY_REG16(CM_ADC1->SYNCCR, ADC_SYNCCR_SYNCMD | ADC_SYNCCR_SYNCDLY, u16SyncMode);
+}
+
+/**
+ * @brief  Enable or disable synchronous mode.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_SyncModeCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    WRITE_REG32(bCM_ADC1->SYNCCR_b.SYNCEN, enNewState);
+}
+
+/**
+ * @brief  Configures analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be configured.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @param  [in]  u8Ch                   The channel that to be used as an analog watchdog channel.
+ *                                      This parameter can be a value of @ref ADC_Channel
+ * @param  [in]  pstcAwd                Pointer to a @ref stc_adc_awd_config_t structure value that
+ *                                      contains the configuration information of the AWD.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcAwd == NULL.
+ */
+int32_t ADC_AWD_Config(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint8_t u8Ch, const stc_adc_awd_config_t *pstcAwd)
+{
+    uint32_t u32AwdDr0;
+    uint32_t u32AwdDr1;
+    uint32_t u32AwdChsr;
+    uint32_t u32Addr;
+    uint8_t u8Pos;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+
+    if (pstcAwd != NULL) {
+        DDL_ASSERT(IS_ADC_AWD_MD(pstcAwd->u16WatchdogMode));
+
+        u8Pos      = (u8AwdUnit * 4U) + ADC_AWDCR_AWD0MD_POS;
+        u32Addr    = (uint32_t)&ADCx->AWDCR;
+        u32AwdDr0  = (uint32_t)&ADCx->AWD0DR0;
+        u32AwdDr1  = (uint32_t)&ADCx->AWD0DR1;
+        u32AwdChsr = (uint32_t)&ADCx->AWD0CHSR;
+
+        WRITE_REG32(PERIPH_BIT_BAND(u32Addr, u8Pos), pstcAwd->u16WatchdogMode);
+        WRITE_REG16(ADC_AWDx_DR(u8AwdUnit, u32AwdDr0), pstcAwd->u16LowThreshold);
+        WRITE_REG16(ADC_AWDx_DR(u8AwdUnit, u32AwdDr1), pstcAwd->u16HighThreshold);
+        WRITE_REG8(ADC_AWDx_CHSR(u8AwdUnit, u32AwdChsr), u8Ch);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Specifies combination mode of analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u16CombMode            Combination mode of analog watchdog.
+ *                                      This parameter can be a value of @ref ADC_AWD_Comb_Mode
+ *   @arg  ADC_AWD_COMB_INVD            Combination mode is invalid.
+ *   @arg  ADC_AWD_COMB_OR:             The status of AWD0 is set or the status of AWD1 is set, the status of combination mode is set.
+ *   @arg  ADC_AWD_COMB_AND:            The status of AWD0 is set and the status of AWD1 is set, the status of combination mode is set.
+ *   @arg  ADC_AWD_COMB_XOR:            Only one of the status of AWD0 and AWD1 is set, the status of combination mode is set.
+ * @retval None
+ */
+void ADC_AWD_SetCombMode(CM_ADC_TypeDef *ADCx, uint16_t u16CombMode)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD_COMB_MD(u16CombMode));
+    MODIFY_REG16(ADCx->AWDCR, ADC_AWDCR_AWDCM, u16CombMode);
+}
+
+/**
+ * @brief  Specifies the compare mode of analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be configured.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @param  [in]  u16WatchdogMode        Analog watchdog compare mode.
+ *                                      This parameter can be a value of @ref ADC_AWD_Mode
+ *   @arg  ADC_AWD_MD_CMP_OUT:          ADCValue > HighThreshold or ADCValue < LowThreshold
+ *   @arg  ADC_AWD_MD_CMP_IN:           LowThreshold < ADCValue < HighThreshold
+ * @retval None
+ */
+void ADC_AWD_SetMode(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint16_t u16WatchdogMode)
+{
+    uint8_t u8Pos;
+    uint32_t u32Addr;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+    DDL_ASSERT(IS_ADC_AWD_MD(u16WatchdogMode));
+
+    u8Pos   = (u8AwdUnit * 4U) + ADC_AWDCR_AWD0MD_POS;
+    u32Addr = (uint32_t)&ADCx->AWDCR;
+    WRITE_REG32(PERIPH_BIT_BAND(u32Addr, u8Pos), u16WatchdogMode);
+}
+
+/**
+ * @brief  Get the compare mode of analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be configured.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @retval Analog watchdog compare mode. A value of @ref ADC_AWD_Mode
+ *         - ADC_AWD_MD_CMP_OUT:        ADCValue > HighThreshold or ADCValue < LowThreshold
+ *         - ADC_AWD_MD_CMP_IN:         LowThreshold < ADCValue < HighThreshold
+ */
+uint16_t ADC_AWD_GetMode(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit)
+{
+    uint16_t u16RetMode;
+
+    uint8_t u8Pos;
+    uint32_t u32Addr;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+
+    u8Pos   = (u8AwdUnit * 4U) + ADC_AWDCR_AWD0MD_POS;
+    u32Addr = (uint32_t)&ADCx->AWDCR;
+    u16RetMode = (uint16_t)PERIPH_BIT_BAND(u32Addr, u8Pos);
+
+    return u16RetMode;
+}
+
+/**
+ * @brief  Specifies the low threshold and high threshold of analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be configured.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @param  [in]  u16LowThreshold        Low threshold of analog watchdog.
+ * @param  [in]  u16HighThreshold       High threshold of analog watchdog.
+ * @retval None
+ */
+void ADC_AWD_SetThreshold(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint16_t u16LowThreshold, uint16_t u16HighThreshold)
+{
+    uint32_t u32AwdDr0;
+    uint32_t u32AwdDr1;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+
+    u32AwdDr0 = (uint32_t)&ADCx->AWD0DR0;
+    u32AwdDr1 = (uint32_t)&ADCx->AWD0DR1;
+    WRITE_REG16(ADC_AWDx_DR(u8AwdUnit, u32AwdDr0), u16LowThreshold);
+    WRITE_REG16(ADC_AWDx_DR(u8AwdUnit, u32AwdDr1), u16HighThreshold);
+}
+
+/**
+ * @brief  Select the specified ADC channel as an analog watchdog channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be configured.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @param  [in]  u8Ch                   The channel that to be used as an analog watchdog channel.
+ *                                      This parameter can be a value of @ref ADC_Channel
+ * @retval None
+ */
+void ADC_AWD_SelectCh(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, uint8_t u8Ch)
+{
+    uint32_t u32AwdChsr;
+    DDL_ASSERT(IS_ADC_CH(ADCx, u8Ch));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+
+    u32AwdChsr = (uint32_t)&ADCx->AWD0CHSR;
+    WRITE_REG8(ADC_AWDx_CHSR(u8AwdUnit, u32AwdChsr), u8Ch);
+}
+
+/**
+ * @brief  Enable or disable the specified analog watchdog.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8AwdUnit              AWD unit that is going to be enabled or disabled.
+ *                                      This parameter can be a value of @ref ADC_AWD_Unit
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_AWD_Cmd(CM_ADC_TypeDef *ADCx, uint8_t u8AwdUnit, en_functional_state_t enNewState)
+{
+    uint32_t u32Addr;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD(u8AwdUnit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Addr = (uint32_t)&ADCx->AWDCR;
+    /* Enable bit position: u8AwdUnit * 4 */
+    WRITE_REG32(PERIPH_BIT_BAND(u32Addr, (u8AwdUnit * 4UL)), enNewState);
+}
+
+/**
+ * @brief  Enable or disable the specified analog watchdog interrupts.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u16IntType             Interrupt of AWD.
+ *                                      This parameter can be a value of @ref ADC_AWD_Int_Type
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_AWD_IntCmd(CM_ADC_TypeDef *ADCx, uint16_t u16IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD_INT(u16IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(ADCx->AWDCR, u16IntType);
+    } else {
+        CLR_REG16_BIT(ADCx->AWDCR, u16IntType);
+    }
+}
+
+/**
+ * @brief  Get the status of the specified analog watchdog flag.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u32Flag                AWD status flag.
+ *                                      This parameter can be values of @ref ADC_AWD_Status_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ADC_AWD_GetStatus(const CM_ADC_TypeDef *ADCx, uint32_t u32Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD_FLAG(u32Flag));
+    if (READ_REG8_BIT(ADCx->AWDSR, u32Flag) != 0U) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified analog watchdog flag.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u32Flag                AWD status flag.
+ *                                      This parameter can be values of @ref ADC_AWD_Status_Flag
+ * @retval None
+ */
+void ADC_AWD_ClearStatus(CM_ADC_TypeDef *ADCx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_AWD_FLAG(u32Flag));
+    WRITE_REG8(ADCx->AWDSCLRR, u32Flag);
+}
+
+/**
+ * @brief  Specifies sampling time of sample-hold.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8SampleTime           Sampling time of sample hold.
+ * @retval None
+ */
+void ADC_SH_SetSampleTime(CM_ADC_TypeDef *ADCx, uint8_t u8SampleTime)
+{
+    DDL_ASSERT(IS_ADC_SH_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_SPLHOLD_SPLTIME(u8SampleTime));
+    MODIFY_REG16(ADCx->SHCR, ADC_SHCR_SHSST, u8SampleTime);
+}
+
+/**
+ * @brief  Enable or disable sample-hold channel.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8Ch                   Sample hold channel.
+ *                                      This parameter can be ADC_CH0, ADC_CH1 and ADC_CH2 of @ref ADC_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_SH_ChCmd(CM_ADC_TypeDef *ADCx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_SH_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_SH_CH(u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(ADCx->SHCR, (1UL << u8Ch) << ADC_SHCR_SHSEL_POS);
+    } else {
+        CLR_REG16_BIT(ADCx->SHCR, (1UL << u8Ch) << ADC_SHCR_SHSEL_POS);
+    }
+}
+
+/**
+ * @brief  Configures the specified programmable gain amplifier.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8PgaUnit              The PGA unit.
+ *                                      This parameter can be a value of @ref ADC_PGA_Unit
+ * @param  [in]  u8Gain                 Gain of the specified PGA.
+ *                                      This parameter can be a value of @ref ADC_PGA_Gain
+ *   @arg  ADC_PGA_GAIN_2:              PGA gain factor is 2.
+ *   @arg  ADC_PGA_GAIN_2P133:          PGA gain factor is 2.133.
+ *   @arg  ADC_PGA_GAIN_2P286:          PGA gain factor is 2.286.
+ *   @arg  ADC_PGA_GAIN_2P667:          PGA gain factor is 2.667.
+ *   @arg  ADC_PGA_GAIN_2P909:          PGA gain factor is 2.909.
+ *   @arg  ADC_PGA_GAIN_3P2:            PGA gain factor is 3.2.
+ *   @arg  ADC_PGA_GAIN_3P556:          PGA gain factor is 2.556.
+ *   @arg  ADC_PGA_GAIN_4:              PGA gain factor is 4.
+ *   @arg  ADC_PGA_GAIN_4P571:          PGA gain factor is 4.571.
+ *   @arg  ADC_PGA_GAIN_5P333:          PGA gain factor is 5.333.
+ *   @arg  ADC_PGA_GAIN_6P4:            PGA gain factor is 6.4.
+ *   @arg  ADC_PGA_GAIN_8:              PGA gain factor is 8.
+ *   @arg  ADC_PGA_GAIN_10P667:         PGA gain factor is 10.667.
+ *   @arg  ADC_PGA_GAIN_16:             PGA gain factor is 16.
+ *   @arg  ADC_PGA_GAIN_32:             PGA gain factor is 32.
+ * @param  [in]  u8PgaVss               VSS for the specified PGA.
+ *                                      This parameter can be a value of @ref ADC_PGA_VSS
+ *   @arg  ADC_PGA_VSS_PGAVSS:          Use pin PGAx_VSS as the reference GND of PGAx
+ *   @arg  ADC_PGA_VSS_AVSS:            Use AVSS as the reference GND of PGAx.
+ * @retval None
+ */
+void ADC_PGA_Config(CM_ADC_TypeDef *ADCx, uint8_t u8PgaUnit, uint8_t u8Gain, uint8_t u8PgaVss)
+{
+    uint32_t u32Addr;
+    __IO uint8_t *PGACRx;
+    DDL_ASSERT(IS_ADC_PGA(ADCx, u8PgaUnit));
+    DDL_ASSERT(IS_ADC_PGA_GAIN(u8Gain));
+    DDL_ASSERT(IS_ADC_PGA_VSS(u8PgaVss));
+
+    if (ADCx == CM_ADC2) {
+        u8PgaUnit = 0U;
+    }
+    PGACRx = (__IO uint8_t *)((uint32_t)&ADCx->PGACR1 + u8PgaUnit);
+    MODIFY_REG8(*PGACRx, ADC_PGACR_PGAGAIN, u8Gain << ADC_PGACR_PGAGAIN_POS);
+    u32Addr = (uint32_t)&ADCx->PGAVSSENR;
+    WRITE_REG32(PERIPH_BIT_BAND(u32Addr, u8PgaUnit), u8PgaVss);
+}
+
+/**
+ * @brief  Enable the specified programmable gain amplifier.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u8PgaUnit              The PGA unit.
+ *                                      This parameter can be a value of @ref ADC_PGA_Unit
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_PGA_Cmd(CM_ADC_TypeDef *ADCx, uint8_t u8PgaUnit, en_functional_state_t enNewState)
+{
+    const uint8_t au8Cmd[] = {ADC_PGA_DISABLE, ADC_PGA_ENABLE};
+    __IO uint8_t *PGACRx;
+
+    DDL_ASSERT(IS_ADC_PGA(ADCx, u8PgaUnit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ADCx == CM_ADC2) {
+        u8PgaUnit = 0U;
+    }
+    PGACRx = (__IO uint8_t *)((uint32_t)&ADCx->PGACR1 + u8PgaUnit);
+    MODIFY_REG8(*PGACRx, ADC_PGACR_PGACTL, au8Cmd[(uint8_t)enNewState]);
+}
+
+/**
+ * @brief  Enable or disable automatically clear data register.
+ *         The automatic clearing function is mainly used to detect whether the data register is updated.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ADC_DataRegAutoClearCmd(CM_ADC_TypeDef *ADCx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(ADCx->CR0, ADC_CR0_CLREN);
+    } else {
+        CLR_REG16_BIT(ADCx->CR0, ADC_CR0_CLREN);
+    }
+}
+
+/**
+ * @brief  Sequence A restart channel selection.
+ * @param  [in]  ADCx                   Pointer to ADC instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_ADC or CM_ADCx:           ADC instance register base.
+ * @param  [in]  u16SeqAResumeMode      Sequence A resume mode.
+ *                                      This parameter can be a value of @ref ADC_SeqA_Resume_Mode
+ *   @arg  ADC_SEQA_RESUME_SCAN_CONT:   Scanning will continue from the interrupted channel.
+ *   @arg  ADC_SEQA_RESUME_SCAN_RESTART: Scanning will start from the first channel.
+ * @retval None
+ */
+void ADC_SetSeqAResumeMode(CM_ADC_TypeDef *ADCx, uint16_t u16SeqAResumeMode)
+{
+    DDL_ASSERT(IS_ADC_UNIT(ADCx));
+    DDL_ASSERT(IS_ADC_SEQA_RESUME_MD(u16SeqAResumeMode));
+    WRITE_REG16(ADCx->CR1, u16SeqAResumeMode);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_ADC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_aes.c
+++ b/hc32f4a2/src/hc32_ll_aes.c
@@ -1,0 +1,323 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_aes.c
+ * @brief This file provides firmware functions to manage the Advanced Encryption
+ *        Standard(AES).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add API AES_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_aes.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_AES AES
+ * @brief AES Driver Library
+ * @{
+ */
+
+#if (LL_AES_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup AES_Local_Macros AES Local Macros
+ * @{
+ */
+/* Delay count for timeout */
+#define AES_TIMEOUT                     (30000UL)
+
+/* AES block size */
+#define AES_BLOCK_SIZE                  (16U)
+
+/**
+ * @defgroup AES_Check_Parameters_Validity AES Check Parameters Validity
+ * @{
+ */
+#define IS_AES_KEY_SIZE(x)                                                     \
+(   ((x) == AES_KEY_SIZE_16BYTE)        ||                                     \
+    ((x) == AES_KEY_SIZE_24BYTE)        ||                                     \
+    ((x) == AES_KEY_SIZE_32BYTE))
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup AES_Local_Functions AES Local Functions
+ * @{
+ */
+/**
+ * @brief  Write the input buffer in data register.
+ * @param  [in] pu8SrcData              Point to the source data buffer.
+ * @retval None
+ */
+static void AES_WriteData(const uint8_t *pu8SrcData)
+{
+    uint8_t i;
+    __IO uint32_t *regDR = &CM_AES->DR0;
+    const uint32_t *pu32Data = (const uint32_t *)((uint32_t)pu8SrcData);
+
+    for (i = 0U; i < 4U; i++) {
+        regDR[i] = pu32Data[i];
+    }
+}
+
+/**
+ * @brief  Read the from data register.
+ * @param  [out] pu8Result              Point to the result buffer.
+ * @retval None
+ */
+static void AES_ReadData(uint8_t *pu8Result)
+{
+    uint8_t i;
+    __IO uint32_t *regDR = &CM_AES->DR0;
+    uint32_t *pu32Result = (uint32_t *)((uint32_t)pu8Result);
+
+    for (i = 0U; i < 4U; i++) {
+        pu32Result[i] = regDR[i];
+    }
+}
+
+/**
+ * @brief  Write the input buffer in key register.
+ * @param  [in]  pu8Key                 Pointer to the key buffer.
+ * @param  [in]  u8KeySize              AES key size. This parameter can be a value of @ref AES_Key_Size
+ * @retval None
+ */
+static void AES_WriteKey(const uint8_t *pu8Key, uint8_t u8KeySize)
+{
+    uint8_t i;
+    uint8_t u8KeyWordSize = u8KeySize / 4U;
+    __IO uint32_t *regKR = &CM_AES->KR0;
+    const uint32_t *pu32Key = (const uint32_t *)((uint32_t)pu8Key);
+
+    for (i = 0U; i < u8KeyWordSize; i++) {
+        regKR[i] = pu32Key[i];
+    }
+    switch (u8KeySize) {
+        case 16U:
+            u8KeySize = 0U;
+            break;
+        case 24U:
+            u8KeySize = 1U;
+            break;
+        case 32U:
+            u8KeySize = 2U;
+            break;
+        default:
+            break;
+    }
+    MODIFY_REG32(CM_AES->CR, AES_CR_KEYSIZE, ((uint32_t)u8KeySize << AES_CR_KEYSIZE_POS));
+}
+
+/**
+ * @brief  Wait AES operation done.
+ * @param  None
+ * @retval None
+ */
+static int32_t AES_WaitDone(void)
+{
+    __IO uint32_t u32TimeCount = 0UL;
+    int32_t i32Ret = LL_OK;
+
+    while (bCM_AES->CR_b.START != 0UL) {
+        if (u32TimeCount++ >= AES_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    return i32Ret;
+}
+/**
+ * @}
+ */
+
+/**
+ * @defgroup AES_Global_Functions AES Global Functions
+ * @{
+ */
+
+/**
+ * @brief  AES encryption.
+ * @param  [in]  pu8Plaintext           Buffer of the plaintext(the source data which will be encrypted).
+ * @param  [in]  u32PlaintextSize       Length of plaintext in bytes.
+ * @param  [in]  pu8Key                 Pointer to the AES key.
+ * @param  [in]  u8KeySize              AES key size. This parameter can be a value of @ref AES_Key_Size
+ * @param  [out] pu8Ciphertext          Buffer of the ciphertext.
+ * @retval int32_t:
+ *           - LL_OK:                   Encrypt successfully.
+ *           - LL_ERR_INVD_PARAM:       Invalid parameter.
+ *           - LL_TIMEOUT:              Encrypt timeout.
+ */
+int32_t AES_Encrypt(const uint8_t *pu8Plaintext, uint32_t u32PlaintextSize,
+                    const uint8_t *pu8Key, uint8_t u8KeySize,
+                    uint8_t *pu8Ciphertext)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint32_t u32Index = 0UL;
+
+    DDL_ASSERT(IS_AES_KEY_SIZE(u8KeySize));
+    DDL_ASSERT((u32PlaintextSize % AES_BLOCK_SIZE) == 0U);
+
+    if ((pu8Plaintext != NULL) && (u32PlaintextSize > 0UL) && \
+        (pu8Key != NULL) && (pu8Ciphertext != NULL)) {
+        AES_WriteKey(pu8Key, u8KeySize);
+        /* Set AES encrypt. */
+        WRITE_REG32(bCM_AES->CR_b.MODE, 0UL);
+        while (u32Index < u32PlaintextSize) {
+            AES_WriteData(&pu8Plaintext[u32Index]);
+            /* Start AES calculating. */
+            WRITE_REG32(bCM_AES->CR_b.START, 1UL);
+            /* Wait for AES to stop */
+            i32Ret = AES_WaitDone();
+            if (i32Ret != LL_OK) {
+                break;
+            }
+            AES_ReadData(&pu8Ciphertext[u32Index]);
+            u32Index += AES_BLOCK_SIZE;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  AES decryption.
+ * @param  [in]  pu8Ciphertext          Buffer of the Ciphertext(the source data which will be decrypted).
+ * @param  [in]  u32CiphertextSize      Length of ciphertext in bytes.
+ * @param  [in]  pu8Key                 Pointer to the AES key.
+ * @param  [in]  u8KeySize              AES key size. This parameter can be a value of @ref AES_Key_Size
+ * @param  [out] pu8Plaintext           Buffer of the plaintext.
+ * @retval int32_t:
+ *           - LL_OK:                   Decrypt successfully.
+ *           - LL_ERR_INVD_PARAM:       Invalid parameter.
+ *           - LL_TIMEOUT:              Decrypt timeout.
+ */
+int32_t AES_Decrypt(const uint8_t *pu8Ciphertext, uint32_t u32CiphertextSize,
+                    const uint8_t *pu8Key, uint8_t u8KeySize,
+                    uint8_t *pu8Plaintext)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint32_t u32Index = 0UL;
+
+    DDL_ASSERT(IS_AES_KEY_SIZE(u8KeySize));
+    DDL_ASSERT((u32CiphertextSize % AES_BLOCK_SIZE) == 0U);
+
+    if ((pu8Plaintext != NULL) && (u32CiphertextSize > 0UL) && \
+        (pu8Key != NULL) && (pu8Ciphertext != NULL)) {
+        AES_WriteKey(pu8Key, u8KeySize);
+        /* Set AES decrypt. */
+        WRITE_REG32(bCM_AES->CR_b.MODE, 1UL);
+        while (u32Index < u32CiphertextSize) {
+            AES_WriteData(&pu8Ciphertext[u32Index]);
+            /* Start AES calculating. */
+            WRITE_REG32(bCM_AES->CR_b.START, 1UL);
+            /* Wait for AES to stop */
+            i32Ret = AES_WaitDone();
+            if (i32Ret != LL_OK) {
+                break;
+            }
+            AES_ReadData(&pu8Plaintext[u32Index]);
+            u32Index += AES_BLOCK_SIZE;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize AES function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ *           - LL_ERR_TIMEOUT:          Timeout.
+ */
+int32_t AES_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32TimeOut = 0U;
+    uint8_t i;
+    __IO uint32_t *regDR = &CM_AES->DR0;
+    __IO uint32_t *regKR = &CM_AES->KR0;
+    /* Wait generating done */
+    while (0UL != READ_REG32(bCM_AES->CR_b.START)) {
+        u32TimeOut++;
+        if (u32TimeOut > AES_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+    if (LL_OK == i32Ret) {
+        /* Configures the registers to reset value. */
+        WRITE_REG32(CM_AES->CR, 0x00000000UL);
+        for (i = 0U; i < 4U; i++) {
+            regDR[i] = 0x00000000UL;
+        }
+        for (i = 0U; i < 8U; i++) {
+            regKR[i] = 0x00000000UL;
+        }
+    }
+    return i32Ret;
+}
+/**
+ * @}
+ */
+
+#endif /* LL_AES_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/
+

--- a/hc32f4a2/src/hc32_ll_aos.c
+++ b/hc32f4a2/src/hc32_ll_aos.c
@@ -1,0 +1,164 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_aos.c
+ * @brief This file provides firmware functions to manage the AOS.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Macro name modified: from IS_AOS_TRIG_SEL to IS_AOS_TARGET
+                                    Modified parameters name and comments of AOS_CommonTriggerCmd() and AOS_SetTriggerEventSrc()
+   2024-08-31       CDT             Optimize assert IS_AOS_TARGET
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_aos.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_AOS AOS
+ * @brief AOS Driver Library
+ * @{
+ */
+
+#if (LL_AOS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup AOS_Local_Macros AOS Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup AOS_Const_Value_Def AOS Const Value Definition
+ * @{
+ */
+#define AOS_TRG_START               AOS_DCU1
+#define AOS_TRG_END                 AOS_COMM_2
+/**
+ * @}
+ */
+
+/**
+ * @defgroup AOS_Common_Trigger_ID_Validity AOS Common Trigger ID Validity
+ * @{
+ */
+#define IS_AOS_COMM_TRIG(x)                                                    \
+(   ((x) != 0UL)                                &&                             \
+    ((x) | AOS_COMM_TRIG_MASK) == AOS_COMM_TRIG_MASK)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup AOS_Target_Select_Validity AOS Target Select Validity
+ * @{
+ */
+#define IS_AOS_TARGET(x)                                                       \
+(   ((x) >= AOS_TRG_START) && ((x) <= AOS_TRG_END) && (((x) & 0x03UL) == 0UL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup AOS_Global_Functions AOS Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Common trigger function command
+ * @param  [in] u32Target           AOS target that need to be triggered by common trigger @ref AOS_Target_Select in details
+ * @param  [in] u32CommonTrigger    Common trigger ID
+ *                                  This parameter can be one of the following values:
+ *   @arg  AOS_COMM_TRIG1:          Common trigger 1.
+ *   @arg  AOS_COMM_TRIG2:          Common trigger 2.
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void AOS_CommonTriggerCmd(uint32_t u32Target, uint32_t u32CommonTrigger, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_AOS_TARGET(u32Target));
+    DDL_ASSERT(IS_AOS_COMM_TRIG(u32CommonTrigger));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*(__IO uint32_t *)u32Target, u32CommonTrigger);
+    } else {
+        CLR_REG32_BIT(*(__IO uint32_t *)u32Target, u32CommonTrigger);
+    }
+}
+
+/**
+ * @brief  Set trigger event source
+ * @param  [in] u32Target       AOS target that need to be triggered by AOS source @ref AOS_Target_Select in details
+ * @param  [in] enSource        AOS source that trigger the AOS target @ref en_event_src_t in details
+ * @retval None
+ */
+void AOS_SetTriggerEventSrc(uint32_t u32Target, en_event_src_t enSource)
+{
+    DDL_ASSERT(IS_AOS_TARGET(u32Target));
+
+    MODIFY_REG32(*(__IO uint32_t *)u32Target, AOS_TRIG_SEL_MASK, enSource);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_AOS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_can.c
+++ b/hc32f4a2/src/hc32_ll_can.c
@@ -1,0 +1,1571 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_can.c
+ * @brief This file provides firmware functions to manage the CAN.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Deleted redundant comments
+                                    API fixed: CAN_FillTxFrame(), CAN_GetStatus(), CAN_ClearStatus()
+   2023-06-30       CDT             Added 3 APIs for local-reset.Refine local function CAN_ReadRxBuf(), CAN_WriteTxBuf()
+                                    Modify typo
+   2024-06-30       CDT             API CAN_DeInit() added return value
+                                    API optimized: CAN_WriteTxBuf()
+                                    Replace constants with Macros
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_can.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_CAN CAN
+ * @brief CAN Driver Library
+ * @{
+ */
+
+#if (LL_CAN_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CAN_Local_Macros CAN Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup CAN_Check_Parameters_Validity CAN Check Parameters Validity
+ * @{
+ */
+#define IS_CAN_BIT_MASK(x, mask)    (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+#define IS_CAN_FUNC_EN(x, en)       (((x) == 0U) || ((x) == (en)))
+
+#define IS_CAN_UNIT(x)              (((x) == CM_CAN1) || ((x) == CM_CAN2))
+#define IS_CAN_FD_UNIT(x)           (((x) == CM_CAN1) || ((x) == CM_CAN2))
+
+#define IS_CAN_BIT_TIME_PRESC(x)    (((x) >= 1U) && ((x) <= 256U))
+
+#define IS_CAN_WORK_MD(x)           ((x) <= CAN_WORK_MD_ELB_SILENT)
+
+#define IS_CAN_TX_BUF_TYPE(x)       (((x) == CAN_TX_BUF_PTB) || ((x) == CAN_TX_BUF_STB))
+
+#define IS_CAN_PTB_SINGLESHOT_TX(x) IS_CAN_FUNC_EN(x, CAN_PTB_SINGLESHOT_TX_ENABLE)
+
+#define IS_CAN_STB_SINGLESHOT_TX(x) IS_CAN_FUNC_EN(x, CAN_STB_SINGLESHOT_TX_ENABLE)
+
+#define IS_CAN_STB_PRIO_MD(x)       IS_CAN_FUNC_EN(x, CAN_STB_PRIO_MD_ENABLE)
+
+#define IS_CAN_TX_REQ(x)            IS_CAN_BIT_MASK(x, CAN_TX_REQ_STB_ONE|CAN_TX_REQ_STB_ALL|CAN_TX_REQ_PTB)
+
+#define IS_CAN_RX_ALL_FRAME(x)      IS_CAN_FUNC_EN(x, CAN_RX_ALL_FRAME_ENABLE)
+
+#define IS_CAN_RX_OVF_MD(x)         (((x) == CAN_RX_OVF_SAVE_NEW) || ((x) == CAN_RX_OVF_DISCARD_NEW))
+
+#define IS_CAN_SELF_ACK(x)          IS_CAN_FUNC_EN(x, CAN_SELF_ACK_ENABLE)
+
+#define IS_CAN_INT(x)               IS_CAN_BIT_MASK(x, CAN_INT_ALL)
+
+#define IS_CAN_FLAG(x)              IS_CAN_BIT_MASK(x, CAN_FLAG_ALL)
+
+#define IS_CAN_ID(ide, x)                                                      \
+(   (((ide) == 1U) && (((x) | CAN_EXT_ID_MASK) == CAN_EXT_ID_MASK))     ||     \
+    (((ide) == 0U) && (((x) | CAN_STD_ID_MASK) == CAN_STD_ID_MASK)))
+
+#define IS_CAN_ID_MASK(x)           (((x) | CAN_EXT_ID_MASK) == CAN_EXT_ID_MASK)
+
+#define IS_CAN_IDE(x)               (((x) == 0U) || ((x) == 1U))
+
+#define IS_CAN_FILTER(x)            IS_CAN_BIT_MASK(x, CAN_FILTER_ALL)
+
+#define IS_CAN_RX_WARN(x)           (((x) >= CAN_RX_WARN_MIN) && ((x) <= CAN_RX_WARN_MAX))
+
+#define IS_CAN_ERR_WARN(x)          ((x) < 16U)
+
+#define IS_CAN_FD_MD(x)             (((x) == CAN_FD_MD_BOSCH) || ((x) == CAN_FD_MD_ISO))
+
+#define IS_CAN_FD_TDC(x)            IS_CAN_FUNC_EN(x, CAN_FD_TDC_ENABLE)
+
+#define IS_CAN_FD_SSP(x)            ((x) < 128U)
+
+#define IS_TTCAN_TX_BUF_MD(x)       (((x) == CAN_TTC_TX_BUF_MD_CAN) || ((x) == CAN_TTC_TX_BUF_MD_TTCAN))
+
+#define IS_TTCAN_TX_BUF_SEL(x)      ((x) <= CAN_TTC_TX_BUF_STB3)
+
+#define IS_TTCAN_INT(x)             IS_CAN_BIT_MASK(x, CAN_TTC_INT_ALL)
+
+#define IS_TTCAN_FLAG(x)            IS_CAN_BIT_MASK(x, CAN_TTC_FLAG_ALL)
+
+#define IS_TTCAN_TX_EN_WINDOW(x)    (((x) > 0U) && ((x) <= 16U))
+
+#define IS_TTCAN_NTU_PRESCALER(x)                                              \
+(   ((x) == CAN_TTC_NTU_PRESCALER1)             ||                             \
+    ((x) == CAN_TTC_NTU_PRESCALER2)             ||                             \
+    ((x) == CAN_TTC_NTU_PRESCALER4)             ||                             \
+    ((x) == CAN_TTC_NTU_PRESCALER8))
+
+#define IS_TTCAN_TRIG_TYPE(x)                                                  \
+(   ((x) == CAN_TTC_TRIG_IMMED_TRIG)            ||                             \
+    ((x) == CAN_TTC_TRIG_TIME_TRIG)             ||                             \
+    ((x) == CAN_TTC_TRIG_SINGLESHOT_TX_TRIG)    ||                             \
+    ((x) == CAN_TTC_TRIG_TX_START_TRIG)         ||                             \
+    ((x) == CAN_TTC_TRIG_TX_STOP_TRIG))
+
+#define IS_CAN_ID_TYPE(x)                                                      \
+(   ((x) == CAN_ID_STD_EXT)                     ||                             \
+    ((x) == CAN_ID_STD)                         ||                             \
+    ((x) == CAN_ID_EXT))
+
+#define IS_CAN_SBT(seg1, seg2, sjw)                                            \
+(   (((seg1) >= 2U) && ((seg1) <= 65U))         &&                             \
+    (((seg2) >= 1U) && ((seg2) <= 8U))          &&                             \
+    (((sjw) >= 1U) && ((sjw) <= 16U))           &&                             \
+    ((seg1) >= ((seg2) + 1U))                   &&                             \
+    ((seg2) >= (sjw)))
+
+#define IS_CAN_FD_SBT(seg1, seg2, sjw)                                         \
+(   (((seg1) >= 2U) && ((seg1) <= 65U))         &&                             \
+    (((seg2) >= 1U) && ((seg2) <= 32U))         &&                             \
+    (((sjw) >= 1U) && ((sjw) <= 16U))           &&                             \
+    ((seg1) >= ((seg2) + 1U))                   &&                             \
+    ((seg2) >= (sjw)))
+
+#define IS_CAN_FD_FBT(seg1, seg2, sjw)                                         \
+(   (((seg1) >= 2U) && ((seg1) <= 17U))         &&                             \
+    (((seg2) >= 1U) && ((seg2) <= 8U))          &&                             \
+    (((sjw) >= 1U) && ((sjw) <= 8U))            &&                             \
+    ((seg1) >= ((seg2) + 1U))                   &&                             \
+    ((seg2) >= (sjw)))
+
+/* FDF bit check */
+#define IS_CAN20_FDF(x)                     ((x) == 0U)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Miscellaneous_Macros CAN Miscellaneous Macros
+ * @{
+ */
+#define CAN_RX_BUF_NUM                      (8U)
+
+#define CAN_RX_WARN_MIN                     (1U)
+#define CAN_RX_WARN_MAX                     (CAN_RX_BUF_NUM)
+
+#define CAN_ERRINT_FLAG_MASK                (CAN_ERRINT_BEIF | CAN_ERRINT_ALIF | CAN_ERRINT_EPIF)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup CAN_Local_Variables CAN Local Variables
+ * @{
+ */
+const static uint8_t m_au8DLC2WordSize[16U] = {
+    0U, 1U, 1U, 1U, 1U, 2U, 2U, 2U, 2U, 3U, 4U, 5U, 6U, 8U, 12U, 16U
+};
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup CAN_Local_Functions CAN Local Functions
+ * @{
+ */
+
+#if defined __DEBUG
+/**
+ * @brief  Initialization parameter check.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcCanInit            Pointer to a stc_can_init_t structure value that
+ *                                      contains the configuration information for the CAN.
+ * @retval None
+ */
+static void CAN_InitParameterCheck(CM_CAN_TypeDef *CANx, const stc_can_init_t *pstcCanInit)
+{
+    stc_canfd_config_t *pstcCanFd = pstcCanInit->pstcCanFd;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_WORK_MD(pstcCanInit->u8WorkMode));
+    DDL_ASSERT(IS_CAN_PTB_SINGLESHOT_TX(pstcCanInit->u8PTBSingleShotTx));
+    DDL_ASSERT(IS_CAN_STB_SINGLESHOT_TX(pstcCanInit->u8STBSingleShotTx));
+    DDL_ASSERT(IS_CAN_STB_PRIO_MD(pstcCanInit->u8STBPrioMode));
+    DDL_ASSERT(IS_CAN_RX_WARN(pstcCanInit->u8RxWarnLimit));
+    DDL_ASSERT(IS_CAN_ERR_WARN(pstcCanInit->u8ErrorWarnLimit));
+    DDL_ASSERT(IS_CAN_FILTER(pstcCanInit->u16FilterSelect));
+    DDL_ASSERT(IS_CAN_RX_ALL_FRAME(pstcCanInit->u8RxAllFrame));
+    DDL_ASSERT(IS_CAN_RX_OVF_MD(pstcCanInit->u8RxOvfMode));
+    DDL_ASSERT(IS_CAN_SELF_ACK(pstcCanInit->u8SelfAck));
+
+    if (pstcCanFd != NULL) {
+        DDL_ASSERT(IS_CAN_FD_UNIT(CANx));
+        DDL_ASSERT(IS_CAN_BIT_TIME_PRESC(pstcCanInit->stcBitCfg.u32Prescaler));
+        DDL_ASSERT(IS_CAN_FD_SBT(pstcCanInit->stcBitCfg.u32TimeSeg1,
+                                 pstcCanInit->stcBitCfg.u32TimeSeg2,
+                                 pstcCanInit->stcBitCfg.u32SJW));
+
+        DDL_ASSERT(IS_CAN_BIT_TIME_PRESC(pstcCanFd->stcBitCfg.u32Prescaler));
+        DDL_ASSERT(IS_CAN_FD_FBT(pstcCanFd->stcBitCfg.u32TimeSeg1,
+                                 pstcCanFd->stcBitCfg.u32TimeSeg2,
+                                 pstcCanFd->stcBitCfg.u32SJW));
+
+        DDL_ASSERT(IS_CAN_FD_MD(pstcCanFd->u8Mode));
+        DDL_ASSERT(IS_CAN_FD_TDC(pstcCanFd->u8TDC));
+        DDL_ASSERT(IS_CAN_FD_SSP(pstcCanFd->u8SSPOffset));
+    } else {
+        DDL_ASSERT(IS_CAN_BIT_TIME_PRESC(pstcCanInit->stcBitCfg.u32Prescaler));
+        DDL_ASSERT(IS_CAN_SBT(pstcCanInit->stcBitCfg.u32TimeSeg1,
+                              pstcCanInit->stcBitCfg.u32TimeSeg2,
+                              pstcCanInit->stcBitCfg.u32SJW));
+    }
+}
+#endif
+
+/**
+ * @brief  Specifies work mode for the specified CAN unit.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8WorkMode             Work mode of CAN.
+ *                                      This parameter can be a value of @ref CAN_Work_Mode
+ *   @arg  CAN_WORK_MD_NORMAL:          Normal work mode.
+ *   @arg  CAN_WORK_MD_SILENT:          Silent work mode. Prohibit data transmission.
+ *   @arg  CAN_WORK_MD_ILB:             Internal loop back mode, just for self-test while developing.
+ *   @arg  CAN_WORK_MD_ELB:             External loop back mode, just for self-test while developing.
+ *   @arg  CAN_WORK_MD_ELB_SILENT:      External loop back silent mode, just for self-test while developing.
+ *                                      It is forbidden to respond to received frames and error frames,
+ *                                      but data can be transmitted.
+ * @retval None
+ * @note Call this function when CFG_STAT.RESET is 0.
+ */
+static void CAN_SetWorkMode(CM_CAN_TypeDef *CANx, uint8_t u8WorkMode)
+{
+    uint8_t u8CFGSTAT = 0U;
+    uint8_t u8TCMD    = 0U;
+
+    switch (u8WorkMode) {
+        case CAN_WORK_MD_SILENT:
+            u8TCMD    = CAN_TCMD_LOM;
+            break;
+        case CAN_WORK_MD_ILB:
+            u8CFGSTAT = CAN_CFG_STAT_LBMI;
+            break;
+        case CAN_WORK_MD_ELB:
+            u8CFGSTAT = CAN_CFG_STAT_LBME;
+            break;
+        case CAN_WORK_MD_ELB_SILENT:
+            u8TCMD    = CAN_TCMD_LOM;
+            u8CFGSTAT = CAN_CFG_STAT_LBME;
+            break;
+        case CAN_WORK_MD_NORMAL:
+        default:
+            break;
+    }
+
+    MODIFY_REG8(CANx->CFG_STAT, CAN_CFG_STAT_LBMI | CAN_CFG_STAT_LBME, u8CFGSTAT);
+    MODIFY_REG8(CANx->TCMD, CAN_TCMD_LOM, u8TCMD);
+}
+
+/**
+ * @brief  Configures acceptance filter. Set ID and ID mask for the specified acceptance filters.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16FilterSelect        Acceptance filters selection.
+ *                                      This parameter can be values of @ref CAN_Acceptance_Filter
+ * @param  [in]  pstcFilter             Pointer to a stc_can_filter_config_t structure type array which contains ID and ID mask
+ *                                      values for the acceptance filters specified by parameter u16FilterSelect.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       If one the following cases matches:
+ *                                      - u16FilterSelect == 0U.
+ *                                      - pstcFilter == NULL.
+ * @note Call this function when CFG_STAT.RESET is 1.
+ */
+static int32_t CAN_FilterConfig(CM_CAN_TypeDef *CANx, uint16_t u16FilterSelect,
+                                const stc_can_filter_config_t *pstcFilter)
+{
+    uint8_t u8FilterAddr = 0U;
+    uint8_t i = 0U;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    if ((u16FilterSelect != 0U) && (pstcFilter != NULL)) {
+        while (u16FilterSelect != 0U) {
+            if ((u16FilterSelect & 0x1U) != 0U) {
+                DDL_ASSERT(IS_CAN_ID_TYPE(pstcFilter[i].u32IDType));
+                DDL_ASSERT(IS_CAN_ID_MASK(pstcFilter[i].u32IDMask));
+                WRITE_REG8(CANx->ACFCTRL, u8FilterAddr);
+                WRITE_REG32(CANx->ACF, pstcFilter[i].u32ID);
+                SET_REG8_BIT(CANx->ACFCTRL, CAN_ACFCTRL_SELMASK);
+                WRITE_REG32(CANx->ACF, pstcFilter[i].u32IDMask | pstcFilter[i].u32IDType);
+                i++;
+            }
+            u16FilterSelect >>= 1U;
+            u8FilterAddr++;
+        }
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configures the specified CAN FD according to the specified parameters
+ *         in a @ref stc_canfd_config_t structure.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcCanFd              Pointer to a @ref stc_canfd_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanFd == NULL.
+ * @note Call this function when CFG_STAT.RESET is 1.
+ */
+static int32_t CAN_FD_Config(CM_CAN_TypeDef *CANx, const stc_canfd_config_t *pstcCanFd)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanFd != NULL) {
+        /* Specifies CAN FD ISO mode. */
+        MODIFY_REG8(CANx->TCTRL, CAN_TCTRL_FD_ISO, pstcCanFd->u8Mode);
+        /**
+         * Configures fast bit time.
+         * Restrictions: u32TimeSeg1 >= u32TimeSeg2 + 1, u32TimeSeg2 >= u32SJW.
+         * TQ = u32Prescaler / CANClock.
+         * Fast bit time = (u32TimeSeg1 + u32TimeSeg2) * TQ.
+         */
+        WRITE_REG32(CANx->FBT, ((pstcCanFd->stcBitCfg.u32TimeSeg1 - 2U) | \
+                                ((pstcCanFd->stcBitCfg.u32TimeSeg2 - 1U) << CAN_FBT_F_SEG_2_POS) | \
+                                ((pstcCanFd->stcBitCfg.u32SJW - 1U) << CAN_FBT_F_SJW_POS) | \
+                                ((pstcCanFd->stcBitCfg.u32Prescaler - 1U) << CAN_FBT_F_PRESC_POS)));
+
+        /* Specifies the secondary sample point. Number of TQ.
+           Enable or disable TDC. */
+        WRITE_REG8(CANx->TDC, pstcCanFd->u8TDC | pstcCanFd->u8SSPOffset);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Write TX buffer register in bytes.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcTx                 Pointer to a @ref stc_can_tx_frame_t structure.
+ * @retval None
+ */
+static void CAN_WriteTxBuf(CM_CAN_TypeDef *CANx, const stc_can_tx_frame_t *pstcTx)
+{
+    uint8_t i;
+    uint8_t u8WordLen;
+    __IO uint32_t *reg32TBUF;
+    uint32_t *pu32TxData = (uint32_t *)((uint32_t)(&pstcTx->au8Data[0U]));
+
+    reg32TBUF = (__IO uint32_t *)((uint32_t)&CANx->TBUF);
+    reg32TBUF[0U] = pstcTx->u32ID;
+    reg32TBUF[1U] = pstcTx->u32Ctrl;
+
+    u8WordLen = m_au8DLC2WordSize[pstcTx->DLC];
+    if ((pstcTx->FDF == 0U) && (u8WordLen > 2U)) {
+        /* Maximum size of data payload is 8 bytes(2words) for classical CAN frame. */
+        u8WordLen = 2U;
+    }
+
+    if (pstcTx->RTR == 0U) {
+        for (i = 0U; i < u8WordLen; i++) {
+            reg32TBUF[2U + i] = pu32TxData[i];
+        }
+    }
+}
+
+/**
+ * @brief  Read RX buffer register in bytes.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcRx                 Pointer to a @ref stc_can_rx_frame_t structure.
+ * @retval None
+ */
+static void CAN_ReadRxBuf(const CM_CAN_TypeDef *CANx, stc_can_rx_frame_t *pstcRx)
+{
+    __I uint32_t *reg32RBUF;
+    uint8_t i;
+    uint8_t u8WordLen;
+    uint32_t *pu32RxData = (uint32_t *)((uint32_t)(&pstcRx->au8Data[0U]));
+
+    reg32RBUF = (__I uint32_t *)((uint32_t)&CANx->RBUF);
+    pstcRx->u32ID   = reg32RBUF[0U];
+    pstcRx->u32Ctrl = reg32RBUF[1U];
+
+    if (pstcRx->IDE == 0U) {
+        pstcRx->u32ID &= CAN_STD_ID_MASK;
+    } else {
+        pstcRx->u32ID &= CAN_EXT_ID_MASK;
+    }
+
+    u8WordLen = m_au8DLC2WordSize[pstcRx->DLC];
+    if ((pstcRx->FDF == 0U) && (u8WordLen > 2U)) {
+        /* Maximum size of data payload is 8 bytes(2words) for classical CAN frame. */
+        u8WordLen = 2U;
+    }
+
+    for (i = 0U; i < u8WordLen; i++) {
+        pu32RxData[i] = reg32RBUF[2U + i];
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CAN_Global_Functions CAN Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes the specified CAN peripheral according to the specified parameters
+ *         in the structure pstcCanInit.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcCanInit            Pointer to a @ref stc_can_init_t structure value that
+ *                                      contains the configuration information for the CAN.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanInit == NULL
+ */
+int32_t CAN_Init(CM_CAN_TypeDef *CANx, const stc_can_init_t *pstcCanInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanInit != NULL) {
+#if defined __DEBUG
+        CAN_InitParameterCheck(CANx, pstcCanInit);
+#endif
+        /* Enable FD of CAN1. */
+        if (CANx == CM_CAN1) {
+            SET_REG32_BIT(RW_MEM32(0x40055418UL), 1UL << 0U);
+        }
+        /* Local reset. */
+        SET_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+        /* Configures nominal bit time. */
+        WRITE_REG32(CANx->SBT, ((pstcCanInit->stcBitCfg.u32TimeSeg1 - 2U) | \
+                                ((pstcCanInit->stcBitCfg.u32TimeSeg2 - 1U) << CAN_SBT_S_SEG_2_POS) | \
+                                ((pstcCanInit->stcBitCfg.u32SJW - 1U) << CAN_SBT_S_SJW_POS) | \
+                                ((pstcCanInit->stcBitCfg.u32Prescaler - 1U) << CAN_SBT_S_PRESC_POS)));
+        /* Enable or disable STB priority mode. */
+        MODIFY_REG8(CANx->TCTRL, CAN_TCTRL_TSMODE, pstcCanInit->u8STBPrioMode);
+        /* Configures acceptance filters. */
+        (void)CAN_FilterConfig(CANx, pstcCanInit->u16FilterSelect, pstcCanInit->pstcFilter);
+
+        /* Configures CAN-FD if needed. */
+        if (pstcCanInit->pstcCanFd != NULL) {
+            (void)CAN_FD_Config(CANx, pstcCanInit->pstcCanFd);
+        }
+
+        /* CAN enters normal communication mode. */
+        CLR_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+        /* Specifies CAN work mode. */
+        CAN_SetWorkMode(CANx, pstcCanInit->u8WorkMode);
+        /* Enable or disable single shot transmission mode of PTB and STB. */
+        MODIFY_REG8(CANx->CFG_STAT, \
+                    (CAN_CFG_STAT_TPSS | CAN_CFG_STAT_TSSS), \
+                    (pstcCanInit->u8PTBSingleShotTx | pstcCanInit->u8STBSingleShotTx));
+        /* Specifies receive buffer almost full warning limit. Specifies error warning limit. */
+        WRITE_REG8(CANx->LIMIT, ((pstcCanInit->u8RxWarnLimit << CAN_LIMIT_AFWL_POS) | pstcCanInit->u8ErrorWarnLimit));
+
+        /* Enable or disable RX all frames(include frames with error).
+           Specifies receive overflow mode. In case of a full rx buffer when a new message is received.
+           Enable or disable self-acknowledge. */
+        WRITE_REG8(CANx->RCTRL, pstcCanInit->u8RxAllFrame | \
+                   pstcCanInit->u8RxOvfMode  | \
+                   pstcCanInit->u8SelfAck);
+        /* Enable acceptance filters that configured before. */
+        WRITE_REG16(CANx->ACFEN, pstcCanInit->u16FilterSelect);
+        /* Configures TTCAN if needed. */
+        if (pstcCanInit->pstcCanTtc != NULL) {
+            (void)CAN_TTC_Config(CANx, pstcCanInit->pstcCanTtc);
+        }
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set each @ref stc_can_init_t field to a default value.
+ *         Classical CAN bit time configuration:
+ *         Based on 40MHz CAN clock, TQ clock is CAN clock divided by 4.
+ *         Bit rate 500Kbps, 1 bit time is 20TQs, sample point is 80%.
+ *         CAN-FD bit time configuration:
+ *         Based on 40MHz CAN clock, TQ clock is CAN clock divided by 1.
+ *         Bit rate 2Mbps, 1 bit time is 20TQs, primary sample point is 80%,
+ *         secondary sample point is 80%.
+ * @param  [in]  pstcCanInit            Pointer to a @ref stc_can_init_t structure
+ *                                      whose fields will be set to default values.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanInit == NULL.
+ */
+int32_t CAN_StructInit(stc_can_init_t *pstcCanInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanInit != NULL) {
+        /**
+         * Synchronization Segment(SS): Fixed as 1TQ
+         * Propagation Time Segment(PTS) and Phase Buffer Segment 1(PBS1): 15TQs
+         * Phase Buffer Segment 2(PBS2): 4TQs
+         *
+         * Field 'S_SEG_1' in register CAN_SBT contains SS, PTS and PBS1.
+         * Field 'S_SEG_2' in register CAN_SBT only contains PBS2.
+         * Sample point = (SS + PTS + PBS1) / (SS + PTS + PBS1 + PBS2)
+         *              = (1 + 15) / (1 + 15 + 4)
+         *              = 80%.
+         */
+        pstcCanInit->stcBitCfg.u32Prescaler = 4U;
+        pstcCanInit->stcBitCfg.u32TimeSeg1  = 16U;
+        pstcCanInit->stcBitCfg.u32TimeSeg2  = 4U;
+        pstcCanInit->stcBitCfg.u32SJW       = 2U;
+        pstcCanInit->pstcFilter        = NULL;
+        pstcCanInit->u16FilterSelect   = 0U;
+        pstcCanInit->u8WorkMode        = CAN_WORK_MD_NORMAL;
+        pstcCanInit->u8PTBSingleShotTx = CAN_PTB_SINGLESHOT_TX_DISABLE;
+        pstcCanInit->u8STBSingleShotTx = CAN_STB_SINGLESHOT_TX_DISABLE;
+        pstcCanInit->u8STBPrioMode     = CAN_STB_PRIO_MD_DISABLE;
+        pstcCanInit->u8RxWarnLimit     = CAN_RX_WARN_MAX;
+        pstcCanInit->u8ErrorWarnLimit  = 7U;
+        pstcCanInit->u8RxAllFrame      = CAN_RX_ALL_FRAME_DISABLE;
+        pstcCanInit->u8RxOvfMode       = CAN_RX_OVF_DISCARD_NEW;
+        pstcCanInit->u8SelfAck         = CAN_SELF_ACK_DISABLE;
+        pstcCanInit->pstcCanTtc        = NULL;
+        pstcCanInit->pstcCanFd = NULL;
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Deinitialize the specified CAN peripheral registers to their default reset values.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t CAN_DeInit(CM_CAN_TypeDef *CANx)
+{
+    uint8_t i;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    /* Disable FD of CAN1. */
+    if (CANx == CM_CAN1) {
+        CLR_REG32_BIT(RW_MEM32(0x40055418UL), 1UL << 0U);
+    }
+    CLR_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+    for (i = 0U; i < 2U; i++) {
+        WRITE_REG8(CANx->CFG_STAT, 0x80U);
+        WRITE_REG8(CANx->TCMD, 0x00U);
+        WRITE_REG8(CANx->TCTRL, 0x90U);
+        WRITE_REG8(CANx->RCTRL, 0x10U);
+        WRITE_REG8(CANx->RTIE, 0xFEU);
+        WRITE_REG8(CANx->RTIF, 0xFFU);
+        WRITE_REG8(CANx->ERRINT, 0xD5U);
+        WRITE_REG8(CANx->LIMIT, 0x1BU);
+        WRITE_REG32(CANx->SBT, 0x01020203UL);
+        WRITE_REG8(CANx->RECNT, 0x00U);
+        WRITE_REG8(CANx->TECNT, 0x00U);
+        WRITE_REG8(CANx->ACFCTRL, 0x00U);
+        WRITE_REG8(CANx->TBSLOT, 0x00U);
+        WRITE_REG8(CANx->TTCFG, 0xD8U);
+        WRITE_REG16(CANx->TRG_CFG, 0x00U);
+        WRITE_REG16(CANx->TT_TRIG, 0x00U);
+        WRITE_REG16(CANx->TT_WTRIG, 0x00U);
+        WRITE_REG16(CANx->ACFEN, 0x01U);
+        WRITE_REG32(CANx->FBT, 0x01020203UL);
+        WRITE_REG8(CANx->TDC, 0x00U);
+        SET_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+    }
+    return LL_OK;
+}
+
+/**
+ * @brief  Enable or disable specified interrupts.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u32IntType             Interrupt of CAN.
+ *                                      This parameter can be values of @ref CAN_Interrupt_Type
+ *   @arg  CAN_INT_ERR_INT:             Register bit RTIE.EIE. Error interrupt.
+ *   @arg  CAN_INT_STB_TX:              Register bit RTIE.TSIE. STB was transmitted successfully.
+ *   @arg  CAN_INT_PTB_TX:              Register bit RTIE.TPIE. PTB was transmitted successfully.
+ *   @arg  CAN_INT_RX_BUF_WARN:         Register bit RTIE.RAFIE. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value.
+ *   @arg  CAN_INT_RX_BUF_FULL:         Register bit RTIE.RFIE. The FIFO of receive buffer is full.
+ *   @arg  CAN_INT_RX_OVERRUN:          Register bit RTIE.ROIE. Receive buffers are full and there is a further message to be stored.
+ *   @arg  CAN_INT_RX:                  Register bit RTIE.RIE. Received a valid data frame or remote frame.
+ *   @arg  CAN_INT_BUS_ERR:             Register bit ERRINT.BEIE. Arbitration lost caused bus error
+ *   @arg  CAN_INT_ARBITR_LOST:         Register bit ERRINT.ALIE. Arbitration lost.
+ *   @arg  CAN_INT_ERR_PASSIVE:         Register bit ERRINT.EPIE. A change from error-passive to error-active or error-active to error-passive has occurred.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CAN_IntCmd(CM_CAN_TypeDef *CANx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint8_t u8RTIE;
+    uint8_t u8ERRINT;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u8RTIE   = (uint8_t)u32IntType;
+    u8ERRINT = (uint8_t)(u32IntType >> 8U);
+
+    if (enNewState == ENABLE) {
+        SET_REG8_BIT(CANx->RTIE, u8RTIE);
+        SET_REG8_BIT(CANx->ERRINT, u8ERRINT);
+    } else {
+        CLR_REG8_BIT(CANx->RTIE, u8RTIE);
+        CLR_REG8_BIT(CANx->ERRINT, u8ERRINT);
+    }
+}
+
+/**
+ * @brief  Fills transmit frame.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8TxBufType            CAN transmit buffer type.
+ *                                      This parameter can be a value of @ref CAN_Tx_Buf_Type
+ * @param  [in]  pstcTx                 Pointer to a @ref stc_can_tx_frame_t structure.
+ *   @arg  CAN_TX_BUF_PTB:              Primary transmit buffer.
+ *   @arg  CAN_TX_BUF_STB:              Secondary transmit buffer.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTx == NULL.
+ *           - LL_ERR_BUF_FULL:         The specified transmit buffer is full.
+ *           - LL_ERR_BUSY:             The specified transmit buffer is being transmitted.
+ */
+int32_t CAN_FillTxFrame(CM_CAN_TypeDef *CANx, uint8_t u8TxBufType, const stc_can_tx_frame_t *pstcTx)
+{
+    uint8_t u8RTIE;
+    uint8_t u8TCTRL;
+    uint32_t u32RegAddr;
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_TX_BUF_TYPE(u8TxBufType));
+
+    if (pstcTx != NULL) {
+        if (u8TxBufType == CAN_TX_BUF_PTB) {
+            if (READ_REG8_BIT(CANx->TCMD, CAN_TCMD_TPE) != 0U) {
+                /* PTB is being transmitted. */
+                i32Ret = LL_ERR_BUSY;
+            }
+        } else {
+            if (READ_REG8_BIT(CANx->TCMD, (CAN_TCMD_TSONE | CAN_TCMD_TSALL)) != 0U) {
+                /* STB is being transmitted. */
+                i32Ret = LL_ERR_BUSY;
+            } else {
+                u8RTIE  = READ_REG8(CANx->RTIE);
+                u8TCTRL = READ_REG8(CANx->TCTRL);
+                if (((u8RTIE & CAN_RTIE_TSFF) == CAN_RTIE_TSFF) || \
+                    ((u8TCTRL & CAN_TCTRL_TSSTAT) == CAN_TCTRL_TSSTAT)) {
+                    /* All STBs are filled. */
+                    i32Ret = LL_ERR_BUF_FULL;
+                }
+            }
+        }
+
+        if (i32Ret == LL_OK) {
+            /* Assert ID */
+            DDL_ASSERT(IS_CAN_ID(pstcTx->IDE, pstcTx->u32ID));
+
+            /* Specifies the transmit buffer, PTB or STB. */
+            u32RegAddr = (uint32_t)&CANx->TCMD;
+            WRITE_REG32(PERIPH_BIT_BAND(u32RegAddr, CAN_TCMD_TBSEL_POS), u8TxBufType);
+
+            CAN_WriteTxBuf(CANx, pstcTx);
+
+            if (u8TxBufType == CAN_TX_BUF_STB) {
+                /* After writes the data in transmit buffer(TB), sets the TSNEXT bit to indicate that the current
+                   STB slot has been filled, so that the hardware will point TB to the next STB slot. */
+                SET_REG8_BIT(CANx->TCTRL, CAN_TCTRL_TSNEXT);
+            }
+        }
+    } else {
+        i32Ret = LL_ERR_INVD_PARAM;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Starts transmission.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8TxRequest            The transmit buffer to be transmitted.
+ *                                      This parameter can be values of @ref CAN_Tx_Request
+ *   @arg  CAN_TX_REQ_STB_ONE:          Transmit one STB frame.
+ *   @arg  CAN_TX_REQ_STB_ALL:          Transmit all STB frames.
+ *   @arg  CAN_TX_REQ_PTB:              Transmit PTB frame.
+ * @retval None
+ * @note Call this function when CFG_STAT.RESET is 0.
+ */
+void CAN_StartTx(CM_CAN_TypeDef *CANx, uint8_t u8TxRequest)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_TX_REQ(u8TxRequest));
+    SET_REG8_BIT(CANx->TCMD, u8TxRequest);
+}
+
+/**
+ * @brief  Abort the transmission of the specified transmit buffer.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8TxBufType            The transmit buffer to be aborted.
+ *                                      This parameter can be a value of @ref CAN_Tx_Buf_Type
+ *   @arg  CAN_TX_BUF_PTB:              Abort PTB transmission.
+ *   @arg  CAN_TX_BUF_STB:              Abort STB transmission.
+ * @retval None
+ * @note Call this function when CFG_STAT.RESET is 0.
+ */
+void CAN_AbortTx(CM_CAN_TypeDef *CANx, uint8_t u8TxBufType)
+{
+    uint8_t au8Abort[] = {CAN_TCMD_TPA, CAN_TCMD_TSA};
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_TX_BUF_TYPE(u8TxBufType));
+    SET_REG8_BIT(CANx->TCMD, au8Abort[u8TxBufType]);
+}
+
+/**
+ * @brief  Get one received frame.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [out] pstcRx                 Pointer to a @ref stc_can_rx_frame_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Get one received frame successfully.
+ *           - LL_ERR_BUF_EMPTY:        Receive buffer is empty, and no frame has been read.
+ *           - LL_ERR_INVD_PARAM:       pstcRx == NULL.
+ */
+int32_t CAN_GetRxFrame(CM_CAN_TypeDef *CANx, stc_can_rx_frame_t *pstcRx)
+{
+    int32_t i32Ret = LL_ERR_BUF_EMPTY;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    if (pstcRx == NULL) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        if (READ_REG8_BIT(CANx->RCTRL, CAN_RCTRL_RSTAT) != CAN_RX_BUF_EMPTY) {
+            CAN_ReadRxBuf(CANx, pstcRx);
+            /* Set RB to point to the next RB slot. */
+            SET_REG8_BIT(CANx->RCTRL, CAN_RCTRL_RREL);
+
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/** Request a local-reset. The some register (e.g for node configuration) can only be modified if RESET=1.
+ *  Bit RESET forces several components to a reset state, see the reference manual for details.
+ * @brief
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval None
+ */
+void CAN_EnterLocalReset(CM_CAN_TypeDef *CANx)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    SET_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+}
+
+/** Exit the local-reset state. A CAN node will participate in CAN communication after RESET is switched to 0 after 11 CAN bit times.
+ * @brief
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval None
+ */
+void CAN_ExitLocalReset(CM_CAN_TypeDef *CANx)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    CLR_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET);
+}
+
+/** Check whether CAN is in the local-reset state.
+ * @brief
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CAN_GetLocalResetStatus(CM_CAN_TypeDef *CANx)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    if (READ_REG8_BIT(CANx->CFG_STAT, CAN_CFG_STAT_RESET) != 0U) {
+        /* The CAN is in local-reset state */
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Get the status of specified flag.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u32Flag                CAN status flag.
+ *                                      This parameter can be a value of @ref CAN_Status_Flag
+ *   @arg  CAN_FLAG_BUS_OFF:            Register bit CFG_STAT.BUSOFF. CAN bus off.
+ *   @arg  CAN_FLAG_TX_GOING:           Register bit CFG_STAT.TACTIVE. CAN bus is transmitting.
+ *   @arg  CAN_FLAG_RX_GOING:           Register bit CFG_STAT.RACTIVE. CAN bus is receiving.
+ *   @arg  CAN_FLAG_RX_BUF_OVF:         Register bit RCTRL.ROV. Receive buffer is full and there is a further bit to be stored. At least one data is lost.
+ *   @arg  CAN_FLAG_TX_BUF_FULL:        Register bit RTIE.TSFF. Transmit buffers are all full:
+ *                                      TTCFG.TTEN == 0 or TCTRL.TTTEM == 0: ALL STB slots are filled.
+ *                                      TTCFG.TTEN == 1 and TCTRL.TTTEM == 1: Transmit buffer that pointed by TBSLOT.TBPTR is filled.
+ *   @arg  CAN_FLAG_TX_ABORTED:         Register bit RTIF.AIF. Transmit messages requested via TCMD.TPA and TCMD.TSA were successfully canceled.
+ *   @arg  CAN_FLAG_ERR_INT:            Register bit RTIF.EIF. The CFG_STAT.BUSOFF bit changes, or the relative relationship between the value of the error counter and the
+ *                                      set value of the ERROR warning limit changes. For example, the value of the error counter changes from less than
+ *                                      the set value to greater than the set value, or from greater than the set value to less than the set value.
+ *   @arg  CAN_FLAG_STB_TX:             Register bit RTIF.TSIF. STB was transmitted successfully.
+ *   @arg  CAN_FLAG_PTB_TX:             Register bit RTIF.TPIF. PTB was transmitted successfully.
+ *   @arg  CAN_FLAG_RX_BUF_WARN:        Register bit RTIF.RAFIF. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value.
+ *   @arg  CAN_FLAG_RX_BUF_FULL:        Register bit RTIF.RFIF. The FIFO of receive buffer is full.
+ *   @arg  CAN_FLAG_RX_OVERRUN:         Register bit RTIF.ROIF. Receive buffers are all full and there is a further message to be stored.
+ *   @arg  CAN_FLAG_RX:                 Register bit RTIF.RIF. Received a valid data frame or remote frame.
+ *   @arg  CAN_FLAG_BUS_ERR:            Register bit ERRINT.BEIF. In case of an error, KOER and the error counters get updated. BEIF gets set if BEIE is enabled
+ *                                      and the other error interrupt flags will act accordingly.
+ *   @arg  CAN_FLAG_ARBITR_LOST:        Register bit ERRINT.ALIF. Arbitration lost.
+ *   @arg  CAN_FLAG_ERR_PASSIVE:        Register bit ERRINT.EPIF. A change from error-passive to error-active or error-active to error-passive has occurred.
+ *   @arg  CAN_FLAG_ERR_PASSIVE_NODE:   Register bit ERRINT.EPASS. The node is an error-passive node.
+ *   @arg  CAN_FLAG_TEC_REC_WARN:       Register bit ERRINT.EWARN. REC or TEC is greater than or equal to the LIMIT.EWL setting value.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CAN_GetStatus(const CM_CAN_TypeDef *CANx, uint32_t u32Flag)
+{
+    uint8_t u8CFGSTAT;
+    uint8_t u8RCTRL;
+    uint8_t u8RTIE;
+    uint8_t u8RTIF;
+    uint8_t u8ERRINT;
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_FLAG(u32Flag));
+
+    u8CFGSTAT = (uint8_t)(u32Flag & 0x7UL);
+    u8RCTRL   = (uint8_t)(u32Flag & CAN_FLAG_RX_BUF_OVF);
+    u8RTIE    = (uint8_t)(u32Flag >> 8U);
+    u8RTIF    = (uint8_t)(u32Flag >> 16U);
+    u8ERRINT  = (uint8_t)(u32Flag >> 24U);
+
+    u8CFGSTAT = READ_REG8_BIT(CANx->CFG_STAT, u8CFGSTAT);
+    u8RCTRL   = READ_REG8_BIT(CANx->RCTRL, u8RCTRL);
+    u8RTIE    = READ_REG8_BIT(CANx->RTIE, u8RTIE);
+    u8RTIF    = READ_REG8_BIT(CANx->RTIF, u8RTIF);
+    u8ERRINT  = READ_REG8_BIT(CANx->ERRINT, u8ERRINT);
+
+    if ((u8CFGSTAT != 0U) || (u8RCTRL != 0U) || \
+        (u8RTIE != 0U) || (u8RTIF != 0U) || (u8ERRINT != 0U)) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of specified flags.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u32Flag                CAN status flag.
+ *                                      This parameter can be values of @ref CAN_Status_Flag
+ *   @arg  CAN_FLAG_TX_ABORTED:         Register bit RTIF.AIF. Transmit messages requested via TCMD.TPA and TCMD.TSA were successfully canceled.
+ *   @arg  CAN_FLAG_ERR_INT:            Register bit RTIF.EIF. The CFG_STAT.BUSOFF bit changes, or the relative relationship between the value of the error counter
+ *                                      and the set value of the ERROR warning limit changes. For example, the value of the error counter changes from less than
+ *                                      the set value to greater than the set value, or from greater than the set value to less than the set value.
+ *   @arg  CAN_FLAG_STB_TX:             Register bit RTIF.TSIF. STB was transmitted successfully.
+ *   @arg  CAN_FLAG_PTB_TX:             Register bit RTIF.TPIF. PTB was transmitted successfully.
+ *   @arg  CAN_FLAG_RX_BUF_WARN:        Register bit RTIF.RAFIF. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value.
+ *   @arg  CAN_FLAG_RX_BUF_FULL:        Register bit RTIF.RFIF. The FIFO of receive buffer is full.
+ *   @arg  CAN_FLAG_RX_OVERRUN:         Register bit RTIF.ROIF. Receive buffers are all full and there is a further message to be stored.
+ *   @arg  CAN_FLAG_RX:                 Register bit RTIF.RIF. Received a valid data frame or remote frame.
+ *   @arg  CAN_FLAG_BUS_ERR:            Register bit ERRINT.BEIF. In case of an error, KOER and the error counters get updated. BEIF gets set if BEIE is enabled
+ *                                      and the other error interrupt flags will act accordingly.
+ *   @arg  CAN_FLAG_ARBITR_LOST:        Register bit ERRINT.ALIF. Arbitration lost.
+ *   @arg  CAN_FLAG_ERR_PASSIVE:        Register bit ERRINT.EPIF. A change from error-passive to error-active or error-active to error-passive has occurred.
+ *   @arg  CAN_FLAG_ERR_PASSIVE_NODE:   Register bit ERRINT.EPASS. The node is an error-passive node.
+ *   @arg  CAN_FLAG_TEC_REC_WARN:       Register bit ERRINT.EWARN. REC or TEC is greater than or equal to the LIMIT.EWL setting value.
+ * @retval None
+ */
+void CAN_ClearStatus(CM_CAN_TypeDef *CANx, uint32_t u32Flag)
+{
+    uint8_t u8RTIF;
+    uint8_t u8ERRINT;
+    uint8_t u8Reg;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_FLAG(u32Flag));
+
+    u32Flag &= CAN_FLAG_CLR_ALL;
+    u8RTIF   = (uint8_t)(u32Flag >> 16U);
+    u8ERRINT = (uint8_t)(u32Flag >> 24U);
+
+    WRITE_REG8(CANx->RTIF, u8RTIF);
+
+    u8Reg  = READ_REG8(CANx->ERRINT);
+    u8Reg &= (uint8_t)(~CAN_ERRINT_FLAG_MASK);
+    u8Reg |= u8ERRINT;
+    WRITE_REG8(CANx->ERRINT, u8Reg);
+}
+
+/**
+ * @brief  Get the value of CAN status.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval An uint32_t type value that includes the flowing status flags.
+ *         - CAN_FLAG_BUS_OFF:          Register bit CFG_STAT.BUSOFF. CAN bus off.
+ *         - CAN_FLAG_TX_GOING:         Register bit CFG_STAT.TACTIVE. CAN bus is transmitting.
+ *         - CAN_FLAG_RX_GOING:         Register bit CFG_STAT.RACTIVE. CAN bus is receiving.
+ *         - CAN_FLAG_RX_BUF_OVF:       Register bit RCTRL.ROV. Receive buffer is full and there is a further bit to be stored. At least one data is lost.
+ *         - CAN_FLAG_TX_BUF_FULL:      Register bit RTIE.TSFF. Transmit buffers are all full:
+ *                                      TTCFG.TTEN == 0 or TCTRL.TTTEM == 0: ALL STB slots are filled.
+ *                                      TTCFG.TTEN == 1 and TCTRL.TTTEM == 1: Transmit buffer that pointed by TBSLOT.TBPTR is filled.
+ *         - CAN_FLAG_TX_ABORTED:       Register bit RTIF.AIF. Transmit messages requested via TCMD.TPA and TCMD.TSA were successfully canceled.
+ *         - CAN_FLAG_ERR_INT:          Register bit RTIF.EIF. The CFG_STAT.BUSOFF bit changes, or the relative relationship between the value of the error counter and the
+ *                                      set value of the ERROR warning limit changes. For example, the value of the error counter changes from less than
+ *                                      the set value to greater than the set value, or from greater than the set value to less than the set value.
+ *         - CAN_FLAG_STB_TX:           Register bit RTIF.TSIF. STB was transmitted successfully.
+ *         - CAN_FLAG_PTB_TX:           Register bit RTIF.TPIF. PTB was transmitted successfully.
+ *         - CAN_FLAG_RX_BUF_WARN:      Register bit RTIF.RAFIF. The number of filled RB slot is greater than or equal to the LIMIT.AFWL setting value.
+ *         - CAN_FLAG_RX_BUF_FULL:      Register bit RTIF.RFIF. The FIFO of receive buffer is full.
+ *         - CAN_FLAG_RX_OVERRUN:       Register bit RTIF.ROIF. Receive buffers are all full and there is a further message to be stored.
+ *         - CAN_FLAG_RX:               Register bit RTIF.RIF. Received a valid data frame or remote frame.
+ *         - CAN_FLAG_BUS_ERR:          Register bit ERRINT.BEIF. In case of an error, KOER and the error counters get updated. BEIF gets set if BEIE is enabled
+ *                                      and the other error interrupt flags will act accordingly.
+ *         - CAN_FLAG_ARBITR_LOST:      Register bit ERRINT.ALIF. Arbitration lost.
+ *         - CAN_FLAG_ERR_PASSIVE:      Register bit ERRINT.EPIF. A change from error-passive to error-active or error-active to error-passive has occurred.
+ *         - CAN_FLAG_ERR_PASSIVE_NODE: Register bit ERRINT.EPASS. The node is an error-passive node.
+ *         - CAN_FLAG_TEC_REC_WARN:     Register bit ERRINT.EWARN. REC or TEC is greater than or equal to the LIMIT.EWL setting value.
+ */
+uint32_t CAN_GetStatusValue(const CM_CAN_TypeDef *CANx)
+{
+    uint32_t u32RCTRL;
+    uint32_t u32RTIE;
+    uint32_t u32RTIF;
+    uint32_t u32ERRINT;
+    uint32_t u32RetVal;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    u32RetVal  = CANx->CFG_STAT;
+    u32RCTRL   = CANx->RCTRL;
+    u32RCTRL  &= CAN_FLAG_RX_BUF_OVF;
+    u32RTIE    = CANx->RTIE;
+    u32RTIF    = CANx->RTIF;
+    u32ERRINT  = CANx->ERRINT;
+
+    u32RetVal |= (u32RCTRL | (u32RTIE << 8U) | (u32RTIF << 16U) | (u32ERRINT << 24U));
+    u32RetVal &= CAN_FLAG_ALL;
+
+    return u32RetVal;
+}
+
+/**
+ * @brief  Get the information of CAN errors.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [out] pstcErr                Pointer to a @ref stc_can_error_info_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcErr == NULL.
+ */
+int32_t CAN_GetErrorInfo(const CM_CAN_TypeDef *CANx, stc_can_error_info_t *pstcErr)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    if (pstcErr != NULL) {
+        pstcErr->u8ArbitrLostPos = READ_REG8_BIT(CANx->EALCAP, CAN_EALCAP_ALC);
+        pstcErr->u8ErrorType     = READ_REG8_BIT(CANx->EALCAP, CAN_EALCAP_KOER) >> CAN_EALCAP_KOER_POS;
+        pstcErr->u8RxErrorCount  = READ_REG8(CANx->RECNT);
+        pstcErr->u8TxErrorCount  = READ_REG8(CANx->TECNT);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get status(full or empty) of transmit buffer.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval An uint8_t type value of status of transmit buffer. It can be a value of @ref CAN_Tx_Buf_Status
+ *     - CAN_TX_BUF_EMPTY:              TTCAN is disabled(TTEN == 0): STB is empty.
+ *                                      TTCAN is disabled(TTEN == 1) and transmit buffer is specified by TBPTR and TTPTR(TTTBM == 1):
+ *                                      PTB and STB are both empty.
+ *     - CAN_TX_BUF_NOT_MORE_THAN_HALF: TTEN == 0: STB is not less than half full;
+ *                                      TTEN == 1 && TTTBM == 1: PTB and STB are neither empty.
+ *     - CAN_TX_BUF_MORE_THAN_HALF:     TTEN == 0: STB is more than half full;
+ *                                      TTEN == 1 && TTTBM == 1: reserved value.
+ *     - CAN_TX_BUF_FULL:               TTEN == 0: STB is full;
+ *                                      TTEN == 1 && TTTBM == 1: PTB and STB are both full.
+ */
+uint8_t CAN_GetTxBufStatus(const CM_CAN_TypeDef *CANx)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    return (READ_REG8_BIT(CANx->TCTRL, CAN_TCTRL_TSSTAT));
+}
+
+/**
+ * @brief  Get status(full or empty) of receive buffer.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval An uint8_t type value of status of receive buffer. It can be a value of @ref CAN_Rx_Buf_Status
+ *          - CAN_RX_BUF_EMPTY:         Receive buffer is empty.
+ *          - CAN_RX_BUF_NOT_WARN:      Receive buffer is not empty, but is less than almost full warning limit.
+ *          - CAN_RX_BUF_WARN:          Receive buffer is not full, but is more than or equal to almost full warning limit.
+ *          - CAN_RX_BUF_FULL:          Receive buffer is full.
+ */
+uint8_t CAN_GetRxBufStatus(const CM_CAN_TypeDef *CANx)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    return (READ_REG8_BIT(CANx->RCTRL, CAN_RCTRL_RSTAT));
+}
+
+/**
+ * @brief  Enable or disable the specified acceptance filters.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16FilterSelect        Acceptance filters selection.
+ *                                      This parameter can be values of @ref CAN_Acceptance_Filter
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CAN_FilterCmd(CM_CAN_TypeDef *CANx, uint16_t u16FilterSelect, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_FILTER(u16FilterSelect));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(CANx->ACFEN, u16FilterSelect);
+    } else {
+        CLR_REG16_BIT(CANx->ACFEN, u16FilterSelect);
+    }
+}
+
+/**
+ * @brief  Set receive buffer full warning limit.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in] u8RxWarnLimit:          Receive buffer full warning limit.
+ *                                      When the number of received frames reaches the value specified by
+ *                                      parameter 'u8RxWarnLimit', register bit RTIF.RAFIF set and the
+ *                                      interrupt occurred if it was enabled.
+ * @retval None
+ */
+void CAN_SetRxWarnLimit(CM_CAN_TypeDef *CANx, uint8_t u8RxWarnLimit)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_RX_WARN(u8RxWarnLimit));
+    MODIFY_REG8(CANx->LIMIT, CAN_LIMIT_AFWL, u8RxWarnLimit << CAN_LIMIT_AFWL_POS);
+}
+
+/**
+ * @brief  Set error warning limit.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8ErrorWarnLimit       Programmable error warning limit. Range is [0, 15].
+ *                                      Error warning limit = (u8ErrorWarnLimit + 1) * 8.
+ * @retval None
+ */
+void CAN_SetErrorWarnLimit(CM_CAN_TypeDef *CANx, uint8_t u8ErrorWarnLimit)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_CAN_ERR_WARN(u8ErrorWarnLimit));
+    MODIFY_REG8(CANx->LIMIT, CAN_LIMIT_EWL, u8ErrorWarnLimit);
+}
+
+/**
+ * @brief  Set each @ref stc_canfd_config_t field to a default value.
+ *         Based on 40MHz CAN clock, TQ clock is CAN clock divided by 1.
+ *         Bit rate 2Mbps, 1 bit time is 20TQs, primary sample point is 80%,
+ *         secondary sample point is 80%.
+ * @param  [in]  pstcCanFd              Pointer to a @ref stc_canfd_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanFd == NULL.
+ */
+int32_t CAN_FD_StructInit(stc_canfd_config_t *pstcCanFd)
+{
+    /**
+     * u8TDC: Enable(CAN_FD_TDC_ENABLE) or disable(CAN_FD_TDC_DISABLE) transmitter delay compensation.
+     * u8SSPOffset: The position(TQs) of secondary sample point.
+     *
+     * Primary sample point: u32TimeSeg1 / (u32TimeSeg1 + u32TimeSeg2) = 80%
+     * Secondary sample point: u8SSPOffset / (u32TimeSeg1 + u32TimeSeg2) = 80%
+     *
+     * u32TimeSeg1: TQs of segment 1. Contains synchronization segment,
+     *              propagation time segment and phase buffer segment 1.
+     * u32TimeSeg2: TQs of segment 2(Phase buffer segment 2).
+     * u32SJW: TQs of synchronization jump width.
+     * u32Prescaler: Range [1, 256].
+     */
+
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanFd != NULL) {
+        pstcCanFd->stcBitCfg.u32Prescaler = 1U;
+        pstcCanFd->stcBitCfg.u32TimeSeg1  = 16U;
+        pstcCanFd->stcBitCfg.u32TimeSeg2  = 4U;
+        pstcCanFd->stcBitCfg.u32SJW       = 4U;
+        pstcCanFd->u8Mode                 = CAN_FD_MD_ISO;
+        pstcCanFd->u8TDC                  = CAN_FD_TDC_ENABLE;
+        pstcCanFd->u8SSPOffset            = 16U;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the FD function of the specified CAN controller.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CAN_FD_Cmd(const CM_CAN_TypeDef *CANx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_CAN_FD_UNIT(CANx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (CANx == CM_CAN1) {
+        WRITE_REG32(bCM_PERIC->CAN_SYCTLREG_b.CAN1FDE, enNewState);
+    } else {
+        WRITE_REG32(bCM_PERIC->CAN_SYCTLREG_b.CAN2FDE, enNewState);
+    }
+}
+
+/**
+ * @brief  Set each @ref stc_can_ttc_config_t field to a default value.
+ * @param  [in]  pstcCanTtc             Pointer to a @ref stc_can_ttc_config_t structure value that
+ *                                      contains the configuration information for TTCAN.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanTtc == NULL.
+ */
+int32_t CAN_TTC_StructInit(stc_can_ttc_config_t *pstcCanTtc)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanTtc != NULL) {
+        pstcCanTtc->u8NTUPrescaler      = CAN_TTC_NTU_PRESCALER1;
+        pstcCanTtc->u32RefMsgID         = 0x0UL;
+        pstcCanTtc->u32RefMsgIDE        = 0U;
+        pstcCanTtc->u8TxBufMode         = CAN_TTC_TX_BUF_MD_TTCAN;
+        pstcCanTtc->u16TriggerType      = CAN_TTC_TRIG_SINGLESHOT_TX_TRIG;
+        pstcCanTtc->u16TxEnableWindow   = 16U;
+        pstcCanTtc->u16TxTriggerTime    = 0xFFFFU;
+        pstcCanTtc->u16WatchTriggerTime = 0xFFFFU;
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configures the specified TTCAN according to the specified parameters
+ *         in @ref stc_can_ttc_config_t type structure.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  pstcCanTtc             Pointer to a @ref stc_can_ttc_config_t structure value that
+ *                                      contains the configuration information for TTCAN.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanTtc == NULL.
+ */
+int32_t CAN_TTC_Config(CM_CAN_TypeDef *CANx, const stc_can_ttc_config_t *pstcCanTtc)
+{
+    uint32_t u32RefMsgID;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+
+    if (pstcCanTtc != NULL) {
+        DDL_ASSERT(IS_TTCAN_TX_BUF_MD(pstcCanTtc->u8TxBufMode));
+        DDL_ASSERT(IS_TTCAN_NTU_PRESCALER(pstcCanTtc->u8NTUPrescaler));
+        DDL_ASSERT(IS_CAN_ID(pstcCanTtc->u32RefMsgIDE, pstcCanTtc->u32RefMsgID));
+        DDL_ASSERT(IS_TTCAN_TRIG_TYPE(pstcCanTtc->u16TriggerType));
+        DDL_ASSERT(IS_TTCAN_TX_EN_WINDOW(pstcCanTtc->u16TxEnableWindow));
+
+        u32RefMsgID = pstcCanTtc->u32RefMsgID & ((uint32_t)(~CAN_REF_MSG_REF_IDE));
+        /* Specifies transmission buffer mode. */
+        MODIFY_REG8(CANx->TCTRL, CAN_TCTRL_TTTBM, pstcCanTtc->u8TxBufMode);
+        /* Specifies Tx_Enable window and trigger type. */
+        WRITE_REG16(CANx->TRG_CFG, pstcCanTtc->u16TriggerType |
+                    ((pstcCanTtc->u16TxEnableWindow - 1U) << CAN_TRG_CFG_TEW_POS));
+        /* Specifies ID of reference message and its extension bit. */
+        WRITE_REG32(CANx->REF_MSG, (((pstcCanTtc->u32RefMsgIDE << CAN_REF_MSG_REF_IDE_POS) | u32RefMsgID)));
+        /* Specifies transmission trigger time. */
+        WRITE_REG16(CANx->TT_TRIG, pstcCanTtc->u16TxTriggerTime);
+        /* Specifies watch trigger time. */
+        WRITE_REG16(CANx->TT_WTRIG, pstcCanTtc->u16WatchTriggerTime);
+        /* Specifies NTU prescaler. */
+        MODIFY_REG8(CANx->TTCFG, CAN_TTCFG_T_PRESC, pstcCanTtc->u8NTUPrescaler);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the specified interrupts of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8IntType              Interrupt of TTCAN.
+ *                                      This parameter can be values of @ref TTCAN_Interrupt_Type
+ *   @arg  CAN_TTC_INT_TIME_TRIG:       Time trigger interrupt.
+ *   @arg  CAN_TTC_INT_WATCH_TRIG:      Watch trigger interrupt.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CAN_TTC_IntCmd(CM_CAN_TypeDef *CANx, uint8_t u8IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_INT(u8IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG8_BIT(CANx->TTCFG, u8IntType);
+    } else {
+        CLR_REG8_BIT(CANx->TTCFG, u8IntType);
+    }
+}
+
+/**
+ * @brief  Enable or disable TTCAN of the specified CAN unit.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note Call this function when CFG_STAT.RESET is 0.
+ */
+void CAN_TTC_Cmd(CM_CAN_TypeDef *CANx, en_functional_state_t enNewState)
+{
+    uint32_t u32Addr;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Addr = (uint32_t)&CANx->TTCFG;
+    WRITE_REG32(PERIPH_BIT_BAND(u32Addr, CAN_TTCFG_TTEN_POS), enNewState);
+}
+
+/**
+ * @brief  Get status of the specified TTCAN flag.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8Flag                 Status flag of TTCAN.
+ *                                      This parameter can be values of @ref TTCAN_Status_Flag
+ *   @arg  CAN_TTC_FLAG_TIME_TRIG:      Time trigger interrupt flag.
+ *   @arg  CAN_TTC_FLAG_TRIG_ERR:       Trigger error interrupt flag.
+ *   @arg  CAN_TTC_FLAG_WATCH_TRIG:     Watch trigger interrupt flag.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CAN_TTC_GetStatus(const CM_CAN_TypeDef *CANx, uint8_t u8Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_FLAG(u8Flag));
+
+    if (READ_REG8_BIT(CANx->TTCFG, (u8Flag & CAN_TTC_FLAG_ALL)) != 0U) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of TTCAN flags.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8Flag                 Status flag of TTCAN.
+ *                                      This parameter can be a value of @ref TTCAN_Status_Flag except CAN_TTC_FLAG_TRIG_ERR.
+ *   @arg  CAN_TTC_FLAG_TIME_TRIG:      Time trigger interrupt flag.
+ *   @arg  CAN_TTC_FLAG_WATCH_TRIG:     Watch trigger interrupt flag.
+ * @retval None
+ */
+void CAN_TTC_ClearStatus(CM_CAN_TypeDef *CANx, uint8_t u8Flag)
+{
+    uint8_t u8Reg;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_FLAG(u8Flag));
+
+    u8Reg   = READ_REG8(CANx->TTCFG);
+    u8Reg  &= (uint8_t)(~CAN_TTC_FLAG_ALL);
+    u8Reg  |= u8Flag;
+    WRITE_REG8(CANx->TTCFG, u8Reg);
+}
+
+/**
+ * @brief  Get the status value of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @retval An uint8_t type value that includes the flowing status flags.
+ *         - CAN_TTC_FLAG_TIME_TRIG:    Time trigger interrupt flag.
+ *         - CAN_TTC_FLAG_TRIG_ERR:     Trigger error interrupt flag.
+ *         - CAN_TTC_FLAG_WATCH_TRIG:   Watch trigger interrupt flag.
+ */
+uint8_t CAN_TTC_GetStatusValue(const CM_CAN_TypeDef *CANx)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    return READ_REG8_BIT(CANx->TTCFG, CAN_TTC_FLAG_ALL);
+}
+
+/**
+ * @brief  Specifies trigger type of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16TriggerType         TTCAN trigger type.
+ *                                      This parameter can be a value of @ref TTCAN_Trigger_Type
+ *   @arg  CAN_TTC_TRIG_IMMED_TRIG:     Immediate trigger for immediate transmission.
+ *   @arg  CAN_TTC_TRIG_TIME_TRIG:      Time trigger for receive triggers.
+ *   @arg  CAN_TTC_TRIG_SINGLESHOT_TX_TRIG: Single shot transmit trigger for exclusive time windows.
+ *   @arg  CAN_TTC_TRIG_TX_START_TRIG:  Transmit start trigger for merged arbitrating time windows.
+ *   @arg  CAN_TTC_TRIG_TX_STOP_TRIG:   Transmit stop trigger for merged arbitrating time windows.
+ * @retval None
+ */
+void CAN_TTC_SetTriggerType(CM_CAN_TypeDef *CANx, uint16_t u16TriggerType)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_TRIG_TYPE(u16TriggerType));
+    MODIFY_REG16(CANx->TRG_CFG, CAN_TRG_CFG_TTYPE, u16TriggerType);
+}
+
+/**
+ * @brief  Specifies transmit enable window time of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16TxEnableWindow      Number of NTU. Time period within which the transmit of a message may be started.
+ * @retval None
+ */
+void CAN_TTC_SetTxEnableWindow(CM_CAN_TypeDef *CANx, uint16_t u16TxEnableWindow)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_TX_EN_WINDOW(u16TxEnableWindow));
+    MODIFY_REG16(CANx->TRG_CFG, CAN_TRG_CFG_TEW, (u16TxEnableWindow - 1U) << CAN_TRG_CFG_TEW_POS);
+}
+
+/**
+ * @brief  Specifies transmit trigger time of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16TxTriggerTime       Transmit trigger time(number of NTU).
+ * @retval None
+ */
+void CAN_TTC_SetTxTriggerTime(CM_CAN_TypeDef *CANx, uint16_t u16TxTriggerTime)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    WRITE_REG16(CANx->TT_TRIG, u16TxTriggerTime);
+}
+
+/**
+ * @brief  TTCAN specifies watch-trigger time.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u16WatchTriggerTime    Watch trigger time(number of NTU).
+ * @retval None
+ */
+void CAN_TTC_SetWatchTriggerTime(CM_CAN_TypeDef *CANx, uint16_t u16WatchTriggerTime)
+{
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    WRITE_REG16(CANx->TT_WTRIG, u16WatchTriggerTime);
+}
+
+/**
+ * @brief  TTCAN fill transmit frame.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [in]  u8CANTTCTxBuf          TTCAN transmit buffer selection.
+ *                                      This parameter can be a value of @ref TTCAN_Tx_Buf_Sel
+ * @param  [in]  pstcTx                 Pointer to a @ref stc_can_tx_frame_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTx == NULL.
+ *           - LL_ERR_BUF_FULL:         The target transmit buffer is full.
+ */
+int32_t CAN_TTC_FillTxFrame(CM_CAN_TypeDef *CANx, uint8_t u8CANTTCTxBuf, const stc_can_tx_frame_t *pstcTx)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_CAN_UNIT(CANx));
+    DDL_ASSERT(IS_TTCAN_TX_BUF_SEL(u8CANTTCTxBuf));
+
+    if (pstcTx != NULL) {
+        DDL_ASSERT(IS_CAN20_FDF(pstcTx->FDF));
+
+        if (READ_REG8_BIT(CANx->TCTRL, CAN_TX_BUF_FULL) == CAN_TX_BUF_FULL) {
+            i32Ret = LL_ERR_BUF_FULL;
+        } else {
+            WRITE_REG8(CANx->TBSLOT, u8CANTTCTxBuf);
+            MODIFY_REG16(CANx->TRG_CFG, CAN_TRG_CFG_TTPTR, u8CANTTCTxBuf);
+            CAN_WriteTxBuf(CANx, pstcTx);
+
+            /* Set buffer as filled. */
+            SET_REG8_BIT(CANx->TBSLOT, CAN_TBSLOT_TBF);
+
+            /* Write MSB of TT_TRIG to transmit. */
+            WRITE_REG16(CANx->TT_TRIG, CANx->TT_TRIG);
+
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get the configuration of TTCAN.
+ * @param  [in]  CANx                   Pointer to CAN instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_CAN or CM_CANx:           CAN instance register base.
+ * @param  [out] pstcCanTtc             Pointer to a @ref stc_can_ttc_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcCanTtc == NULL.
+ */
+int32_t CAN_TTC_GetConfig(const CM_CAN_TypeDef *CANx, stc_can_ttc_config_t *pstcCanTtc)
+{
+    uint32_t u32Tmp;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcCanTtc != NULL) {
+        u32Tmp = READ_REG32(CANx->REF_MSG);
+        pstcCanTtc->u8TxBufMode         = READ_REG8_BIT(CANx->TCTRL, CAN_TCTRL_TTTBM);
+        pstcCanTtc->u8NTUPrescaler      = READ_REG8_BIT(CANx->TTCFG, CAN_TTCFG_T_PRESC);
+        pstcCanTtc->u32RefMsgIDE        = (u32Tmp >> CAN_REF_MSG_REF_IDE_POS) & 0x1UL;
+        pstcCanTtc->u32RefMsgID         = u32Tmp & CAN_EXT_ID_MASK;
+        pstcCanTtc->u16TriggerType      = READ_REG16_BIT(CANx->TRG_CFG, CAN_TRG_CFG_TTYPE);
+        pstcCanTtc->u16TxEnableWindow   = (READ_REG16_BIT(CANx->TRG_CFG, CAN_TRG_CFG_TEW) >> CAN_TRG_CFG_TEW_POS) + 1U;
+        pstcCanTtc->u16TxTriggerTime    = READ_REG16(CANx->TT_TRIG);
+        pstcCanTtc->u16WatchTriggerTime = READ_REG16(CANx->TT_WTRIG);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_CAN_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_clk.c
+++ b/hc32f4a2/src/hc32_ll_clk.c
@@ -1,0 +1,1732 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_clk.c
+ * @brief This file provides firmware functions to manage the Clock(CLK).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Fixed bug# GetClockFreq() API xtal32 value
+                                    Modified CLK_PLLN_DEFAULT value
+   2023-01-15       CDT             Optimize API CLK_SetCANClockSrc(), add assert IS_PWC_UNLOCKED()
+   2023-06-30       CDT             Modify typo
+                                    Modify CLK_SetUSBClockSrc(), add delay after configure USB clock
+   2023-09-30       CDT             Modify API CLK_Xtal32Cmd(), CLK_MrcCmd() and CLK_LrcCmd(), use DDL_DelayUS() to replace CLK_Delay()
+   2023-12-15       CDT             Refine API CLK_XtalStdInit. and add API CLK_XtalStdCmd, CLK_SetXtalStdExceptionType
+   2024-08-31       CDT             Modify CLK_PLLXM_DIV_MAX as 25U
+                                    Modify CLK_PLLXM_DIV_MIN as 1U
+   2024-11-08       CDT             Delete group definition for CLK_FREQ
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_clk.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_CLK CLK
+ * @brief Clock Driver Library
+ * @{
+ */
+
+#if (LL_CLK_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CLK_Local_Macros CLK Local Macros
+ * @{
+ */
+
+/**
+ * @brief Be able to modify TIMEOUT according to board condition.
+ */
+#define CLK_TIMEOUT                     ((uint32_t)0x1000UL)
+#define CLK_LRC_TIMEOUT                 (160U)
+#define CLK_MRC_TIMEOUT                 (1U)
+#define CLK_XTAL32_TIMEOUT              (160U)
+
+/**
+ * @brief XTALSTD exception type mask
+ */
+#define CLK_XTALSTD_EXP_TYPE_MASK       (CMU_XTALSTDCR_XTALSTDIE | CMU_XTALSTDCR_XTALSTDRE | CMU_XTALSTDCR_XTALSTDRIS)
+
+/**
+ * @brief LRC State ON or OFF
+ */
+#define CLK_LRC_OFF                     (CMU_LRCCR_LRCSTP)
+#define CLK_LRC_ON                      (0x00U)
+
+/**
+ * @brief MRC State ON or OFF
+ */
+#define CLK_MRC_OFF                     (CMU_MRCCR_MRCSTP)
+#define CLK_MRC_ON                      (0x80U)
+
+/**
+ * @brief Clk PLL Relevant Parameter Range Definition
+ */
+#define CLK_PLLP_DEFAULT                (0x01UL)
+#define CLK_PLLQ_DEFAULT                (0x01UL)
+#define CLK_PLLR_DEFAULT                (0x01UL)
+#define CLK_PLLN_DEFAULT                (0x13UL)
+#define CLK_PLLM_DEFAULT                (0x00UL)
+
+#define CLK_PLLR_DIV_MIN                (2UL)
+#define CLK_PLLR_DIV_MAX                (16UL)
+#define CLK_PLLQ_DIV_MIN                (2UL)
+#define CLK_PLLQ_DIV_MAX                (16UL)
+#define CLK_PLLP_DIV_MIN                (2UL)
+#define CLK_PLLP_DIV_MAX                (16UL)
+
+#define CLK_PLLX_FREQ_MIN               (15UL*1000UL*1000UL)
+#define CLK_PLLX_VCO_IN_MIN             (1UL*1000UL*1000UL)
+#define CLK_PLLX_VCO_IN_MAX             (25UL*1000UL*1000UL)
+#define CLK_PLLX_VCO_OUT_MIN            (240UL*1000UL*1000UL)
+#define CLK_PLLX_VCO_OUT_MAX            (480UL*1000UL*1000UL)
+#define CLK_PLLXM_DIV_MIN               (1UL)
+#define CLK_PLLXM_DIV_MAX               (25UL)
+#define CLK_PLLXN_MULTI_MIN             (20UL)
+#define CLK_PLLXN_MULTI_MAX             (480UL)
+#define CLK_PLLXR_DIV_MIN               (2UL)
+#define CLK_PLLXR_DIV_MAX               (16UL)
+#define CLK_PLLXQ_DIV_MIN               (2UL)
+#define CLK_PLLXQ_DIV_MAX               (16UL)
+#define CLK_PLLXP_DIV_MIN               (2UL)
+#define CLK_PLLXP_DIV_MAX               (16UL)
+#define CLK_PLLXP_DEFAULT               (0x01UL)
+#define CLK_PLLXQ_DEFAULT               (0x01UL)
+#define CLK_PLLXR_DEFAULT               (0x01UL)
+#define CLK_PLLXN_DEFAULT               (0x13UL)
+#define CLK_PLLXM_DEFAULT               (0x00UL)
+
+#define CLK_PLLX_FREQ_MAX               (240UL*1000UL*1000UL)
+#define CLK_PLL_FREQ_MIN                (375UL*100UL*1000UL)
+#define CLK_PLL_FREQ_MAX                (240UL*1000UL*1000UL)
+#define CLK_PLL_VCO_IN_MIN              (8UL*1000UL*1000UL)
+#define CLK_PLL_VCO_IN_MAX              (25UL*1000UL*1000UL)
+#define CLK_PLL_VCO_OUT_MIN             (600UL*1000UL*1000UL)
+#define CLK_PLL_VCO_OUT_MAX             (1200UL*1000UL*1000UL)
+#define CLK_PLLM_DIV_MIN                (1UL)
+#define CLK_PLLM_DIV_MAX                (4UL)
+#define CLK_PLLN_MULTI_MIN              (25UL)
+#define CLK_PLLN_MULTI_MAX              (150UL)
+
+/**
+ * @brief Clk PLL Register Redefinition
+ */
+#define PLL_SRC_REG                     (CM_CMU->PLLHCFGR)
+#define PLL_SRC_BIT                     (CMU_PLLHCFGR_PLLSRC)
+#define PLL_SRC_POS                     (CMU_PLLHCFGR_PLLSRC_POS)
+#define PLL_SRC                         ((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLSRC) >> CMU_PLLHCFGR_PLLSRC_POS)
+#define PLL_EN_REG                      (CM_CMU->PLLHCR)
+#define PLLX_EN_REG                     (CM_CMU->PLLACR)
+
+/**
+ * @brief Switch clock stable time
+ * @note Approx. 30us
+ */
+#define CLK_SYSCLK_SW_STB               (30U)
+
+/**
+ * @brief Clk FCG Default Value
+ */
+#define CLK_FCG0_DEFAULT                (0xFFFFFA0EUL)
+#define CLK_FCG1_DEFAULT                (0xFFFFFFFFUL)
+#define CLK_FCG2_DEFAULT                (0xFFFFFFFFUL)
+#define CLK_FCG3_DEFAULT                (0xFFFFFFFFUL)
+
+/**
+ * @defgroup CLK_Check_Parameters_Validity CLK Check Parameters Validity
+ * @{
+ */
+/* Check CLK register lock status. */
+#define IS_CLK_UNLOCKED()               ((CM_PWC->FPRC & PWC_FPRC_FPRCB0) == PWC_FPRC_FPRCB0)
+#define IS_PWC_UNLOCKED()               ((CM_PWC->FPRC & PWC_FPRC_FPRCB1) == PWC_FPRC_FPRCB1)
+
+/* Parameter valid check for XTAL state */
+#define IS_CLK_XTAL_STATE(x)                                                   \
+(   ((x) == CLK_XTAL_OFF)                         ||                           \
+    ((x) == CLK_XTAL_ON))
+
+/* Parameter valid check for XTAL mode */
+#define IS_CLK_XTAL_MD(x)                                                      \
+(   ((x) == CLK_XTAL_MD_OSC)                      ||                           \
+    ((x) == CLK_XTAL_MD_EXCLK))
+
+/* Parameter valid check for XTAL driver ability mode */
+#define IS_CLK_XTAL_DRV_MD(x)                                                  \
+(   ((x) == CLK_XTAL_DRV_HIGH)                    ||                           \
+    ((x) == CLK_XTAL_DRV_MID)                     ||                           \
+    ((x) == CLK_XTAL_DRV_LOW)                     ||                           \
+    ((x) == CLK_XTAL_DRV_ULOW))
+
+/* Parameter valid check for XTAL stable time selection */
+#define IS_CLK_XTAL_STB_SEL(x)                                                 \
+(   ((x) == CLK_XTAL_STB_133US)                   ||                           \
+    ((x) == CLK_XTAL_STB_255US)                   ||                           \
+    ((x) == CLK_XTAL_STB_499US)                   ||                           \
+    ((x) == CLK_XTAL_STB_988US)                   ||                           \
+    ((x) == CLK_XTAL_STB_2MS)                     ||                           \
+    ((x) == CLK_XTAL_STB_4MS)                     ||                           \
+    ((x) == CLK_XTAL_STB_8MS)                     ||                           \
+    ((x) == CLK_XTAL_STB_16MS)                    ||                           \
+    ((x) == CLK_XTAL_STB_31MS))
+
+/* Parameter valid check for XTALSTD state */
+#define IS_CLK_XTALSTD_STATE(x)                                                \
+(   ((x) == CLK_XTALSTD_OFF)                      ||                           \
+    ((x) == CLK_XTALSTD_ON))
+
+/* Parameter valid check for XTALSTD exception type */
+#define IS_CLK_XTALSTD_EXP_TYPE(x)                                             \
+(   ((x) == CLK_XTALSTD_EXP_TYPE_NONE)            ||                           \
+    ((x) == CLK_XTALSTD_EXP_TYPE_RST)             ||                           \
+    ((x) == CLK_XTALSTD_EXP_TYPE_INT))
+
+/* Parameter valid check for PLL state */
+#define IS_CLK_PLL_STATE(x)                                                    \
+(   ((x) == CLK_PLL_OFF)                          ||                           \
+    ((x) == CLK_PLL_ON))
+
+/* Parameter validity check for PLL input source */
+#define IS_CLK_PLL_SRC(x)                                                      \
+(   ((x) == CLK_PLL_SRC_XTAL)                     ||                           \
+    ((x) == CLK_PLL_SRC_HRC))
+
+/* Parameter validity check for PLL frequency range */
+#define IS_CLK_PLL_FREQ(x)                                                     \
+(   ((x) <= CLK_PLL_FREQ_MAX)                     &&                           \
+    ((x) >= CLK_PLL_FREQ_MIN))
+
+/* Parameter validity check for PLL M divide */
+#define IS_CLK_PLLM_DIV(x)                                                     \
+(   ((x) <= CLK_PLLM_DIV_MAX)                     &&                           \
+    ((x) >= CLK_PLLM_DIV_MIN))
+
+/* Parameter validity check for PLL N multi- */
+#define IS_CLK_PLLN_MULTI(x)                                                   \
+(   ((x) <= CLK_PLLN_MULTI_MAX)                   &&                           \
+    ((x) >= CLK_PLLN_MULTI_MIN))
+
+/* Parameter validity check for PLL P divide */
+#define IS_CLK_PLLP_DIV(x)                                                     \
+(   ((x) <= CLK_PLLP_DIV_MAX)                     &&                           \
+    ((x) >= CLK_PLLP_DIV_MIN))
+
+/* Parameter validity check for PLL_input freq./PLLM(vco_in) */
+#define IS_CLK_PLL_VCO_IN(x)                                                   \
+(   ((x) <= CLK_PLL_VCO_IN_MAX)                   &&                           \
+    ((x) >= CLK_PLL_VCO_IN_MIN))
+
+/* Parameter validity check for PLL vco_in*PLLN(vco_out) */
+#define IS_CLK_PLL_VCO_OUT(x)                                                  \
+(   ((x) <= CLK_PLL_VCO_OUT_MAX)                  &&                           \
+    ((x) >= CLK_PLL_VCO_OUT_MIN))
+
+/* Parameter validity check for PLL R divide */
+#define IS_CLK_PLLR_DIV(x)                                                     \
+(   ((x) <= CLK_PLLR_DIV_MAX)                     &&                           \
+    ((x) >= CLK_PLLR_DIV_MIN))
+
+/* Parameter validity check for PLL Q divide */
+#define IS_CLK_PLLQ_DIV(x)                                                     \
+(   ((x) <= CLK_PLLQ_DIV_MAX)                     &&                           \
+    ((x) >= CLK_PLLQ_DIV_MIN))
+
+/* Parameter valid check for PLLX state */
+#define IS_CLK_PLLX_STATE(x)                                                   \
+(   ((x) == CLK_PLLX_OFF)                         ||                           \
+    ((x) == CLK_PLLX_ON))
+
+/* Parameter validity check for PLLX frequency range */
+#define IS_CLK_PLLX_FREQ(x)                                                    \
+(   (CLK_PLLX_FREQ_MIN <= (x))                    &&                           \
+    (CLK_PLLX_FREQ_MAX >= (x)))
+
+/* Parameter validity check for PLLX M divide */
+#define IS_CLK_PLLXM_DIV(x)                                                    \
+(   (CLK_PLLXM_DIV_MIN <= (x))                    &&                           \
+    (CLK_PLLXM_DIV_MAX >= (x)))
+
+/* Parameter validity check for PLLX N multi- */
+#define IS_CLK_PLLXN_MULTI(x)                                                  \
+(   (CLK_PLLXN_MULTI_MIN <= (x))                  &&                           \
+    (CLK_PLLXN_MULTI_MAX >= (x)))
+
+/* Parameter validity check for PLLX R divide */
+#define IS_CLK_PLLXR_DIV(x)                                                    \
+(   (CLK_PLLXR_DIV_MIN <= (x))                    &&                           \
+    (CLK_PLLXR_DIV_MAX >= (x)))
+
+/* Parameter validity check for PLLX Q divide */
+#define IS_CLK_PLLXQ_DIV(x)                                                    \
+(   (CLK_PLLXQ_DIV_MIN <= (x))                    &&                           \
+    (CLK_PLLXQ_DIV_MAX >= (x)))
+
+/* Parameter validity check for PLLX P divide */
+#define IS_CLK_PLLXP_DIV(x)                                                    \
+(   (CLK_PLLXP_DIV_MIN <= (x))                    &&                           \
+    (CLK_PLLXP_DIV_MAX >= (x)))
+
+/* Parameter validity check for PLLX_input freq./PLLM(vco_in) */
+#define IS_CLK_PLLX_VCO_IN(x)                                                  \
+(   (CLK_PLLX_VCO_IN_MIN <= (x))                  &&                           \
+    (CLK_PLLX_VCO_IN_MAX >= (x)))
+
+/* Parameter validity check for PLLX vco_in*PLLN(vco_out) */
+#define IS_CLK_PLLX_VCO_OUT(x)                                                 \
+(   (CLK_PLLX_VCO_OUT_MIN <= (x))                 &&                           \
+    (CLK_PLLX_VCO_OUT_MAX >= (x)))
+
+/* Parameter valid check for XTAL32 state */
+#define IS_CLK_XTAL32_STATE(x)                                                 \
+(   ((x) == CLK_XTAL32_OFF)                       ||                           \
+    ((x) == CLK_XTAL32_ON))
+
+/* Parameter valid check for XTAL32 driver ability mode */
+#define IS_CLK_XTAL32_DRV_MD(x)                                                \
+(   ((x) == CLK_XTAL32_DRV_MID)                   ||                           \
+    ((x) == CLK_XTAL32_DRV_HIGH))
+
+/* Parameter valid check for XTAL32 filtering selection */
+#define IS_CLK_XTAL32_FILT_SEL(x)                                              \
+(   ((x) == CLK_XTAL32_FILTER_ALL_MD)             ||                           \
+    ((x) == CLK_XTAL32_FILTER_RUN_MD)             ||                           \
+    ((x) == CLK_XTAL32_FILTER_OFF))
+
+/* Parameter valid check for system clock source */
+#define IS_CLK_SYSCLK_SRC(x)                                                   \
+(   ((x) == CLK_SYSCLK_SRC_HRC)                   ||                           \
+    ((x) == CLK_SYSCLK_SRC_MRC)                   ||                           \
+    ((x) == CLK_SYSCLK_SRC_LRC)                   ||                           \
+    ((x) == CLK_SYSCLK_SRC_XTAL)                  ||                           \
+    ((x) == CLK_SYSCLK_SRC_XTAL32)                ||                           \
+    ((x) == CLK_SYSCLK_SRC_PLL))
+
+/* Parameter valid check for CLK stable flag. */
+#define IS_CLK_STB_FLAG(x)                                                     \
+(   ((x) != 0x00U)                                &&                           \
+    (((x) | CLK_STB_FLAG_MASK) == CLK_STB_FLAG_MASK))
+
+/* Parameter valid check for bus clock category */
+#define IS_CLK_BUS_CLK_CATE(x)                   (((x) & CLK_BUS_CLK_ALL) != (0x00U))
+
+/* Parameter valid check for HCLK divider */
+#define IS_CLK_HCLK_DIV(x)                                                     \
+(   ((x) == CLK_HCLK_DIV1)                        ||                           \
+    ((x) == CLK_HCLK_DIV2)                        ||                           \
+    ((x) == CLK_HCLK_DIV4)                        ||                           \
+    ((x) == CLK_HCLK_DIV8)                        ||                           \
+    ((x) == CLK_HCLK_DIV16)                       ||                           \
+    ((x) == CLK_HCLK_DIV32)                       ||                           \
+    ((x) == CLK_HCLK_DIV64))
+
+/* Parameter valid check for PCLK1 divider */
+#define IS_CLK_PCLK1_DIV(x)                                                    \
+(   ((x) == CLK_PCLK1_DIV1)                       ||                           \
+    ((x) == CLK_PCLK1_DIV2)                       ||                           \
+    ((x) == CLK_PCLK1_DIV4)                       ||                           \
+    ((x) == CLK_PCLK1_DIV8)                       ||                           \
+    ((x) == CLK_PCLK1_DIV16)                      ||                           \
+    ((x) == CLK_PCLK1_DIV32)                      ||                           \
+    ((x) == CLK_PCLK1_DIV64))
+
+/* Parameter valid check for PCLK4 divider */
+#define IS_CLK_PCLK4_DIV(x)                                                    \
+(   ((x) == CLK_PCLK4_DIV1)                       ||                           \
+    ((x) == CLK_PCLK4_DIV2)                       ||                           \
+    ((x) == CLK_PCLK4_DIV4)                       ||                           \
+    ((x) == CLK_PCLK4_DIV8)                       ||                           \
+    ((x) == CLK_PCLK4_DIV16)                      ||                           \
+    ((x) == CLK_PCLK4_DIV32)                      ||                           \
+    ((x) == CLK_PCLK4_DIV64))
+
+/* Parameter valid check for PCLK3 divider */
+#define IS_CLK_PCLK3_DIV(x)                                                    \
+(   ((x) == CLK_PCLK3_DIV1)                       ||                           \
+    ((x) == CLK_PCLK3_DIV2)                       ||                           \
+    ((x) == CLK_PCLK3_DIV4)                       ||                           \
+    ((x) == CLK_PCLK3_DIV8)                       ||                           \
+    ((x) == CLK_PCLK3_DIV16)                      ||                           \
+    ((x) == CLK_PCLK3_DIV32)                      ||                           \
+    ((x) == CLK_PCLK3_DIV64))
+
+/* Parameter valid check for EXCLK divider */
+#define IS_CLK_EXCLK_DIV(x)                                                    \
+(   ((x) == CLK_EXCLK_DIV1)                       ||                           \
+    ((x) == CLK_EXCLK_DIV2)                       ||                           \
+    ((x) == CLK_EXCLK_DIV4)                       ||                           \
+    ((x) == CLK_EXCLK_DIV8)                       ||                           \
+    ((x) == CLK_EXCLK_DIV16)                      ||                           \
+    ((x) == CLK_EXCLK_DIV32)                      ||                           \
+    ((x) == CLK_EXCLK_DIV64))
+
+/* Parameter valid check for PCLK0 divider */
+#define IS_CLK_PCLK0_DIV(x)                                                    \
+(   ((x) == CLK_PCLK0_DIV1)                       ||                           \
+    ((x) == CLK_PCLK0_DIV2)                       ||                           \
+    ((x) == CLK_PCLK0_DIV4)                       ||                           \
+    ((x) == CLK_PCLK0_DIV8)                       ||                           \
+    ((x) == CLK_PCLK0_DIV16)                      ||                           \
+    ((x) == CLK_PCLK0_DIV32)                      ||                           \
+    ((x) == CLK_PCLK0_DIV64))
+
+/* Parameter valid check for PCLK2 divider */
+#define IS_CLK_PCLK2_DIV(x)                                                    \
+(   ((x) == CLK_PCLK2_DIV1)                       ||                           \
+    ((x) == CLK_PCLK2_DIV2)                       ||                           \
+    ((x) == CLK_PCLK2_DIV4)                       ||                           \
+    ((x) == CLK_PCLK2_DIV8)                       ||                           \
+    ((x) == CLK_PCLK2_DIV16)                      ||                           \
+    ((x) == CLK_PCLK2_DIV32)                      ||                           \
+    ((x) == CLK_PCLK2_DIV64))
+
+/* Parameter valid check for bus clock */
+#define IS_CLK_BUS_CLK(x)                                                      \
+(   ((x) == CLK_BUS_HCLK)                         ||                           \
+    ((x) == CLK_BUS_EXCLK)                        ||                           \
+    ((x) == CLK_BUS_PCLK0)                        ||                           \
+    ((x) == CLK_BUS_PCLK1)                        ||                           \
+    ((x) == CLK_BUS_PCLK2)                        ||                           \
+    ((x) == CLK_BUS_PCLK3)                        ||                           \
+    ((x) == CLK_BUS_PCLK4))
+
+/* Parameter valid check for USB clock source */
+#define IS_CLK_USBCLK_SRC(x)                                                   \
+(   ((x) == CLK_USBCLK_SYSCLK_DIV2)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV3)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV4)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV5)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV6)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV7)               ||                           \
+    ((x) == CLK_USBCLK_SYSCLK_DIV8)               ||                           \
+    ((x) == CLK_USBCLK_PLLQ)                      ||                           \
+    ((x) == CLK_USBCLK_PLLR)                      ||                           \
+    ((x) == CLK_USBCLK_PLLXP)                     ||                           \
+    ((x) == CLK_USBCLK_PLLXQ)                     ||                           \
+    ((x) == CLK_USBCLK_PLLXR))
+
+/* Parameter valid check for CAN clock source */
+#define IS_CLK_CANCLK(x)                                                       \
+(   ((x) == CLK_CANCLK_SYSCLK_DIV2)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV3)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV4)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV5)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV6)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV7)               ||                           \
+    ((x) == CLK_CANCLK_SYSCLK_DIV8)               ||                           \
+    ((x) == CLK_CANCLK_PLLQ)                      ||                           \
+    ((x) == CLK_CANCLK_PLLR)                      ||                           \
+    ((x) == CLK_CANCLK_PLLXP)                     ||                           \
+    ((x) == CLK_CANCLK_PLLXQ)                     ||                           \
+    ((x) == CLK_CANCLK_PLLXR)                     ||                           \
+    ((x) == CLK_CANCLK_XTAL))
+
+/* Parameter valid check for CAN channel for clock source config */
+#define IS_CLK_CAN_UNIT(x)                                                     \
+(   ((x) == CLK_CAN1)                             ||                           \
+    ((x) == CLK_CAN2))
+
+/* Parameter valid check for I2S channel for clock  source config */
+#define IS_CLK_I2S_UNIT(x)                                                     \
+(   ((x) == CLK_I2S1)                             ||                           \
+    ((x) == CLK_I2S2)                             ||                           \
+    ((x) == CLK_I2S3)                             ||                           \
+    ((x) == CLK_I2S4))
+
+/* Parameter valid check for peripheral source */
+#define IS_CLK_PERIPHCLK_SRC(x)                                                \
+(   ((x) == CLK_PERIPHCLK_PCLK)                   ||                           \
+    ((x) == CLK_PERIPHCLK_PLLQ)                   ||                           \
+    ((x) == CLK_PERIPHCLK_PLLR)                   ||                           \
+    ((x) == CLK_PERIPHCLK_PLLXP)                  ||                           \
+    ((x) == CLK_PERIPHCLK_PLLXQ)                  ||                           \
+    ((x) == CLK_PERIPHCLK_PLLXR))
+
+/* Parameter valid check for TPIU clock divider */
+#define IS_CLK_TPIUCLK_DIV(x)                                                 \
+(   ((x) == CLK_TPIUCLK_DIV1)                     ||                          \
+    ((x) == CLK_TPIUCLK_DIV2)                     ||                          \
+    ((x) == CLK_TPIUCLK_DIV4))
+
+/* Parameter valid check for CLK MCO clock source  . */
+#define IS_CLK_MCO_SRC(x)                                                      \
+(   ((x) == CLK_MCO_SRC_HRC)                      ||                           \
+    ((x) == CLK_MCO_SRC_MRC)                      ||                           \
+    ((x) == CLK_MCO_SRC_LRC)                      ||                           \
+    ((x) == CLK_MCO_SRC_XTAL)                     ||                           \
+    ((x) == CLK_MCO_SRC_XTAL32)                   ||                           \
+    ((x) == CLK_MCO_SRC_PLLP)                     ||                           \
+    ((x) == CLK_MCO_SRC_PLLQ)                     ||                           \
+    ((x) == CLK_MCO_SRC_PLLXP)                    ||                           \
+    ((x) == CLK_MCO_SRC_PLLXQ)                    ||                           \
+    ((x) == CLK_MCO_SRC_PLLXR)                    ||                           \
+    ((x) == CLK_MCO_SRC_HCLK))
+
+/* Parameter valid check for CLK MCO clock divide. */
+#define IS_CLK_MCO_DIV(x)                                                      \
+(   ((x) == CLK_MCO_DIV1)                         ||                           \
+    ((x) == CLK_MCO_DIV2)                         ||                           \
+    ((x) == CLK_MCO_DIV4)                         ||                           \
+    ((x) == CLK_MCO_DIV8)                         ||                           \
+    ((x) == CLK_MCO_DIV16)                        ||                           \
+    ((x) == CLK_MCO_DIV32)                        ||                           \
+    ((x) == CLK_MCO_DIV64)                        ||                           \
+    ((x) == CLK_MCO_DIV128))
+
+/* Parameter valid check for CLK MCO channel. */
+#define IS_CLK_MCO_CH(x)                                                       \
+(   ((x) == CLK_MCO1)                             ||                           \
+    ((x) == CLK_MCO2))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup CLK_Local_Functions CLK Local Functions
+ * @{
+ */
+/**
+ * @brief  Wait clock stable flag.
+ * @param  [in] u8Flag      Specifies the stable flag to be wait. @ref CLK_STB_Flag
+ * @param  [in] u32Time     Specifies the time to wait while the flag not be set.
+ * @retval int32_t
+ */
+static int32_t CLK_WaitStable(uint8_t u8Flag, uint32_t u32Time)
+{
+    __IO uint32_t u32Timeout = 0UL;
+    int32_t i32Ret = LL_ERR_TIMEOUT;
+
+    while (u32Timeout <= u32Time) {
+        if (SET == CLK_GetStableStatus(u8Flag)) {
+            i32Ret = LL_OK;
+            break;
+        }
+        u32Timeout++;
+    }
+    return i32Ret;
+}
+
+#ifdef __DEBUG
+static void PLLxParamCheck(const stc_clock_pllx_init_t *pstcPLLxInit)
+{
+    uint32_t vcoIn;
+    uint32_t vcoOut;
+
+    DDL_ASSERT(IS_CLK_PLLXM_DIV(pstcPLLxInit->PLLCFGR_f.PLLM + 1UL));
+    DDL_ASSERT(IS_CLK_PLLXN_MULTI(pstcPLLxInit->PLLCFGR_f.PLLN + 1UL));
+    DDL_ASSERT(IS_CLK_PLLXR_DIV(pstcPLLxInit->PLLCFGR_f.PLLR + 1UL));
+    DDL_ASSERT(IS_CLK_PLLXQ_DIV(pstcPLLxInit->PLLCFGR_f.PLLQ + 1UL));
+    DDL_ASSERT(IS_CLK_PLLXP_DIV(pstcPLLxInit->PLLCFGR_f.PLLP + 1UL));
+
+    vcoIn = ((CLK_PLL_SRC_XTAL == PLL_SRC ?
+              XTAL_VALUE : HRC_VALUE) / (pstcPLLxInit->PLLCFGR_f.PLLM + 1UL));
+    vcoOut = vcoIn * (pstcPLLxInit->PLLCFGR_f.PLLN + 1UL);
+
+    DDL_ASSERT(IS_CLK_PLLX_VCO_IN(vcoIn));
+    DDL_ASSERT(IS_CLK_PLLX_VCO_OUT(vcoOut));
+    DDL_ASSERT(IS_CLK_PLLX_FREQ(vcoOut / (pstcPLLxInit->PLLCFGR_f.PLLR + 1UL)));
+    DDL_ASSERT(IS_CLK_PLLX_FREQ(vcoOut / (pstcPLLxInit->PLLCFGR_f.PLLQ + 1UL)));
+    DDL_ASSERT(IS_CLK_PLLX_FREQ(vcoOut / (pstcPLLxInit->PLLCFGR_f.PLLP + 1UL)));
+    DDL_ASSERT(IS_CLK_PLLX_STATE(pstcPLLxInit->u8PLLState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+}
+#endif /* __DEBUG */
+
+static void SetSysClockSrc(uint8_t u8Src)
+{
+    uint8_t u8TmpFlag = 0U;
+    /* backup FCGx setting */
+    __IO uint32_t fcg0 = CM_PWC->FCG0;
+    __IO uint32_t fcg1 = CM_PWC->FCG1;
+    __IO uint32_t fcg2 = CM_PWC->FCG2;
+    __IO uint32_t fcg3 = CM_PWC->FCG3;
+
+    DDL_ASSERT(IS_CLK_SYSCLK_SRC(u8Src));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    /* Only current system clock source or target system clock source is PLLH
+    need to close fcg0~fcg3 and open fcg0~fcg3 during switch system clock source.
+    We need to backup fcg0~fcg3 before close them. */
+    if (CLK_SYSCLK_SRC_PLL == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW) || (CLK_SYSCLK_SRC_PLL == u8Src)) {
+        u8TmpFlag = 1U;
+        /* FCG0 protect judgment */
+        DDL_ASSERT((CM_PWC->FCG0PC & PWC_FCG0PC_PRT0) == PWC_FCG0PC_PRT0);
+        /* Close FCGx. */
+        WRITE_REG32(CM_PWC->FCG0, CLK_FCG0_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG1, CLK_FCG1_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG2, CLK_FCG2_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG3, CLK_FCG3_DEFAULT);
+        /* Wait stable after close FCGx. */
+        DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    }
+    /* Set system clock source */
+    WRITE_REG8(CM_CMU->CKSWR, u8Src);
+    /* Wait stable after setting system clock source */
+    DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    if (1U == u8TmpFlag) {
+        WRITE_REG32(CM_PWC->FCG0, fcg0);
+        WRITE_REG32(CM_PWC->FCG1, fcg1);
+        WRITE_REG32(CM_PWC->FCG2, fcg2);
+        WRITE_REG32(CM_PWC->FCG3, fcg3);
+        /* Wait stable after open fcg. */
+        DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    }
+}
+
+static void GetClockFreq(stc_clock_freq_t *pstcClockFreq)
+{
+    stc_clock_scale_t *pstcClockScale;
+    uint32_t u32HrcValue;
+    uint8_t plln;
+    uint8_t pllp;
+    uint8_t pllm;
+
+    switch (READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+        case CLK_SYSCLK_SRC_HRC:
+            /* HRC is used to system clock */
+            pstcClockFreq->u32SysclkFreq = HRC_VALUE;
+            break;
+        case CLK_SYSCLK_SRC_MRC:
+            /* MRC is used to system clock */
+            pstcClockFreq->u32SysclkFreq = MRC_VALUE;
+            break;
+        case CLK_SYSCLK_SRC_LRC:
+            /* LRC is used to system clock */
+            pstcClockFreq->u32SysclkFreq = LRC_VALUE;
+            break;
+        case CLK_SYSCLK_SRC_XTAL:
+            /* XTAL is used to system clock */
+            pstcClockFreq->u32SysclkFreq = XTAL_VALUE;
+            break;
+        case CLK_SYSCLK_SRC_XTAL32:
+            /* XTAL32 is used to system clock */
+            pstcClockFreq->u32SysclkFreq = XTAL32_VALUE;
+            break;
+        case CLK_SYSCLK_SRC_PLL:
+            /* PLLHP is used as system clock. */
+            pllp = (uint8_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHP) >> CMU_PLLHCFGR_PLLHP_POS);
+            plln = (uint8_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHN) >> CMU_PLLHCFGR_PLLHN_POS);
+            pllm = (uint8_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHM) >> CMU_PLLHCFGR_PLLHM_POS);
+            /* pll = ((pllin / pllm) * plln) / pllp */
+            if (CLK_PLL_SRC_XTAL == PLL_SRC) {
+                pstcClockFreq->u32SysclkFreq = ((XTAL_VALUE / (pllm + 1UL)) * (plln + 1UL)) / (pllp + 1UL);
+            } else {
+                u32HrcValue = HRC_VALUE;
+                pstcClockFreq->u32SysclkFreq = ((u32HrcValue / (pllm + 1UL)) * (plln + 1UL)) / (pllp + 1UL);
+            }
+            break;
+        default:
+            break;
+    }
+
+    pstcClockScale = (stc_clock_scale_t *)((uint32_t)&CM_CMU->SCFGR);
+    pstcClockScale->SCFGR = READ_REG32(CM_CMU->SCFGR);
+    /* Get hclk. */
+    pstcClockFreq->u32HclkFreq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.HCLKS;
+    /* Get pclk1. */
+    pstcClockFreq->u32Pclk1Freq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.PCLK1S;
+    /* Get pclk4. */
+    pstcClockFreq->u32Pclk4Freq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.PCLK4S;
+    /* Get pclk3. */
+    pstcClockFreq->u32Pclk3Freq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.PCLK3S;
+    /* Get exclk. */
+    pstcClockFreq->u32ExclkFreq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.EXCKS;
+    /* Get pclk0. */
+    pstcClockFreq->u32Pclk0Freq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.PCLK0S;
+    /* Get pclk2. */
+    pstcClockFreq->u32Pclk2Freq = pstcClockFreq->u32SysclkFreq >> pstcClockScale->SCFGR_f.PCLK2S;
+}
+
+static void SetSysClockDiv(uint32_t u32Clock, uint32_t u32Div)
+{
+    uint8_t u8TmpFlag = 0U;
+
+    /* backup FCGx setting */
+    __IO uint32_t fcg0 = CM_PWC->FCG0;
+    __IO uint32_t fcg1 = CM_PWC->FCG1;
+    __IO uint32_t fcg2 = CM_PWC->FCG2;
+    __IO uint32_t fcg3 = CM_PWC->FCG3;
+
+    DDL_ASSERT(IS_CLK_HCLK_DIV(u32Div & CMU_SCFGR_HCLKS));
+    DDL_ASSERT(IS_CLK_PCLK1_DIV(u32Div & CMU_SCFGR_PCLK1S));
+    DDL_ASSERT(IS_CLK_PCLK4_DIV(u32Div & CMU_SCFGR_PCLK4S));
+    DDL_ASSERT(IS_CLK_EXCLK_DIV(u32Div & CMU_SCFGR_EXCKS));
+    DDL_ASSERT(IS_CLK_PCLK0_DIV(u32Div & CMU_SCFGR_PCLK0S));
+    DDL_ASSERT(IS_CLK_PCLK2_DIV(u32Div & CMU_SCFGR_PCLK2S));
+    DDL_ASSERT(IS_CLK_PCLK3_DIV(u32Div & CMU_SCFGR_PCLK3S));
+    DDL_ASSERT(IS_CLK_BUS_CLK_CATE(u32Clock));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    /* Only current system clock source or target system clock source is PLLH
+    need to close fcg0~fcg3 and open fcg0~fcg3 during switch system clock source.
+    We need to backup fcg0~fcg3 before close them. */
+    if (CLK_SYSCLK_SRC_PLL == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+        u8TmpFlag = 1U;
+        DDL_ASSERT((CM_PWC->FCG0PC & PWC_FCG0PC_PRT0) == PWC_FCG0PC_PRT0);
+        /* Close FCGx. */
+        WRITE_REG32(CM_PWC->FCG0, CLK_FCG0_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG1, CLK_FCG1_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG2, CLK_FCG2_DEFAULT);
+        WRITE_REG32(CM_PWC->FCG3, CLK_FCG3_DEFAULT);
+        /* Wait stable after close FCGx. */
+        DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    }
+    MODIFY_REG32(CM_CMU->SCFGR, u32Clock, u32Div);
+    DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    if (1U == u8TmpFlag) {
+        WRITE_REG32(CM_PWC->FCG0, fcg0);
+        WRITE_REG32(CM_PWC->FCG1, fcg1);
+        WRITE_REG32(CM_PWC->FCG2, fcg2);
+        WRITE_REG32(CM_PWC->FCG3, fcg3);
+        /* Wait stable after open fcg. */
+        DDL_DelayUS(CLK_SYSCLK_SW_STB);
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CLK_Global_Functions CLK Global Functions
+ * @{
+ */
+/**
+ * @brief  LRC function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: LRC operate successfully
+ *         - LL_ERR_BUSY: LRC is the system clock, CANNOT stop it.
+ * @note   DO NOT STOP LRC while using it as system clock.
+ */
+int32_t CLK_LrcCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_LRC == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else {
+            WRITE_REG8(CM_CMU->LRCCR, CLK_LRC_OFF);
+        }
+    } else {
+        WRITE_REG8(CM_CMU->LRCCR, CLK_LRC_ON);
+    }
+    /* wait approx, 5 * LRC cycle */
+    DDL_DelayUS(CLK_LRC_TIMEOUT);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  MRC function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: MRC operate successfully
+ *         - LL_ERR_BUSY: MRC is the system clock, CANNOT stop it.
+ * @note   DO NOT STOP MRC while using it as system clock.
+ */
+int32_t CLK_MrcCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_MRC == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else {
+            WRITE_REG8(CM_CMU->MRCCR, CLK_MRC_OFF);
+        }
+    } else {
+        WRITE_REG8(CM_CMU->MRCCR, CLK_MRC_ON);
+    }
+    /* Wait approx. 5 * MRC cycle */
+    DDL_DelayUS(CLK_MRC_TIMEOUT);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  HRC function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: HRC operate successfully
+ *         - LL_ERR_BUSY: HRC is the system clock or as the PLL source clock, CANNOT stop it.
+ *         - LL_ERR_TIMEOUT: HRC operate Timeout
+ * @note   DO NOT STOP HRC while using it as system clock or as the PLL source clock.
+ */
+int32_t CLK_HrcCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_HRC == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else if (CLK_PLL_SRC_HRC == PLL_SRC) {
+            /* HRC as PLL clock source and PLL is working */
+            if (0UL == PLL_EN_REG) {
+                i32Ret = LL_ERR_BUSY;
+            } else {
+                WRITE_REG8(CM_CMU->HRCCR, CLK_HRC_OFF);
+            }
+        } else {
+            WRITE_REG8(CM_CMU->HRCCR, CLK_HRC_OFF);
+        }
+    } else {
+        WRITE_REG8(CM_CMU->HRCCR, CLK_HRC_ON);
+        i32Ret = CLK_WaitStable(CLK_STB_FLAG_HRC, CLK_TIMEOUT);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set HRC trimming value.
+ * @param  [in] i8TrimVal specifies the trimming value for HRC.
+ * @retval None
+ */
+void CLK_HrcTrim(int8_t i8TrimVal)
+{
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->HRCTRM, i8TrimVal);
+}
+
+/**
+ * @brief  Set MRC trimming value.
+ * @param  [in] i8TrimVal specifies the trimming value for MRC.
+ * @retval None
+ */
+void CLK_MrcTrim(int8_t i8TrimVal)
+{
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->MRCTRM, i8TrimVal);
+}
+
+/**
+ * @brief  Set LRC trimming value.
+ * @param  [in] i8TrimVal specifies the trimming value for LRC.
+ * @retval None
+ */
+void CLK_LrcTrim(int8_t i8TrimVal)
+{
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->LRCTRM, i8TrimVal);
+}
+
+/**
+ * @brief  Set RTC LRC trimming value.
+ * @param  [in] i8TrimVal specifies the trimming value for RTC LRC.
+ * @retval None
+ */
+void CLK_RtcLrcTrim(int8_t i8TrimVal)
+{
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->RTCLRCTRM, i8TrimVal);
+}
+
+/**
+ * @brief  Init Xtal initial structure with default value.
+ * @param  [in] pstcXtalInit specifies the Parameter of XTAL.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t CLK_XtalStructInit(stc_clock_xtal_init_t *pstcXtalInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcXtalInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcXtalInit->u8State = CLK_XTAL_OFF;
+        pstcXtalInit->u8Mode  = CLK_XTAL_MD_OSC;
+        pstcXtalInit->u8Drv = CLK_XTAL_DRV_HIGH;
+        pstcXtalInit->u8StableTime = CLK_XTAL_STB_2MS;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL initialize.
+ * @param  [in] pstcXtalInit specifies the XTAL initial config.
+ * @retval int32_t:
+ *         - LL_OK: XTAL initial successfully.
+ *         - LL_ERR_TIMEOUT: XTAL operate timeout.
+ *         - LL_ERR_BUSY: XTAL is the system clock, CANNOT stop it.
+ *         - LL_ERR_INVD_PARAM: NULL pointer.
+ * @note   DO NOT STOP XTAL while using it as system clock.
+ */
+int32_t CLK_XtalInit(const stc_clock_xtal_init_t *pstcXtalInit)
+{
+    int32_t i32Ret;
+
+    if (NULL == pstcXtalInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_CLK_XTAL_STATE(pstcXtalInit->u8State));
+        DDL_ASSERT(IS_CLK_XTAL_DRV_MD(pstcXtalInit->u8Drv));
+        DDL_ASSERT(IS_CLK_XTAL_MD(pstcXtalInit->u8Mode));
+        DDL_ASSERT(IS_CLK_XTAL_STB_SEL(pstcXtalInit->u8StableTime));
+        DDL_ASSERT(IS_CLK_UNLOCKED());
+
+        WRITE_REG8(CM_CMU->XTALSTBCR, pstcXtalInit->u8StableTime);
+        WRITE_REG8(CM_CMU->XTALCFGR, (0x80U | pstcXtalInit->u8Drv | pstcXtalInit->u8Mode));
+        if (CLK_XTAL_ON == pstcXtalInit->u8State) {
+            i32Ret = CLK_XtalCmd(ENABLE);
+        } else {
+            i32Ret = CLK_XtalCmd(DISABLE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: XTAL operate successfully
+ *         - LL_ERR_BUSY: XTAL is the system clock or as the PLL source clock, CANNOT stop it.
+ *         - LL_ERR_TIMEOUT: XTAL operate timeout.
+ * @note   DO NOT STOP XTAL while using it as system clock or as the PLL source clock.
+ */
+int32_t CLK_XtalCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_XTAL == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else if (CLK_PLL_SRC_XTAL == PLL_SRC) {
+            /* XTAL as PLL clock source and PLL is working */
+            if (0UL == PLL_EN_REG) {
+                i32Ret = LL_ERR_BUSY;
+            } else {
+                WRITE_REG8(CM_CMU->XTALCR, CLK_XTAL_OFF);
+            }
+        } else {
+            WRITE_REG8(CM_CMU->XTALCR, CLK_XTAL_OFF);
+        }
+    } else {
+        WRITE_REG8(CM_CMU->XTALCR, CLK_XTAL_ON);
+        i32Ret = CLK_WaitStable(CLK_STB_FLAG_XTAL, CLK_TIMEOUT);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL status detection function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CLK_XtalStdCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        CLR_REG8_BIT(CM_CMU->XTALSTDCR, CMU_XTALSTDCR_XTALSTDE);
+    } else {
+        SET_REG8_BIT(CM_CMU->XTALSTDCR, CMU_XTALSTDCR_XTALSTDE);
+    }
+}
+
+/**
+ * @brief  Initialise the XTAL status detection.
+ * @param  [in] u8State specifies the Parameter of XTALSTD.
+ * @param  [in] u8ExceptionType specifies the Parameter of XTALSTD.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t CLK_XtalStdInit(uint8_t u8State, uint8_t u8ExceptionType)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Parameter valid check */
+    DDL_ASSERT(IS_CLK_XTALSTD_STATE(u8State));
+    DDL_ASSERT(IS_CLK_XTALSTD_EXP_TYPE(u8ExceptionType));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if ((CLK_PLL_SRC_XTAL == PLL_SRC) && (u8ExceptionType == CLK_XTALSTD_EXP_TYPE_INT)) {
+        if (0UL == PLL_EN_REG) {
+            /* while xtal used as PLL clock source, XTALSTD only choose reset exception */
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+    }
+    if (LL_OK == i32Ret) {
+        /* Initialize XTALSTD */
+        WRITE_REG8(CM_CMU->XTALSTDCR, u8State | u8ExceptionType);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set XTALSTD exception type.
+ * @param  [in] u8ExceptionType specifies the XTALSTD exception type.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t CLK_SetXtalStdExceptionType(uint8_t u8ExceptionType)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Parameter valid check */
+    DDL_ASSERT(IS_CLK_XTALSTD_EXP_TYPE(u8ExceptionType));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if ((CLK_PLL_SRC_XTAL == PLL_SRC) && (u8ExceptionType == CLK_XTALSTD_EXP_TYPE_INT)) {
+        if (0UL == PLL_EN_REG) {
+            /* while xtal used as PLL clock source, XTALSTD only choose reset exception */
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+    }
+    if (LL_OK == i32Ret) {
+        /* Set exception type */
+        MODIFY_REG8(CM_CMU->XTALSTDCR, CLK_XTALSTD_EXP_TYPE_MASK, u8ExceptionType);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Clear the XTAL error flag.
+ * @param  None
+ * @retval None
+ * @note   The system clock should not be XTAL before call this function.
+ */
+void CLK_ClearXtalStdStatus(void)
+{
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (0x01U == READ_REG8(CM_CMU->XTALSTDSR)) {
+        /* Clear the XTAL STD flag */
+        WRITE_REG8(CM_CMU->XTALSTDSR, 0x00U);
+    }
+}
+
+/**
+ * @brief  Get the XTAL error flag.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CLK_GetXtalStdStatus(void)
+{
+    return ((0x00U != READ_REG8(CM_CMU->XTALSTDSR)) ? SET : RESET);
+}
+
+/**
+ * @brief  Init Xtal32 initial structure with default value.
+ * @param  [in] pstcXtal32Init specifies the Parameter of XTAL32.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t CLK_Xtal32StructInit(stc_clock_xtal32_init_t *pstcXtal32Init)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcXtal32Init) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcXtal32Init->u8State  = CLK_XTAL32_ON;
+        pstcXtal32Init->u8Drv    = CLK_XTAL32_DRV_MID;
+        pstcXtal32Init->u8Filter = CLK_XTAL32_FILTER_ALL_MD;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL32 initialize.
+ * @param  [in] pstcXtal32Init specifies the XTAL32 initial config.
+ *   @arg  u8State  : The new state of the XTAL32.
+ *   @arg  u8Drv    : The XTAL32 drive capacity.
+ *   @arg  u8Filter : The XTAL32 noise filter on or off.
+ * @retval int32_t:
+ *         - LL_OK: XTAL32 initial successfully.
+ *         - LL_ERR_BUSY: XTAL32 is the system clock, CANNOT stop it.
+ *         - LL_ERR_INVD_PARAM: NULL pointer.
+ * @note   DO NOT STOP XTAL32 while using it as system clock.
+ */
+int32_t CLK_Xtal32Init(const stc_clock_xtal32_init_t *pstcXtal32Init)
+{
+    int32_t i32Ret;
+
+    if (NULL == pstcXtal32Init) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Parameters check */
+        DDL_ASSERT(IS_CLK_XTAL32_STATE(pstcXtal32Init->u8State));
+        DDL_ASSERT(IS_CLK_XTAL32_DRV_MD(pstcXtal32Init->u8Drv));
+        DDL_ASSERT(IS_CLK_XTAL32_FILT_SEL(pstcXtal32Init->u8Filter));
+        DDL_ASSERT(IS_CLK_UNLOCKED());
+
+        WRITE_REG8(CM_CMU->XTAL32CFGR, pstcXtal32Init->u8Drv);
+        WRITE_REG8(CM_CMU->XTAL32NFR, pstcXtal32Init->u8Filter);
+        if (CLK_XTAL32_ON == pstcXtal32Init->u8State) {
+            i32Ret = CLK_Xtal32Cmd(ENABLE);
+        } else {
+            i32Ret = CLK_Xtal32Cmd(DISABLE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL32 function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: XTAL32 operate successfully
+ *         - LL_ERR_BUSY: XTAL32 is the system clock, CANNOT stop it.
+ * @note   DO NOT STOP XTAL32 while using it as system clock.
+ */
+int32_t CLK_Xtal32Cmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_XTAL32 == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else {
+            WRITE_REG8(CM_CMU->XTAL32CR, CLK_XTAL32_OFF);
+        }
+    } else {
+        WRITE_REG8(CM_CMU->XTAL32CR, CLK_XTAL32_ON);
+        /* wait stable*/
+    }
+    /* wait approx. 5 * xtal32 cycle */
+    DDL_DelayUS(CLK_XTAL32_TIMEOUT);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  XTAL32 clock input function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CLK_Xtal32InputCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG32(bCM_CMU->XTAL32CFGR_b.XTAL32IE, enNewState);
+}
+
+/**
+ * @brief  Set PLL source clock.
+ * @param  [in] u32PllSrc PLL source clock.
+ *   @arg  CLK_PLL_SRC_XTAL
+ *   @arg  CLK_PLL_SRC_HRC
+ * @retval None
+ */
+void CLK_SetPLLSrc(uint32_t u32PllSrc)
+{
+    DDL_ASSERT(IS_CLK_PLL_SRC(u32PllSrc));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    MODIFY_REG32(PLL_SRC_REG, PLL_SRC_BIT, u32PllSrc << PLL_SRC_POS);
+}
+
+/**
+ * @brief  Init PLL initial structure with default value.
+ * @param  [in] pstcPLLInit specifies the Parameter of PLL.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t CLK_PLLStructInit(stc_clock_pll_init_t *pstcPLLInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcPLLInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcPLLInit->PLLCFGR          = 0UL;
+        pstcPLLInit->PLLCFGR_f.PLLSRC = CLK_PLL_SRC_XTAL;
+        pstcPLLInit->PLLCFGR_f.PLLM   = CLK_PLLM_DEFAULT;
+        pstcPLLInit->PLLCFGR_f.PLLN   = CLK_PLLN_DEFAULT;
+        pstcPLLInit->PLLCFGR_f.PLLP   = CLK_PLLP_DEFAULT;
+        pstcPLLInit->PLLCFGR_f.PLLQ   = CLK_PLLQ_DEFAULT;
+        pstcPLLInit->PLLCFGR_f.PLLR   = CLK_PLLR_DEFAULT;
+        pstcPLLInit->u8PLLState       = CLK_PLL_OFF;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  PLL initialize.
+ * @param  [in] pstcPLLInit specifies the structure of PLLH initial config.
+ *   @arg  u8PLLState  : The new state of the PLLH.
+ *   @arg  PLLCFGR     : PLLH config.
+ * @retval int32_t:
+ *         - LL_OK: PLLH initial successfully
+ *         - LL_ERR_TIMEOUT: PLLH initial timeout
+ *         - LL_ERR_BUSY: PLLH is the source clock, CANNOT stop it.
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t CLK_PLLInit(const stc_clock_pll_init_t *pstcPLLInit)
+{
+    int32_t i32Ret;
+#ifdef __DEBUG
+    uint32_t vcoIn;
+    uint32_t vcoOut;
+#endif
+
+    if (NULL == pstcPLLInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_CLK_PLL_SRC(pstcPLLInit->PLLCFGR_f.PLLSRC));
+        DDL_ASSERT(IS_CLK_PLLM_DIV(pstcPLLInit->PLLCFGR_f.PLLM + 1UL));
+        DDL_ASSERT(IS_CLK_PLLN_MULTI(pstcPLLInit->PLLCFGR_f.PLLN + 1UL));
+        DDL_ASSERT(IS_CLK_PLLP_DIV(pstcPLLInit->PLLCFGR_f.PLLP + 1UL));
+#ifdef __DEBUG
+        vcoIn = ((CLK_PLL_SRC_XTAL == pstcPLLInit->PLLCFGR_f.PLLSRC ?
+                  XTAL_VALUE : HRC_VALUE) / (pstcPLLInit->PLLCFGR_f.PLLM + 1UL));
+        vcoOut = vcoIn * (pstcPLLInit->PLLCFGR_f.PLLN + 1UL);
+        DDL_ASSERT(IS_CLK_PLL_VCO_IN(vcoIn));
+        DDL_ASSERT(IS_CLK_PLL_VCO_OUT(vcoOut));
+        DDL_ASSERT(IS_CLK_PLL_FREQ(vcoOut / (pstcPLLInit->PLLCFGR_f.PLLP + 1UL)));
+        DDL_ASSERT(IS_CLK_PLLQ_DIV(pstcPLLInit->PLLCFGR_f.PLLQ + 1UL));
+        DDL_ASSERT(IS_CLK_PLLR_DIV(pstcPLLInit->PLLCFGR_f.PLLR + 1UL));
+        DDL_ASSERT(IS_CLK_PLL_FREQ(vcoOut / (pstcPLLInit->PLLCFGR_f.PLLR + 1UL)));
+        DDL_ASSERT(IS_CLK_PLL_FREQ(vcoOut / (pstcPLLInit->PLLCFGR_f.PLLQ + 1UL)));
+#endif /* __DEBUG */
+        DDL_ASSERT(IS_CLK_PLL_STATE(pstcPLLInit->u8PLLState));
+        DDL_ASSERT(IS_CLK_UNLOCKED());
+
+        /* set PLL source in advance */
+        MODIFY_REG32(PLL_SRC_REG, PLL_SRC_BIT, pstcPLLInit->PLLCFGR_f.PLLSRC << PLL_SRC_POS);
+        WRITE_REG32(CM_CMU->PLLHCFGR, pstcPLLInit->PLLCFGR);
+        if (CLK_PLL_ON == pstcPLLInit->u8PLLState) {
+            i32Ret = CLK_PLLCmd(ENABLE);
+        } else {
+            i32Ret = CLK_PLLCmd(DISABLE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  PLL function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: PLL operate successfully
+ *         - LL_ERR_BUSY: PLL is the system clock, CANNOT stop it.
+ *         - LL_ERR_TIMEOUT: PLL operate timeout
+ * @note   DO NOT STOP PLL while using it as system clock.
+ */
+int32_t CLK_PLLCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        if (CLK_SYSCLK_SRC_PLL == READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+            i32Ret = LL_ERR_BUSY;
+        } else {
+            WRITE_REG8(PLL_EN_REG, CLK_PLL_OFF);
+        }
+    } else {
+        if (CLK_PLL_SRC_XTAL == PLL_SRC) {
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_XTAL, CLK_TIMEOUT);
+        } else {
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_HRC, CLK_TIMEOUT);
+        }
+        if (LL_OK == i32Ret) {
+            WRITE_REG8(PLL_EN_REG, CLK_PLL_ON);
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_PLL, CLK_TIMEOUT);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Init PLLx initial structure with default value.
+ * @param  [in] pstcPLLxInit specifies the Parameter of PLLx.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ *         PLLx for PLLA
+ */
+int32_t CLK_PLLxStructInit(stc_clock_pllx_init_t *pstcPLLxInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcPLLxInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcPLLxInit->PLLCFGR        = 0UL;
+        pstcPLLxInit->u8PLLState     = CLK_PLLX_OFF;
+        pstcPLLxInit->PLLCFGR_f.PLLP = CLK_PLLXP_DEFAULT;
+        pstcPLLxInit->PLLCFGR_f.PLLQ = CLK_PLLXQ_DEFAULT;
+        pstcPLLxInit->PLLCFGR_f.PLLR = CLK_PLLXR_DEFAULT;
+        pstcPLLxInit->PLLCFGR_f.PLLN = CLK_PLLXN_DEFAULT;
+        pstcPLLxInit->PLLCFGR_f.PLLM = CLK_PLLXM_DEFAULT;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  PLLx Initialize.
+ * @param  [in] pstcPLLxInit specifies the structure of PLLx initial config.
+ *   @arg  u8PLLState  : The new state of the PLLx.
+ *   @arg  PLLCFGR     : PLLx config.
+ * @retval int32_t:
+ *         - LL_OK: PLLx initial successfully
+ *         - LL_ERR_TIMEOUT: PLLx initial timeout
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ *         PLLx for PLLA
+ */
+int32_t CLK_PLLxInit(const stc_clock_pllx_init_t *pstcPLLxInit)
+{
+    int32_t i32Ret;
+
+    if (NULL == pstcPLLxInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+#ifdef __DEBUG
+        PLLxParamCheck(pstcPLLxInit);
+#endif
+
+        WRITE_REG32(CM_CMU->PLLACFGR, pstcPLLxInit->PLLCFGR);
+        if (CLK_PLLX_ON == pstcPLLxInit->u8PLLState) {
+            i32Ret = CLK_PLLxCmd(ENABLE);
+        } else {
+            i32Ret = CLK_PLLxCmd(DISABLE);
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  PLLx function enable/disable.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: UPLL operate successfully
+ *         - LL_ERR_TIMEOUT: UPLL operate timeout
+ *         PLLx for PLLA
+ */
+int32_t CLK_PLLxCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    if (DISABLE == enNewState) {
+        WRITE_REG8(PLLX_EN_REG, CLK_PLLX_OFF);
+    } else {
+        if (CLK_PLL_SRC_XTAL == PLL_SRC) {
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_XTAL, CLK_TIMEOUT);
+        } else {
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_HRC, CLK_TIMEOUT);
+        }
+        if (LL_OK == i32Ret) {
+            WRITE_REG8(PLLX_EN_REG, CLK_PLLX_ON);
+            i32Ret = CLK_WaitStable(CLK_STB_FLAG_PLLX, CLK_TIMEOUT);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Selects the clock source to output on MCO pin.
+ * @param  [in] u8Ch        Specifies the MCO channel. @ref CLK_MCO_Channel_Sel
+ * @param  [in] u8Src       Specifies the clock source to output. @ref CLK_MCO_Clock_Source
+ * @param  [in] u8Div       Specifies the MCOx prescaler. @ref CLK_MCO_Clock_Prescaler
+ * @retval None
+ * @note   MCO pin should be configured in alternate function 1 mode.
+ */
+void CLK_MCOConfig(uint8_t u8Ch, uint8_t u8Src, uint8_t u8Div)
+{
+    __IO uint8_t *MCOCFGRx;
+
+    /* Check the parameters. */
+    DDL_ASSERT(IS_CLK_MCO_SRC(u8Src));
+    DDL_ASSERT(IS_CLK_MCO_DIV(u8Div));
+    DDL_ASSERT(IS_CLK_MCO_CH(u8Ch));
+    /* enable register write. */
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    MCOCFGRx = &(*(__IO uint8_t *)((uint32_t)&CM_CMU->MCO1CFGR + u8Ch));
+    /* Config the MCO */
+    MODIFY_REG8(*MCOCFGRx, (CMU_MCOCFGR_MCOSEL | CMU_MCOCFGR_MCODIV), (u8Src | u8Div));
+}
+
+/**
+ * @brief  Enable or disable the MCO1 output.
+ * @param  [in] u8Ch        Specifies the MCO channel. @ref CLK_MCO_Channel_Sel
+ * @param  [in] enNewState  An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CLK_MCOCmd(uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    __IO uint8_t *MCOCFGRx;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+    DDL_ASSERT(IS_CLK_MCO_CH(u8Ch));
+
+    MCOCFGRx = &(*(__IO uint8_t *)((uint32_t)&CM_CMU->MCO1CFGR + u8Ch));
+    /* Enable or disable clock output. */
+    MODIFY_REG8(*MCOCFGRx, CMU_MCOCFGR_MCOEN, (uint8_t)enNewState << CMU_MCOCFGR_MCOEN_POS);
+}
+
+/**
+ * @brief  PLL/XTAL/HRC stable flag read.
+ * @param  [in] u8Flag      specifies the stable flag to be read. @ref CLK_STB_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CLK_GetStableStatus(uint8_t u8Flag)
+{
+    DDL_ASSERT(IS_CLK_STB_FLAG(u8Flag));
+
+    return ((0x00U != READ_REG8_BIT(CM_CMU->OSCSTBSR, u8Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Set the system clock source.
+ * @param  [in] u8Src specifies the source of system clock. @ref CLK_System_Clock_Source
+ * @retval None
+ */
+void CLK_SetSysClockSrc(uint8_t u8Src)
+{
+    /* Set system clock source */
+    SetSysClockSrc(u8Src);
+    /* Update system clock */
+    SystemCoreClockUpdate();
+}
+
+/**
+ * @brief  Get bus clock frequency.
+ * @param  [out] pstcClockFreq specifies the pointer to get bus frequency.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t CLK_GetClockFreq(stc_clock_freq_t *pstcClockFreq)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcClockFreq) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        GetClockFreq(pstcClockFreq);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Get bus clock frequency.
+ * @param  [in] u32Clock specifies the bus clock to get frequency. @ref CLK_Bus_Clock_Sel
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+uint32_t CLK_GetBusClockFreq(uint32_t u32Clock)
+{
+    uint32_t u32ClockFreq;
+    DDL_ASSERT(IS_CLK_BUS_CLK(u32Clock));
+
+    switch (u32Clock) {
+        case CLK_BUS_HCLK:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_HCLKS) >> CMU_SCFGR_HCLKS_POS);
+            break;
+        case CLK_BUS_PCLK1:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK1S) >> CMU_SCFGR_PCLK1S_POS);
+            break;
+        case CLK_BUS_PCLK4:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK4S) >> CMU_SCFGR_PCLK4S_POS);
+            break;
+        case CLK_BUS_PCLK3:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK3S) >> CMU_SCFGR_PCLK3S_POS);
+            break;
+        case CLK_BUS_EXCLK:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_EXCKS) >> CMU_SCFGR_EXCKS_POS);
+            break;
+        case CLK_BUS_PCLK0:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK0S) >> CMU_SCFGR_PCLK0S_POS);
+            break;
+        case CLK_BUS_PCLK2:
+            u32ClockFreq = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK2S) >> CMU_SCFGR_PCLK2S_POS);
+            break;
+        default:
+            u32ClockFreq = SystemCoreClock;
+            break;
+    }
+    return u32ClockFreq;
+}
+
+/**
+ * @brief  Get PLL clock frequency.
+ * @param  [out] pstcPllClkFreq specifies the pointer to get PLL frequency.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ * @note   PLL for PLLH, PLLx for PLLA
+ */
+int32_t CLK_GetPLLClockFreq(stc_pll_clock_freq_t *pstcPllClkFreq)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t pllin;
+    uint32_t plln;
+    uint32_t pllm;
+    uint32_t pllp;
+    uint32_t pllq;
+    uint32_t pllr;
+    uint32_t pllxn;
+    uint32_t pllxm;
+    uint32_t pllxp;
+    uint32_t pllxq;
+    uint32_t pllxr;
+
+    if (NULL == pstcPllClkFreq) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pllp = (uint32_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHP) >> CMU_PLLHCFGR_PLLHP_POS);
+        pllq = (uint32_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHQ) >> CMU_PLLHCFGR_PLLHQ_POS);
+        pllr = (uint32_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHR) >> CMU_PLLHCFGR_PLLHR_POS);
+        plln = (uint32_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHN) >> CMU_PLLHCFGR_PLLHN_POS);
+        pllm = (uint32_t)((CM_CMU->PLLHCFGR & CMU_PLLHCFGR_PLLHM) >> CMU_PLLHCFGR_PLLHM_POS);
+
+        pllxp = (uint32_t)((CM_CMU->PLLACFGR & CMU_PLLACFGR_PLLAP) >> CMU_PLLACFGR_PLLAP_POS);
+        pllxq = (uint32_t)((CM_CMU->PLLACFGR & CMU_PLLACFGR_PLLAQ) >> CMU_PLLACFGR_PLLAQ_POS);
+        pllxr = (uint32_t)((CM_CMU->PLLACFGR & CMU_PLLACFGR_PLLAR) >> CMU_PLLACFGR_PLLAR_POS);
+        pllxn = (uint32_t)((CM_CMU->PLLACFGR & CMU_PLLACFGR_PLLAN) >> CMU_PLLACFGR_PLLAN_POS);
+        pllxm = (uint32_t)((CM_CMU->PLLACFGR & CMU_PLLACFGR_PLLAM) >> CMU_PLLACFGR_PLLAM_POS);
+
+        /* PLLHP is used as system clock. */
+        if (CLK_PLL_SRC_XTAL == PLL_SRC) {
+            pllin = XTAL_VALUE;
+        } else {
+            pllin = HRC_VALUE;
+        }
+        pstcPllClkFreq->u32PllVcin = (pllin / (pllm + 1UL));
+        pstcPllClkFreq->u32PllVco = ((pllin / (pllm + 1UL)) * (plln + 1UL));
+        pstcPllClkFreq->u32PllP = ((pllin / (pllm + 1UL)) * (plln + 1UL)) / (pllp + 1UL);
+        pstcPllClkFreq->u32PllQ = ((pllin / (pllm + 1UL)) * (plln + 1UL)) / (pllq + 1UL);
+        pstcPllClkFreq->u32PllR = ((pllin / (pllm + 1UL)) * (plln + 1UL)) / (pllr + 1UL);
+        pstcPllClkFreq->u32PllxVcin = (pllin / (pllxm + 1UL));
+        pstcPllClkFreq->u32PllxVco = ((pllin / (pllxm + 1UL)) * (pllxn + 1UL));
+        pstcPllClkFreq->u32PllxP = ((pllin / (pllxm + 1UL)) * (pllxn + 1UL)) / (pllxp + 1UL);
+        pstcPllClkFreq->u32PllxQ = ((pllin / (pllxm + 1UL)) * (pllxn + 1UL)) / (pllxq + 1UL);
+        pstcPllClkFreq->u32PllxR = ((pllin / (pllxm + 1UL)) * (pllxn + 1UL)) / (pllxr + 1UL);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  HCLK/PCLK divide setting.
+ * @param  [in] u32Clock specifies the clock to be divided.  @ref CLK_Bus_Clock_Sel
+ * @param  [in] u32Div specifies the clock divide factor. @ref CLK_Clock_Divider
+ * @retval None
+ * @note   u32Div could choose CLK_HCLK_Divider, CLK_PCLK0_Divider, CLK_PCLK1_Divider,
+ * CLK_PCLK2_Divider, CLK_PCLK3_Divider, CLK_PCLK4_Divider, CLK_EXCLK_Divider, according to the MCU
+ */
+void CLK_SetClockDiv(uint32_t u32Clock, uint32_t u32Div)
+{
+    /* Set clock divider */
+    SetSysClockDiv(u32Clock, u32Div);
+    /* Update system clock */
+    SystemCoreClockUpdate();
+}
+
+/**
+ * @brief  Set peripheral clock source.
+ * @param  [in] u16Src specifies the peripheral clock source. @ref CLK_PERIPH_Sel
+ * @retval None
+ * @note   peripheral for ADC/DAC/TRNG
+ * @note   peripheral for ADC/DAC
+ */
+void CLK_SetPeriClockSrc(uint16_t u16Src)
+{
+    DDL_ASSERT(IS_CLK_PERIPHCLK_SRC(u16Src));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->PERICKSEL, u16Src);
+}
+
+/**
+ * @brief  USB clock source config.
+ * @param  [in] u8Src specifies the USB clock source. @ref CLK_USBCLK_Sel
+ * @retval None
+ */
+void CLK_SetUSBClockSrc(uint8_t u8Src)
+{
+    DDL_ASSERT(IS_CLK_USBCLK_SRC(u8Src));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    WRITE_REG8(CM_CMU->USBCKCFGR, u8Src);
+
+    DDL_DelayUS(CLK_SYSCLK_SW_STB);
+}
+
+/**
+ * @brief  I2S clock source config.
+ * @param  [in] u8Unit specifies the I2S channel for clock source. @ref CLK_I2S_Sel
+ *   @arg  CLK_I2S1:  I2S Channel 1
+ *   @arg  CLK_I2S2:  I2S Channel 2
+ *   @arg  CLK_I2S3:  I2S Channel 3
+ *   @arg  CLK_I2S4:  I2S Channel 4
+ * @param  [in] u8Src specifies the I2S clock source. @ref CLK_PERIPH_Sel
+ * @retval None
+ */
+void CLK_SetI2SClockSrc(uint8_t u8Unit, uint8_t u8Src)
+{
+    DDL_ASSERT(IS_CLK_I2S_UNIT(u8Unit));
+    DDL_ASSERT(IS_CLK_PERIPHCLK_SRC(u8Src));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG16(CM_CMU->I2SCKSEL, (uint16_t)CMU_I2SCKSEL_I2S1CKSEL << (u8Unit * CMU_I2SCKSEL_I2S2CKSEL_POS), \
+                 (uint16_t)u8Src << (u8Unit * CMU_I2SCKSEL_I2S2CKSEL_POS));
+}
+
+/**
+ * @brief  CAN clock source config.
+ * @param  [in] u8Unit specifies the CAN channel for clock source. @ref CLK_CAN_Sel
+ * @param  [in] u8Src specifies the CAN clock source. @ref CLK_CANCLK_Sel
+ * @retval None
+ */
+void CLK_SetCANClockSrc(uint8_t u8Unit, uint8_t u8Src)
+{
+    uint32_t u32UnitPos = 0UL;
+
+    DDL_ASSERT(IS_CLK_CAN_UNIT(u8Unit));
+    DDL_ASSERT(IS_CLK_CANCLK(u8Src));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    while (0UL != u8Unit) {
+        if (0UL != (u8Unit & 0x1UL)) {
+            MODIFY_REG8(CM_CMU->CANCKCFGR, (uint32_t)CMU_CANCKCFGR_CAN1CKS << u32UnitPos, (uint32_t)u8Src << u32UnitPos);
+        }
+        u8Unit >>= 1UL;
+        u32UnitPos += 4U;
+    }
+}
+
+/**
+ * @brief  Enable or disable the TPIU clock.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CLK_TpiuClockCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    MODIFY_REG8(CM_CMU->TPIUCKCFGR, CMU_TPIUCKCFGR_TPIUCKOE, (uint8_t)enNewState << CMU_TPIUCKCFGR_TPIUCKOE_POS);
+}
+
+/**
+ * @brief  TPIU clock divider config.
+ * @param  [in] u8Div specifies the TPIU clock divide factor. @ref CLK_TPIU_Divider
+ *   @arg  CLK_TPIUCLK_DIV1: TPIU clock no divide
+ *   @arg  CLK_TPIUCLK_DIV2: TPIU clock divide by 2
+ *   @arg  CLK_TPIUCLK_DIV4: TPIU clock divide by 4
+ * @retval None
+ */
+void CLK_SetTpiuClockDiv(uint8_t u8Div)
+{
+    DDL_ASSERT(IS_CLK_TPIUCLK_DIV(u8Div));
+    DDL_ASSERT(IS_CLK_UNLOCKED());
+
+    MODIFY_REG8(CM_CMU->TPIUCKCFGR, CMU_TPIUCKCFGR_TPIUCKS, u8Div);
+}
+/**
+ * @}
+ */
+
+#endif /* LL_CLK_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_cmp.c
+++ b/hc32f4a2/src/hc32_ll_cmp.c
@@ -1,0 +1,735 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_cmp.c
+ * @brief This file provides firmware functions to manage the Comparator(CMP).
+ *
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify structure stc_cmp_window_init_t
+                                    Modify macro define for API
+   2023-06-30       CDT             Modify typo
+   2023-09-30       CDT             Add assert for CIEN bit in GetCmpFuncStatusAndDisFunc function
+                                    Remove redundant code in function CMP_WindowModeInit
+   2024-11-08       CDT             Refine relation of CMP out detect flag functions and Unified Register Bit Names
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_cmp.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_CMP CMP
+ * @brief CMP Driver Library
+ * @{
+ */
+
+#if (LL_CMP_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CMP_Local_Macros CMP Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup CMP_Check_Parameters_Validity CMP Check Parameters Validity
+ * @{
+ */
+#define IS_CMP_UNIT(x)                                                         \
+(   ((x) == CM_CMP1)                            ||                             \
+    ((x) == CM_CMP2)                            ||                             \
+    ((x) == CM_CMP3)                            ||                             \
+    ((x) == CM_CMP4))
+
+#define IS_CMP_WIN_MD_UNIT(x)                                                  \
+(   ((x) == CMP_WIN_CMP12)                      ||                             \
+    ((x) == CMP_WIN_CMP34))
+
+#define IS_CMP1_3_POSITIVE_IN(x)                                               \
+(   ((x) == CMP_POSITIVE_NONE)                  ||                             \
+    ((x) == CMP1_POSITIVE_PGA1_BP)              ||                             \
+    ((x) == CMP1_POSITIVE_PGA1)                 ||                             \
+    ((x) == CMP1_POSITIVE_PGA2)                 ||                             \
+    ((x) == CMP1_POSITIVE_CMP1_INP2)            ||                             \
+    ((x) == CMP1_POSITIVE_CMP1_INP3)            ||                             \
+    ((x) == CMP1_POSITIVE_CMP2_INP3)            ||                             \
+    ((x) == CMP1_POSITIVE_CMP1_INP4))
+
+#define IS_CMP2_4_POSITIVE_IN(x)                                               \
+(   ((x) == CMP_POSITIVE_NONE)                  ||                             \
+    ((x) == CMP2_POSITIVE_PGA2_BP)              ||                             \
+    ((x) == CMP2_POSITIVE_PGA2)                 ||                             \
+    ((x) == CMP2_POSITIVE_CMP2_INP3)            ||                             \
+    ((x) == CMP2_POSITIVE_CMP2_INP4))
+
+#define IS_CMP_NEGATIVE_IN(x)                                                  \
+(   ((x) == CMP_NEGATIVE_NONE)                  ||                             \
+    ((x) == CMP_NEGATIVE_INM1)                  ||                             \
+    ((x) == CMP_NEGATIVE_INM2)                  ||                             \
+    ((x) == CMP_NEGATIVE_INM3)                  ||                             \
+    ((x) == CMP_NEGATIVE_INM4))
+
+#define IS_CMP_WIN_LOW_IN(x)                                                   \
+(   ((x) == CMP_WIN_LOW_NONE)                   ||                             \
+    ((x) == CMP_WIN_LOW_INM1)                   ||                             \
+    ((x) == CMP_WIN_LOW_INM2)                   ||                             \
+    ((x) == CMP_WIN_LOW_INM3)                   ||                             \
+    ((x) == CMP_WIN_LOW_INM4))
+
+#define IS_CMP_WIN_HIGH_IN(x)                                                  \
+(   ((x) == CMP_WIN_HIGH_NONE)                  ||                             \
+    ((x) == CMP_WIN_HIGH_INM1)                  ||                             \
+    ((x) == CMP_WIN_HIGH_INM2)                  ||                             \
+    ((x) == CMP_WIN_HIGH_INM3)                  ||                             \
+    ((x) == CMP_WIN_HIGH_INM4))
+
+#define IS_CMP_OUT_POLARITY(x)                                                 \
+(   ((x) == CMP_OUT_INVT_OFF)                   ||                             \
+    ((x) == CMP_OUT_INVT_ON))
+
+#define IS_CMP_OUT_FILTER(x)                                                   \
+(   ((x) == CMP_OUT_FILTER_NONE)                ||                             \
+    ((x) == CMP_OUT_FILTER_CLK)                 ||                             \
+    ((x) == CMP_OUT_FILTER_CLK_DIV8)            ||                             \
+    ((x) == CMP_OUT_FILTER_CLK_DIV32))
+
+#define IS_CMP_OUT_DETECT_EDGE(x)                                              \
+(   ((x) == CMP_DETECT_EDGS_NONE)               ||                             \
+    ((x) == CMP_DETECT_EDGS_RISING)             ||                             \
+    ((x) == CMP_DETECT_EDGS_FALLING)            ||                             \
+    ((x) == CMP_DETECT_EDGS_BOTH))
+
+#define IS_CMP_BLANKWIN_VALID_LVL(x)                                           \
+(   ((x) == CMP_BLANKWIN_VALID_LVL_LOW)         ||                             \
+    ((x) == CMP_BLANKWIN_VALID_LVL_HIGH))
+
+#define IS_CMP_BLANKWIN_OUT_LVL(x)                                             \
+(   ((x) == CMP_BLANKWIN_OUTPUT_LVL_LOW)        ||                             \
+    ((x) == CMP_BLANKWIN_OUTPUT_LVL_HIGH))
+
+/**
+ * @}
+ */
+
+#define CMP_MDR_CENA        (CMP_MDR_CENB)
+#define CMP_MDR_WDEN        (CMP_MDR_CWDE)
+#define CMP_OCR_BWEN        (CMP_OCR_TWOE)
+#define CMP_OCR_BWOL        (CMP_OCR_TWOL)
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup CMP_Local_Functions CMP Local Functions
+ * @{
+ */
+
+/**
+ * @brief Delay function, delay us approximately
+ * @param [in] u32Count                   us
+ * @retval None
+ */
+static void CMP_DelayUS(uint32_t u32Count)
+{
+    __IO uint32_t i;
+    const uint32_t u32Cyc = HCLK_VALUE / 10000000UL;
+
+    while (u32Count-- > 0UL) {
+        i = u32Cyc;
+        while (i-- > 0UL) {
+            ;
+        }
+    }
+}
+
+/**
+ * @brief  Get CMP function status and disable CMP
+ * @param  [in] CMPx            Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @retval uint16_t             The register value
+ */
+static uint16_t GetCmpFuncStatusAndDisFunc(CM_CMP_TypeDef *CMPx)
+{
+    uint16_t u16temp;
+    /* It is possible that the interrupt may occurs after CMP status switch. */
+    DDL_ASSERT(READ_REG8_BIT(CMPx->FIR, CMP_FIR_CIEN) == 0U);
+
+    /* Read CMP status */
+    u16temp = (uint16_t)(uint8_t)READ_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+    /* Stop CMP function */
+    CLR_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+    return u16temp;
+}
+
+/**
+ * @brief  Recover CMP function status
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u16CmpFuncStatus    CMP function status backup value
+ * @retval None
+ */
+static void RecoverCmpFuncStatus(CM_CMP_TypeDef *CMPx, uint16_t u16CmpFuncStatus)
+{
+    if (u16CmpFuncStatus != 0U) {
+        /* Recover CMP status */
+        MODIFY_REG8(CMPx->MDR, CMP_MDR_CENA, u16CmpFuncStatus);
+        /* Delay 1us */
+        CMP_DelayUS(1U);
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CMP_Global_Functions CMP Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initialize structure stc_cmp_init_t variable with default value.
+ * @param  [in] pstcCmpInit         Pointer to a structure variable which will be initialized. @ref stc_cmp_init_t
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t CMP_StructInit(stc_cmp_init_t *pstcCmpInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (pstcCmpInit != NULL) {
+        pstcCmpInit->u16PositiveInput = CMP_POSITIVE_NONE;
+        pstcCmpInit->u16NegativeInput = CMP_NEGATIVE_NONE;
+        pstcCmpInit->u16OutPolarity = CMP_OUT_INVT_OFF;
+        pstcCmpInit->u16OutDetectEdge = CMP_DETECT_EDGS_NONE;
+        pstcCmpInit->u16OutFilter = CMP_OUT_FILTER_NONE;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize structure stc_cmp_window_init_t variable with default value.
+ * @param  [in] pstcCmpWindowInit   Pointer to a structure variable. @ref stc_cmp_window_init_t
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t CMP_WindowStructInit(stc_cmp_window_init_t *pstcCmpWindowInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (pstcCmpWindowInit != NULL) {
+        pstcCmpWindowInit->u16WinVolLow = CMP_NEGATIVE_NONE;
+        pstcCmpWindowInit->u16WinVolHigh = CMP_NEGATIVE_NONE;
+        pstcCmpWindowInit->u16OutPolarity = CMP_OUT_INVT_OFF;
+        pstcCmpWindowInit->u16OutDetectEdge = CMP_DETECT_EDGS_NONE;
+        pstcCmpWindowInit->u16OutFilter = CMP_OUT_FILTER_NONE;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize structure stc_cmp_blankwindow_t variable with default value.
+ * @param  [in] pstcBlankWindowConfig   Pointer to a structure variable. @ref stc_cmp_blankwindow_t
+ * @retval int32_t
+ *         - LL_OK:                     Success
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t CMP_BlankWindowStructInit(stc_cmp_blankwindow_t *pstcBlankWindowConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (pstcBlankWindowConfig != NULL) {
+        pstcBlankWindowConfig->u8ValidLevel = CMP_BLANKWIN_VALID_LVL_LOW;
+        pstcBlankWindowConfig->u8OutLevel = CMP_BLANKWIN_OUTPUT_LVL_LOW;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize CMP unit
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @retval None
+ */
+void CMP_DeInit(CM_CMP_TypeDef *CMPx)
+{
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+
+    CLR_REG8(CMPx->MDR);
+    CLR_REG8(CMPx->FIR);
+    CLR_REG8(CMPx->OCR);
+    CLR_REG8(CMPx->PMSR);
+    CLR_REG16(CMPx->VISR);
+    CLR_REG16(CMPx->TWSR);
+    CLR_REG16(CMPx->TWPR);
+}
+
+/**
+ * @brief  CMP normal mode initialize
+ * @param  [in] CMPx                        Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] pstcCmpInit                 CMP function base parameter structure
+ *   @arg  pstcCmpInit->u16PositiveInput:   @ref CMP_Positive_Input_Select
+ *   @arg  pstcCmpInit->u16NegativeInput:   @ref CMP_Negative_Input_Select
+ *   @arg  pstcCmpInit->u16OutPolarity:     @ref CMP_Out_Polarity_Select
+ *   @arg  pstcCmpInit->u16OutDetectEdge:   @ref CMP_Out_Detect_Edge_Select
+ *   @arg  pstcCmpInit->u16OutFilter:       @ref CMP_Out_Filter
+ * @retval int32_t
+ *         - LL_OK:                         Success
+ *         - LL_ERR_INVD_PARAM:             Parameter error
+ */
+int32_t CMP_NormalModeInit(CM_CMP_TypeDef *CMPx, const stc_cmp_init_t *pstcCmpInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    /* Check CMPx instance and configuration structure*/
+    if (NULL != pstcCmpInit) {
+        /* Check parameters */
+        DDL_ASSERT(IS_CMP_UNIT(CMPx));
+        DDL_ASSERT(IS_CMP_OUT_POLARITY(pstcCmpInit->u16OutPolarity));
+        DDL_ASSERT(IS_CMP_OUT_DETECT_EDGE(pstcCmpInit->u16OutDetectEdge));
+        DDL_ASSERT(IS_CMP_OUT_FILTER(pstcCmpInit->u16OutFilter));
+        if ((CM_CMP1 == CMPx) || (CM_CMP3 == CMPx)) {
+            DDL_ASSERT(IS_CMP1_3_POSITIVE_IN(pstcCmpInit->u16PositiveInput));
+        } else {
+            DDL_ASSERT(IS_CMP2_4_POSITIVE_IN(pstcCmpInit->u16PositiveInput));
+        }
+        DDL_ASSERT(IS_CMP_NEGATIVE_IN(pstcCmpInit->u16NegativeInput));
+
+        /* Stop CMP compare */
+        CLR_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+
+        /* Set voltage in */
+        WRITE_REG8(CMPx->PMSR, (pstcCmpInit->u16PositiveInput & CMP_PMSR_CVSL) | pstcCmpInit->u16NegativeInput);
+        if ((CM_CMP1 == CMPx) || (CM_CMP3 == CMPx)) {
+            if ((CMP_PMSR_CVSL_1 == (pstcCmpInit->u16PositiveInput & CMP_PMSR_CVSL)) \
+                || (CMP_PMSR_CVSL_2 == (pstcCmpInit->u16PositiveInput & CMP_PMSR_CVSL))) {
+                WRITE_REG16(CMPx->VISR, (pstcCmpInit->u16PositiveInput >> VISR_OFFSET) & (CMP_VISR_P3SL | CMP_VISR_P2SL));
+            }
+        }
+
+        /* Delay 1us*/
+        CMP_DelayUS(1U);
+        /* Start CMP compare */
+        SET_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+        /* Delay 1us*/
+        CMP_DelayUS(1U);
+        /* Set output filter and output detect edge and output polarity */
+        WRITE_REG8(CMPx->FIR, (pstcCmpInit->u16OutFilter | pstcCmpInit->u16OutDetectEdge));
+        WRITE_REG8(CMPx->OCR, pstcCmpInit->u16OutPolarity);
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Voltage compare function command
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CMP_FuncCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState)
+{
+    /* Check CMPx instance */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+        /* Delay 1us*/
+        CMP_DelayUS(1U);
+    } else {
+        CLR_REG8_BIT(CMPx->MDR, CMP_MDR_CENA);
+    }
+
+}
+
+/**
+ * @brief  Voltage compare interrupt function command
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CMP_IntCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CMPx->FIR, CMP_FIR_CIEN);
+    } else {
+        CLR_REG8_BIT(CMPx->FIR, CMP_FIR_CIEN);
+    }
+}
+
+/**
+ * @brief  Voltage compare output command
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CMP_CompareOutCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CMPx->OCR, CMP_OCR_COEN);
+    } else {
+        CLR_REG8_BIT(CMPx->OCR, CMP_OCR_COEN);
+    }
+}
+
+/**
+ * @brief  Voltage compare output port VCOUT function command
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CMP_PinVcoutCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CMPx->OCR, CMP_OCR_CPOE);
+    } else {
+        CLR_REG8_BIT(CMPx->OCR, CMP_OCR_CPOE);
+    }
+
+}
+
+/**
+ * @brief  Voltage compare result flag read
+ * @param  [in] CMPx            Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @retval An @ref en_flag_status_t enumeration type value.
+ *         In normal mode
+ *         - RESET:             compare voltage < reference voltage
+ *         - SET:               compare voltage > reference voltage
+ *         In Window mode
+ *         - RESET:             compare voltage < reference low voltage or compare voltage > reference high voltage
+ *         - SET:               reference low voltage < compare voltage < reference high voltage
+ */
+en_flag_status_t CMP_GetStatus(const CM_CMP_TypeDef *CMPx)
+{
+    en_flag_status_t enRet;
+    /* Check CMPx instance */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    enRet = (READ_REG8_BIT(CMPx->MDR, CMP_MDR_CMON) != 0U) ? SET : RESET;
+    return enRet;
+}
+
+/**
+ * @brief  Set output detect edge
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u8CmpEdges          CMP output detect edge selection. @ref CMP_Out_Detect_Edge_Select
+ * @retval None
+ */
+void CMP_SetOutDetectEdge(CM_CMP_TypeDef *CMPx, uint8_t u8CmpEdges)
+{
+    uint16_t u16temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_CMP_OUT_DETECT_EDGE(u8CmpEdges));
+    /* Read CMP status */
+    u16temp = GetCmpFuncStatusAndDisFunc(CMPx);
+
+    /* CMP output detect edge selection */
+    MODIFY_REG8(CMPx->FIR, CMP_FIR_EDGS, u8CmpEdges);
+    /* Recover CMP function */
+    RecoverCmpFuncStatus(CMPx, u16temp);
+}
+
+/**
+ * @brief  Set output filter
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u8CmpFilter         CMP output filter selection. @ref CMP_Out_Filter
+ * @retval None
+ */
+void CMP_SetOutFilter(CM_CMP_TypeDef *CMPx, uint8_t u8CmpFilter)
+{
+    uint16_t u16temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_CMP_OUT_FILTER(u8CmpFilter));
+    /* Read CMP status */
+    u16temp = GetCmpFuncStatusAndDisFunc(CMPx);
+    /* CMP output filter selection */
+    MODIFY_REG8(CMPx->FIR, CMP_FIR_FCKS, u8CmpFilter);
+    /* Recover CMP function */
+    RecoverCmpFuncStatus(CMPx, u16temp);
+}
+
+/**
+ * @brief  Set output polarity
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u16CmpPolarity      CMP output polarity selection. @ref CMP_Out_Polarity_Select
+ * @retval None
+ */
+void CMP_SetOutPolarity(CM_CMP_TypeDef *CMPx, uint16_t u16CmpPolarity)
+{
+    uint16_t u16temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_CMP_OUT_POLARITY(u16CmpPolarity));
+    /* Read CMP status */
+    u16temp = GetCmpFuncStatusAndDisFunc(CMPx);
+
+    /* CMP output polarity selection */
+    MODIFY_REG8(CMPx->OCR, CMP_OCR_COPS, u16CmpPolarity);
+    /* Recover CMP function */
+    RecoverCmpFuncStatus(CMPx, u16temp);
+}
+
+/**
+ * @brief  Set positive in(compare voltage)
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u16PositiveInput    @ref CMP_Positive_Input_Select
+ * @retval None
+ */
+void CMP_SetPositiveInput(CM_CMP_TypeDef *CMPx, uint16_t u16PositiveInput)
+{
+    uint16_t u16temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    if ((CM_CMP1 == CMPx) || (CM_CMP3 == CMPx)) {
+        DDL_ASSERT(IS_CMP1_3_POSITIVE_IN(u16PositiveInput));
+    } else {
+        DDL_ASSERT(IS_CMP2_4_POSITIVE_IN(u16PositiveInput));
+    }
+
+    /* Read CMP status */
+    u16temp = GetCmpFuncStatusAndDisFunc(CMPx);
+
+    /* Set voltage in */
+    MODIFY_REG8(CMPx->PMSR, CMP_PMSR_CVSL, (u16PositiveInput & CMP_PMSR_CVSL));
+    if ((CM_CMP1 == CMPx) || (CM_CMP3 == CMPx)) {
+        if ((CMP_PMSR_CVSL_1 == (u16PositiveInput & CMP_PMSR_CVSL)) || (CMP_PMSR_CVSL_2 == (u16PositiveInput & CMP_PMSR_CVSL))) {
+            MODIFY_REG16(CMPx->VISR, (CMP_VISR_P3SL | CMP_VISR_P2SL), (u16PositiveInput >> VISR_OFFSET));
+        }
+    }
+
+    /* Recover CMP function */
+    RecoverCmpFuncStatus(CMPx, u16temp);
+}
+
+/**
+ * @brief  Set negative in(reference voltage)
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u16NegativeInput    @ref CMP_Negative_Input_Select
+ * @retval None
+ */
+void CMP_SetNegativeInput(CM_CMP_TypeDef *CMPx, uint16_t u16NegativeInput)
+{
+    uint16_t u16temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_CMP_NEGATIVE_IN(u16NegativeInput));
+    /* Read CMP status */
+    u16temp = GetCmpFuncStatusAndDisFunc(CMPx);
+
+    /* Set voltage in */
+    MODIFY_REG8(CMPx->PMSR, CMP_PMSR_RVSL, u16NegativeInput);
+
+    /* Recover CMP function */
+    RecoverCmpFuncStatus(CMPx, u16temp);
+}
+
+/**
+ * @brief  CMP window mode initialize
+ * @param  [in] u8WinCMPx               @ref CMP_Window_Mode_Unit
+ * @param  [in] pstcCmpWindowInit       CMP function base parameter structure @ref stc_cmp_window_init_t
+ * @retval int32_t
+ *         - LL_OK:                     Success
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t CMP_WindowModeInit(uint8_t u8WinCMPx, const stc_cmp_window_init_t *pstcCmpWindowInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    /* Check configuration structure */
+    if (NULL != pstcCmpWindowInit) {
+        /* Check parameters */
+        DDL_ASSERT(IS_CMP_WIN_MD_UNIT(u8WinCMPx));
+        DDL_ASSERT(IS_CMP_OUT_POLARITY(pstcCmpWindowInit->u16OutPolarity));
+        DDL_ASSERT(IS_CMP_OUT_DETECT_EDGE(pstcCmpWindowInit->u16OutDetectEdge));
+        DDL_ASSERT(IS_CMP_OUT_FILTER(pstcCmpWindowInit->u16OutFilter));
+        DDL_ASSERT(IS_CMP_WIN_LOW_IN(pstcCmpWindowInit->u16WinVolLow));
+        DDL_ASSERT(IS_CMP_WIN_HIGH_IN(pstcCmpWindowInit->u16WinVolHigh));
+
+        CM_CMP_TypeDef *pCMP_MAIN;
+        CM_CMP_TypeDef *pCMP_MINOR;
+
+        if (u8WinCMPx == CMP_WIN_CMP12) {
+            pCMP_MAIN = CM_CMP2;
+            pCMP_MINOR = CM_CMP1;
+        } else {
+            pCMP_MAIN = CM_CMP4;
+            pCMP_MINOR = CM_CMP3;
+        }
+        /* Stop CMP compare */
+        CLR_REG8_BIT(pCMP_MINOR->MDR, CMP_MDR_CENA);
+        CLR_REG8_BIT(pCMP_MAIN->MDR, CMP_MDR_CENA);
+
+        /* Set positive in(compare voltage), window voltage */
+        WRITE_REG8(pCMP_MINOR->PMSR, (CMP1_POSITIVE_CMP2_INP3 & CMP_PMSR_CVSL) | pstcCmpWindowInit->u16WinVolLow);
+        WRITE_REG8(pCMP_MAIN->PMSR, (CMP2_POSITIVE_CMP2_INP3 & CMP_PMSR_CVSL) | pstcCmpWindowInit->u16WinVolHigh);
+        WRITE_REG16(pCMP_MINOR->VISR, (CMP1_POSITIVE_CMP2_INP3 >> VISR_OFFSET) & (CMP_VISR_P3SL | CMP_VISR_P2SL));
+        /* Select window compare mode */
+        SET_REG8_BIT(pCMP_MAIN->MDR, CMP_MDR_WDEN);
+        /* Start CMP compare function */
+        SET_REG8_BIT(pCMP_MINOR->MDR, CMP_MDR_CENA);
+        SET_REG8_BIT(pCMP_MAIN->MDR, CMP_MDR_CENA);
+        /* Delay 1us*/
+        CMP_DelayUS(1U);
+        /* Set output filter and output detect edge and output polarity */
+        WRITE_REG8(pCMP_MAIN->FIR, pstcCmpWindowInit->u16OutFilter | pstcCmpWindowInit->u16OutDetectEdge);
+        WRITE_REG8(pCMP_MAIN->OCR, pstcCmpWindowInit->u16OutPolarity);
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Blank window function disable specified window source
+ * @param  [in] CMPx                    Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] u16BlankWindowSrc       Blank window source. can be any combination of @ref CMP_BlankWindow_Src
+ * @retval None
+ */
+void CMP_BlankWindowSrcDisable(CM_CMP_TypeDef *CMPx, uint16_t u16BlankWindowSrc)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+
+    /* Set blank window valid level high */
+    CLR_REG16_BIT(CMPx->TWPR, u16BlankWindowSrc);
+    /* Disable blank window source  */
+    CLR_REG16_BIT(CMPx->TWSR, u16BlankWindowSrc);
+}
+
+/**
+ * @brief  Voltage compare blank window function configuration
+ * @param  [in] CMPx                    Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] pstcBlankWindowConfig   Configuration structure for blank window mode.
+ * @retval int32_t
+ *         - LL_OK:                     Success
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t CMP_BlankWindowConfig(CM_CMP_TypeDef *CMPx, const stc_cmp_blankwindow_t *pstcBlankWindowConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    /* Check CMPx instance and configuration structure*/
+    if (NULL != pstcBlankWindowConfig) {
+        i32Ret = LL_OK;
+        /* Check parameters */
+        DDL_ASSERT(IS_CMP_UNIT(CMPx));
+        DDL_ASSERT(IS_CMP_BLANKWIN_VALID_LVL(pstcBlankWindowConfig->u8ValidLevel));
+        DDL_ASSERT(IS_CMP_BLANKWIN_OUT_LVL(pstcBlankWindowConfig->u8OutLevel));
+
+        /* Select output level when blank window valid */
+        MODIFY_REG8(CMPx->OCR, CMP_OCR_BWOL, pstcBlankWindowConfig->u8OutLevel);
+        /* Select blank window valid level */
+        if (CMP_BLANKWIN_VALID_LVL_LOW == pstcBlankWindowConfig->u8ValidLevel) {
+            SET_REG16_BIT(CMPx->TWPR, pstcBlankWindowConfig->u16Src);
+        } else {
+            CLR_REG16_BIT(CMPx->TWPR, pstcBlankWindowConfig->u16Src);
+        }
+        /* Select blank window source  */
+        SET_REG16_BIT(CMPx->TWSR, pstcBlankWindowConfig->u16Src);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  CMP out blank window function command
+ * @param  [in] CMPx                Pointer to CMP instance register base
+ *   @arg  CM_CMPx
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CMP_BlankWindowCmd(CM_CMP_TypeDef *CMPx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_CMP_UNIT(CMPx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CMPx->OCR, CMP_OCR_BWEN);
+    } else {
+        CLR_REG8_BIT(CMPx->OCR, CMP_OCR_BWEN);
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif  /* LL_CMP_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_crc.c
+++ b/hc32f4a2/src/hc32_ll_crc.c
@@ -1,0 +1,574 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_crc.c
+ * @brief This file provides firmware functions to manage the Cyclic Redundancy
+ *        Check(CRC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add waiting time after write CRC data
+   2023-06-30       CDT             Reconstruct interface function relate to calculate CRC
+                                    Optimize CRC_DeInit function
+   2023-09-30       CDT             Delete and modify some of group/function relate to calculate CRC
+                                    Modify typo
+   2024-06-30       CDT             Add API CRC_GetResult() & CRC_SetInitValue()
+                                    Optimized APIs CRC_WriteData8/16/32
+   2024-11-08       CDT             Modify interface of AccumulateData and Calculate functions
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_crc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_CRC CRC
+ * @brief Cyclic Redundancy Check Driver Library
+ * @{
+ */
+
+#if (LL_CRC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CRC_Local_Macros CRC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup CRC_Check_Parameters_Validity CRC Check Parameters Validity
+ * @{
+ */
+/*! Parameter validity check for CRC protocol. */
+#define IS_CRC_PROTOCOL(x)                                                     \
+(   ((x) == CRC_CRC16)                  ||                                     \
+    ((x) == CRC_CRC32))
+
+/*! Parameter validity check for CRC data width. */
+#define IS_CRC_DATA_WIDTH(x)                                                   \
+(   ((x) == CRC_DATA_WIDTH_8BIT)        ||                                     \
+    ((x) == CRC_DATA_WIDTH_16BIT)       ||                                     \
+    ((x) == CRC_DATA_WIDTH_32BIT))
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_Registers_Reset_Value_definition CRC Registers Reset Value
+ * @{
+ */
+#define CRC_CR_RST_VALUE                (0x0001UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_DATA_Register_Address CRC Data Register Address
+ * @{
+ */
+#define CRC_DATA_ADDR                   ((uint32_t)(&CM_CRC->DAT0))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_Calculate_Clock_Count CRC Calculate Clock Count
+ * @{
+ */
+#define CRC_CALC_CLK_COUNT              (10UL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup CRC_Local_Functions CRC Local Functions
+ * @{
+ */
+
+/**
+ * @brief  Calculate the CRC value of a 8-bit data buffer.
+ * @param  [in] au8Data                 Pointer to the input data buffer.
+ * @param  [in] u32Len                  The length(counted in byte) of the data to be calculated.
+ * @retval None
+ */
+static void CRC_WriteData8(const uint8_t au8Data[], uint32_t u32Len)
+{
+    uint32_t i;
+    __IO uint8_t *reg8DR = (__IO uint8_t *)CRC_DATA_ADDR;
+    for (i = 0UL; i < u32Len; i++) {
+        *reg8DR = au8Data[i];
+    }
+}
+
+/**
+ * @brief  Calculate the CRC value of a 16-bit data buffer.
+ * @param  [in] au16Data                Pointer to the input data buffer.
+ * @param  [in] u32Len                  The length(counted in half-word) of the data to be calculated.
+ * @retval None
+ */
+static void CRC_WriteData16(const uint16_t au16Data[], uint32_t u32Len)
+{
+    uint32_t i;
+    __IO uint16_t *reg16DR = (__IO uint16_t *)CRC_DATA_ADDR;
+    for (i = 0UL; i < u32Len; i++) {
+        *reg16DR = au16Data[i];
+    }
+}
+
+/**
+ * @brief  Calculate the CRC value of a 32-bit data buffer.
+ * @param  [in] au32Data                Pointer to the input data buffer.
+ * @param  [in] u32Len                  The length(counted in word) of the data to be calculated.
+ * @retval None
+ */
+static void CRC_WriteData32(const uint32_t au32Data[], uint32_t u32Len)
+{
+    uint32_t i;
+    __IO uint32_t *reg32DR = (__IO uint32_t *)CRC_DATA_ADDR;
+    for (i = 0UL; i < u32Len; i++) {
+        *reg32DR = au32Data[i];
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CRC_Global_Functions CRC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_crc_init_t to default values.
+ * @param  [out] pstcCrcInit            Pointer to a @ref stc_crc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ */
+int32_t CRC_StructInit(stc_crc_init_t *pstcCrcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcCrcInit) {
+        pstcCrcInit->u32Protocol = CRC_CRC16;
+        pstcCrcInit->u32InitValue = CRC_INIT_VALUE_DEFAULT;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize the CRC.
+ * @param  [in] pstcCrcInit             Pointer to a @ref stc_crc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ */
+int32_t CRC_Init(const stc_crc_init_t *pstcCrcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcCrcInit) {
+        DDL_ASSERT(IS_CRC_PROTOCOL(pstcCrcInit->u32Protocol));
+
+        MODIFY_REG32(CM_CRC->CR, CRC_CRC32, pstcCrcInit->u32Protocol);
+
+        /* Set initial value */
+        if (CRC_CRC16 == (pstcCrcInit->u32Protocol & CRC_CRC32)) {
+            WRITE_REG16(CM_CRC->RESLT, (uint16_t)pstcCrcInit->u32InitValue);
+        } else {
+            WRITE_REG32(CM_CRC->RESLT, pstcCrcInit->u32InitValue);
+        }
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize the CRC.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t CRC_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+    WRITE_REG32(CM_CRC->CR, CRC_CR_RST_VALUE);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get the CRC result
+ * @param  None
+ * @retval The CRC result.
+ * @note   None.
+ */
+uint32_t CRC_GetResult(void)
+{
+    if (CRC_CRC32 == READ_REG32_BIT(CM_CRC->CR, CRC_CR_CR)) {
+        return READ_REG32(CM_CRC->RESLT);
+    } else {
+        return READ_REG32_BIT(CM_CRC->RESLT, 0x0000FFFFUL);
+    }
+}
+
+/**
+ * @brief  Set the CRC initial value
+ * @param  [in] u32Value        The CRC initial value.
+ * @retval None
+ * @note   None.
+ */
+void CRC_SetInitValue(uint32_t u32Value)
+{
+    if (CRC_CRC32 == READ_REG32_BIT(CM_CRC->CR, CRC_CR_CR)) {
+        WRITE_REG32(CM_CRC->RESLT, u32Value);
+    } else {
+        WRITE_REG32(CM_CRC->RESLT, u32Value & 0x0000FFFFUL);
+    }
+}
+
+/**
+ * @brief  Get status of the CRC operation result.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CRC_GetResultStatus(void)
+{
+    uint32_t u32Status;
+
+    u32Status = READ_REG32_BIT(CM_CRC->CR, CRC_CR_FLAG);
+
+    return (u32Status > 0UL) ? SET : RESET;
+}
+
+/**
+ * @brief  Calculate the CRC16 value and start with the previously calculated CRC as initial value.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the macros group @ref CRC_DATA_Bit_Width
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be calculated.
+ * @param  [in] u32Len                  The length(counted in bytes or half word or word, depending on
+ *                                      the bit width) of the data to be calculated.
+ * @param  [out] pu16Out                Pointer to the calculated CRC value.
+ * @retval int32_t:
+ *          - LL_OK:                   Initialize successfully.
+ *          - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ * @note   The function fetch data in byte or half word or word depending on the data bit width(the parameter u8DataWidth).
+ */
+int32_t CRC_CRC16_AccumulateData(uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t *pu16Out)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        DDL_ASSERT(IS_CRC_DATA_WIDTH(u8DataWidth));
+
+        /* Write data */
+        if (CRC_DATA_WIDTH_32BIT == u8DataWidth) {
+            CRC_WriteData32((const uint32_t *)pvData, u32Len);
+        } else if (CRC_DATA_WIDTH_16BIT == u8DataWidth) {
+            CRC_WriteData16((const uint16_t *)pvData, u32Len);
+        } else {
+            CRC_WriteData8((const uint8_t *)pvData, u32Len);
+        }
+
+        if (pu16Out != NULL) {
+            /* Get checksum */
+            *pu16Out = (uint16_t)READ_REG16(CM_CRC->RESLT);
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate the CRC32 value and start with the previously calculated CRC as initial value.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the macros group @ref CRC_DATA_Bit_Width
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be calculated.
+ * @param  [in] u32Len                  The length(counted in bytes or half word or word, depending on
+ *                                      the bit width) of the data to be calculated.
+ * @param  [out] pu32Out                Pointer to the calculated CRC value.
+ * @retval int32_t:
+ *          - LL_OK:                   Initialize successfully.
+ *          - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ * @note   The function fetch data in byte or half word or word depending on the data bit width(the parameter u8DataWidth).
+ */
+int32_t CRC_CRC32_AccumulateData(uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t *pu32Out)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        DDL_ASSERT(IS_CRC_DATA_WIDTH(u8DataWidth));
+
+        /* Write data */
+        if (CRC_DATA_WIDTH_32BIT == u8DataWidth) {
+            CRC_WriteData32((const uint32_t *)pvData, u32Len);
+        } else if (CRC_DATA_WIDTH_16BIT == u8DataWidth) {
+            CRC_WriteData16((const uint16_t *)pvData, u32Len);
+        } else {
+            CRC_WriteData8((const uint8_t *)pvData, u32Len);
+        }
+
+        if (pu32Out != NULL) {
+            /* Get checksum */
+            *pu32Out = READ_REG32(CM_CRC->RESLT);
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate the CRC16 value and start with the specified initial value.
+ * @param  [in] u16InitValue            The CRC initialization value which is the valid bits same as
+ *                                      the bits of CRC Protocol.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the macros group @ref CRC_DATA_Bit_Width
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be computed.
+ * @param  [in] u32Len                  The length(counted in bytes or half word or word, depending on
+ *                                      the bit width) of the data to be computed.
+ * @param  [out] pu16Out                Pointer to the calculated CRC value.
+ * @retval int32_t:
+ *          - LL_OK:                   Initialize successfully.
+ *          - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ * @note   The function fetch data in byte or half word or word depending on the data bit width(the parameter u8DataWidth).
+ */
+int32_t CRC_CRC16_Calculate(uint16_t u16InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t *pu16Out)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        /* Set initial value */
+        WRITE_REG16(CM_CRC->RESLT, u16InitValue);
+        i32Ret = CRC_CRC16_AccumulateData(u8DataWidth, pvData, u32Len, pu16Out);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate the CRC32 value and start with the specified initial value.
+ * @param  [in] u32InitValue            The CRC initialization value which is the valid bits same as
+ *                                      the bits of CRC Protocol.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the macros group @ref CRC_DATA_Bit_Width
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be computed.
+ * @param  [in] u32Len                  The length(counted in bytes or half word or word, depending on
+ *                                      the bit width) of the data to be computed.
+ * @param  [out] pu32Out                Pointer to the calculated CRC value.
+ * @retval int32_t:
+ *          - LL_OK:                   Initialize successfully.
+ *          - LL_ERR_INVD_PARAM:       The pointer pstcCrcInit value is NULL.
+ * @note   The function fetch data in byte or half word or word depending on the data bit width(the parameter u8DataWidth).
+ */
+int32_t CRC_CRC32_Calculate(uint32_t u32InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t *pu32Out)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        /* Set initial value */
+        WRITE_REG32(CM_CRC->RESLT, u32InitValue);
+        i32Ret = CRC_CRC32_AccumulateData(u8DataWidth, pvData, u32Len, pu32Out);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Check the CRC16 calculating result with the expected value.
+ * @param  [in] u16InitValue            The CRC initialization value which is the valid bits same as
+ *                                      the bits of CRC Protocol.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the following values:
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be computed.
+ * @param  [in] u32Len                  The length(counted in byte) of the data to be calculated.
+ * @param  [in] u16ExpectValue          The expected CRC value to be checked.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CRC_CRC16_CheckData(uint16_t u16InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint16_t u16ExpectValue)
+{
+    __IO uint32_t u32Count = CRC_CALC_CLK_COUNT;
+    en_flag_status_t enStatus = RESET;
+    uint32_t u32ExpectValueTemp = u16ExpectValue;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        (void)CRC_CRC16_Calculate(u16InitValue, u8DataWidth, pvData, u32Len, NULL);
+
+        /* Writes the expected CRC value to be checked */
+        CRC_WriteData16((uint16_t *)((void *)&u32ExpectValueTemp), 1UL);
+
+        /* Delay for waiting CRC result flag */
+        while (u32Count-- != 0UL) {
+            __NOP();
+        }
+
+        enStatus = CRC_GetResultStatus();
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Check the CRC32 calculating result with the expected value.
+ * @param  [in] u32InitValue            The CRC initialization value which is the valid bits same as
+ *                                      the bits of CRC Protocol.
+ * @param  [in] u8DataWidth             Bit width of the data.
+ *         This parameter can be one of the following values:
+ *           @arg CRC_DATA_WIDTH_8BIT:  8  Bit
+ *           @arg CRC_DATA_WIDTH_16BIT: 16 Bit
+ *           @arg CRC_DATA_WIDTH_32BIT: 32 Bit
+ * @param  [in] pvData                  Pointer to the buffer containing the data to be computed.
+ * @param  [in] u32Len                  The length(counted in byte) of the data to be calculated.
+ * @param  [in] u32ExpectValue          The expected CRC value to be checked.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CRC_CRC32_CheckData(uint32_t u32InitValue, uint8_t u8DataWidth, const void *pvData, uint32_t u32Len, uint32_t u32ExpectValue)
+{
+    __IO uint32_t u32Count = CRC_CALC_CLK_COUNT;
+    en_flag_status_t enStatus = RESET;
+    uint32_t u32ExpectValueTemp = u32ExpectValue;
+
+    if ((pvData != NULL) && (u32Len != 0UL)) {
+        (void)CRC_CRC32_Calculate(u32InitValue, u8DataWidth, pvData, u32Len, NULL);
+
+        /* Writes the expected CRC value to be checked */
+        CRC_WriteData32(&u32ExpectValueTemp, 1UL);
+
+        /* Delay for waiting CRC result flag */
+        while (u32Count-- != 0UL) {
+            __NOP();
+        }
+
+        enStatus = CRC_GetResultStatus();
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Get the CRC16 check result with the expected value.
+ * @param  [in] u16ExpectValue          The expected CRC value to be checked.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CRC_CRC16_GetCheckResult(uint16_t u16ExpectValue)
+{
+    __IO uint32_t u32Count = CRC_CALC_CLK_COUNT;
+    en_flag_status_t enStatus;
+    uint32_t u32ExpectValueTemp = u16ExpectValue;
+
+    /* Writes the expected CRC value to be checked */
+    CRC_WriteData16((uint16_t *)((void *)&u32ExpectValueTemp), 1UL);
+
+    /* Delay for waiting CRC result flag */
+    while (u32Count-- != 0UL) {
+        __NOP();
+    }
+
+    enStatus = CRC_GetResultStatus();
+
+    return enStatus;
+}
+
+/**
+ * @brief  Get the CRC32 check result with the expected value.
+ * @param  [in] u32ExpectValue          The expected CRC value to be checked.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t CRC_CRC32_GetCheckResult(uint32_t u32ExpectValue)
+{
+    __IO uint32_t u32Count = CRC_CALC_CLK_COUNT;
+    en_flag_status_t enStatus;
+    uint32_t u32ExpectValueTemp = u32ExpectValue;
+
+    /* Writes the expected CRC value to be checked */
+    CRC_WriteData32(&u32ExpectValueTemp, 1UL);
+
+    /* Delay for waiting CRC result flag */
+    while (u32Count-- != 0UL) {
+        __NOP();
+    }
+
+    enStatus = CRC_GetResultStatus();
+
+    return enStatus;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_CRC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_ctc.c
+++ b/hc32f4a2/src/hc32_ll_ctc.c
@@ -1,0 +1,386 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_ctc.c
+ * @brief This file provides firmware functions to manage the Clock Trimming
+ *        Controller(CTC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify typo
+                                    Modify the init assignment of i32Ret in CTC_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_ctc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_CTC CTC
+ * @brief CTC Driver Library
+ * @{
+ */
+
+#if (LL_CTC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup CTC_Local_Macros CTC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup CTC_Check_Parameters_Validity CTC Check Parameters Validity
+ * @{
+ */
+#define IS_CTC_REF_CLK_SRC(x)                                                  \
+(   ((x) == CTC_REF_CLK_SRC_XTAL)           ||                                 \
+    ((x) == CTC_REF_CLK_SRC_XTAL32)         ||                                 \
+    ((x) == CTC_REF_CLK_SRC_CTCREF))
+
+#define IS_CTC_REF_CLK_DIV(x)                                                  \
+(   ((x) == CTC_REF_CLK_DIV8)               ||                                 \
+    ((x) == CTC_REF_CLK_DIV32)              ||                                 \
+    ((x) == CTC_REF_CLK_DIV128)             ||                                 \
+    ((x) == CTC_REF_CLK_DIV256)             ||                                 \
+    ((x) == CTC_REF_CLK_DIV512)             ||                                 \
+    ((x) == CTC_REF_CLK_DIV1024)            ||                                 \
+    ((x) == CTC_REF_CLK_DIV2048)            ||                                 \
+    ((x) == CTC_REF_CLK_DIV4096))
+
+#define IS_CTC_OFFSET_VALUE(x)              ((x) <= 0xFFUL)
+
+#define IS_CTC_RELOAD_VALUE(x)              ((x) <= 0xFFFFUL)
+
+#define IS_CTC_TRIM_VALUE(x)                ((x) <= 0x3FUL)
+
+#define IS_CTC_TOLERANT_ERR(x)                                                 \
+(   ((x) >= 0.0F) &&                                                           \
+    ((x) <= CTC_TOLERANT_ERR_MAX))
+
+#define IS_CTC_FLAG(x)                                                         \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | CTC_FLAG_ALL) == CTC_FLAG_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CTC_Tolerant_Error_Max CTC Tolerant Error Max
+ * @{
+ */
+#define CTC_TOLERANT_ERR_MAX                (1.0F)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup CTC_Local_Functions CTC Local Functions
+ * @{
+ */
+
+/**
+ * @brief  Get HRC clock frequency.
+ * @param  None
+ * @retval HRC clock frequency.
+ */
+static uint32_t CTC_GetHrcClockFreq(void)
+{
+    return HRC_VALUE;
+}
+
+/**
+ * @brief  Get reference clock division.
+ * @param  [in] u32Cr1RefPsc            CTC CR1 REFPSC bits value.
+ *         This parameter can be between Min_Data=0 and Max_Data=7
+ * @retval Reference clock division.
+ */
+static uint32_t CTC_GetRefClockDiv(uint32_t u32Cr1RefPsc)
+{
+    uint32_t u32RefclkDiv;
+
+    if (u32Cr1RefPsc < CTC_REF_CLK_DIV128) {
+        u32RefclkDiv = (8UL << (2UL * u32Cr1RefPsc));
+    } else {
+        u32RefclkDiv = (32UL << u32Cr1RefPsc);
+    }
+
+    return u32RefclkDiv;
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup CTC_Global_Functions CTC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_ctc_ct_init_t to default values.
+ * @param  [out] pstcCtcInit            Pointer to a @ref stc_ctc_ct_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcCtcInit value is NULL.
+ */
+int32_t CTC_CT_StructInit(stc_ctc_ct_init_t *pstcCtcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcCtcInit) {
+        pstcCtcInit->u32RefClockFreq = 0UL;
+        pstcCtcInit->u32RefClockSrc = CTC_REF_CLK_SRC_CTCREF;
+        pstcCtcInit->u32RefClockDiv = CTC_REF_CLK_DIV8;
+        pstcCtcInit->f32TolerantErrRate = 0.0F;
+        pstcCtcInit->u8TrimValue = 0U;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize CTC continuous trim function.
+ * @param  [in] pstcCtcInit             Pointer to a @ref stc_ctc_ct_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_BUSY:             CTC state is busy.
+ *           - LL_ERR_INVD_PARAM:       If one of following cases matches:
+ *                                      - The pointer pstcCtcInit value is NULL.
+ *                                      - Reference frequency is out of range.
+ *                                      - Calculate reload & offset value out of range.
+ */
+int32_t CTC_CT_Init(const stc_ctc_ct_init_t *pstcCtcInit)
+{
+    float32_t f32OffsetValue;
+    uint32_t u32RegValue;
+    uint32_t u32ReloadValue;
+    uint32_t u32OffsetValue;
+    uint32_t u32RefClockDiv;
+    uint32_t u32CtcHrcFreq;
+    uint32_t u32Multiplier;
+    uint64_t u64InterClock;
+    int32_t i32Ret = LL_ERR_BUSY;
+
+    /* Check CTC status */
+    if (CTC_FLAG_BUSY != (READ_REG32_BIT(CM_CTC->STR, CTC_FLAG_BUSY))) {
+        if ((NULL == pstcCtcInit) || (0UL == pstcCtcInit->u32RefClockFreq)) {
+            i32Ret = LL_ERR_INVD_PARAM;
+        } else {
+            DDL_ASSERT(IS_CTC_REF_CLK_SRC(pstcCtcInit->u32RefClockSrc));
+            DDL_ASSERT(IS_CTC_REF_CLK_DIV(pstcCtcInit->u32RefClockDiv));
+            DDL_ASSERT(IS_CTC_TRIM_VALUE(pstcCtcInit->u8TrimValue));
+            DDL_ASSERT(IS_CTC_TOLERANT_ERR(pstcCtcInit->f32TolerantErrRate));
+            u32CtcHrcFreq = CTC_GetHrcClockFreq();
+
+            u32RefClockDiv = CTC_GetRefClockDiv(pstcCtcInit->u32RefClockDiv);
+            u64InterClock = ((uint64_t)u32CtcHrcFreq) * ((uint64_t)(u32RefClockDiv));
+            u32Multiplier = (uint32_t)(u64InterClock / pstcCtcInit->u32RefClockFreq);
+
+            /* Calculate offset value formula: OFSVAL = (Fhrc / (Fref * Fref_division)) * TA */
+            f32OffsetValue = ((float32_t)u32Multiplier) * (pstcCtcInit->f32TolerantErrRate);
+            u32OffsetValue = (uint32_t)(f32OffsetValue);
+
+            /* Calculate reload value formula: RLDVAL = (Fhrc / (Fref * Fref_division)) + OFSVAL */
+            u32ReloadValue = u32Multiplier + u32OffsetValue;
+
+            /* Check reload and offset value */
+            if ((IS_CTC_OFFSET_VALUE(u32OffsetValue)) && (IS_CTC_RELOAD_VALUE(u32ReloadValue))) {
+                /* Set CR1 */
+                u32RegValue = (pstcCtcInit->u32RefClockDiv | pstcCtcInit->u32RefClockSrc | \
+                               ((uint32_t)pstcCtcInit->u8TrimValue << CTC_CR1_TRMVAL_POS));
+                WRITE_REG32(CM_CTC->CR1, u32RegValue);
+
+                /* Set CR2 */
+                u32RegValue = ((u32ReloadValue << CTC_CR2_RLDVAL_POS) | u32OffsetValue);
+                WRITE_REG32(CM_CTC->CR2, u32RegValue);
+                i32Ret = LL_OK;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize CTC function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success
+ *           - LL_ERR_BUSY:             CTC state is busy
+ */
+int32_t CTC_DeInit(void)
+{
+    int32_t i32Ret = LL_ERR_BUSY;
+
+    /* Check CTC status */
+    if (CTC_FLAG_BUSY != (READ_REG32_BIT(CM_CTC->STR, CTC_FLAG_BUSY))) {
+        /* Configures the registers to reset value. */
+        WRITE_REG32(CM_CTC->CR1, 0UL);
+        WRITE_REG32(CM_CTC->CR2, 0UL);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable CTC error interrupt function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void CTC_IntCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_CTC->CR1, CTC_CR1_ERRIE);
+    } else {
+        CLR_REG32_BIT(CM_CTC->CR1, CTC_CR1_ERRIE);
+    }
+}
+
+/**
+ * @brief  Get CTC flag status.
+ * @param  [in] u32Flag                 CTC flag
+ *         This parameter can be any composed value of the macros group @ref CTC_Flag
+ *           @arg CTC_FLAG_TRIM_OK:     Trimming OK flag
+ *           @arg CTC_FLAG_TRIM_OVF:    Trimming overflow flag
+ *           @arg CTC_FLAG_TRIM_UDF:    Trimming underflow flag
+ *           @arg CTC_FLAG_BUSY:        CTC busy flag
+ * @retval Returned value can be one of the following values:
+ */
+en_flag_status_t CTC_GetStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_CTC_FLAG(u32Flag));
+
+    return ((0UL == READ_REG32_BIT(CM_CTC->STR, u32Flag)) ? RESET : SET);
+}
+
+/**
+ * @brief  Set CTC trimming value.
+ * @param  [in] u8TrimValue             CTC trimming value
+ *         This parameter can be Min_Data=0 && Max_Data=0x3F
+ * @retval None
+ */
+void CTC_SetTrimValue(uint8_t u8TrimValue)
+{
+    DDL_ASSERT(IS_CTC_TRIM_VALUE(u8TrimValue));
+
+    MODIFY_REG32(CM_CTC->CR1, CTC_CR1_TRMVAL, ((uint32_t)u8TrimValue << CTC_CR1_TRMVAL_POS));
+}
+
+/**
+ * @brief  Get CTC trimming value.
+ * @param  None
+ * @retval CTC trimming value(between Min_Data=0 and Max_Data=0x3F)
+ */
+uint8_t CTC_GetTrimValue(void)
+{
+    return (uint8_t)(READ_REG32_BIT(CM_CTC->CR1, CTC_CR1_TRMVAL) >> CTC_CR1_TRMVAL_POS);
+}
+
+/**
+ * @brief  Set CTC reload value.
+ * @param  [in] u16ReloadValue          CTC reload value
+ *         This parameter can be between Min_Data=0 and Max_Data=0xFFFF
+ * @retval None
+ */
+void CTC_SetReloadValue(uint16_t u16ReloadValue)
+{
+    MODIFY_REG32(CM_CTC->CR2, CTC_CR2_RLDVAL, ((uint32_t)u16ReloadValue << CTC_CR2_RLDVAL_POS));
+}
+
+/**
+ * @brief  Get CTC reload value.
+ * @param  None
+ * @retval CTC reload value (between Min_Data=0 and Max_Data=0xFFFF)
+ */
+uint16_t CTC_GetReloadValue(void)
+{
+    return (uint16_t)(READ_REG32_BIT(CM_CTC->CR2, CTC_CR2_RLDVAL) >> CTC_CR2_RLDVAL_POS);
+}
+
+/**
+ * @brief  Set CTC offset value.
+ * @param  [in] u8OffsetValue           CTC offset value
+ *         This parameter can be between Min_Data=0 and Max_Data=0xFF
+ * @retval None
+ */
+void CTC_SetOffsetValue(uint8_t u8OffsetValue)
+{
+    MODIFY_REG32(CM_CTC->CR2, CTC_CR2_OFSVAL, ((uint32_t)u8OffsetValue << CTC_CR2_OFSVAL_POS));
+}
+
+/**
+ * @brief  Get CTC offset value.
+ * @param  None
+ * @retval CTC offset value (between Min_Data=0 and Max_Data=0xFF)
+ */
+uint8_t CTC_GetOffsetValue(void)
+{
+    return (uint8_t)(READ_REG32_BIT(CM_CTC->CR2, CTC_CR2_OFSVAL) >> CTC_CR2_OFSVAL_POS);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_CTC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dac.c
+++ b/hc32f4a2/src/hc32_ll_dac.c
@@ -1,0 +1,549 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dac.c
+ * @brief This file provides firmware functions to manage the Digital-to-Analog
+ *        Converter(DAC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify function: DAC_AMPCmd and add assert
+                                    Synchronize register: EN->E,ADPSL->ADCSL,ALIGN->DPSEL
+   2023-06-30       CDT             Refine data validation
+                                    Modify function:DAC_DeInit
+   2024-06-30       CDT             All parameter assert add module name
+   2024-11-08       CDT             Add DAC data align configuration
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dac.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_DAC DAC
+ * @brief DAC Driver Library
+ * @{
+ */
+
+#if (LL_DAC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DAC_Local_Macros DAC Local Macros
+ * @{
+ */
+#define DAC_RESOLUTION                  (DAC_RESOLUTION_12BIT)
+#define DAC_DATA_REG_WIDTH              (16U)
+#define DAC_DATA_RIGHT_ALIGN_MASK       ((2U << DAC_RESOLUTION) - 1U)
+#define DAC_DATA_LEFT_ALIGN_MASK        (DAC_DATA_RIGHT_ALIGN_MASK << (DAC_DATA_REG_WIDTH - DAC_RESOLUTION))
+
+/**
+ * @defgroup DAC_Check_Parameters_Validity DAC Check Parameters Validity
+ * @{
+ */
+#define IS_DAC_UNIT(x)                  (((x) == CM_DAC1) || ((x) == CM_DAC2))
+
+#define IS_DAC_CH(x)                    (((x) == DAC_CH1) || ((x) == DAC_CH2))
+
+#define IS_DAC_DATA_ALIGN(x)            (((x) == DAC_DATA_ALIGN_LEFT) || ((x) == DAC_DATA_ALIGN_RIGHT))
+
+#define IS_DAC_DATA_SRC(x)              (((x) == DAC_DATA_SRC_DATAREG) || ((x) == DAC_DATA_SRC_DCU))
+
+#define IS_DAC_ADCPRIO_CONFIG(x)        ((0U != (x)) && (DAC_ADP_SEL_ALL == ((x) | DAC_ADP_SEL_ALL)))
+
+#define IS_DAC_RIGHT_ALIGNED_DATA(data) (((data) & ~DAC_DATA_RIGHT_ALIGN_MASK) == 0U)
+#define IS_DAC_LEFT_ALIGNED_DATA(data)  (((data) & ~DAC_DATA_LEFT_ALIGN_MASK) == 0U)
+
+#define IS_DAC_ADP_CTRL_ALLOWED(x,src1,src2)                                   \
+(   ((x) == DISABLE)                    ||                                     \
+    (((src1) == (DAC_DATA_SRC_DATAREG)) && ((src2) == (DAC_DATA_SRC_DATAREG))))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup DAC_Global_Functions DAC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set DAC data source for specified channel
+ * @param  [in] DACx       Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch      Specify the DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @param  [in] u16Src     Specify the data source.
+ *         This parameter can be a value of @ref DAC_DATA_SRC
+ *         - DAC_DATA_SRC_DATAREG:   convert source is from data register
+ *         - DAC_DATA_SRC_DCU:       convert source is from DCU
+ * @retval None
+ */
+void DAC_SetDataSrc(CM_DAC_TypeDef *DACx, uint16_t u16Ch, uint16_t u16Src)
+{
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+    DDL_ASSERT(IS_DAC_DATA_SRC(u16Src));
+
+    MODIFY_REG16(DACx->DACR, DAC_DACR_EXTDSL1 << u16Ch, u16Src << u16Ch);
+}
+
+/**
+ * @brief  DAC data register's data alignment pattern configuration
+ * @param  [in] DACx       Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Align   Specify the data alignment.
+ *         This parameter can be a value of @ref DAC_DATAREG_ALIGN_PATTERN
+ *         - DAC_DATA_ALIGN_LEFT:  left alignment
+ *         - DAC_DATA_ALIGN_RIGHT:  right alignment
+ * @retval None
+ */
+void DAC_DataRegAlignConfig(CM_DAC_TypeDef *DACx, uint16_t u16Align)
+{
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_DATA_ALIGN(u16Align));
+
+    MODIFY_REG16(DACx->DACR, DAC_DACR_DPSEL, u16Align);
+}
+
+/**
+ * @brief  DAC output function command
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch      Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @param  [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DAC_OutputCmd(CM_DAC_TypeDef *DACx, uint16_t u16Ch, en_functional_state_t enNewState)
+{
+    uint16_t u16Cmd;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u16Cmd = (uint16_t)(1UL << (DAC_DAOCR_DAODIS1_POS + u16Ch));
+
+    if (ENABLE == enNewState) {
+        CLR_REG16_BIT(DACx->DAOCR, u16Cmd);
+    } else {
+        SET_REG16_BIT(DACx->DAOCR, u16Cmd);
+    }
+}
+
+/**
+ * @brief  DAC AMP function command
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch      Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @param  [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DAC_AMPCmd(CM_DAC_TypeDef *DACx, uint16_t u16Ch, en_functional_state_t enNewState)
+{
+    uint16_t u16Cmd;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    u16Cmd = (uint16_t)(1UL << (DAC_DACR_DAAMP1_POS + u16Ch));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(DACx->DACR, u16Cmd);
+    } else {
+        CLR_REG16_BIT(DACx->DACR, u16Cmd);
+    }
+}
+
+/**
+ * @brief  DAC ADC priority function command
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   please make sure ADC is in stopped status before calling DAC_ADCPrioCmd
+ */
+void DAC_ADCPrioCmd(CM_DAC_TypeDef *DACx, en_functional_state_t enNewState)
+{
+#ifdef __DEBUG
+    uint16_t u16DataSrc1;
+    uint16_t u16DataSrc2;
+#endif
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+#ifdef __DEBUG
+    u16DataSrc1 = READ_REG16_BIT(DACx->DACR, DAC_DACR_EXTDSL1);
+    u16DataSrc2 = READ_REG16_BIT(DACx->DACR, DAC_DACR_EXTDSL2);
+    DDL_ASSERT(IS_DAC_ADP_CTRL_ALLOWED(enNewState, u16DataSrc1, u16DataSrc2));
+#endif
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(DACx->DAADPCR, DAC_DAADPCR_ADPEN);
+    } else {
+        CLR_REG16_BIT(DACx->DAADPCR, DAC_DAADPCR_ADPEN);
+    }
+}
+
+/**
+ * @brief  Enable or Disable the ADC priority for the selected ADCx
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16ADCxPrio  ADCx priority to be enabled or disabled.
+ *         This parameter can be one or any combination of the following values:
+ *         @arg DAC_ADP_SEL_ADC1
+ *         @arg DAC_ADP_SEL_ADC2
+ *         @arg DAC_ADP_SEL_ADC3
+ * @param  [in] enNewState    An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   please make sure ADC is in stopped status before calling DAC_ADCPrioConfig
+ */
+void DAC_ADCPrioConfig(CM_DAC_TypeDef *DACx, uint16_t u16ADCxPrio, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_ADCPRIO_CONFIG(u16ADCxPrio));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(DACx->DAADPCR, u16ADCxPrio);
+    } else {
+        CLR_REG16_BIT(DACx->DAADPCR, u16ADCxPrio);
+    }
+}
+
+/**
+ * @brief  Start the specified DAC channel
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch  Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @retval int32_t:
+ *         - LL_OK: No errors occurred
+ *         - LL_ERR_INVD_MD: cannot start single channel when \n
+ *                           this channel have already been started by \n
+ *                           @ref DAC_StartDualCh
+ */
+int32_t DAC_Start(CM_DAC_TypeDef *DACx, uint16_t u16Ch)
+{
+    int32_t i32Ret = LL_OK;
+    uint16_t u16Cmd;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+
+    if ((DACx->DACR & DAC_DACR_DAE) != 0U) {
+        i32Ret = LL_ERR_INVD_MD;
+    } else {
+        u16Cmd = (uint16_t)(1UL << (DAC_DACR_DA1E_POS + u16Ch));
+        SET_REG16_BIT(DACx->DACR, u16Cmd);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Stop the specified DAC channel
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch  Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @retval int32_t:
+ *         - LL_OK: No errors occurred
+ *         - LL_ERR_INVD_MD: cannot stop single channel when \n
+ *                           this channel is started by \n
+ *                           @ref DAC_StartDualCh
+ */
+int32_t DAC_Stop(CM_DAC_TypeDef *DACx, uint16_t u16Ch)
+{
+    int32_t i32Ret = LL_OK;
+    uint16_t u16Cmd;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+
+    if ((DACx->DACR & DAC_DACR_DAE) != 0U) {
+        i32Ret = LL_ERR_INVD_MD;
+    } else {
+        u16Cmd = (uint16_t)(1UL << (DAC_DACR_DA1E_POS + u16Ch));
+        CLR_REG16_BIT(DACx->DACR, u16Cmd);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Start DAC channel 1 and channel 2
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @retval None
+ */
+void DAC_StartDualCh(CM_DAC_TypeDef *DACx)
+{
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+
+    SET_REG16_BIT(DACx->DACR, DAC_DACR_DAE);
+}
+
+/**
+ * @brief  Stop DAC channel 1 and channel 2
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @retval None
+ */
+void DAC_StopDualCh(CM_DAC_TypeDef *DACx)
+{
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+
+    CLR_REG16_BIT(DACx->DACR, DAC_DACR_DAE);
+}
+
+/**
+ * @brief  Set the specified data to the data holding register of specified DAC channel
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch  Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @param  [in] u16Data   Data to be loaded into data holding register of specified channel
+ * @retval None
+ */
+void DAC_SetChData(CM_DAC_TypeDef *DACx, uint16_t u16Ch, uint16_t u16Data)
+{
+    __IO uint16_t *u16DADRx;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+
+    if (READ_REG16_BIT(DACx->DACR, DAC_DACR_DPSEL) == DAC_DATA_ALIGN_LEFT) {
+        DDL_ASSERT(IS_DAC_LEFT_ALIGNED_DATA(u16Data));
+    } else {
+        DDL_ASSERT(IS_DAC_RIGHT_ALIGNED_DATA(u16Data));
+    }
+
+    u16DADRx = (uint16_t *)((uint32_t) & (DACx->DADR1) + u16Ch * 2UL);
+    WRITE_REG16(*u16DADRx, u16Data);
+}
+
+/**
+ * @brief  Set the specified data to the data holding register of DAC channel 1 and channel 2
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  u16Data1:    Data to be loaded into data holding register of channel 1
+ * @param  u16Data2:    Data to be loaded into data holding register of channel 2
+ * @retval None
+ */
+void DAC_SetDualChData(CM_DAC_TypeDef *DACx, uint16_t u16Data1, uint16_t u16Data2)
+{
+    uint32_t u32Data;
+    __IO uint32_t *u32DADRx;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+
+    if (READ_REG16_BIT(DACx->DACR, DAC_DACR_DPSEL) == DAC_DATA_ALIGN_LEFT) {
+        DDL_ASSERT(IS_DAC_LEFT_ALIGNED_DATA(u16Data1));
+        DDL_ASSERT(IS_DAC_LEFT_ALIGNED_DATA(u16Data2));
+    } else {
+        DDL_ASSERT(IS_DAC_RIGHT_ALIGNED_DATA(u16Data1));
+        DDL_ASSERT(IS_DAC_RIGHT_ALIGNED_DATA(u16Data2));
+    }
+
+    u32Data = ((uint32_t)u16Data2 << 16U) | u16Data1;
+    u32DADRx = (__IO uint32_t *)(uint32_t)(&DACx->DADR1);
+    WRITE_REG32(*u32DADRx, u32Data);
+}
+
+/**
+ * @brief  Get convert status of specified channel in ADC priority mode
+ * @param  [in] DACx   Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch  Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @retval int32_t:
+ *         - LL_ERR_INVD_MD: Could not get convert status when adc priority is not enabled
+ *         - LL_OK: Data convert completed
+ *         - LL_ERR_BUSY: Data convert is ongoing
+ */
+int32_t DAC_GetChConvertState(const CM_DAC_TypeDef *DACx, uint16_t u16Ch)
+{
+    int32_t i32Ret = LL_ERR_INVD_MD;
+
+    DDL_ASSERT(IS_DAC_UNIT(DACx));
+    DDL_ASSERT(IS_DAC_CH(u16Ch));
+
+    if (0U != READ_REG16_BIT(DACx->DAADPCR, DAC_DAADPCR_ADPEN)) {
+        i32Ret = LL_ERR_BUSY;
+
+        if (READ_REG16_BIT(DACx->DAADPCR, (DAC_DAADPCR_DA1SF << u16Ch)) == 0U) {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each pstcDacInit member with its default value
+ * @param  [in] pstcDacInit   pointer to a stc_dac_init_t structure which will
+ *         be initialized.
+ * @retval int32_t:
+ *         - LL_OK: No errors occurred.
+ *         - LL_ERR_INVD_PARAM: pstcDacInit is NULL
+ */
+int32_t DAC_StructInit(stc_dac_init_t *pstcDacInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcDacInit != NULL) {
+        pstcDacInit->u16Src = DAC_DATA_SRC_DATAREG;
+        pstcDacInit->u16Align = DAC_DATA_ALIGN_RIGHT;
+        pstcDacInit->enOutput = ENABLE;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize the DAC peripheral according to the specified parameters
+ *         in the stc_dac_init_t
+ * @param  [in] DACx       Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @param  [in] u16Ch  Specify DAC channel @ref DAC_CH.
+ *         This parameter can be a value of the following:
+ *         @arg DAC_CH1
+ *         @arg DAC_CH2
+ * @param  [in] pstcDacInit   pointer to a stc_dac_init_t structure that contains
+ *         the configuration information for the specified DAC channel.
+ * @retval int32_t:
+ *         - LL_OK: Initialize successfully
+ *         - LL_ERR_INVD_PARAM: pstcDacInit is NULL
+ */
+int32_t DAC_Init(CM_DAC_TypeDef *DACx, uint16_t u16Ch, const stc_dac_init_t *pstcDacInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcDacInit != NULL) {
+        DDL_ASSERT(IS_DAC_UNIT(DACx));
+        DDL_ASSERT(IS_DAC_CH(u16Ch));
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(pstcDacInit->enOutput));
+        DDL_ASSERT(IS_DAC_DATA_SRC(pstcDacInit->u16Src));
+        DAC_SetDataSrc(DACx, u16Ch, pstcDacInit->u16Src);
+        DDL_ASSERT(IS_DAC_DATA_ALIGN(pstcDacInit->u16Align));
+
+        MODIFY_REG16(DACx->DACR, DAC_DACR_DPSEL, pstcDacInit->u16Align);
+        DAC_OutputCmd(DACx, u16Ch, pstcDacInit->enOutput);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Deinitialize the DAC peripheral registers to their default reset values
+ * @param  [in] DACx       Pointer to the DAC peripheral register.
+ *         This parameter can be a value of the following:
+ *         @arg CM_DAC or CM_DACx
+ * @retval int32_t:
+ *           - LL_OK:               Reset success.
+ * @retval None
+ */
+int32_t DAC_DeInit(CM_DAC_TypeDef *DACx)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *u32DADRx;
+    WRITE_REG16(DACx->DACR, 0x0000UL);
+    WRITE_REG16(DACx->DAOCR, 0x0000UL);
+    WRITE_REG16(DACx->DAADPCR, 0x0000UL);
+    u32DADRx = (__IO uint32_t *)(uint32_t)(&DACx->DADR1);
+    WRITE_REG32(*u32DADRx, 0x0000UL);
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_DAC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dbgc.c
+++ b/hc32f4a2/src/hc32_ll_dbgc.c
@@ -1,0 +1,174 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dbgc.c
+ * @brief This file provides firmware functions to manage the DBGC.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2023-09-30       CDT             First version
+   2024-06-30       CDT             Delete redundancies API and Correct DBGC spell
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dbgc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_DBGC DBGC
+ * @brief DBGC Driver Library
+ * @{
+ */
+
+#if (LL_DBGC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/**
+ * @defgroup DBGC_Local_Macros DBGC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup DBGC_Check_Parameters_Validity DBGC Check Parameters Validity
+ * @{
+ */
+#define IS_SECURITY_FLAG(x)                                                    \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | DBGC_SECURITY_ALL) == DBGC_SECURITY_ALL))
+
+/* Parameter valid check for debug trace mode */
+#define IS_DBGC_TRACE_MD(x)                                                    \
+(   ((x) == DBGC_TRACE_ASYNC)                       ||                         \
+    ((x) == DBGC_TRACE_SYNC_1BIT)                   ||                         \
+    ((x) == DBGC_TRACE_SYNC_2BIT)                   ||                         \
+    ((x) == DBGC_TRACE_SYNC_4BIT))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup DBGC_Global_Functions DBGC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Whether to stop the peripheral while mcu core stop.
+ * @param  [in] u32Periph Specifies the peripheral. @ref DBGC_Periph_Sel
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DBGC_PeriphCmd(uint32_t u32Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_DBGC->MCUSTPCTL, u32Periph);
+    } else {
+        SET_REG32_BIT(CM_DBGC->MCUSTPCTL, u32Periph);
+    }
+}
+
+/**
+ * @brief  Whether to stop the peripheral2 while mcu core stop.
+ * @param  [in] u32Periph Specifies the peripheral. @ref DBGC_Periph2_Sel
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DBGC_Periph2Cmd(uint32_t u32Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_DBGC->MCUSTPCTL2, u32Periph);
+    } else {
+        SET_REG32_BIT(CM_DBGC->MCUSTPCTL2, u32Periph);
+    }
+}
+
+/**
+ * @brief  Enable or disable the trace pin output.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DBGC_TraceIoCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_DBGC->MCUTRACECTL, DBGC_MCUTRACECTL_TRACEIOEN);
+    } else {
+        CLR_REG32_BIT(CM_DBGC->MCUTRACECTL, DBGC_MCUTRACECTL_TRACEIOEN);
+    }
+}
+
+/**
+ * @brief  Config trace mode.
+ * @param  [in] u32TraceMode Specifies the trace mode. @ref DBGC_Trace_Mode
+ * @retval None
+ */
+void DBGC_TraceModeConfig(uint32_t u32TraceMode)
+{
+    DDL_ASSERT(IS_DBGC_TRACE_MD(u32TraceMode));
+
+    MODIFY_REG32(CM_DBGC->MCUTRACECTL, DBGC_MCUTRACECTL_TRACEMODE, u32TraceMode);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_DBGC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dcu.c
+++ b/hc32f4a2/src/hc32_ll_dcu.c
@@ -1,0 +1,606 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dcu.c
+ * @brief This file provides firmware functions to manage the DCU(Data Computing
+ *        Unit).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Synchronize register: DCU_INTSEL -> DCU_INTEVTSEL
+                                    Modify function comments: DCU_IntCmd
+   2023-06-30       CDT             Modify typo
+                                    Modify API DCU_DeInit()
+                                    Modify function DCU_IntCmd() for misra
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dcu.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_DCU DCU
+ * @brief DCU Driver Library
+ * @{
+ */
+
+#if (LL_DCU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DCU_Local_Macros DCU Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup DCU_Check_Parameters_Validity DCU Check Parameters Validity
+ * @{
+ */
+#define IS_DCU_WAVE_FUNC_UNIT(x)                                               \
+(   ((x) == CM_DCU1)                    ||                                     \
+    ((x) == CM_DCU2)                    ||                                     \
+    ((x) == CM_DCU3)                    ||                                     \
+    ((x) == CM_DCU4))
+
+#define IS_DCU_BASE_FUNC_UNIT(x)                                               \
+(   ((x) == CM_DCU5)                    ||                                     \
+    ((x) == CM_DCU6)                    ||                                     \
+    ((x) == CM_DCU7)                    ||                                     \
+    ((x) == CM_DCU8))
+
+#define IS_DCU_UNIT(x)                                                         \
+(   (IS_DCU_BASE_FUNC_UNIT(x))          ||                                     \
+    (IS_DCU_WAVE_FUNC_UNIT(x)))
+
+#define IS_DCU_BASE_FUNC_UNIT_MD(x)                                            \
+(   ((x) == DCU_MD_CMP)                 ||                                     \
+    ((x) == DCU_MD_ADD)                 ||                                     \
+    ((x) == DCU_MD_SUB)                 ||                                     \
+    ((x) == DCU_MD_HW_ADD)              ||                                     \
+    ((x) == DCU_MD_HW_SUB)              ||                                     \
+    ((x) == DCU_MD_INVD))
+
+#define IS_DCU_WAVE_FUNC_UNIT_MD(x)                                            \
+(   IS_DCU_BASE_FUNC_UNIT_MD(x)         ||                                     \
+    ((x) == DCU_MD_TRIANGLE_WAVE)       ||                                     \
+    ((x) == DCU_MD_SAWTOOTH_WAVE_DEC)   ||                                     \
+    ((x) == DCU_MD_SAWTOOTH_WAVE_INC))
+
+#define IS_DCU_BASE_FUNC_UNIT_FLAG(x)                                          \
+(   (0UL != (x))                        &&                                     \
+    (0UL == ((x) & (~DCU_BASE_FUNC_UNIT_FLAG_MASK))))
+
+#define IS_DCU_WAVE_FUNC_UNIT_FLAG(x)                                          \
+(   (0UL != (x))                        &&                                     \
+    (0UL == ((x) & (~DCU_WAVE_FUNC_UNIT_FLAG_MASK))))
+
+#define IS_DCU_CMP_COND(x)                                                     \
+(   ((x) == DCU_CMP_TRIG_DATA0)         ||                                     \
+    ((x) == DCU_CMP_TRIG_DATA0_DATA1_DATA2))
+
+#define IS_DCU_DATA_WIDTH(x)                                                   \
+(   ((x) == DCU_DATA_WIDTH_8BIT)        ||                                     \
+    ((x) == DCU_DATA_WIDTH_16BIT)       ||                                     \
+    ((x) == DCU_DATA_WIDTH_32BIT))
+
+#define IS_DCU_INT_CATEGORY(x)                                                 \
+(   ((x) == DCU_CATEGORY_OP)            ||                                     \
+    ((x) == DCU_CATEGORY_CMP_WIN)       ||                                     \
+    ((x) == DCU_CATEGORY_CMP_NON_WIN)   ||                                     \
+    ((x) == DCU_CATEGORY_WAVE))
+
+#define IS_DCU_INT_OP(x)                ((x) == DCU_INT_OP_CARRY)
+
+#define IS_DCU_INT_CMP_WIN(x)                                                  \
+(   ((x) == DCU_INT_CMP_WIN_INSIDE)     ||                                     \
+    ((x) == DCU_INT_CMP_WIN_OUTSIDE))
+
+#define IS_DCU_INT_CMP_NON_WIN(x)                                              \
+(   ((x) != 0UL)                        ||                                     \
+    (((x) | DCU_INT_CMP_NON_WIN_ALL) == DCU_INT_CMP_NON_WIN_ALL))
+
+#define IS_DCU_INT_WAVE_MD(x)                                                  \
+(   ((x) != 0UL)                        &&                                     \
+    (((x) | DCU_INT_WAVE_MD_ALL) == DCU_INT_WAVE_MD_ALL))
+
+#define IS_DCU_DATA_REG(x)                                                     \
+(   ((x) == DCU_DATA0_IDX)              ||                                     \
+    ((x) == DCU_DATA1_IDX)              ||                                     \
+    ((x) == DCU_DATA2_IDX))
+
+#define IS_DCU_WAVE_UPPER_LIMIT(x)      ((x) <= 0xFFFUL)
+
+#define IS_DCU_WAVE_LOWER_LIMIT(x)      ((x) <= 0xFFFUL)
+
+#define IS_DCU_WAVE_STEP(x)             ((x) <= 0xFFFUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Flag_Mask DCU Flag Mask
+ * @{
+ */
+#define DCU_BASE_FUNC_UNIT_FLAG_MASK    (0x0E7FUL)
+#define DCU_WAVE_FUNC_UNIT_FLAG_MASK    (DCU_BASE_FUNC_UNIT_FLAG_MASK | 0x0E00UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_DATA1_Limit_Position DCU_DATA1 Limit Position
+ * @{
+ */
+#define DCU_DATA1_LOWER_LIMIT_POS       (0UL)
+#define DCU_DATA1_UPPER_LIMIT_POS       (16UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DCU_Register_Address DCU Register Address
+ * @{
+ */
+#define DCU_REG_ADDR(_REG_)                 ((uint32_t)(&(_REG_)))
+#define DCU_DATA_REG_ADDR(_UNITx_, _IDX_)   (DCU_REG_ADDR((_UNITx_)->DATA0) + ((_IDX_) << 2UL))
+
+#define DCU_DATA_REG8(_UNITx_, _IDX_)       (*(__IO uint8_t *)DCU_DATA_REG_ADDR(_UNITx_, _IDX_))
+#define DCU_DATA_REG16(_UNITx_, _IDX_)      (*(__IO uint16_t *)DCU_DATA_REG_ADDR(_UNITx_, _IDX_))
+#define DCU_DATA_REG32(_UNITx_, _IDX_)      (*(__IO uint32_t *)DCU_DATA_REG_ADDR(_UNITx_, _IDX_))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup DCU_Global_Functions DCU Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_dcu_init_t to default values.
+ * @param  [out] pstcDcuInit            Pointer to a @ref stc_dcu_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDcuInit value is NULL.
+ */
+int32_t DCU_StructInit(stc_dcu_init_t *pstcDcuInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDcuInit) {
+        pstcDcuInit->u32Mode = DCU_MD_INVD;
+        pstcDcuInit->u32DataWidth = DCU_DATA_WIDTH_8BIT;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DCU function.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] pstcDcuInit             Pointer to a @ref stc_dcu_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDcuInit value is NULL.
+ */
+int32_t DCU_Init(CM_DCU_TypeDef *DCUx, const stc_dcu_init_t *pstcDcuInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDcuInit) {
+        DDL_ASSERT((IS_DCU_WAVE_FUNC_UNIT(DCUx) && IS_DCU_WAVE_FUNC_UNIT_MD(pstcDcuInit->u32Mode)) || \
+                   (IS_DCU_BASE_FUNC_UNIT(DCUx) && IS_DCU_BASE_FUNC_UNIT_MD(pstcDcuInit->u32Mode)));
+        DDL_ASSERT(IS_DCU_DATA_WIDTH(pstcDcuInit->u32DataWidth));
+
+        /* Set register: CTL */
+        WRITE_REG32(DCUx->CTL, (pstcDcuInit->u32Mode | pstcDcuInit->u32DataWidth));
+
+        /* Disable interrupt */
+        WRITE_REG32(DCUx->INTEVTSEL, 0x00000000UL);
+
+        /* Clear Flag */
+        WRITE_REG32(DCUx->FLAGCLR, 0x0000007FUL);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize DCU function.
+ * @param [in] DCUx                     Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t DCU_DeInit(CM_DCU_TypeDef *DCUx)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+
+    /* Configures the registers to reset value. */
+    WRITE_REG32(DCUx->CTL, 0x00000000UL);
+    WRITE_REG32(DCUx->INTEVTSEL, 0x00000000UL);
+
+    /* Clear Flag */
+    WRITE_REG32(DCUx->FLAGCLR, 0x0000007FUL);
+    return LL_OK;
+}
+
+/**
+ * @brief  Initialize DCU function.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] pstcWaveConfig          Pointer to a @ref stc_dcu_wave_config_t structure (DCU wave function configuration data structure).
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcWaveConfig value is NULL.
+ */
+int32_t DCU_WaveConfig(CM_DCU_TypeDef *DCUx, const stc_dcu_wave_config_t *pstcWaveConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcWaveConfig) {
+        DDL_ASSERT(IS_DCU_WAVE_FUNC_UNIT(DCUx));
+        DDL_ASSERT(IS_DCU_WAVE_LOWER_LIMIT(pstcWaveConfig->u32LowerLimit));
+        DDL_ASSERT(IS_DCU_WAVE_UPPER_LIMIT(pstcWaveConfig->u32UpperLimit));
+        DDL_ASSERT(IS_DCU_WAVE_STEP(pstcWaveConfig->u32Step));
+
+        WRITE_REG32(DCUx->DATA0, 0x00000000UL);
+        WRITE_REG32(DCUx->DATA1, ((pstcWaveConfig->u32LowerLimit << DCU_DATA1_LOWER_LIMIT_POS) | \
+                                  (pstcWaveConfig->u32UpperLimit << DCU_DATA1_UPPER_LIMIT_POS)));
+        WRITE_REG32(DCUx->DATA2, pstcWaveConfig->u32Step);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DCU operation mode.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32Mode                 DCU mode
+ *         This parameter can be one of the macros group @ref DCU_Mode.
+ * @retval None
+ */
+void DCU_SetMode(CM_DCU_TypeDef *DCUx, uint32_t u32Mode)
+{
+    DDL_ASSERT((IS_DCU_WAVE_FUNC_UNIT(DCUx) && IS_DCU_WAVE_FUNC_UNIT_MD(u32Mode)) || \
+               (IS_DCU_BASE_FUNC_UNIT(DCUx) && IS_DCU_BASE_FUNC_UNIT_MD(u32Mode)));
+
+    MODIFY_REG32(DCUx->CTL, DCU_CTL_MODE, u32Mode);
+}
+
+/**
+ * @brief  Set DCU data size.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataWidth            DCU data width
+ *         This parameter can be one of the macros group @ref DCU_Data_Width
+ *           @arg DCU_DATA_WIDTH_8BIT:  DCU data size 8 bit
+ *           @arg DCU_DATA_WIDTH_16BIT: DCU data size 16 bit
+ *           @arg DCU_DATA_WIDTH_32BIT: DCU data size 32 bit
+ * @retval None
+ */
+void DCU_SetDataWidth(CM_DCU_TypeDef *DCUx, uint32_t u32DataWidth)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_WIDTH(u32DataWidth));
+
+    MODIFY_REG32(DCUx->CTL, DCU_CTL_DATASIZE, u32DataWidth);
+}
+
+/**
+ * @brief  Set DCU compare trigger condition.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32Cond                 DCU compare trigger condition
+ *         This parameter can be one of the macros group @ref DCU_Compare_Trigger_Condition
+ *           @arg DCU_CMP_TRIG_DATA0:               DCU compare triggered by DATA0.
+ *           @arg DCU_CMP_TRIG_DATA0_DATA1_DATA2:   DCU compare triggered by DATA0 or DATA1 or DATA2.
+ * @retval None
+ */
+void DCU_SetCompareCond(CM_DCU_TypeDef *DCUx, uint32_t u32Cond)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_CMP_COND(u32Cond));
+
+    MODIFY_REG32(DCUx->CTL, DCU_CTL_COMPTRG, u32Cond);
+}
+
+/**
+ * @brief  Get DCU flag.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32Flag                 The specified DCU flag
+ *         This parameter can be any composed value of the macros group @ref DCU_Flag.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t DCU_GetStatus(const CM_DCU_TypeDef *DCUx, uint32_t u32Flag)
+{
+    DDL_ASSERT((IS_DCU_WAVE_FUNC_UNIT(DCUx) && IS_DCU_WAVE_FUNC_UNIT_FLAG(u32Flag)) || \
+               (IS_DCU_BASE_FUNC_UNIT(DCUx) && IS_DCU_BASE_FUNC_UNIT_FLAG(u32Flag)));
+
+    return (0UL == READ_REG32_BIT(DCUx->FLAG, u32Flag)) ? RESET : SET;
+}
+
+/**
+ * @brief  Clear DCU flag.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32Flag                 The specified DCU flag
+ *         This parameter can be any composed value of the macros group @ref DCU_Mode.
+ * @retval None
+ */
+void DCU_ClearStatus(CM_DCU_TypeDef *DCUx, uint32_t u32Flag)
+{
+    DDL_ASSERT((IS_DCU_WAVE_FUNC_UNIT(DCUx) && IS_DCU_WAVE_FUNC_UNIT_FLAG(u32Flag)) || \
+               (IS_DCU_BASE_FUNC_UNIT(DCUx) && IS_DCU_BASE_FUNC_UNIT_FLAG(u32Flag)));
+
+    WRITE_REG32(DCUx->FLAGCLR, u32Flag);
+}
+
+/**
+ * @brief  Enable or disable DCU interrupt function.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx: DCU instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DCU_GlobalIntCmd(CM_DCU_TypeDef *DCUx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(DCUx->CTL, DCU_CTL_INTEN);
+    } else {
+        CLR_REG32_BIT(DCUx->CTL, DCU_CTL_INTEN);
+    }
+}
+
+/**
+ * @brief  Enable/disable DCU the specified interrupt source.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32IntCategory          DCU interrupt category
+ *         This parameter can be one of the macros group @ref DCU_Category.
+ * @param  [in] u32IntType              DCU interrupt type
+ *         This parameter can be one of the macros group @ref DCU_Interrupt_Type.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DCU_IntCmd(CM_DCU_TypeDef *DCUx, uint32_t u32IntCategory, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint32_t u32Type;
+
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_INT_CATEGORY(u32IntCategory));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DCU_CATEGORY_OP == u32IntCategory) {
+        DDL_ASSERT(IS_DCU_INT_OP(u32IntType));
+        u32Type = (u32IntType & DCU_INT_OP_CARRY);
+    } else if (DCU_CATEGORY_CMP_WIN == u32IntCategory) {
+        DDL_ASSERT(IS_DCU_INT_CMP_WIN(u32IntType));
+        u32Type = (u32IntType & DCU_INT_CMP_WIN_ALL);
+    } else if (DCU_CATEGORY_WAVE == u32IntCategory) {
+        DDL_ASSERT(IS_DCU_WAVE_FUNC_UNIT(DCUx));
+        DDL_ASSERT(IS_DCU_INT_WAVE_MD(u32IntType));
+        u32Type = (u32IntType & DCU_INT_WAVE_MD_ALL);
+    } else {
+        DDL_ASSERT(IS_DCU_INT_CMP_NON_WIN(u32IntType));
+        u32Type = (u32IntType & DCU_INT_CMP_NON_WIN_ALL);
+    }
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(DCUx->INTEVTSEL, u32Type);
+    } else {
+        CLR_REG32_BIT(DCUx->INTEVTSEL, u32Type);
+    }
+}
+
+/**
+ * @brief  Read DCU register DATA for byte.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @retval DCU register DATA value for byte
+ */
+uint8_t DCU_ReadData8(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    return READ_REG8(DCU_DATA_REG8(DCUx, u32DataIndex));
+}
+
+/**
+ * @brief  Write DCU register DATA for byte.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @param  [in] u8Data                  The data to write.
+ * @retval None
+ */
+void DCU_WriteData8(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint8_t u8Data)
+{
+    __IO uint8_t *DATA;
+
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    DATA = &DCU_DATA_REG8(DCUx, u32DataIndex);
+    WRITE_REG8(*DATA, u8Data);
+}
+
+/**
+ * @brief  Read DCU register DATA for half-word.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @retval DCU register DATA value for half-word
+ */
+uint16_t DCU_ReadData16(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    return READ_REG16(DCU_DATA_REG16(DCUx, u32DataIndex));
+}
+
+/**
+ * @brief  Write DCU register DATA for half-word.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @param  [in] u16Data                 The data to write.
+ * @retval None
+ */
+void DCU_WriteData16(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint16_t u16Data)
+{
+    __IO uint16_t *DATA;
+
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    DATA = &DCU_DATA_REG16(DCUx, u32DataIndex);
+    WRITE_REG16(*DATA, u16Data);
+}
+
+/**
+ * @brief  Read DCU register DATA for word.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @retval DCU register DATA value for word
+ */
+uint32_t DCU_ReadData32(const CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex)
+{
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    return READ_REG32(DCU_DATA_REG32(DCUx, u32DataIndex));
+}
+
+/**
+ * @brief  Write DCU register DATA0 for word.
+ * @param  [in] DCUx                    Pointer to DCU instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_DCU or CM_DCUx:    DCU instance register base
+ * @param  [in] u32DataIndex            DCU data register index
+ *         This parameter can be one of the macros group @ref DCU_Data_Register_Index
+ *           @arg DCU_DATA0_IDX:        DCU DATA0
+ *           @arg DCU_DATA1_IDX:        DCU DATA1
+ *           @arg DCU_DATA2_IDX:        DCU DATA2
+ * @param  [in] u32Data                 The data to write.
+ * @retval None
+ */
+void DCU_WriteData32(CM_DCU_TypeDef *DCUx, uint32_t u32DataIndex, uint32_t u32Data)
+{
+    __IO uint32_t *DATA;
+
+    DDL_ASSERT(IS_DCU_UNIT(DCUx));
+    DDL_ASSERT(IS_DCU_DATA_REG(u32DataIndex));
+
+    DATA = &DCU_DATA_REG32(DCUx, u32DataIndex);
+    WRITE_REG32(*DATA, u32Data);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_DCU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dma.c
+++ b/hc32f4a2/src/hc32_ll_dma.c
@@ -1,0 +1,1369 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dma.c
+ * @brief This file provides firmware functions to manage the Direct Memory
+ *        Access (DMA).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify DMA_StructInit() default value
+   2023-01-15       CDT             Modify API DMA_DeInit and add LLP address assert
+   2023-06-30       CDT             Modify typo
+                                    Modify blocksize assert, 1024U is valid
+                                    Add API DMA_SetDataWidth()
+                                    Optimize set blocksize & repeat count process
+   2023-12-15       CDT             Add DMA Repeat size assert
+                                    Modify API input param type:u16->u32
+                                    Use macros replace immediate data, modify IS_DMA_NON_SEQ_TRANS_CNT
+                                    Add API DMA_ReconfigNonSeqStructInit() & DMA_ReconfigNonSeqInit()
+   2024-06-30       CDT             Optimize DMA_ClearErrStatus() & DMA_ClearTransCompleteStatus()
+   2024-08-31       CDT             Add assert IS_DMA_DATA_WIDTH_ADDR
+   2024-11-08       CDT             Add API DMA_MxChSWTrigger() & DMA_SWReconfig()
+                                    Add API DMA_AHB_HProtBufCacheCmd()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dma.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_DMA DMA
+ * @brief Direct Memory Access Driver Library
+ * @{
+ */
+
+#if (LL_DMA_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DMA_Local_Macros DMA Local Macros
+ * @{
+ */
+#define DMA_CH_REG(reg_base, ch)        (*(__IO uint32_t *)((uint32_t)(&(reg_base)) + ((ch) * 0x40UL)))
+
+#define DMA_SW_TRIGGER_UNLOCK           (0xA1UL << DMA_SWREQ_SWREQWP_POS)
+#define DMA_SW_RECONFIG_UNLOCK          (0xA2UL << DMA_SWREQ_SWRCFGWP_POS)
+
+/**
+ * @defgroup DMA_Check_Parameters_Validity DMA Check Parameters Validity
+ * @{
+ */
+/* Parameter valid check for DMA unit. */
+#define IS_DMA_UNIT(x)                                                          \
+(   ((x) == CM_DMA1)                        ||                                  \
+    ((x) == CM_DMA2))
+
+/* Parameter valid check for DMA channel. */
+#define IS_DMA_CH(x)                    ((x) <= DMA_CH7)
+
+/* Parameter valid check for DMA multiplex channel. */
+#define IS_DMA_MX_CH(x)                                                         \
+(   ((x) != 0x00UL)                         &&                                  \
+    (((x) | DMA_MX_CH_ALL) == DMA_MX_CH_ALL))
+
+/* Parameter valid check for DMA block size. */
+#define IS_DMA_BLOCK_SIZE(x)            ((x) <= 1024UL)
+
+/* Parameter valid check for DMA repeat block size. */
+#define IS_DMA_REPEAT_SIZE(x)           ((x) <= 1024UL)
+#define IS_DMA_RC_REPEAT_SIZE(x)        (((x) > 0UL) && ((x) < 1024UL))
+
+/* Parameter valid check for DMA non-sequence transfer count. */
+#define IS_DMA_NON_SEQ_TRANS_CNT(x)     ((x) <= 4096U)
+#define IS_DMA_RC_NON_SEQ_TRANS_CNT(x)  (((x) > 0U) && ((x) < 4096U))
+
+/* Parameter valid check for DMA non-sequence offset. */
+#define IS_DMA_NON_SEQ_OFFSET(x)        ((x) <= DMA_SNSEQCTL_SOFFSET)
+#define IS_DMA_RC_NON_SEQ_DIST(x)       ((x) <= DMA_SNSEQCTLB_SNSDIST)
+
+/* Parameter valid check for DMA LLP function. */
+#define IS_DMA_LLP_EN(x)                                                        \
+(   ((x) == DMA_LLP_ENABLE)                 ||                                  \
+    ((x) == DMA_LLP_DISABLE))
+
+/* Parameter valid check for DMA linked-list-pointer mode. */
+#define IS_DMA_LLP_MD(x)                                                        \
+(   ((x) == DMA_LLP_RUN)                    ||                                  \
+    ((x) == DMA_LLP_WAIT))
+
+/* Parameter valid check for address alignment of DMA linked-list-pointer descriptor  */
+#define IS_DMA_LLP_ADDR_ALIGN(x)        IS_ADDR_ALIGN_WORD(x)
+
+/* Parameter valid check for DMA error flag. */
+#define IS_DMA_ERR_FLAG(x)                                                      \
+(   ((x)!= 0x00000000UL)                    &&                                  \
+    (((x)| DMA_FLAG_ERR_MASK) == DMA_FLAG_ERR_MASK))
+
+/* Parameter valid check for DMA transfer flag. */
+#define IS_DMA_TRANS_FLAG(x)                                                    \
+(   ((x)!= 0x00000000UL)                    &&                                  \
+    (((x)| DMA_FLAG_TRANS_MASK) == DMA_FLAG_TRANS_MASK))
+
+/* Parameter valid check for DMA error interrupt. */
+#define IS_DMA_ERR_INT(x)                                                       \
+(   ((x)!= 0x00000000UL)                    &&                                  \
+    (((x)| DMA_INT_ERR_MASK) == DMA_INT_ERR_MASK))
+
+/* Parameter valid check for DMA transfer interrupt. */
+#define IS_DMA_TRANS_INT(x)                                                     \
+(   ((x)!= 0x00000000UL)                    &&                                  \
+    (((x)| DMA_INT_TRANS_MASK) == DMA_INT_TRANS_MASK))
+
+/* Parameter valid check for DMA request status. */
+#define IS_DMA_REQ_STAT(x)                                                      \
+(   ((x) != 0x00000000UL)                   &&                                  \
+    (((x) | DMA_STAT_REQ_MASK) == DMA_STAT_REQ_MASK))
+
+/* Parameter valid check for DMA transfer status. */
+#define IS_DMA_TRANS_STAT(x)                                                    \
+(   ((x) != 0x00000000UL)                   &&                                  \
+    (((x) | DMA_STAT_TRANS_MASK) == DMA_STAT_TRANS_MASK))
+
+/* Parameter valid check for DMA transfer data width. */
+#define IS_DMA_DATA_WIDTH(x)                                                    \
+(   ((x) == DMA_DATAWIDTH_8BIT)             ||                                  \
+    ((x) == DMA_DATAWIDTH_16BIT)            ||                                  \
+    ((x) == DMA_DATAWIDTH_32BIT))
+
+/* Parameter valid check for DMA transfer data width and addr. */
+#define IS_DMA_DATA_WIDTH_ADDR(width, addr)                                     \
+(   ((width) == DMA_DATAWIDTH_8BIT)                                      ||     \
+    (((width) == DMA_DATAWIDTH_16BIT) && (IS_ADDR_ALIGN_HALFWORD(addr))) ||     \
+    (((width) == DMA_DATAWIDTH_32BIT) && (IS_ADDR_ALIGN_WORD(addr))))
+
+/* Parameter valid check for DMA source address mode. */
+#define IS_DMA_SADDR_MD(x)                                                      \
+(   ((x) == DMA_SRC_ADDR_FIX)               ||                                  \
+    ((x) == DMA_SRC_ADDR_INC)               ||                                  \
+    ((x) == DMA_SRC_ADDR_DEC))
+
+/* Parameter valid check for DMA destination address mode. */
+#define IS_DMA_DADDR_MD(x)                                                      \
+(   ((x) == DMA_DEST_ADDR_FIX)              ||                                  \
+    ((x) == DMA_DEST_ADDR_INC)              ||                                  \
+    ((x) == DMA_DEST_ADDR_DEC))
+
+/* Parameter valid check for DMA repeat mode. */
+#define IS_DMA_RPT_MD(x)                                                        \
+(   ((x) == DMA_RPT_NONE)                   ||                                  \
+    ((x) == DMA_RPT_SRC)                    ||                                  \
+    ((x) == DMA_RPT_DEST)                   ||                                  \
+    ((x) == DMA_RPT_BOTH))
+
+/* Parameter valid check for DMA non_sequence mode. */
+#define IS_DMA_NON_SEQ_MD(x)                                                    \
+(   ((x) == DMA_NON_SEQ_NONE)               ||                                  \
+    ((x) == DMA_NON_SEQ_SRC)                ||                                  \
+    ((x) == DMA_NON_SEQ_DEST)               ||                                  \
+    ((x) == DMA_NON_SEQ_BOTH))
+
+/* Parameter valid check for DMA global interrupt function. */
+#define IS_DMA_INT_FUNC(x)                                                      \
+(   ((x) == DMA_INT_ENABLE)                 ||                                  \
+    ((x) == DMA_INT_DISABLE))
+
+/* Parameter valid check for DMA reconfig count mode. */
+#define IS_DMA_RC_CNT_MD(x)                                                     \
+(   ((x) == DMA_RC_CNT_KEEP)                ||                                  \
+    ((x) == DMA_RC_CNT_SRC)                 ||                                  \
+    ((x) == DMA_RC_CNT_DEST))
+
+/* Parameter valid check for DMA reconfig destination address mode. */
+#define IS_DMA_RC_DA_MD(x)                                                      \
+(   ((x) == DMA_RC_DEST_ADDR_KEEP)          ||                                  \
+    ((x) == DMA_RC_DEST_ADDR_NS)            ||                                  \
+    ((x) == DMA_RC_DEST_ADDR_RPT))
+
+/* Parameter valid check for DMA reconfig source address mode. */
+#define IS_DMA_RC_SA_MD(x)                                                      \
+(   ((x) == DMA_RC_SRC_ADDR_KEEP)           ||                                  \
+    ((x) == DMA_RC_SRC_ADDR_NS)             ||                                  \
+    ((x) == DMA_RC_SRC_ADDR_RPT))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup DMA_Global_Functions DMA Global Functions
+ * @{
+ */
+
+/**
+ * @brief  DMA global function config.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_Cmd(CM_DMA_TypeDef *DMAx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Global setting, ENABLE or DISABLE DMA */
+    WRITE_REG32(DMAx->EN, enNewState);
+}
+
+/**
+ * @brief  DMA error IRQ function config.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32ErrInt DMA error IRQ flag.  @ref DMA_Int_Request_Err_Sel, @ref DMA_Int_Trans_Err_Sel
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_ErrIntCmd(CM_DMA_TypeDef *DMAx, uint32_t u32ErrInt, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_ERR_INT(u32ErrInt));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE == enNewState) {
+        SET_REG32_BIT(DMAx->INTMASK0, u32ErrInt);
+    } else {
+        CLR_REG32_BIT(DMAx->INTMASK0, u32ErrInt);
+    }
+}
+
+/**
+ * @brief  Get DMA error flag.
+ * @param  [in] DMAx        DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Flag     DMA error IRQ flag.  @ref DMA_Flag_Trans_Err_Sel, @ref DMA_Flag_Request_Err_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ * @note   Include transfer error flag & request error flag
+ */
+en_flag_status_t DMA_GetErrStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_ERR_FLAG(u32Flag));
+
+    return (0U != READ_REG32_BIT(DMAx->INTSTAT0, u32Flag) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear DMA error flag.
+ * @param  [in] DMAx        DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Flag     DMA error IRQ flag. @ref DMA_Flag_Trans_Err_Sel, @ref DMA_Flag_Request_Err_Sel
+ * @retval None
+ * @note   Include transfer error flag & request error flag
+ */
+void DMA_ClearErrStatus(CM_DMA_TypeDef *DMAx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_ERR_FLAG(u32Flag));
+
+    WRITE_REG32(DMAx->INTCLR0, u32Flag);
+}
+
+/**
+ * @brief  DMA transfer IRQ function config.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32TransCompleteInt DMA transfer complete IRQ flag. @ref DMA_Int_Btc_Sel, @ref DMA_Int_Tc_Sel
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_TransCompleteIntCmd(CM_DMA_TypeDef *DMAx, uint32_t u32TransCompleteInt, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_TRANS_INT(u32TransCompleteInt));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE == enNewState) {
+        SET_REG32_BIT(DMAx->INTMASK1, u32TransCompleteInt);
+    } else {
+        CLR_REG32_BIT(DMAx->INTMASK1, u32TransCompleteInt);
+    }
+}
+
+/**
+ * @brief  Get DMA transfer flag.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Flag DMA transfer IRQ flag. @ref DMA_Flag_Btc_Sel, @ref DMA_Flag_Tc_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ * @note   Include transfer complete flag & block transfer complete flag
+ */
+en_flag_status_t DMA_GetTransCompleteStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DMA_TRANS_FLAG(u32Flag));
+    return ((0U != READ_REG32_BIT(DMAx->INTSTAT1, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear DMA transfer flag.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Flag DMA transfer complete flag.  @ref DMA_Flag_Btc_Sel, @ref DMA_Flag_Tc_Sel
+ * @retval None
+ * @note   Include transfer complete flag & block transfer complete flag
+ */
+void DMA_ClearTransCompleteStatus(CM_DMA_TypeDef *DMAx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_TRANS_FLAG(u32Flag));
+
+    WRITE_REG32(DMAx->INTCLR1, u32Flag);
+}
+
+/**
+ * @brief  DMA multiplex channel function config.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8MxCh DMA multiplex channel. @ref DMA_Mx_Channel_selection
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_MxChCmd(CM_DMA_TypeDef *DMAx, uint8_t u8MxCh, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_MX_CH(u8MxCh));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        WRITE_REG32(DMAx->CHEN, u8MxCh);
+    } else {
+        WRITE_REG32(DMAx->CHENCLR, u8MxCh);
+    }
+}
+
+/**
+ * @brief  DMA channel function config.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval int32_t
+ */
+int32_t DMA_ChCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        WRITE_REG32(DMAx->CHEN, ((1UL << u8Ch) & DMA_CHEN_CHEN));
+    } else {
+        WRITE_REG32(DMAx->CHENCLR, ((1UL << u8Ch) & DMA_CHENCLR_CHENCLR));
+    }
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Get DMA transfer status.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Status DMA transfer status. @ref DMA_Trans_Status_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t DMA_GetTransStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Status)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_TRANS_STAT(u32Status));
+
+    return ((0U != READ_REG32_BIT(DMAx->CHSTAT, u32Status)) ? SET : RESET);
+}
+
+/**
+ * @brief  Get DMA request status.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u32Status DMA request status. @ref DMA_Req_Status_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t DMA_GetRequestStatus(const CM_DMA_TypeDef *DMAx, uint32_t u32Status)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_REQ_STAT(u32Status));
+
+    return ((0U != READ_REG32_BIT(DMAx->REQSTAT, u32Status)) ? SET : RESET);
+}
+
+/**
+ * @brief  Config DMA source address.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Addr DMA source address.
+ * @retval int32_t
+ * @note   The addr should half word align while the data width is 16bit, or word align while the data width is 32bit.
+ */
+int32_t DMA_SetSrcAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    WRITE_REG32(DMA_CH_REG(DMAx->SAR0, u8Ch), u32Addr);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA destination address.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Addr DMA destination address.
+ * @retval int32_t
+ * @note   The addr should half word align while the data width is 16bit, or word align while the data width is 32bit.
+ */
+int32_t DMA_SetDestAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    WRITE_REG32(DMA_CH_REG(DMAx->DAR0, u8Ch), u32Addr);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA transfer count.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u16Count DMA transfer count (0: infinite, 1 ~ 65535).
+ * @retval int32_t
+ */
+int32_t DMA_SetTransCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint16_t u16Count)
+{
+    __IO uint32_t *DTCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    DTCTLx = &DMA_CH_REG(DMAx->DTCTL0, u8Ch);
+    MODIFY_REG32(*DTCTLx, DMA_DTCTL_CNT, ((uint32_t)(u16Count) << DMA_DTCTL_CNT_POS));
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA block size per transfer.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u16Size DMA block size (range: 0~1024, 0 is for 1024).
+ * @retval int32_t
+ */
+int32_t DMA_SetBlockSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint16_t u16Size)
+{
+    __IO uint32_t *DTCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_BLOCK_SIZE(u16Size));
+
+    DTCTLx = &DMA_CH_REG(DMAx->DTCTL0, u8Ch);
+    MODIFY_REG32(*DTCTLx, DMA_DTCTL_BLKSIZE, u16Size);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA data width per transfer.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32DataWidth DMA data width. @ref DMA_DataWidth_Sel
+ * @retval int32_t
+ */
+int32_t DMA_SetDataWidth(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32DataWidth)
+{
+    __IO uint32_t *CHxCTL0;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_DATA_WIDTH(u32DataWidth));
+
+    CHxCTL0 = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+    MODIFY_REG32(*CHxCTL0, DMA_CHCTL_HSIZE, u32DataWidth);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA source repeat size.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Size DMA source repeat size (0, 1024: 1024, 1 ~ 1023).
+ * @retval int32_t
+ */
+int32_t DMA_SetSrcRepeatSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Size)
+{
+    __IO uint32_t *RPTx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_REPEAT_SIZE(u32Size));
+
+    RPTx = &DMA_CH_REG(DMAx->RPT0, u8Ch);
+    MODIFY_REG32(*RPTx, DMA_RPT_SRPT, (u32Size << DMA_RPT_SRPT_POS));
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA destination repeat size.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Size DMA destination repeat size (0, 1024: 1024, 1 ~ 1023).
+ * @retval int32_t
+ */
+int32_t DMA_SetDestRepeatSize(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Size)
+{
+    __IO uint32_t *RPTx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_REPEAT_SIZE(u32Size));
+
+    RPTx = &DMA_CH_REG(DMAx->RPT0, u8Ch);
+    MODIFY_REG32(*RPTx, DMA_RPT_DRPT, (u32Size << DMA_RPT_DRPT_POS));
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA source transfer count under non-sequence mode.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Count DMA source transfer count (0, 4096: 4096, 1 ~ 4095).
+ * @retval int32_t
+ */
+int32_t DMA_SetNonSeqSrcCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Count)
+{
+    __IO uint32_t *SNSEQCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_NON_SEQ_TRANS_CNT(u32Count));
+
+    SNSEQCTLx = &DMA_CH_REG(DMAx->SNSEQCTL0, u8Ch);
+    MODIFY_REG32(*SNSEQCTLx, DMA_SNSEQCTL_SNSCNT, (u32Count << DMA_SNSEQCTL_SNSCNT_POS));
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA destination transfer count under non-sequence mode.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Count DMA destination transfer count (0, 4096: 4096, 1 ~ 4095).
+ * @retval int32_t
+ */
+int32_t DMA_SetNonSeqDestCount(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Count)
+{
+    __IO uint32_t *DNSEQCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_NON_SEQ_TRANS_CNT(u32Count));
+
+    DNSEQCTLx = &DMA_CH_REG(DMAx->DNSEQCTL0, u8Ch);
+    MODIFY_REG32(*DNSEQCTLx, DMA_DNSEQCTL_DNSCNT, (u32Count << DMA_DNSEQCTL_DNSCNT_POS));
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA source offset number under non-sequence mode.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Offset DMA source offset (0 ~ 2^20 - 1).
+ * @retval int32_t
+ */
+int32_t DMA_SetNonSeqSrcOffset(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Offset)
+{
+    __IO uint32_t *SNSEQCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_NON_SEQ_OFFSET(u32Offset));
+
+    SNSEQCTLx = &DMA_CH_REG(DMAx->SNSEQCTL0, u8Ch);
+    MODIFY_REG32(*SNSEQCTLx, DMA_SNSEQCTL_SOFFSET, u32Offset);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Config DMA destination offset number under non-sequence mode.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Offset DMA destination offset (0 ~ 2^20 - 1).
+ * @retval int32_t
+ */
+int32_t DMA_SetNonSeqDestOffset(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Offset)
+{
+    __IO uint32_t *DNSEQCTLx;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_NON_SEQ_OFFSET(u32Offset));
+
+    DNSEQCTLx = &DMA_CH_REG(DMAx->DNSEQCTL0, u8Ch);
+    MODIFY_REG32(*DNSEQCTLx, DMA_DNSEQCTL_DOFFSET, u32Offset);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  De-Initialize DMA channel function.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+  * @retval None
+ */
+void DMA_DeInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    /* Disable */
+    SET_REG32_BIT(DMAx->CHENCLR, DMA_CHENCLR_CHENCLR_0 << u8Ch);
+
+    /* Set default value. */
+    WRITE_REG32(DMA_CH_REG(DMAx->SAR0, u8Ch), 0UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->DAR0, u8Ch), 0UL);
+    CLR_REG32_BIT(DMAx->INTMASK0, (DMA_INTMASK0_MSKTRNERR_0 | DMA_INTMASK0_MSKREQERR_0) << u8Ch);
+    CLR_REG32_BIT(DMAx->INTMASK1, (DMA_INTMASK1_MSKTC_0 | DMA_INTMASK1_MSKBTC_0) << u8Ch);
+    SET_REG32_BIT(DMAx->INTCLR0, (DMA_INTCLR0_CLRTRNERR_0 | DMA_INTCLR0_CLRREQERR_0) << u8Ch);
+    SET_REG32_BIT(DMAx->INTCLR1, (DMA_INTCLR1_CLRTC_0 | DMA_INTCLR1_CLRBTC_0) << u8Ch);
+
+    WRITE_REG32(DMA_CH_REG(DMAx->DTCTL0, u8Ch), 1UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->CHCTL0, u8Ch), 0x00001000UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->RPT0, u8Ch), 0UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->SNSEQCTL0, u8Ch), 0UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->DNSEQCTL0, u8Ch), 0UL);
+    WRITE_REG32(DMA_CH_REG(DMAx->LLP0, u8Ch), 0UL);
+
+}
+
+/**
+ * @brief  Initialize DMA config structure. Fill each pstcDmaInit with default value
+ * @param  [in] pstcDmaInit Pointer to a stc_dma_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *         - LL_OK: DMA structure initialize successful
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_StructInit(stc_dma_init_t *pstcDmaInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaInit->u32IntEn       = DMA_INT_DISABLE;
+        pstcDmaInit->u32SrcAddr     = 0x00UL;
+        pstcDmaInit->u32DestAddr    = 0x00UL;
+        pstcDmaInit->u32DataWidth   = DMA_DATAWIDTH_8BIT;
+        pstcDmaInit->u32BlockSize   = 0x01UL;
+        pstcDmaInit->u32TransCount  = 0x00UL;
+        pstcDmaInit->u32SrcAddrInc  = DMA_SRC_ADDR_FIX;
+        pstcDmaInit->u32DestAddrInc = DMA_DEST_ADDR_FIX;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA basic function initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaInit DMA config structure.
+ *   @arg  u32IntEn         DMA interrupt ENABLE or DISABLE.
+ *   @arg  u32SrcAddr       DMA source address.
+ *   @arg  u32DestAddr      DMA destination address.
+ *   @arg  u32DataWidth     DMA data width.
+ *   @arg  u32BlockSize     DMA block size.
+ *   @arg  u32TransCount    DMA transfer count.
+ *   @arg  u32SrcAddrInc    DMA source address direction.
+ *   @arg  u32DestAddrInc   DMA destination address direction.
+ * @retval int32_t:
+ *          - LL_OK: DMA basic function initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_Init(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_init_t *pstcDmaInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *CHCTLx;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_DATA_WIDTH_ADDR(pstcDmaInit->u32DataWidth, pstcDmaInit->u32SrcAddr));
+        DDL_ASSERT(IS_DMA_DATA_WIDTH_ADDR(pstcDmaInit->u32DataWidth, pstcDmaInit->u32DestAddr));
+        DDL_ASSERT(IS_DMA_SADDR_MD(pstcDmaInit->u32SrcAddrInc));
+        DDL_ASSERT(IS_DMA_DADDR_MD(pstcDmaInit->u32DestAddrInc));
+        DDL_ASSERT(IS_DMA_BLOCK_SIZE(pstcDmaInit->u32BlockSize));
+        DDL_ASSERT(IS_DMA_INT_FUNC(pstcDmaInit->u32IntEn));
+
+        WRITE_REG32(DMA_CH_REG(DMAx->SAR0, u8Ch), pstcDmaInit->u32SrcAddr);
+        WRITE_REG32(DMA_CH_REG(DMAx->DAR0, u8Ch), pstcDmaInit->u32DestAddr);
+
+        WRITE_REG32(DMA_CH_REG(DMAx->DTCTL0, u8Ch), ((pstcDmaInit->u32BlockSize & DMA_DTCTL_BLKSIZE) | \
+                                                     (pstcDmaInit->u32TransCount << DMA_DTCTL_CNT_POS)));
+
+        CHCTLx = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+        MODIFY_REG32(*CHCTLx, (DMA_CHCTL_SINC | DMA_CHCTL_DINC | DMA_CHCTL_HSIZE | DMA_CHCTL_IE),       \
+                     (pstcDmaInit->u32IntEn | pstcDmaInit->u32DataWidth | pstcDmaInit->u32SrcAddrInc | \
+                      pstcDmaInit->u32DestAddrInc));
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DMA repeat mode config structure.
+ *          Fill each pstcDmaInit with default value
+ * @param  [in] pstcDmaRepeatInit Pointer to a stc_dma_repeat_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA repeat mode config structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_RepeatStructInit(stc_dma_repeat_init_t *pstcDmaRepeatInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaRepeatInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaRepeatInit->u32Mode       = DMA_RPT_NONE;
+        pstcDmaRepeatInit->u32SrcCount  = 0x00UL;
+        pstcDmaRepeatInit->u32DestCount = 0x00UL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA repeat mode initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaRepeatInit DMA repeat mode config structure.
+ * @note Call this function after DMA_Init();
+ */
+int32_t DMA_RepeatInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_repeat_init_t *pstcDmaRepeatInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *CHCTLx;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaRepeatInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_RPT_MD(pstcDmaRepeatInit->u32Mode));
+        DDL_ASSERT(IS_DMA_REPEAT_SIZE(pstcDmaRepeatInit->u32DestCount));
+        DDL_ASSERT(IS_DMA_REPEAT_SIZE(pstcDmaRepeatInit->u32SrcCount));
+
+        CHCTLx = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+        MODIFY_REG32(*CHCTLx, (DMA_CHCTL_SRPTEN | DMA_CHCTL_DRPTEN), pstcDmaRepeatInit->u32Mode);
+
+        WRITE_REG32(DMA_CH_REG(DMAx->RPT0, u8Ch), \
+                    ((pstcDmaRepeatInit->u32DestCount << DMA_RPT_DRPT_POS) | pstcDmaRepeatInit->u32SrcCount) & \
+                    (DMA_RPT_DRPT | DMA_RPT_SRPT));
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DMA non-sequence mode config structure.
+ *          Fill each pstcDmaInit with default value
+ * @param  [in] pstcDmaNonSeqInit Pointer to a stc_dma_nonseq_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA non-sequence mode structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_NonSeqStructInit(stc_dma_nonseq_init_t *pstcDmaNonSeqInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaNonSeqInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaNonSeqInit->u32Mode       = DMA_NON_SEQ_NONE;
+        pstcDmaNonSeqInit->u32SrcCount   = 0x00UL;
+        pstcDmaNonSeqInit->u32SrcOffset  = 0x00UL;
+        pstcDmaNonSeqInit->u32DestCount  = 0x00UL;
+        pstcDmaNonSeqInit->u32DestOffset = 0x00UL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA non-sequence mode initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaNonSeqInit DMA non-sequence mode config structure.
+ * @retval int32_t:
+ *          - LL_OK: DMA non-sequence function initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ * @note Call this function after DMA_Init();
+ */
+int32_t DMA_NonSeqInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_nonseq_init_t *pstcDmaNonSeqInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *CHCTLx;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaNonSeqInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_NON_SEQ_MD(pstcDmaNonSeqInit->u32Mode));
+
+        DDL_ASSERT(IS_DMA_NON_SEQ_TRANS_CNT(pstcDmaNonSeqInit->u32SrcCount));
+        DDL_ASSERT(IS_DMA_NON_SEQ_TRANS_CNT(pstcDmaNonSeqInit->u32DestCount));
+        DDL_ASSERT(IS_DMA_NON_SEQ_OFFSET(pstcDmaNonSeqInit->u32SrcOffset));
+        DDL_ASSERT(IS_DMA_NON_SEQ_OFFSET(pstcDmaNonSeqInit->u32DestOffset));
+
+        CHCTLx = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+        MODIFY_REG32(*CHCTLx, (DMA_CHCTL_SNSEQEN | DMA_CHCTL_DNSEQEN), pstcDmaNonSeqInit->u32Mode);
+
+        WRITE_REG32(DMA_CH_REG(DMAx->SNSEQCTL0, u8Ch), ((pstcDmaNonSeqInit->u32SrcCount << DMA_SNSEQCTL_SNSCNT_POS) | \
+                                                        pstcDmaNonSeqInit->u32SrcOffset));
+        WRITE_REG32(DMA_CH_REG(DMAx->DNSEQCTL0, u8Ch), ((pstcDmaNonSeqInit->u32DestCount << DMA_DNSEQCTL_DNSCNT_POS) | \
+                                                        pstcDmaNonSeqInit->u32DestOffset));
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DMA Linked List Pointer (hereafter, LLP) mode config structure.
+ *          Fill each pstcDmaInit with default value
+ * @param  [in] pstcDmaLlpInit Pointer to a stc_dma_llp_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA LLP mode config structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_LlpStructInit(stc_dma_llp_init_t *pstcDmaLlpInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaLlpInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaLlpInit->u32State = DMA_LLP_DISABLE;
+        pstcDmaLlpInit->u32Mode  = DMA_LLP_WAIT;
+        pstcDmaLlpInit->u32Addr  = 0x00UL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA LLP mode initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaLlpInit DMA LLP config structure.
+ *   @arg  u32State      DMA LLP ENABLE or DISABLE.
+ *   @arg  u32Mode       DMA LLP auto-run or wait request.
+ *   @arg  u32Addr       DMA LLP next list pointer address.
+ *   @arg  u32AddrSelect DMA LLP address mode.
+ * @retval int32_t:
+ *          - LL_OK: DMA LLP function initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ * @note Call this function after DMA_Init();
+ */
+int32_t DMA_LlpInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_llp_init_t *pstcDmaLlpInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *CHCTLx;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaLlpInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_LLP_EN(pstcDmaLlpInit->u32State));
+        DDL_ASSERT(IS_DMA_LLP_MD(pstcDmaLlpInit->u32Mode));
+        DDL_ASSERT(IS_DMA_LLP_ADDR_ALIGN(pstcDmaLlpInit->u32Addr));
+
+        CHCTLx = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+        MODIFY_REG32(*CHCTLx, (DMA_CHCTL_LLPEN | DMA_CHCTL_LLPRUN), \
+                     (pstcDmaLlpInit->u32State | pstcDmaLlpInit->u32Mode));
+
+        WRITE_REG32(DMA_CH_REG(DMAx->LLP0, u8Ch), pstcDmaLlpInit->u32Addr & DMA_LLP_LLP);
+
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Config DMA LLP value.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] u32Addr Next link pointer address for DMA LLP mode.
+ * @retval None
+ */
+void DMA_SetLlpAddr(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, uint32_t u32Addr)
+{
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_DMA_LLP_ADDR_ALIGN(u32Addr));
+
+    WRITE_REG32(DMA_CH_REG(DMAx->LLP0, u8Ch), (u32Addr & DMA_LLP_LLP));
+}
+
+/**
+ * @brief  DMA LLP ENABLE or DISABLE.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_LlpCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(DMA_CH_REG(DMAx->CHCTL0, u8Ch), DMA_CHCTL_LLPEN);
+
+    } else {
+        CLR_REG32_BIT(DMA_CH_REG(DMAx->CHCTL0, u8Ch), DMA_CHCTL_LLPEN);
+
+    }
+}
+
+/**
+ * @brief  DMA reconfig function ENABLE or DISABLE.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_ReconfigCmd(CM_DMA_TypeDef *DMAx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(DMAx->RCFGCTL, 1UL);
+    } else {
+        CLR_REG32_BIT(DMAx->RCFGCTL, 1UL);
+    }
+}
+
+/**
+ * @brief  DMA LLP ENABLE or DISABLE  for reconfig function.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DMA_ReconfigLlpCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(DMAx->RCFGCTL, DMA_RCFGCTL_RCFGCHS | DMA_RCFGCTL_RCFGLLP, \
+                 ((uint32_t)(u8Ch) << DMA_RCFGCTL_RCFGCHS_POS) | ((uint32_t)enNewState << DMA_RCFGCTL_RCFGLLP_POS));
+}
+
+/**
+ * @brief  Initialize DMA re-config mode config structure.
+ *          Fill each pstcDmaRCInit with default value
+ * @param  [in] pstcDmaRCInit Pointer to a stc_dma_reconfig_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA reconfig mode config structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_ReconfigStructInit(stc_dma_reconfig_init_t *pstcDmaRCInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaRCInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaRCInit->u32CountMode         = DMA_RC_CNT_KEEP;
+        pstcDmaRCInit->u32DestAddrMode      = DMA_RC_DEST_ADDR_KEEP;
+        pstcDmaRCInit->u32SrcAddrMode       = DMA_RC_SRC_ADDR_KEEP;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA reconfig mode initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaRCInit DMA reconfig mode config structure
+ *   @arg  u32CountMode         DMA reconfig count mode.
+ *   @arg  u32DestAddrMode      DMA reconfig destination address mode.
+ *   @arg  u32SrcAddrMode       DMA reconfig source address mode.
+ * @retval int32_t:
+ *          - LL_OK: DMA reconfig function initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+*/
+int32_t DMA_ReconfigInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_reconfig_init_t *pstcDmaRCInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaRCInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_RC_CNT_MD(pstcDmaRCInit->u32CountMode));
+        DDL_ASSERT(IS_DMA_RC_DA_MD(pstcDmaRCInit->u32DestAddrMode));
+        DDL_ASSERT(IS_DMA_RC_SA_MD(pstcDmaRCInit->u32SrcAddrMode));
+
+        MODIFY_REG32(DMAx->RCFGCTL,                                                                     \
+                     (DMA_RCFGCTL_RCFGCHS | DMA_RCFGCTL_SARMD | DMA_RCFGCTL_DARMD | DMA_RCFGCTL_CNTMD), \
+                     (pstcDmaRCInit->u32CountMode | pstcDmaRCInit->u32SrcAddrMode |                     \
+                      pstcDmaRCInit->u32DestAddrMode | ((uint32_t)(u8Ch) << DMA_RCFGCTL_RCFGCHS_POS)));
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DMA non-sequence mode config structure.
+ *          Fill each pstcDmaInit with default value
+ * @param  [in] pstcDmaRcNonSeqInit Pointer to a stc_dma_rc_nonseq_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA non-sequence mode structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t DMA_ReconfigNonSeqStructInit(stc_dma_rc_nonseq_init_t *pstcDmaRcNonSeqInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaRcNonSeqInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaRcNonSeqInit->u32Mode       = DMA_NON_SEQ_NONE;
+        pstcDmaRcNonSeqInit->u32SrcCount   = 0x01UL;
+        pstcDmaRcNonSeqInit->u32SrcDist    = 0x00UL;
+        pstcDmaRcNonSeqInit->u32DestCount  = 0x01UL;
+        pstcDmaRcNonSeqInit->u32DestDist   = 0x00UL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA non-sequence mode initialize.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] pstcDmaRcNonSeqInit Pointer to a stc_dma_rc_nonseq_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: DMA non-sequence function initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ * @note Call this function after DMA_Init();
+ */
+int32_t DMA_ReconfigNonSeqInit(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, const stc_dma_rc_nonseq_init_t *pstcDmaRcNonSeqInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *CHCTLx;
+
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (NULL == pstcDmaRcNonSeqInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_DMA_NON_SEQ_MD(pstcDmaRcNonSeqInit->u32Mode));
+        DDL_ASSERT(IS_DMA_RC_NON_SEQ_TRANS_CNT(pstcDmaRcNonSeqInit->u32SrcCount));
+        DDL_ASSERT(IS_DMA_RC_NON_SEQ_TRANS_CNT(pstcDmaRcNonSeqInit->u32DestCount));
+        DDL_ASSERT(IS_DMA_RC_NON_SEQ_DIST(pstcDmaRcNonSeqInit->u32SrcDist));
+        DDL_ASSERT(IS_DMA_RC_NON_SEQ_DIST(pstcDmaRcNonSeqInit->u32DestDist));
+
+        CHCTLx = &DMA_CH_REG(DMAx->CHCTL0, u8Ch);
+        MODIFY_REG32(*CHCTLx, (DMA_CHCTL_SNSEQEN | DMA_CHCTL_DNSEQEN), pstcDmaRcNonSeqInit->u32Mode);
+        WRITE_REG32(DMA_CH_REG(DMAx->SNSEQCTLB0, u8Ch),
+                    ((pstcDmaRcNonSeqInit->u32SrcCount << DMA_SNSEQCTLB_SNSCNTB_POS) | pstcDmaRcNonSeqInit->u32SrcDist));
+        WRITE_REG32(DMA_CH_REG(DMAx->DNSEQCTLB0, u8Ch),
+                    ((pstcDmaRcNonSeqInit->u32DestCount << DMA_DNSEQCTLB_DNSCNTB_POS) | pstcDmaRcNonSeqInit->u32DestDist));
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  DMA get current source address
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current source address.
+ */
+uint32_t DMA_GetSrcAddr(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return READ_REG32(DMA_CH_REG(DMAx->MONSAR0, u8Ch));
+}
+
+/**
+ * @brief  DMA get current destination address
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current destination address.
+ */
+uint32_t DMA_GetDestAddr(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return READ_REG32(DMA_CH_REG(DMAx->MONDAR0, u8Ch));
+}
+
+/**
+ * @brief  DMA get current transfer count
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current transfer count.
+ */
+uint32_t DMA_GetTransCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return ((READ_REG32(DMA_CH_REG(DMAx->MONDTCTL0, u8Ch)) >> DMA_DTCTL_CNT_POS) & 0xFFFFUL);
+}
+
+/**
+ * @brief  DMA get current block size
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current block size.
+ */
+uint32_t DMA_GetBlockSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return (READ_REG32_BIT(DMA_CH_REG(DMAx->MONDTCTL0, u8Ch), DMA_DTCTL_BLKSIZE));
+}
+
+/**
+ * @brief  DMA get current source repeat size
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current source repeat size.
+ */
+uint32_t DMA_GetSrcRepeatSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return (READ_REG32_BIT(DMA_CH_REG(DMAx->MONRPT0, u8Ch), DMA_RPT_SRPT));
+}
+
+/**
+ * @brief  DMA get current destination repeat size
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current destination repeat size.
+ */
+uint32_t DMA_GetDestRepeatSize(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return ((READ_REG32(DMA_CH_REG(DMAx->MONRPT0, u8Ch)) >> DMA_RPT_DRPT_POS) & 0x3FFUL);
+}
+
+/**
+ * @brief  DMA get current source count in non-sequence mode
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current source count in non-sequence mode.
+ */
+uint32_t DMA_GetNonSeqSrcCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return ((READ_REG32(DMA_CH_REG(DMAx->MONSNSEQCTL0, u8Ch)) >> DMA_SNSEQCTLB_SNSCNTB_POS) & 0xFFFUL);
+}
+
+/**
+ * @brief  DMA get current destination count in non-sequence mode
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA,, x can be 0-1
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current destination count in non-sequence mode.
+ */
+uint32_t DMA_GetNonSeqDestCount(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return ((READ_REG32(DMA_CH_REG(DMAx->MONDNSEQCTL0, u8Ch)) >> DMA_DNSEQCTL_DNSCNT_POS) & 0xFFFUL);
+}
+
+/**
+ * @brief  DMA get current source offset in non-sequence mode
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current source offset in non-sequence mode.
+ */
+uint32_t DMA_GetNonSeqSrcOffset(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return (READ_REG32_BIT(DMA_CH_REG(DMAx->MONSNSEQCTL0, u8Ch), DMA_SNSEQCTL_SOFFSET));
+}
+
+/**
+ * @brief  DMA get current destination offset in non-sequence mode
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @retval Current destination offset in non-sequence mode.
+ */
+uint32_t DMA_GetNonSeqDestOffset(const CM_DMA_TypeDef *DMAx, uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    return (READ_REG32_BIT(DMA_CH_REG(DMAx->MONDNSEQCTL0, u8Ch), DMA_DNSEQCTL_DOFFSET));
+}
+
+/**
+ * @brief  Enable or disable AHB HPROT bufferable and cacheable transfer
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8Ch DMA channel. @ref DMA_Channel_selection
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   This command can only be enabled when DMA accesses SMC and DMC, otherwise please disable it
+ */
+void DMA_AHB_HProtBufCacheCmd(CM_DMA_TypeDef *DMAx, uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_CH(u8Ch));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(DMA_CH_REG(DMAx->CHCTL0, u8Ch), DMA_CHCTL_HPROT);
+    } else {
+        CLR_REG32_BIT(DMA_CH_REG(DMAx->CHCTL0, u8Ch), DMA_CHCTL_HPROT);
+    }
+}
+
+/**
+ * @brief  DMA start by software request.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @param  [in] u8MxCh DMA multiplex channel. @ref DMA_Mx_Channel_selection
+ * @retval None.
+ */
+void DMA_MxChSWTrigger(CM_DMA_TypeDef *DMAx, uint8_t u8MxCh)
+{
+    uint32_t u32RegValue;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+    DDL_ASSERT(IS_DMA_MX_CH(u8MxCh));
+
+    u32RegValue = (DMA_SW_TRIGGER_UNLOCK | u8MxCh);
+    WRITE_REG32(DMAx->SWREQ, u32RegValue);
+}
+
+/**
+ * @brief  DMA reconfig by software request.
+ * @param  [in] DMAx DMA unit instance.
+ *   @arg  CM_DMAx or CM_DMA
+ * @retval None.
+ */
+void DMA_SWReconfig(CM_DMA_TypeDef *DMAx)
+{
+    uint32_t u32RegValue;
+    DDL_ASSERT(IS_DMA_UNIT(DMAx));
+
+    u32RegValue = (DMA_SW_RECONFIG_UNLOCK | DMA_SWREQ_SWRCFGREQ);
+    WRITE_REG32(DMAx->SWREQ, u32RegValue);
+}
+/**
+ * @}
+ */
+
+#endif  /* LL_DMA_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dmc.c
+++ b/hc32f4a2/src/hc32_ll_dmc.c
@@ -1,0 +1,572 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dmc.c
+ * @brief This file provides firmware functions to manage the EXMC_DMC
+ *        (External Memory Controller: Dynamic Memory Controller) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+   2024-08-31       CDT             Function EXMC_DMC_DeInit add return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dmc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EXMC EXMC
+ * @brief External Memory Controller Driver Library
+ * @{
+ */
+
+/**
+ * @defgroup LL_DMC DMC
+ * @brief Dynamic Memory Controller Driver Library
+ * @{
+ */
+
+#if (LL_DMC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_DMC_Local_Macros EXMC_DMC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_DMC_Check_Parameters_Validity EXMC_DMC Check Parameters Validity
+ * @{
+ */
+
+#define IS_EXMC_DMC_MEM_WIDTH(x)                                               \
+(   ((x) == EXMC_DMC_MEMORY_WIDTH_16BIT)        ||                             \
+    ((x) == EXMC_DMC_MEMORY_WIDTH_32BIT))
+
+#define IS_EXMC_DMC_CHIP(x)                                                    \
+(   ((x) == EXMC_DMC_CHIP0)                     ||                             \
+    ((x) == EXMC_DMC_CHIP1)                     ||                             \
+    ((x) == EXMC_DMC_CHIP2)                     ||                             \
+    ((x) == EXMC_DMC_CHIP3))
+
+#define IS_EXMC_DMC_BANK(x)                                                    \
+(   ((x) == EXMC_DMC_BANK0)                     ||                             \
+    ((x) == EXMC_DMC_BANK1)                     ||                             \
+    ((x) == EXMC_DMC_BANK2)                     ||                             \
+    ((x) == EXMC_DMC_BANK3))
+
+#define IS_EXMC_DMC_CMD(x)                                                     \
+(   ((x) == EXMC_DMC_CMD_PRECHARGE_ALL)         ||                             \
+    ((x) == EXMC_DMC_CMD_AUTO_REFRESH)          ||                             \
+    ((x) == EXMC_DMC_CMD_MDREG_CONFIG)          ||                             \
+    ((x) == EXMC_DMC_CMD_NOP))
+
+#define IS_EXMC_DMC_CS_DECODE_MD(x)                                            \
+(   ((x) == EXMC_DMC_CS_DECODE_ROWBANKCOL)      ||                             \
+    ((x) == EXMC_DMC_CS_DECODE_BANKROWCOL))
+
+#define IS_EXMC_DMC_COLUMN_BITS_NUM(x)                                         \
+(   ((x) == EXMC_DMC_COLUMN_BITS_NUM8)          ||                             \
+    ((x) == EXMC_DMC_COLUMN_BITS_NUM9)          ||                             \
+    ((x) == EXMC_DMC_COLUMN_BITS_NUM10)         ||                             \
+    ((x) == EXMC_DMC_COLUMN_BITS_NUM11)         ||                             \
+    ((x) == EXMC_DMC_COLUMN_BITS_NUM12))
+
+#define IS_EXMC_DMC_ROW_BITS_NUM(x)                                            \
+(   ((x) == EXMC_DMC_ROW_BITS_NUM11)            ||                             \
+    ((x) == EXMC_DMC_ROW_BITS_NUM12)            ||                             \
+    ((x) == EXMC_DMC_ROW_BITS_NUM13)            ||                             \
+    ((x) == EXMC_DMC_ROW_BITS_NUM14)            ||                             \
+    ((x) == EXMC_DMC_ROW_BITS_NUM15)            ||                             \
+    ((x) == EXMC_DMC_ROW_BITS_NUM16))
+
+#define IS_EXMC_DMC_AUTO_PRECHARGE_PIN(x)                                      \
+(   ((x) == EXMC_DMC_AUTO_PRECHARGE_A8)         ||                             \
+    ((x) == EXMC_DMC_AUTO_PRECHARGE_A10))
+
+#define IS_EXMC_DMC_CKE_OUTPUT_SEL(x)                                          \
+(   ((x) == EXMC_DMC_CKE_OUTPUT_ENABLE)         ||                             \
+    ((x) == EXMC_DMC_CKE_OUTPUT_DISABLE))
+
+#define EXMC_DMC_CLK_SEL(x)                                                    \
+(   ((x) == EXMC_DMC_CLK_NORMAL_OUTPUT)         ||                             \
+    ((x) == EXMC_DMC_CLK_NOP_STOP_OUTPUT))
+
+#define IS_EXMC_DMC_BURST(x)                                                   \
+(   ((x) == EXMC_DMC_BURST_1BEAT)               ||                             \
+    ((x) == EXMC_DMC_BURST_2BEAT)               ||                             \
+    ((x) == EXMC_DMC_BURST_4BEAT)               ||                             \
+    ((x) == EXMC_DMC_BURST_8BEAT)               ||                             \
+    ((x) == EXMC_DMC_BURST_16BEAT))
+
+#define IS_EXMC_DMC_AUTO_REFRESH_CHIPS(x)                                      \
+(   ((x) == EXMC_DMC_AUTO_REFRESH_1CHIP)        ||                             \
+    ((x) == EXMC_DMC_AUTO_REFRESH_2CHIPS)       ||                             \
+    ((x) == EXMC_DMC_AUTO_REFRESH_3CHIPS)       ||                             \
+    ((x) == EXMC_DMC_AUTO_REFRESH_4CHIPS))
+
+#define IS_EXMC_DMC_MAP_ADDR(match, msk)                                       \
+(   (EXMC_DMC_MAP_ADDR((match), (msk)) >= EXMC_DMC_ADDR_MIN) &&                \
+    (EXMC_DMC_MAP_ADDR((match), (msk)) <= EXMC_DMC_ADDR_MAX))
+
+#define IS_EXMC_DMC_STATE(x)                                                   \
+(   ((x) == EXMC_DMC_CTRL_STATE_GO)             ||                             \
+    ((x) == EXMC_DMC_CTRL_STATE_SLEEP)          ||                             \
+    ((x) == EXMC_DMC_CTRL_STATE_WAKEUP)         ||                             \
+    ((x) == EXMC_DMC_CTRL_STATE_PAUSE)          ||                             \
+    ((x) == EXMC_DMC_CTRL_STATE_CONFIG))
+
+#define IS_EXMC_DMC_SAMPLE_CLK(x)                                              \
+(   ((x) == EXMC_DMC_SAMPLE_CLK_EXTCLK)         ||                             \
+    ((x) == EXMC_DMC_SAMPLE_CLK_INTERNCLK)      ||                             \
+    ((x) == EXMC_DMC_SAMPLE_CLK_INTERNCLK_INVT))
+
+#define IS_EXMC_DMC_TIMING_CASL_CYCLE(x)        ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_DQSS_CYCLE(x)        ((x) <= 3UL)
+
+#define IS_EXMC_DMC_TIMING_MRD_CYCLE(x)         ((x) <= 0x7FUL)
+
+#define IS_EXMC_DMC_TIMING_RAS_CYCLE(x)         ((x) <= 0x0FUL)
+
+#define IS_EXMC_DMC_TIMING_RC_CYCLE(x)          ((x) <= 0x0FUL)
+
+#define IS_EXMC_DMC_TIMING_RCD_B_CYCLE(x)       ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_RCD_P_CYCLE(x)       ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_RFC_B_CYCLE(x)       ((x) <= 0x1FUL)
+
+#define IS_EXMC_DMC_TIMING_RFC_P_CYCLE(x)       ((x) <= 0x1FUL)
+
+#define IS_EXMC_DMC_TIMING_RP_B_CYCLE(x)        ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_RP_P_CYCLE(x)        ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_RRD_CYCLE(x)         ((x) <= 0x0FUL)
+
+#define IS_EXMC_DMC_TIMING_WR_CYCLE(x)          ((x) <= 7UL)
+
+#define IS_EXMC_DMC_TIMING_WTR_CYCLE(x)         ((x) <= 7UL)
+
+#define IS_EXMC_DMC_CKE_DISABLE_PERIOD(x)       ((x) <= 0x3FUL)
+
+#define IS_EXMC_DMC_CMD_ADDR(x)                 ((x) <= 0x7FFFUL)
+
+#define IS_EXMC_DMC_REFRESH_PERIOD(x)           ((x) <= 0x7FFFUL)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_DMC_Register EXMC_DMC Register
+ * @{
+ */
+#define EXMC_DMC_CSCRx(__CHIPx__)       ((__IO uint32_t *)(((uint32_t)(&CM_DMC->CSCR0))  + (4UL * (__CHIPx__))))
+/**
+ * @}
+ */
+
+/* EXMC_DMC map address */
+#define EXMC_DMC_MAP_ADDR(MATCH, MSK)   ((~((MATCH) ^ (MSK))) << 24U)
+
+/**
+ * @defgroup EXMC_DMC_Timing EXMC_DMC Timing
+ * @{
+ */
+#define DMC_TMCR_RP_MASK                (DMC_TMCR_T_RP_T_RP_B   | DMC_TMCR_T_RP_T_RP_P)
+#define DMC_TMCR_RCD_MASK               (DMC_TMCR_T_RCD_T_RCD_B | DMC_TMCR_T_RCD_T_RCD_P)
+#define DMC_TMCR_RFC_MASK               (DMC_TMCR_T_RFC_T_RFC_B | DMC_TMCR_T_RFC_T_RFC_P)
+
+#define DMC_TMCR_RP(x)                                                             \
+((uint32_t)(x)->stcTimingConfig.u8RP_B | ((uint32_t)(x)->stcTimingConfig.u8RP_P << DMC_TMCR_T_RP_T_RP_P_POS))
+
+#define DMC_TMCR_RCD(x)                                                            \
+((uint32_t)(x)->stcTimingConfig.u8RCD_B | ((uint32_t)(x)->stcTimingConfig.u8RCD_P << DMC_TMCR_T_RCD_T_RCD_P_POS))
+
+#define DMC_TMCR_RFC(x)                                                            \
+((uint32_t)(x)->stcTimingConfig.u8RFC_B | ((uint32_t)(x)->stcTimingConfig.u8RFC_P << DMC_TMCR_T_RFC_T_RFC_P_POS))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_DMC_Global_Functions EXMC_DMC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_exmc_dmc_init_t to default values
+ * @param  [out] pstcDmcInit            Pointer to a @ref stc_exmc_dmc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDmcInit value is NULL.
+ */
+int32_t EXMC_DMC_StructInit(stc_exmc_dmc_init_t *pstcDmcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDmcInit) {
+        pstcDmcInit->u32SampleClock = EXMC_DMC_SAMPLE_CLK_INTERNCLK;
+        pstcDmcInit->u32MemoryWidth = EXMC_DMC_MEMORY_WIDTH_16BIT;
+        pstcDmcInit->u32RefreshPeriod = 0xA60UL;
+        pstcDmcInit->u32ColumnBitsNumber = EXMC_DMC_COLUMN_BITS_NUM8;
+        pstcDmcInit->u32RowBitsNumber = EXMC_DMC_ROW_BITS_NUM15;
+        pstcDmcInit->u32AutoPrechargePin = EXMC_DMC_AUTO_PRECHARGE_A10;
+        pstcDmcInit->u32CkeOutputSel = EXMC_DMC_CKE_OUTPUT_ENABLE;
+        pstcDmcInit->u32MemClockSel = EXMC_DMC_CLK_NORMAL_OUTPUT;
+        pstcDmcInit->u32CkeDisablePeriod = 0UL;
+        pstcDmcInit->u32MemBurst = EXMC_DMC_BURST_4BEAT;
+        pstcDmcInit->u32AutoRefreshChips = EXMC_DMC_AUTO_REFRESH_1CHIP;
+
+        pstcDmcInit->stcTimingConfig.u8CASL = 0x3U;
+        pstcDmcInit->stcTimingConfig.u8DQSS = 0x1U;
+        pstcDmcInit->stcTimingConfig.u8MRD = 0x02U;
+        pstcDmcInit->stcTimingConfig.u8RAS = 0x07U;
+        pstcDmcInit->stcTimingConfig.u8RC = 0x0BU;
+        pstcDmcInit->stcTimingConfig.u8RCD_B = 0x05U;
+        pstcDmcInit->stcTimingConfig.u8RCD_P = 0x00U;
+        pstcDmcInit->stcTimingConfig.u8RFC_B = 0x12U;
+        pstcDmcInit->stcTimingConfig.u8RFC_P = 0x0U;
+        pstcDmcInit->stcTimingConfig.u8RP_B = 0x05U;
+        pstcDmcInit->stcTimingConfig.u8RP_P = 0x00U;
+        pstcDmcInit->stcTimingConfig.u8RRD = 0x02U;
+        pstcDmcInit->stcTimingConfig.u8WR = 0x03U;
+        pstcDmcInit->stcTimingConfig.u8WTR = 0x02U;
+        pstcDmcInit->stcTimingConfig.u8XP = 0x01U;
+        pstcDmcInit->stcTimingConfig.u8XSR = 0x0AU;
+        pstcDmcInit->stcTimingConfig.u8ESR = 0x14U;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize EXMC_DMC function.
+ * @param  [in] pstcDmcInit             Pointer to a @ref stc_exmc_dmc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDmcInit value is NULL.
+ */
+int32_t EXMC_DMC_Init(const stc_exmc_dmc_init_t *pstcDmcInit)
+{
+    uint32_t u32RegVal;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDmcInit) {
+        DDL_ASSERT(IS_EXMC_DMC_SAMPLE_CLK(pstcDmcInit->u32SampleClock));
+        DDL_ASSERT(IS_EXMC_DMC_MEM_WIDTH(pstcDmcInit->u32MemoryWidth));
+        DDL_ASSERT(IS_EXMC_DMC_REFRESH_PERIOD(pstcDmcInit->u32RefreshPeriod));
+        DDL_ASSERT(IS_EXMC_DMC_COLUMN_BITS_NUM(pstcDmcInit->u32ColumnBitsNumber));
+        DDL_ASSERT(IS_EXMC_DMC_ROW_BITS_NUM(pstcDmcInit->u32RowBitsNumber));
+        DDL_ASSERT(IS_EXMC_DMC_AUTO_PRECHARGE_PIN(pstcDmcInit->u32AutoPrechargePin));
+        DDL_ASSERT(IS_EXMC_DMC_CKE_OUTPUT_SEL(pstcDmcInit->u32CkeOutputSel));
+        DDL_ASSERT(EXMC_DMC_CLK_SEL(pstcDmcInit->u32MemClockSel));
+        DDL_ASSERT(IS_EXMC_DMC_CKE_DISABLE_PERIOD(pstcDmcInit->u32CkeDisablePeriod));
+        DDL_ASSERT(IS_EXMC_DMC_BURST(pstcDmcInit->u32MemBurst));
+        DDL_ASSERT(IS_EXMC_DMC_AUTO_REFRESH_CHIPS(pstcDmcInit->u32AutoRefreshChips));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_CASL_CYCLE(pstcDmcInit->stcTimingConfig.u8CASL));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_DQSS_CYCLE(pstcDmcInit->stcTimingConfig.u8DQSS));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_MRD_CYCLE(pstcDmcInit->stcTimingConfig.u8MRD));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RAS_CYCLE(pstcDmcInit->stcTimingConfig.u8RAS));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RC_CYCLE(pstcDmcInit->stcTimingConfig.u8RC));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RCD_B_CYCLE(pstcDmcInit->stcTimingConfig.u8RCD_B));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RCD_P_CYCLE(pstcDmcInit->stcTimingConfig.u8RCD_P));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RFC_B_CYCLE(pstcDmcInit->stcTimingConfig.u8RFC_B));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RFC_P_CYCLE(pstcDmcInit->stcTimingConfig.u8RFC_P));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RP_B_CYCLE(pstcDmcInit->stcTimingConfig.u8RP_B));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RP_P_CYCLE(pstcDmcInit->stcTimingConfig.u8RP_P));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_RRD_CYCLE(pstcDmcInit->stcTimingConfig.u8RRD));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_WR_CYCLE(pstcDmcInit->stcTimingConfig.u8WR));
+        DDL_ASSERT(IS_EXMC_DMC_TIMING_WTR_CYCLE(pstcDmcInit->stcTimingConfig.u8WTR));
+
+        /* Set sample clock for DMC.*/
+        MODIFY_REG32(CM_DMC->BACR, DMC_BACR_CKSEL, pstcDmcInit->u32SampleClock);
+
+        /* Set memory width(16bit or 32bit) for DMC.*/
+        MODIFY_REG32(CM_DMC->BACR, DMC_BACR_DMCMW, pstcDmcInit->u32MemoryWidth);
+
+        /* set auto refresh period*/
+        WRITE_REG32(CM_DMC->RFTR, pstcDmcInit->u32RefreshPeriod);
+
+        /* Set timing parameters for DMC.*/
+        WRITE_REG32(CM_DMC->TMCR_T_CASL, pstcDmcInit->stcTimingConfig.u8CASL);
+        WRITE_REG32(CM_DMC->TMCR_T_DQSS, pstcDmcInit->stcTimingConfig.u8DQSS);
+        WRITE_REG32(CM_DMC->TMCR_T_MRD, pstcDmcInit->stcTimingConfig.u8MRD);
+        WRITE_REG32(CM_DMC->TMCR_T_RAS, pstcDmcInit->stcTimingConfig.u8RAS);
+        WRITE_REG32(CM_DMC->TMCR_T_RC, pstcDmcInit->stcTimingConfig.u8RC);
+        WRITE_REG32(CM_DMC->TMCR_T_RRD, pstcDmcInit->stcTimingConfig.u8RRD);
+        WRITE_REG32(CM_DMC->TMCR_T_WR, pstcDmcInit->stcTimingConfig.u8WR);
+        WRITE_REG32(CM_DMC->TMCR_T_WTR, pstcDmcInit->stcTimingConfig.u8WTR);
+        WRITE_REG32(CM_DMC->TMCR_T_XP, pstcDmcInit->stcTimingConfig.u8XP);
+        WRITE_REG32(CM_DMC->TMCR_T_XSR, pstcDmcInit->stcTimingConfig.u8XSR);
+        WRITE_REG32(CM_DMC->TMCR_T_ESR, pstcDmcInit->stcTimingConfig.u8ESR);
+        MODIFY_REG32(CM_DMC->TMCR_T_RP, DMC_TMCR_RP_MASK, DMC_TMCR_RP(pstcDmcInit));
+        MODIFY_REG32(CM_DMC->TMCR_T_RCD, DMC_TMCR_RCD_MASK, DMC_TMCR_RCD(pstcDmcInit));
+        MODIFY_REG32(CM_DMC->TMCR_T_RFC, DMC_TMCR_RFC_MASK, DMC_TMCR_RFC(pstcDmcInit));
+
+        /* Set base parameters for DMC: burst length, Rowbitwidth,ColbitWidth etc.*/
+        u32RegVal = (pstcDmcInit->u32ColumnBitsNumber | pstcDmcInit->u32RowBitsNumber | \
+                     pstcDmcInit->u32AutoPrechargePin | pstcDmcInit->u32CkeOutputSel | \
+                     pstcDmcInit->u32AutoRefreshChips | pstcDmcInit->u32MemClockSel | \
+                     (pstcDmcInit->u32CkeDisablePeriod << DMC_CPCR_CKEDISPRD_POS) | \
+                     pstcDmcInit->u32MemBurst);
+        WRITE_REG32(CM_DMC->CPCR, u32RegVal);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize EXMC_DMC function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t EXMC_DMC_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Disable */
+    CLR_REG32_BIT(CM_PERIC->DMC_ENAR, PERIC_DMC_ENAR_DMCEN);
+
+    /* Configures the registers to reset value. */
+    WRITE_REG32(CM_DMC->CPCR, 0x00020040UL);
+
+    WRITE_REG32(CM_DMC->TMCR_T_CASL, 0x00000003UL);
+    WRITE_REG32(CM_DMC->TMCR_T_DQSS, 0x00000001UL);
+    WRITE_REG32(CM_DMC->TMCR_T_MRD, 0x00000002UL);
+    WRITE_REG32(CM_DMC->TMCR_T_RAS, 0x00000007UL);
+    WRITE_REG32(CM_DMC->TMCR_T_RC, 0x0000000BUL);
+    WRITE_REG32(CM_DMC->TMCR_T_RCD, 0x00000035UL);
+    WRITE_REG32(CM_DMC->TMCR_T_RFC, 0x00001012UL);
+    WRITE_REG32(CM_DMC->TMCR_T_RP, 0x00000035UL);
+    WRITE_REG32(CM_DMC->TMCR_T_RRD, 0x00000002UL);
+    WRITE_REG32(CM_DMC->TMCR_T_WR, 0x00000003UL);
+    WRITE_REG32(CM_DMC->TMCR_T_WTR, 0x00000002UL);
+    WRITE_REG32(CM_DMC->TMCR_T_XP, 0x00000001UL);
+    WRITE_REG32(CM_DMC->TMCR_T_XSR, 0x0000000AUL);
+    WRITE_REG32(CM_DMC->TMCR_T_ESR, 0x00000014UL);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable/disable DMC.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_DMC_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_PERIC->DMC_ENAR, PERIC_DMC_ENAR_DMCEN);
+    } else {
+        CLR_REG32_BIT(CM_PERIC->DMC_ENAR, PERIC_DMC_ENAR_DMCEN);
+    }
+}
+
+/**
+ * @brief  Set EXMC_DMC state.
+ * @param  [in] u32State                    The command chip number.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Control_State
+ *           @arg EXMC_DMC_CTRL_STATE_GO:     Go
+ *           @arg EXMC_DMC_CTRL_STATE_SLEEP:  Sleep for low power
+ *           @arg EXMC_DMC_CTRL_STATE_WAKEUP: Wake up
+ *           @arg EXMC_DMC_CTRL_STATE_PAUSE:  Pause
+ *           @arg EXMC_DMC_CTRL_STATE_CONFIG: Configure
+ * @retval None
+ */
+void EXMC_DMC_SetState(uint32_t u32State)
+{
+    DDL_ASSERT(IS_EXMC_DMC_STATE(u32State));
+
+    WRITE_REG32(CM_DMC->STCR, u32State);
+}
+
+/**
+ * @brief  Configure EXMC_DMC CS function.
+ * @param  [in] u32Chip                 The command chip number.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Chip
+ *           @arg EXMC_DMC_CHIP0:       Chip 0
+ *           @arg EXMC_DMC_CHIP1:       Chip 1
+ *           @arg EXMC_DMC_CHIP2:       Chip 2
+ *           @arg EXMC_DMC_CHIP3:       Chip 3
+ * @param  [in] pstcChipConfig          Pointer to a @ref stc_exmc_dmc_chip_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcChipConfig value is NULL.
+ */
+int32_t EXMC_DMC_ChipConfig(uint32_t u32Chip, const stc_exmc_dmc_chip_config_t *pstcChipConfig)
+{
+    uint32_t u32RegVal;
+    __IO uint32_t *DMC_CSCRx;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcChipConfig) {
+        DDL_ASSERT(IS_EXMC_DMC_CHIP(u32Chip));
+        DDL_ASSERT(IS_EXMC_DMC_CS_DECODE_MD(pstcChipConfig->u32AddrDecodeMode));
+        DDL_ASSERT(IS_EXMC_DMC_MAP_ADDR(pstcChipConfig->u32AddrMatch, pstcChipConfig->u32AddrMask));
+
+        /* Set chip selection for DMC.*/
+        DMC_CSCRx = EXMC_DMC_CSCRx(u32Chip);
+        u32RegVal = ((pstcChipConfig->u32AddrMask << DMC_CSCR_ADDMSK_POS)  | \
+                     (pstcChipConfig->u32AddrMatch << DMC_CSCR_ADDMAT_POS) | \
+                     pstcChipConfig->u32AddrDecodeMode);
+        WRITE_REG32(*DMC_CSCRx, u32RegVal);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get the start address of the specified DMC chip.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Chip
+ *           @arg EXMC_DMC_CHIP0:       Chip 0
+ *           @arg EXMC_DMC_CHIP1:       Chip 1
+ *           @arg EXMC_DMC_CHIP2:       Chip 2
+ *           @arg EXMC_DMC_CHIP3:       Chip 3
+ * @retval The start address of the specified DMC chip.
+ */
+uint32_t EXMC_DMC_GetChipStartAddr(uint32_t u32Chip)
+{
+    __IO uint32_t *DMC_CSCRx;
+
+    DDL_ASSERT(IS_EXMC_DMC_CHIP(u32Chip));
+
+    DMC_CSCRx = EXMC_DMC_CSCRx(u32Chip);
+    return (READ_REG32_BIT(*DMC_CSCRx, DMC_CSCR_ADDMAT) << 16U);
+}
+
+/**
+ * @brief  Get the end address of the specified DMC chip.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Chip
+ *           @arg EXMC_DMC_CHIP0:       Chip 0
+ *           @arg EXMC_DMC_CHIP1:       Chip 1
+ *           @arg EXMC_DMC_CHIP2:       Chip 2
+ *           @arg EXMC_DMC_CHIP3:       Chip 3
+ * @retval The end address of the specified DMC chip
+ */
+uint32_t EXMC_DMC_GetChipEndAddr(uint32_t u32Chip)
+{
+    uint32_t u32Mask;
+    uint32_t u32Match;
+    __IO uint32_t *DMC_CSCRx;
+
+    DDL_ASSERT(IS_EXMC_DMC_CHIP(u32Chip));
+
+    DMC_CSCRx = EXMC_DMC_CSCRx(u32Chip);
+    u32Mask = (READ_REG32_BIT(*DMC_CSCRx, DMC_CSCR_ADDMSK) >> DMC_CSCR_ADDMSK_POS);
+    u32Match = (READ_REG32_BIT(*DMC_CSCRx, DMC_CSCR_ADDMAT) >> DMC_CSCR_ADDMAT_POS);
+    return EXMC_DMC_MAP_ADDR(u32Match, u32Mask);
+}
+
+/**
+ * @brief  Set EXMC_SMC command.
+ * @param  [in] u32Chip                 The command chip number.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Chip
+ *           @arg EXMC_DMC_CHIP0:       Chip 0
+ *           @arg EXMC_DMC_CHIP1:       Chip 1
+ *           @arg EXMC_DMC_CHIP2:       Chip 2
+ *           @arg EXMC_DMC_CHIP3:       Chip 3
+ * @param  [in] u32Bank                 The command bank.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Bank
+ *           @arg EXMC_DMC_BANK0:       Bank 0
+ *           @arg EXMC_DMC_BANK1:       Bank 1
+ *           @arg EXMC_DMC_BANK2:       Bank 2
+ *           @arg EXMC_DMC_BANK3:       Bank 3
+ * @param  [in] u32Cmd                  The command.
+ *         This parameter can be one of the macros group @ref EXMC_DMC_Command
+ *           @arg EXMC_DMC_CMD_PRECHARGE_ALL:Precharge all
+ *           @arg EXMC_DMC_CMD_AUTO_REFRESH: Auto refresh
+ *           @arg EXMC_DMC_CMD_MDREG_CONFIG: Set memory device mode register
+ *           @arg EXMC_DMC_CMD_NOP:          NOP
+ * @param  [in] u32Addr                 The address parameter for CMD MdRegConfig only.
+ *         This parameter can be a value between Min_Data = 0 and Max_Data = 0x7FFFUL
+ * @retval None
+ */
+void EXMC_DMC_SetCommand(uint32_t u32Chip, uint32_t u32Bank, uint32_t u32Cmd, uint32_t u32Addr)
+{
+    uint32_t u32RegVal;
+
+    DDL_ASSERT(IS_EXMC_DMC_CHIP(u32Chip));
+    DDL_ASSERT(IS_EXMC_DMC_BANK(u32Bank));
+    DDL_ASSERT(IS_EXMC_DMC_CMD(u32Cmd));
+    DDL_ASSERT(IS_EXMC_DMC_CMD_ADDR(u32Addr));
+
+    u32RegVal = (u32Addr | (u32Bank << DMC_CMDR_CMDBA_POS) | u32Cmd | (u32Chip << DMC_CMDR_CMDCHIP_POS));
+    WRITE_REG32(CM_DMC->CMDR, u32RegVal);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_DMC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_dvp.c
+++ b/hc32f4a2/src/hc32_ll_dvp.c
@@ -1,0 +1,447 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_dvp.c
+ * @brief This file provides firmware functions to manage the DVP(Digital Video
+ *        Processor) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Add function: DVP_GetCaptureState
+   2024-06-30       CDT             Modify DVP_ClearStatus for couping risk
+   2024-08-31       CDT             Function DVP_DeInit add return value
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_dvp.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_DVP DVP
+ * @brief Digital Video Processor Driver Library
+ * @{
+ */
+
+#if (LL_DVP_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup DVP_Local_Macros DVP Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup DVP_Check_Parameters_Validity DVP Check Parameters Validity
+ * @{
+ */
+
+#define IS_DVP_CAPT_MD(x)                                                      \
+(   ((x) == DVP_CAPT_MD_CONT_FRAME)         ||                                 \
+    ((x) == DVP_CAPT_MD_SINGLE_FRAME))
+
+#define IS_DVP_SYNC_MD(x)                                                      \
+(   ((x) == DVP_SYNC_MD_HW)                 ||                                 \
+    ((x) == DVP_SYNC_MD_SW))
+
+#define IS_DVP_PIXCLK_POLARITY(x)                                              \
+(   ((x) == DVP_PIXCLK_RISING)              ||                                 \
+    ((x) == DVP_PIXCLK_FALLING))
+
+#define IS_DVP_HSYNC_POLARITY(x)                                               \
+(   ((x) == DVP_HSYNC_LOW)                  ||                                 \
+    ((x) == DVP_HSYNC_HIGH))
+
+#define IS_DVP_VSYNC_POLARITY(x)                                               \
+(   ((x) == DVP_VSYNC_LOW)                  ||                                 \
+    ((x) == DVP_VSYNC_HIGH))
+
+#define IS_DVP_CAPT_FREQ(x)                                                    \
+(   ((x) == DVP_CAPT_FREQ_ALL_FRAME)        ||                                 \
+    ((x) == DVP_CAPT_FREQ_ONT_TIME_2FRAME)  ||                                 \
+    ((x) == DVP_CAPT_FREQ_ONT_TIME_4FRAME))
+
+#define IS_DVP_DATA_WIDTH(x)                                                   \
+(   ((x) == DVP_DATA_WIDTH_8BIT)            ||                                 \
+    ((x) == DVP_DATA_WIDTH_10BIT)           ||                                 \
+    ((x) == DVP_DATA_WIDTH_12BIT)           ||                                 \
+    ((x) == DVP_DATA_WIDTH_14BIT))
+
+#define IS_DVP_FLAG(x)                                                         \
+(   ((x) != 0UL)                            ||                                 \
+    (((x) | DVP_FLAG_ALL) == DVP_FLAG_ALL))
+
+#define IS_DVP_INT(x)                                                          \
+(   ((x) != 0UL)                            ||                                 \
+    (((x) | DVP_INT_ALL) == DVP_INT_ALL))
+
+#define IS_DVP_CROP_WIN_ROW_START_LINE(x)       ((x) <= 0x3FFFU)
+
+#define IS_DVP_CROP_WIN_COLUMN_START_LINE(x)    ((x) <= 0x3FFFU)
+
+#define IS_DVP_CROP_WIN_ROW_LINE_SIZE(x)        (((x) >= 0x04U) && ((x) <= 0x3FFFU))
+
+#define IS_DVP_CROP_WIN_COLUMN_LINE_SIZE(x)     ((x) <= 0x3FFFU)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup DVP_Global_Functions DVP Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_dvp_init_t to default values
+ * @param  [out] pstcDvpInit            Pointer to a @ref stc_dvp_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDvpInit value is NULL.
+ */
+int32_t DVP_StructInit(stc_dvp_init_t *pstcDvpInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDvpInit) {
+        pstcDvpInit->u32SyncMode       = DVP_SYNC_MD_HW;
+        pstcDvpInit->u32DataWidth      = DVP_DATA_WIDTH_8BIT;
+        pstcDvpInit->u32CaptureMode    = DVP_CAPT_MD_CONT_FRAME;
+        pstcDvpInit->u32CaptureFreq    = DVP_CAPT_FREQ_ALL_FRAME;
+        pstcDvpInit->u32PIXCLKPolarity = DVP_PIXCLK_FALLING;
+        pstcDvpInit->u32HSYNCPolarity  = DVP_HSYNC_LOW;
+        pstcDvpInit->u32VSYNCPolarity  = DVP_VSYNC_LOW;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize DVP function.
+ * @param  [in] pstcDvpInit             Pointer to a @ref stc_dvp_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcDvpInit value is NULL.
+ */
+int32_t DVP_Init(const stc_dvp_init_t *pstcDvpInit)
+{
+    uint32_t u32Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDvpInit) {
+        DDL_ASSERT(IS_DVP_SYNC_MD(pstcDvpInit->u32SyncMode));
+        DDL_ASSERT(IS_DVP_DATA_WIDTH(pstcDvpInit->u32DataWidth));
+        DDL_ASSERT(IS_DVP_CAPT_MD(pstcDvpInit->u32CaptureMode));
+        DDL_ASSERT(IS_DVP_CAPT_FREQ(pstcDvpInit->u32CaptureFreq));
+        DDL_ASSERT(IS_DVP_PIXCLK_POLARITY(pstcDvpInit->u32PIXCLKPolarity));
+        DDL_ASSERT(IS_DVP_HSYNC_POLARITY(pstcDvpInit->u32HSYNCPolarity));
+        DDL_ASSERT(IS_DVP_VSYNC_POLARITY(pstcDvpInit->u32VSYNCPolarity));
+
+        /* Configure DVP */
+        u32Value = (pstcDvpInit->u32SyncMode    | pstcDvpInit->u32DataWidth      | pstcDvpInit->u32CaptureMode   | \
+                    pstcDvpInit->u32CaptureFreq | pstcDvpInit->u32PIXCLKPolarity | pstcDvpInit->u32HSYNCPolarity | \
+                    pstcDvpInit->u32VSYNCPolarity);
+        WRITE_REG32(CM_DVP->CTR, u32Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize DVP function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t DVP_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(CM_DVP->CTR, 0UL);
+    WRITE_REG32(CM_DVP->STR, 0UL);
+    WRITE_REG32(CM_DVP->IER, 0UL);
+    WRITE_REG32(CM_DVP->SSYNDR, 0UL);
+    WRITE_REG32(CM_DVP->SSYNMR, 0xFFFFFFFFUL);
+    WRITE_REG32(CM_DVP->CPSFTR, 0UL);
+    WRITE_REG32(CM_DVP->CPSZER, 0UL);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable/disable DVP.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DVP_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_DVP->CTR, DVP_CTR_DVPEN);
+    } else {
+        CLR_REG32_BIT(CM_DVP->CTR, DVP_CTR_DVPEN);
+    }
+}
+
+/**
+ * @brief  Enable/disable the specified DVP interrupt.
+ * @param  [in] u32IntType              DVP interrupt type
+ *         This parameter can be any composed value of the macros group @ref DVP_Interrupt
+ *           @arg DVP_INT_FRAME_START:  Frame start interrupt
+ *           @arg DVP_INT_LINE_START:   Line start interrupt
+ *           @arg DVP_INT_LINE_END:     Line end interrupt
+ *           @arg DVP_INT_FRAME_END:    Frame end interrupt
+ *           @arg DVP_INT_FIFO_OVF:     FIFO overflow error interrupt
+ *           @arg DVP_INT_SYNC_ERR:     Sync error interrupt
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DVP_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_DVP_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_DVP->IER, u32IntType);
+    } else {
+        CLR_REG32_BIT(CM_DVP->IER, u32IntType);
+    }
+}
+
+/**
+ * @brief  Enable/disable DVP crop.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DVP_CropCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_DVP->CTR_b.CROPEN, enNewState);
+}
+
+/**
+ * @brief  Enable/disable DVP JPEG format.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DVP_JPEGCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_DVP->CTR, DVP_CTR_JPEGEN);
+    } else {
+        CLR_REG32_BIT(CM_DVP->CTR, DVP_CTR_JPEGEN);
+    }
+}
+
+/**
+ * @brief  Enable/disable DVP capture.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void DVP_CaptureCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_DVP->CTR, DVP_CTR_CAPEN);
+    } else {
+        CLR_REG32_BIT(CM_DVP->CTR, DVP_CTR_CAPEN);
+    }
+}
+
+/**
+ * @brief  Get DVP capture status.
+ * @param  None
+ * @retval An @ref en_functional_state_t enumeration value.
+ *           - ENABLE: DVP capture started
+ *           - DISABLE: DVP capture stopped
+ */
+en_functional_state_t DVP_GetCaptureState(void)
+{
+    return (READ_REG32_BIT(CM_DVP->CTR, DVP_CTR_CAPEN) > 0UL) ? ENABLE : DISABLE;
+}
+
+/**
+ * @brief  Get the specified DVP flag status.
+ * @param  [in] u32Flag                 DVP flag
+ *         This parameter can be any composed value of the macros group @ref DVP_Flag
+ *           @arg DVP_FLAG_FRAME_START: Frame start flag
+ *           @arg DVP_FLAG_LINE_START:  Line start flag
+ *           @arg DVP_FLAG_LINE_END:    Line end flag
+ *           @arg DVP_FLAG_FRAME_END:   Frame end flag
+ *           @arg DVP_FLAG_FIFO_OVF:    FIFO overflow error flag
+ *           @arg DVP_FLAG_SYNC_ERR:    Sync error interrupt
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t DVP_GetStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DVP_FLAG(u32Flag));
+
+    return ((READ_REG32_BIT(CM_DVP->STR, u32Flag) == 0UL) ? RESET : SET);
+}
+
+/**
+ * @brief  Clear the specified DVP flag status.
+ * @param  [in] u32Flag                 DVP flag
+ *         This parameter can be any composed value of the macros group @ref DVP_Flag
+ *           @arg DVP_FLAG_FRAME_START: Frame start flag
+ *           @arg DVP_FLAG_LINE_START:  Line start flag
+ *           @arg DVP_FLAG_LINE_END:    Line end flag
+ *           @arg DVP_FLAG_FRAME_END:   Frame end flag
+ *           @arg DVP_FLAG_FIFO_OVF:    FIFO overflow error flag
+ *           @arg DVP_FLAG_SYNC_ERR:    Sync error interrupt
+ * @retval None
+ */
+void DVP_ClearStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_DVP_FLAG(u32Flag));
+
+    WRITE_REG32(CM_DVP->STR, (~u32Flag) & DVP_FLAG_ALL);
+}
+
+/**
+ * @brief  Set DVP software sync code.
+ * @param  [in] pstcSyncCode            Pointer to a @ref stc_dvp_sw_sync_code_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The parameter pstcSyncCode value is NULL.
+ */
+int32_t DVP_SetSWSyncCode(const stc_dvp_sw_sync_code_t *pstcSyncCode)
+{
+    uint32_t u32Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSyncCode) {
+        /* Set sync code. */
+        u32Value = (((uint32_t)pstcSyncCode->u8FrameStartSyncCode << DVP_SSYNDR_FSDAT_POS) | \
+                    ((uint32_t)pstcSyncCode->u8LineStartSyncCode << DVP_SSYNDR_LSDAT_POS)  | \
+                    ((uint32_t)pstcSyncCode->u8LineEndSyncCode << DVP_SSYNDR_LEDAT_POS)    | \
+                    ((uint32_t)pstcSyncCode->u8FrameEndSyncCode << DVP_SSYNDR_FEDAT_POS));
+        WRITE_REG32(CM_DVP->SSYNDR, u32Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DVP software sync mask code.
+ * @param  [in] pstcMaskCode            Pointer to a @ref stc_dvp_sw_mask_code_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The parameter pstcMaskCode value is NULL.
+ */
+int32_t DVP_SetSWMaskCode(const stc_dvp_sw_mask_code_t *pstcMaskCode)
+{
+    uint32_t u32Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcMaskCode) {
+        /* Set sync code. */
+        u32Value = (((uint32_t)pstcMaskCode->u8FrameStartMaskCode << DVP_SSYNMR_FSMSK_POS) | \
+                    ((uint32_t)pstcMaskCode->u8LineStartMaskCode << DVP_SSYNMR_LSMSK_POS)  | \
+                    ((uint32_t)pstcMaskCode->u8LineEndMaskCode << DVP_SSYNMR_LEMSK_POS)    | \
+                    ((uint32_t)pstcMaskCode->u8FrameEndMaskCode << DVP_SSYNMR_FEMSK_POS));
+        WRITE_REG32(CM_DVP->SSYNMR, u32Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DVP software sync mask code.
+ * @param  [in] pstcConfig              Pointer to a @ref stc_dvp_crop_window_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The parameter pstcConfig value is NULL.
+ */
+int32_t DVP_CropWindowConfig(const stc_dvp_crop_window_config_t *pstcConfig)
+{
+    uint32_t u32Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcConfig) {
+        DDL_ASSERT(IS_DVP_CROP_WIN_ROW_START_LINE(pstcConfig->u16RowStartLine));
+        DDL_ASSERT(IS_DVP_CROP_WIN_COLUMN_START_LINE(pstcConfig->u16ColumnStartLine));
+        DDL_ASSERT(IS_DVP_CROP_WIN_ROW_LINE_SIZE(pstcConfig->u16RowLineSize));
+        DDL_ASSERT(IS_DVP_CROP_WIN_COLUMN_LINE_SIZE(pstcConfig->u16ColumnLineSize));
+
+        /* Configure crop window */
+        u32Value = ((uint32_t)pstcConfig->u16RowStartLine | \
+                    ((uint32_t)pstcConfig->u16ColumnStartLine << DVP_CPSFTR_CSHIFT_POS));
+        WRITE_REG32(CM_DVP->CPSFTR, u32Value);
+
+        u32Value = ((uint32_t)pstcConfig->u16RowLineSize | \
+                    ((uint32_t)pstcConfig->u16ColumnLineSize << DVP_CPSZER_CSIZE_POS));
+        WRITE_REG32(CM_DVP->CPSZER, u32Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_DVP_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_efm.c
+++ b/hc32f4a2/src/hc32_ll_efm.c
@@ -1,0 +1,1664 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_efm.c
+ * @brief This file provides firmware functions to manage the Embedded Flash
+ *        Memory unit (EFM).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Use define to replace magic data
+   2022-10-31       CDT             Add API EFM_Protect_Enable & EFM_WriteSecurityCode
+                                    Modify API EFM_Read & EFM_Program
+   2023-01-15       CDT             Code refine
+   2023-06-30       CDT             Modify API EFM_OTP_Lock()
+                                    Modify API EFM_Program()
+                                    Modify assert IS_EFM_ADDR() range
+                                    Modify typo
+                                    Modify API EFM_WriteSecurityCode(), switch to read_only mode before exit
+                                    Use FNWPRT_REG to replace CM_EFM->F0NWPRT0
+   2023-09-30       CDT             Remove address assert from EFM_ReadByte()
+                                    Refine EFM_SequenceProgram() & EFM_ChipErase(), and put them in RAM
+   2023-12-15       CDT             Rename EFM_DataCacheResetCmd() as EFM_CacheRamReset() and modify comment
+   2024-06-30       CDT             Optimize EFM_ClearStatus()
+   2024-08-31       CDT             Optimize condition judgment
+   2024-10-17       CDT             Add const before buffer pointer to cater top-level calls
+                                    Bug Fixed # judge the EFM_FLAG_OPTEND whether set o not before clear EFM_FLAG_OPTEND
+   2024-11-08       CDT             Remap the sector number parameter of EFM_SingleSectorOperateCmd based on SWAP and OTP status
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_efm.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EFM EFM
+ * @brief Embedded Flash Management Driver Library
+ * @{
+ */
+
+#if (LL_EFM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EFM_Local_Macros EFM Local Macros
+ * @{
+ */
+#ifndef __EFM_FUNC
+#define __EFM_FUNC                      __RAM_FUNC
+#endif
+
+/**
+ * @defgroup EFM_Timeout_Definition EFM timeout definition
+ * @{
+ */
+#define EFM_TIMEOUT                     (HCLK_VALUE / 20000UL)  /* EFM wait read timeout */
+#define EFM_PGM_TIMEOUT                 (HCLK_VALUE / 20000UL)  /* EFM Program timeout max 53us */
+#define EFM_ERASE_TIMEOUT               (HCLK_VALUE / 50UL)     /* EFM Erase timeout max 20ms */
+#define EFM_SEQ_PGM_TIMEOUT             (HCLK_VALUE / 62500UL)  /* EFM Sequence Program timeout max 16us */
+/**
+ * @}
+ */
+
+#define REMCR_REG(x)                    (*(__IO uint32_t *)((uint32_t)(&CM_EFM->MMF_REMCR0) + (4UL * (x))))
+
+#define EFM_FLAG0_POS                   (0U)
+#define EFM_FLAG1_POS                   (16U)
+#define EFM_OTP_END_SECTOR_NUM          (15U)
+
+#define EFM_FLASH1_START_SECTOR_NUM     (128U)
+#define FNWPRT_REG                      (CM_EFM->F0NWPRT0)
+
+#define REG_LEN                         (32U)
+#define EFM_SWAP_FLASH1_END_SECTOR_NUM  (EFM_FLASH1_START_SECTOR_NUM + EFM_OTP_END_SECTOR_NUM)
+#define EFM_SWAP_FLASH1_END_ADDR        (EFM_FLASH_1_START_ADDR + EFM_OTP_END_ADDR1)
+#define EFM_OTP_UNLOCK_KEY1             (0x10325476UL)
+#define EFM_OTP_UNLOCK_KEY2             (0xEFCDAB89UL)
+
+/**
+ * @defgroup EFM_SectorOperate EFM sector operate define
+ * @{
+ */
+#define EFM_FNWPRT_REG_OFFSET           (2UL)
+#define EFM_FNWPRT_REG_NUM              (8UL)
+#define EFM_FNWPRT_REG_END_ADDR         (__IO uint32_t *)(uint32_t)(&CM_EFM->F1NWPRT3)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_protect EFM protect define
+ * @{
+ */
+#define EFM_SECURITY_LEN                (12UL)
+#define EFM_PROTECT1_KEY                (0xAF180402UL)
+#define EFM_PROTECT2_KEY                (0xA85173AEUL)
+
+#define EFM_PROTECT3_KEY                (0x42545048UL)
+#define EFM_PROTECT1_ADDR               (0x00000430UL)
+#define EFM_PROTECT2_ADDR               (0x00000434UL)
+#define EFM_PROTECT3_ADDR1              (0x00000420UL)
+#define EFM_PROTECT3_ADDR2              (0x00000424UL)
+#define EFM_PROTECT3_ADDR3              (0x00000428UL)
+#define EFM_SECURITY_ADDR               (0x03004000UL)
+
+#define EFM_SWAP_ON_PROTECT_SECTOR_NUM  EFM_FLASH1_START_SECTOR_NUM
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Check_Parameters_Validity EFM Check Parameters Validity
+ * @{
+ */
+/* Parameter validity check for efm chip . */
+#define IS_EFM_CHIP(x)                                                          \
+(   ((x) == EFM_CHIP0)                  ||                                      \
+    ((x) == EFM_CHIP1)                  ||                                      \
+    ((x) == EFM_CHIP_ALL))
+
+/* Parameter validity check for flash latency. */
+#define IS_EFM_WAIT_CYCLE(x)            ((x) <= EFM_WAIT_CYCLE15)
+
+/* Parameter validity check for operate mode. */
+#define IS_EFM_OP_MD(x)                                                         \
+(   ((x) == EFM_MD_PGM_SINGLE)          ||                                      \
+    ((x) == EFM_MD_PGM_READBACK)        ||                                      \
+    ((x) == EFM_MD_PGM_SEQ)             ||                                      \
+    ((x) == EFM_MD_ERASE_SECTOR)        ||                                      \
+    ((x) == EFM_MD_ERASE_ONE_CHIP)      ||                                      \
+    ((x) == EFM_MD_ERASE_ALL_CHIP)      ||                                      \
+    ((x) == EFM_MD_READONLY))
+
+/* Parameter validity check for efm status. */
+#define IS_EFM_STATUS(x)                                                        \
+(   ((x) == EFM_FLASH0_ACT_FLASH1_ACT)  ||                                      \
+    ((x) == EFM_FLASH0_STP_FLASH1_ACT)  ||                                      \
+    ((x) == EFM_FLASH0_ACT_FLASH1_STP)  ||                                      \
+    ((x) == EFM_FLASH0_STP_FLASH1_STP))
+
+/* Parameter validity check for flash interrupt select. */
+#define IS_EFM_INT_SEL(x)               (((x) | EFM_INT_ALL) == EFM_INT_ALL)
+
+/* Parameter validity check for flash flag. */
+#define IS_EFM_FLAG(x)                  (((x) | EFM_FLAG_ALL) == EFM_FLAG_ALL)
+
+/* Parameter validity check for flash clear flag. */
+#define IS_EFM_CLRFLAG(x)               (((x) | EFM_FLAG_ALL) == EFM_FLAG_ALL)
+
+/* Parameter validity check for bus status while flash program or erase. */
+#define IS_EFM_BUS_STATUS(x)                                                    \
+(   ((x) == EFM_BUS_HOLD)               ||                                      \
+    ((x) == EFM_BUS_RELEASE))
+
+/* Parameter validity check for efm address. */
+#define IS_EFM_ADDR(x)                                                          \
+(   ((x) <= EFM_END_ADDR)               ||                                      \
+    (((x) >= EFM_OTP_START_ADDR) && ((x) <= EFM_OTP_END_ADDR)) ||               \
+    (((x) >= EFM_SECURITY_START_ADDR) && ((x) <= EFM_SECURITY_END_ADDR)))
+
+/* Parameter validity check for efm erase address. */
+#define IS_EFM_ERASE_ADDR(x)                                                    \
+(   ((x) <= EFM_END_ADDR)               ||                                      \
+    (((x) >= EFM_OTP_START_ADDR) && ((x) <= EFM_OTP_END_ADDR)) ||               \
+    (((x) >= EFM_SECURITY_START_ADDR) && ((x) <= EFM_SECURITY_END_ADDR)))
+
+/* Parameter validity check for efm erase mode . */
+#define IS_EFM_ERASE_MD(x)                                                      \
+(   ((x) == EFM_MD_ERASE_ONE_CHIP)      ||                                      \
+    ((x) == EFM_MD_ERASE_FULL))
+
+/* Parameter validity check for EFM lock status. */
+#define IS_EFM_REG_UNLOCK()             (CM_EFM->FAPRT == 0x00000001UL)
+
+/* Parameter validity check for EFM_FWMC register lock status. */
+#define IS_EFM_FWMC_UNLOCK()            (bCM_EFM->FWMC_b.KEY1LOCK == 0U)
+
+/* Parameter validity check for OTP lock status. */
+#define IS_EFM_OTP_UNLOCK()             (bCM_EFM->FWMC_b.KEY2LOCK == 0U)
+
+/* Parameter validity check for sector protected register locking. */
+#define IS_EFM_SECTOR_PROTECT_REG_LOCK(x)           ((x) <= 0xFFU)
+
+/* Parameter validity check for EFM sector number */
+#define IS_EFM_SECTOR_NUM(x)            ((x) <= 256U)
+#define IS_EFM_SECTOR_IDX(x)            ((x) < 256U)
+
+/* Parameter validity check for EFM remap lock status. */
+#define IS_EFM_REMAP_UNLOCK()           (CM_EFM->MMF_REMPRT == 0x00000001UL)
+
+/* Parameter validity check for EFM remap index */
+#define IS_EFM_REMAP_IDX(x)                                                     \
+(   ((x) == EFM_REMAP_IDX0)             ||                                      \
+    ((x) == EFM_REMAP_IDX1))
+
+/* Parameter validity check for EFM remap size */
+#define IS_EFM_REMAP_SIZE(x)                                                    \
+(   ((x) >= EFM_REMAP_4K)               &&                                      \
+    ((x) <= EFM_REMAP_SIZE_MAX))
+
+/* Parameter validity check for EFM remap address */
+#define IS_EFM_REMAP_ADDR(x)                                                    \
+(   ((x) <= EFM_REMAP_ROM_END_ADDR)     ||                                      \
+    (((x) >= EFM_REMAP_RAM_START_ADDR)  &&                                      \
+    ((x) <= EFM_REMAP_RAM_END_ADDR)))
+
+/* Parameter validity check for EFM remap state */
+#define IS_EFM_REMAP_STATE(x)                                                   \
+(   ((x) == EFM_REMAP_OFF)             ||                                       \
+    ((x) == EFM_REMAP_ON))
+
+/* Parameter validity check for EFM security code length */
+#define IS_EFM_SECURITY_CODE_LEN(x)    ((x) <= EFM_SECURITY_LEN)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup EFM_Local_Functions EFM Local Functions
+ * @{
+ */
+
+/**
+ * @brief  Wait EFM flag.
+ * @param  [in] u32Flag     Specifies the flag to be wait. @ref EFM_Flag_Sel
+ * @param  [in] u32Time     Specifies the time to wait while the flag not be set.
+ * @retval int32_t:
+ *         - LL_OK: Flag was set.
+ *         - LL_ERR_TIMEOUT: Flag was not set.
+ */
+static int32_t EFM_WaitFlag(uint32_t u32Flag, uint32_t u32Time)
+{
+    __IO uint32_t u32Timeout = 0UL;
+    int32_t i32Ret = LL_OK;
+
+    while (SET != EFM_GetStatus(u32Flag)) {
+        u32Timeout++;
+        if (u32Timeout > u32Time) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Wait EFM operate end.
+ * @param  [in] u8Shift     Specifies the flag shift bit. @ref EFM_Flag_Sel
+ * @param  [in] u32Time     Specifies the time to wait while the flag not be set.
+ * @retval int32_t:
+ *         - LL_OK: Flash program or erase success.
+ *         - LL_ERR_NOT_RDY: Flash program or erase not ready.
+ *         - LL_ERR: Flash program or erase error.
+ */
+static int32_t EFM_WaitEnd(uint8_t u8Shift, uint32_t u32Time)
+{
+    int32_t i32Ret = LL_OK;
+    /* Wait for ready flag. */
+    if (LL_ERR_TIMEOUT == EFM_WaitFlag(EFM_FLAG_RDY << u8Shift, u32Time)) {
+        i32Ret = LL_ERR_NOT_RDY;
+    }
+    if (LL_OK == i32Ret) {
+        if (SET == EFM_GetStatus(EFM_FLAG_OPTEND << u8Shift)) {
+            /* Clear the operation end flag */
+            EFM_ClearStatus(EFM_FLAG_OPTEND << u8Shift);
+        } else {
+            i32Ret = LL_ERR;
+        }
+    }
+    return i32Ret;
+}
+/**
+ * @brief  Wait EFM program and ReadBack operate end.
+ * @param  [in] u8Shift     Specifies the flag shift bit. @ref EFM_Flag_Sel
+ * @retval int32_t:
+ *         - LL_OK: Flash program or erase success.
+ *         - LL_ERR_NOT_RDY: Flash program or erase not ready.
+ *         - LL_ERR: Flash program or erase error.
+ */
+static int32_t EFM_WaitReadBackEnd(uint8_t u8Shift)
+{
+    int32_t i32Ret = LL_OK;
+    /* Wait for ready flag. */
+    if (LL_ERR_TIMEOUT == EFM_WaitFlag(EFM_FLAG_RDY << u8Shift, EFM_PGM_TIMEOUT)) {
+        i32Ret = LL_ERR_NOT_RDY;
+    }
+    if (LL_OK == i32Ret) {
+        /* Get the flag PGMISMTCH */
+        if (SET == EFM_GetStatus(EFM_FLAG_PGMISMTCH << u8Shift)) {
+            /* Clear flag PGMISMTCH */
+            EFM_ClearStatus(EFM_FLAG_PGMISMTCH << u8Shift);
+            i32Ret = LL_ERR;
+        }
+        if (LL_OK == i32Ret) {
+            if (SET == EFM_GetStatus(EFM_FLAG_OPTEND << u8Shift)) {
+                /* Clear the operation end flag. */
+                EFM_ClearStatus(EFM_FLAG_OPTEND << u8Shift);
+            } else {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Wait EFM flag.
+ * @param  [in] u32Addr     Specifies the address to calculate.
+ * @retval uint8_t:         The count that flag should shift.
+ */
+static uint8_t EFM_FlagShift(uint32_t u32Addr)
+{
+    uint8_t u8Shift;
+    uint8_t u8SwapState;
+    uint8_t u8OtpState;
+    uint8_t u8Flag;
+
+    u8SwapState = (uint8_t)READ_REG32(bCM_EFM->FSWP_b.FSWP);
+    u8OtpState = (0xFFFFFFFFUL == RW_MEM32(EFM_OTP_ENABLE_ADDR)) ? 0U : 1U;
+
+    /* To judge the addr belong to FLASH0 or FLASH1 */
+    if (u32Addr < EFM_OTP_END_ADDR1) {
+        u8Flag = (1U == u8OtpState) ? 0U : 1U;
+        u8Shift = (u8SwapState & u8Flag) * EFM_FLAG1_POS;
+    } else if (u32Addr < EFM_FLASH_1_START_ADDR) {
+        u8Shift = u8SwapState * EFM_FLAG1_POS;
+    } else if (u32Addr < EFM_SWAP_FLASH1_END_ADDR) {
+        u8Flag = (1U == u8SwapState) ? 0U : 1U;
+        u8Shift = (u8Flag | u8OtpState) * EFM_FLAG1_POS;
+    } else if (u32Addr < EFM_END_ADDR) {
+        u8Flag = (1U == u8SwapState) ? 0U : 1U;
+        u8Shift = u8Flag * EFM_FLAG1_POS;
+    } else {
+        u8Shift = EFM_FLAG0_POS;
+    }
+
+    return u8Shift;
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EFM_Global_Functions EFM Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Enable or disable EFM.
+ * @param  [in] u32Flash        Specifies the FLASH. @ref EFM_Chip_Sel
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EFM_Cmd(uint32_t u32Flash, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_CHIP(u32Flash));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_EFM->FSTP, u32Flash);
+    } else {
+        SET_REG32_BIT(CM_EFM->FSTP, u32Flash);
+    }
+}
+
+/**
+ * @brief  Set the efm read wait cycles.
+ * @param  [in] u32WaitCycle            Specifies the efm read wait cycles.
+ *    @arg  This parameter can be of a value of @ref EFM_Wait_Cycle
+ * @retval int32_t:
+ *         - LL_OK: Program successfully.
+ *         - LL_ERR_TIMEOUT: EFM is not ready.
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_SetWaitCycle(uint32_t u32WaitCycle)
+{
+    uint32_t u32Timeout = 0UL;
+
+    /* Param valid check */
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_WAIT_CYCLE(u32WaitCycle));
+
+    MODIFY_REG32(CM_EFM->FRMC, EFM_FRMC_FLWT, u32WaitCycle);
+    while (u32WaitCycle != READ_REG32_BIT(CM_EFM->FRMC, EFM_FRMC_FLWT)) {
+        u32Timeout++;
+        if (u32Timeout > EFM_TIMEOUT) {
+            return LL_ERR_TIMEOUT;
+        }
+    }
+    return LL_OK;
+}
+
+/**
+ * @brief  Reset cache RAM or cache ram release reset.
+ * @param  [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EFM_CacheRamReset(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.CRST, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the flash prefetch.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_PrefetchCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.PREFETE, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the flash data cache.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_DCacheCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.DCACHE, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the flash instruction cache.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_ICacheCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.ICACHE, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the Read of low-voltage mode.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_LowVoltageReadCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.LVM, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the EFM swap function.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *         - LL_OK: Program successfully.
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_SwapCmd(en_functional_state_t enNewState)
+{
+    int32_t i32Ret;
+    uint32_t u32Tmp;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+
+    if (enNewState == ENABLE) {
+        /* Set Program single mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+        /* Enable flash swap function */
+        RW_MEM32(EFM_SWAP_ADDR) = EFM_SWAP_DATA;
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(0U, EFM_PGM_TIMEOUT);
+    } else {
+        /* Set Sector erase mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_SECTOR);
+        /* Disable flash switch function */
+        RW_MEM32(EFM_SWAP_ADDR) = 0x0UL;
+        /* Wait for ready flag. */
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(0U, EFM_ERASE_TIMEOUT);
+    }
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+
+    /* recover CACHE */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks whether the swap function enable or disable.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EFM_GetSwapStatus(void)
+{
+    return ((0UL == READ_REG32(bCM_EFM->FSWP_b.FSWP)) ? RESET : SET);
+}
+
+/**
+ * @brief  Set the FLASH erase program mode .
+ * @param  [in] u32Mode                   Specifies the FLASH erase program mode.
+ *    @arg  This parameter can be of a value of @ref EFM_OperateMode_Sel
+ * @retval int32_t:
+ *         - LL_OK: Set mode successfully.
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ */
+int32_t EFM_SetOperateMode(uint32_t u32Mode)
+{
+    int32_t i32Ret = LL_OK;
+    DDL_ASSERT(IS_EFM_OP_MD(u32Mode));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+    if (LL_ERR_TIMEOUT == EFM_WaitFlag(EFM_FLAG_RDY | EFM_FLAG_RDY1, EFM_SEQ_PGM_TIMEOUT)) {
+        i32Ret = LL_ERR_NOT_RDY;
+    }
+
+    if (i32Ret == LL_OK) {
+        /* Set the program or erase mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, u32Mode);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or Disable EFM interrupt.
+ * @param  [in] u32EfmInt               Specifies the FLASH interrupt source and status. @ref EFM_Interrupt_Sel
+ *   @arg  EFM_INT_OPTEND:              End of EFM Operation Interrupt source
+ *   @arg  EFM_INT_PEERR:               Program/erase error Interrupt source
+ *   @arg  EFM_INT_COLERR:              Read collide error Interrupt source
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_IntCmd(uint32_t u32EfmInt, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_INT_SEL(u32EfmInt));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_EFM->FITE, u32EfmInt);
+    } else {
+        CLR_REG32_BIT(CM_EFM->FITE, u32EfmInt);
+    }
+}
+
+/**
+ * @brief  Check any of the specified flag is set or not.
+ * @param  [in] u32Flag                    Specifies the FLASH flag to check.
+ *   @arg  This parameter can be of a value of @ref EFM_Flag_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EFM_GetAnyStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EFM_FLAG(u32Flag));
+
+    return ((0UL == READ_REG32_BIT(CM_EFM->FSR, u32Flag)) ? RESET : SET);
+}
+
+/**
+ * @brief  Check all the specified flag is set or not.
+ * @param  [in] u32Flag                    Specifies the FLASH flag to check.
+ *   @arg  This parameter can be of a value of @ref EFM_Flag_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EFM_GetStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EFM_FLAG(u32Flag));
+
+    return ((u32Flag == READ_REG32_BIT(CM_EFM->FSR, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear the flash flag.
+ * @param  [in] u32Flag                  Specifies the FLASH flag to clear.
+ *   @arg  This parameter can be of a value of @ref EFM_Flag_Sel
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_ClearStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_CLRFLAG(u32Flag));
+
+    WRITE_REG32(CM_EFM->FSCLR, u32Flag);
+}
+
+/**
+ * @brief  Set bus status while flash program or erase.
+ * @param  [in] u32Status                  Specifies the new bus status while flash program or erase.
+ *  This parameter can be one of the following values:
+ *   @arg  EFM_BUS_HOLD:                   Bus busy while flash program or erase.
+ *   @arg  EFM_BUS_RELEASE:                Bus release while flash program or erase.
+ * @retval None
+ */
+void EFM_SetBusStatus(uint32_t u32Status)
+{
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_BUS_STATUS(u32Status));
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+
+    WRITE_REG32(bCM_EFM->FWMC_b.BUSHLDCTL, u32Status);
+}
+
+/**
+ * @brief  EFM read byte.
+ * @param  [in] u32Addr               The specified address to read.
+ * @param  [in] pu8ReadBuf            The specified read buffer.
+ * @param  [in] u32ByteLen            The specified length to read.
+ * @retval int32_t:
+ *         - LL_OK: Read successfully
+ *         - LL_ERR_INVD_PARAM: Invalid parameter
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ */
+int32_t EFM_ReadByte(uint32_t u32Addr, uint8_t *pu8ReadBuf, uint32_t u32ByteLen)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    __IO uint8_t *pu8Buf = (uint8_t *)u32Addr;
+    uint32_t u32Len = u32ByteLen;
+    uint32_t u32ReadyFlag = EFM_FLAG_RDY;
+
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr));
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr + u32ByteLen - 1UL));
+
+    if (NULL != pu8ReadBuf) {
+        uint32_t u32EndAddr = u32Addr + u32ByteLen;
+        if (u32Addr < EFM_FLASH_1_START_ADDR) {
+            if (u32EndAddr > EFM_FLASH_1_START_ADDR) {
+                u32ReadyFlag |= EFM_FLAG_RDY1;
+            }
+        } else {
+            u32ReadyFlag = EFM_FLAG_RDY1;
+        }
+        if (LL_OK == EFM_WaitFlag(u32ReadyFlag, EFM_TIMEOUT)) {
+            while (0UL != u32Len) {
+                *(pu8ReadBuf++) = *(pu8Buf++);
+                u32Len--;
+            }
+            i32Ret = LL_OK;
+        } else {
+            i32Ret = LL_ERR_NOT_RDY;
+        }
+
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM program (single program mode).
+ * @param  [in] u32Addr                   The specified program address.
+ * @param  [in] pu8Buf                    The pointer of specified program data.
+ * @param  [in] u32Len                    The length of specified program data.
+ * @retval int32_t:
+ *         - LL_OK: Program successful.
+ *         - LL_ERR_NOT_RDY: EFM if not ready.
+ * @note  Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_Program(uint32_t u32Addr, const uint8_t *pu8Buf, uint32_t u32Len)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Tmp;
+    uint8_t u8Shift;
+    uint32_t u32LoopWords = u32Len >> 2UL;
+    uint32_t u32RemainBytes = u32Len % 4UL;
+    uint32_t *u32pSource = (uint32_t *)(uint32_t)pu8Buf;
+    uint32_t *u32pDest = (uint32_t *)u32Addr;
+    uint32_t u32LastWord;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr));
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr + u32Len - 1UL));
+    DDL_ASSERT(IS_ADDR_ALIGN_WORD(u32Addr));
+
+    /* Clear the error flag. */
+    EFM_ClearStatus(EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+
+    /* Set single program mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+
+    while ((u32LoopWords-- > 0UL) && (LL_OK == i32Ret)) {
+        u8Shift = EFM_FlagShift((uint32_t)u32pDest);
+        /* program data. */
+        *u32pDest++ = *u32pSource++;
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(u8Shift, EFM_PGM_TIMEOUT);
+    }
+
+    if ((0U != u32RemainBytes) && (LL_OK == i32Ret)) {
+        u32LastWord = *u32pSource;
+        u32LastWord |= 0xFFFFFFFFUL << (u32RemainBytes * 8UL);
+        u8Shift = EFM_FlagShift((uint32_t)u32pDest);
+        *u32pDest++ = u32LastWord;
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(u8Shift, EFM_PGM_TIMEOUT);
+
+    }
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+    /* Recover CACHE function */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM single program mode(Word).
+ * @param  [in] u32Addr                   The specified program address.
+ * @param  [in] u32Data                   The specified program data.
+ * @retval int32_t:
+ *         - LL_OK: Program successfully
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note  Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_ProgramWord(uint32_t u32Addr, uint32_t u32Data)
+{
+    int32_t i32Ret;
+    uint32_t u32Tmp;
+    uint8_t u8Shift;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr));
+    DDL_ASSERT(IS_ADDR_ALIGN_WORD(u32Addr));
+
+    /* Clear the error flag. */
+    EFM_ClearStatus(EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE function */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    u8Shift = EFM_FlagShift(u32Addr);
+    /* Set single program mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+    /* Program data. */
+    RW_MEM32(u32Addr) = u32Data;
+
+    /* Wait operate end. */
+    i32Ret = EFM_WaitEnd(u8Shift, EFM_PGM_TIMEOUT);
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+
+    /* Recover CACHE function */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM single program with read back(Word).
+ * @param  [in] u32Addr                   The specified program address.
+ * @param  [in] u32Data                   The specified program data.
+ * @retval int32_t:
+ *         - LL_OK: Program successfully
+ *         - LL_ERR: program error
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note  Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_ProgramWordReadBack(uint32_t u32Addr, uint32_t u32Data)
+{
+    int32_t i32Ret;
+    uint32_t u32Tmp;
+    uint8_t u8Shift;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+    DDL_ASSERT(IS_EFM_ADDR(u32Addr));
+    DDL_ASSERT(IS_ADDR_ALIGN_WORD(u32Addr));
+
+    /* Clear the error flag. */
+    EFM_ClearStatus(EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    u8Shift = EFM_FlagShift(u32Addr);
+    /* Set Program and read back mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_READBACK);
+    /* Program data. */
+    RW_MEM32(u32Addr) = (uint32_t)u32Data;
+    /* Wait operate end. */
+    i32Ret = EFM_WaitReadBackEnd(u8Shift);
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+    /* recover CACHE function */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM program (sequence program mode).
+ * @param  [in] u32Addr                   The specified program address.
+ * @param  [in] pu8Buf                    The pointer of specified program data.
+ * @param  [in] u32Len                    The length of specified program data.
+ * @retval int32_t:
+ *         - LL_OK: Program successfully
+ *         - LL_ERR_TIMEOUT: program error timeout
+ * @note  Call EFM_REG_Unlock() unlock EFM register first.
+ *        __EFM_FUNC default value is __RAM_FUNC.
+ *        __EFM_FUNC also could be attributed to FLASH0 or FLASH1 which is determined by users.
+ *        If want to attribute to other place, please define in hc32f4xx_conf.h.
+ */
+__NOINLINE __EFM_FUNC int32_t EFM_SequenceProgram(uint32_t u32Addr, const uint8_t *pu8Buf, uint32_t u32Len)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Tmp;
+    uint32_t u32LoopWords = u32Len >> 2UL;
+    uint32_t u32RemainBytes = u32Len % 4UL;
+    uint32_t *u32pSource = (uint32_t *)(uint32_t)pu8Buf;
+    uint32_t *u32pDest = (uint32_t *)u32Addr;
+    uint32_t u32Timeout;
+    uint32_t u32LastWord;
+    uint8_t u8Shift = 0U;
+    uint8_t u8SwapState;
+    uint8_t u8OtpState;
+    uint8_t u8Flag;
+
+    /* Assert */
+    if (!IS_EFM_REG_UNLOCK()) {
+        return LL_ERR_NOT_RDY;
+    }
+    if ((!IS_EFM_FWMC_UNLOCK()) || (!IS_EFM_ADDR(u32Addr)) || (!IS_EFM_ADDR(u32Addr + u32Len - 1UL))) {
+        return LL_ERR_INVD_PARAM;
+    }
+    if (!IS_ADDR_ALIGN_WORD(u32Addr)) {
+        return LL_ERR_INVD_PARAM;
+    }
+
+    /* Get swap & otp state, enable or disable */
+    u8SwapState = (uint8_t)READ_REG32(bCM_EFM->FSWP_b.FSWP);
+    u8OtpState = (0xFFFFFFFFUL == RW_MEM32(EFM_OTP_ENABLE_ADDR)) ? 0U : 1U;
+
+    /* Clear the error flag. */
+    SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Set sequence program mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SEQ);
+    while (u32LoopWords-- > 0UL) {
+        /* program data. */
+        *u32pDest = *u32pSource++;
+
+        /* To judge the addr belong to FLASH0 or FLASH1 */
+        if ((uint32_t)u32pDest < EFM_OTP_END_ADDR1) {
+            u8Flag = (1U == u8OtpState) ? 0U : 1U;
+            u8Shift = (u8SwapState & u8Flag) * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_FLASH_1_START_ADDR) {
+            u8Shift = u8SwapState * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_SWAP_FLASH1_END_ADDR) {
+            u8Flag = (1U == u8SwapState) ? 0U : 1U;
+            u8Shift = (u8Flag | u8OtpState) * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_END_ADDR) {
+            u8Flag = (1U == u8SwapState) ? 0U : 1U;
+            u8Shift = u8Flag * EFM_FLAG1_POS;
+        } else {
+            u8Shift = EFM_FLAG0_POS;
+        }
+
+        u32pDest++;
+        /* wait for operation end flag. */
+        u32Timeout = 0UL;
+        while ((EFM_FLAG_OPTEND << u8Shift) != READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_OPTEND << u8Shift)) {
+            if (u32Timeout++ >= EFM_PGM_TIMEOUT) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+        /* Clear operation end flag */
+        u32Timeout = 0UL;
+        while ((EFM_FLAG_OPTEND << u8Shift) == READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_OPTEND << u8Shift)) {
+            SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_OPTEND << u8Shift);
+            if (u32Timeout++ >= EFM_TIMEOUT) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+    }
+
+    if (0U != u32RemainBytes) {
+        /* To judge the addr belong to FLASH0 or FLASH1 */
+        if ((uint32_t)u32pDest < EFM_OTP_END_ADDR1) {
+            u8Flag = (1U == u8OtpState) ? 0U : 1U;
+            u8Shift = (u8SwapState & u8Flag) * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_FLASH_1_START_ADDR) {
+            u8Shift = u8SwapState * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_SWAP_FLASH1_END_ADDR) {
+            u8Flag = (1U == u8SwapState) ? 0U : 1U;
+            u8Shift = (u8Flag | u8OtpState) * EFM_FLAG1_POS;
+        } else if ((uint32_t)u32pDest < EFM_END_ADDR) {
+            u8Flag = (1U == u8SwapState) ? 0U : 1U;
+            u8Shift = u8Flag * EFM_FLAG1_POS;
+        } else {
+            u8Shift = EFM_FLAG0_POS;
+        }
+
+        /* Fill the last word */
+        u32LastWord = *u32pSource;
+        u32LastWord |= 0xFFFFFFFFUL << (u32RemainBytes * 8UL);
+        *u32pDest++ = u32LastWord;
+        /* wait for operation end flag. */
+        u32Timeout = 0UL;
+        while ((EFM_FLAG_OPTEND << u8Shift) != READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_OPTEND << u8Shift)) {
+            if (u32Timeout++ >= EFM_PGM_TIMEOUT) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+
+        /* Clear operation end flag */
+        u32Timeout = 0UL;
+        while ((EFM_FLAG_OPTEND << u8Shift) == READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_OPTEND << u8Shift)) {
+            SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_OPTEND << u8Shift);
+            if (u32Timeout++ >= EFM_TIMEOUT) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+    }
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+    /* Wait for ready flag. */
+    u32Timeout = 0UL;
+    while ((EFM_FLAG_RDY << u8Shift) != READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_RDY << u8Shift)) {
+        if (u32Timeout++ >= EFM_PGM_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    /* Recover CACHE */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM sector erase.
+ * @param  [in] u32Addr                   The address in the specified sector.
+ * @retval int32_t:
+ *         - LL_OK: Erase successful.
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+int32_t EFM_SectorErase(uint32_t u32Addr)
+{
+    int32_t i32Ret;
+    uint32_t u32Tmp;
+    uint8_t u8Shift;
+
+    DDL_ASSERT(IS_EFM_ERASE_ADDR(u32Addr));
+    DDL_ASSERT(IS_ADDR_ALIGN_WORD(u32Addr));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+
+    /* Clear the error flag. */
+    EFM_ClearStatus(EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    u8Shift = EFM_FlagShift(u32Addr);
+    /* Set sector erase mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_SECTOR);
+
+    /* Erase */
+    RW_MEM32(u32Addr) = 0UL;
+
+    /* Wait operate end. */
+    i32Ret = EFM_WaitEnd(u8Shift, EFM_ERASE_TIMEOUT);
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+    /* Recover CACHE */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM chip erase.
+ * @param  [in]  u8Chip      Specifies the chip to be erased @ref EFM_Chip_Sel
+ * @retval int32_t:
+ *         - LL_OK: Erase successfully
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ *         __EFM_FUNC default value is __RAM_FUNC.
+ *         __EFM_FUNC also could be attributed to FLASH0 or FLASH1 which is determined by users.
+ *        If want to attribute to other place, please define in hc32f4xx_conf.h.
+ */
+__NOINLINE __EFM_FUNC int32_t EFM_ChipErase(uint8_t u8Chip)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Tmp;
+    uint32_t u32Addr = 0UL;
+    uint8_t u8Shift;
+    uint32_t u32Timeout;
+    uint8_t u8SwapState;
+    uint8_t u8OtpState;
+    uint8_t u8Flag;
+
+    /* Assert */
+    if (!IS_EFM_REG_UNLOCK()) {
+        return LL_ERR_NOT_RDY;
+    }
+    if ((!IS_EFM_FWMC_UNLOCK()) || !IS_EFM_CHIP(u8Chip)) {
+        return LL_ERR_INVD_PARAM;
+    }
+
+    /* Clear the error flag. */
+    SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+
+    if (EFM_CHIP1 == u8Chip) {
+        u32Addr = EFM_FLASH_1_START_ADDR;
+    }
+    /* Get swap & otp state, enable or disable */
+    u8SwapState = (uint8_t)READ_REG32(bCM_EFM->FSWP_b.FSWP);
+    u8OtpState = (0xFFFFFFFFUL == RW_MEM32(EFM_OTP_ENABLE_ADDR)) ? 0U : 1U;
+    /* To judge the addr belong to FLASH0 or FLASH1 */
+    if (u32Addr < EFM_OTP_END_ADDR1) {
+        u8Flag = (1U == u8OtpState) ? 0U : 1U;
+        u8Shift = (u8SwapState & u8Flag) * EFM_FLAG1_POS;
+    } else {
+        u8Flag = (1U == u8SwapState) ? 0U : 1U;
+        u8Shift = (u8Flag | u8OtpState) * EFM_FLAG1_POS;
+    }
+
+    if ((1UL == (READ_REG32(bCM_EFM->FSWP_b.FSWP))) && (EFM_CHIP_ALL == u8Chip)) {
+        /* Set Sector erase mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_SECTOR);
+        /* Disable flash switch function */
+        RW_MEM32(EFM_SWAP_ADDR) = 0x0UL;
+        /* wait for operation end flag. */
+        u32Timeout = 0UL;
+        while (EFM_FLAG_OPTEND != READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_OPTEND)) {
+            if (u32Timeout++ >= EFM_PGM_TIMEOUT) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+        /* Clear the operation end flag */
+        SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_OPTEND);
+    }
+
+    /* Set chip erase mode. */
+    if (EFM_CHIP_ALL == u8Chip) {
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_ALL_CHIP);
+    } else {
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_ONE_CHIP);
+    }
+    /* Erase */
+    RW_MEM32(u32Addr) = 0UL;
+    /* Wait for ready flag. */
+    u32Timeout = 0UL;
+    while ((EFM_FLAG_RDY << u8Shift) != READ_REG32_BIT(CM_EFM->FSR, EFM_FLAG_RDY << u8Shift)) {
+        if (u32Timeout++ >= EFM_ERASE_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+    /* Clear the operation end flag. */
+    SET_REG32_BIT(CM_EFM->FSCLR, EFM_FLAG_OPTEND << u8Shift);
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+
+    /* recover CACHE */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+    return i32Ret;
+}
+
+/**
+ * @brief  FWMC register write enable or disable.
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EFM_FWMC_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        WRITE_REG32(CM_EFM->KEY1, 0x01234567UL);
+        WRITE_REG32(CM_EFM->KEY1, 0xFEDCBA98UL);
+    } else {
+        SET_REG32_BIT(CM_EFM->FWMC, EFM_FWMC_KEY1LOCK);
+    }
+}
+
+/**
+ * @brief  EFM OTP lock.
+ * @param  [in]  u32Addr           Specifies the OTP block
+ * @retval int32_t:
+ *         - LL_OK: Lock successfully
+ *         - LL_ERR_NOT_RDY: EFM is not ready.
+ * @note   The address should be word align.
+ *         Call EFM_REG_Unlock() and EFM_OTP_WP_Unlock() unlock EFM_FWMC register first.
+ */
+int32_t EFM_OTP_Lock(uint32_t u32Addr)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Tmp;
+
+    if ((u32Addr >= EFM_OTP_LOCK_ADDR_START) && (u32Addr < EFM_OTP_LOCK_ADDR_END)) {
+        DDL_ASSERT(IS_ADDR_ALIGN_WORD(u32Addr));
+        DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+        DDL_ASSERT(IS_EFM_REG_UNLOCK());
+        DDL_ASSERT(IS_EFM_OTP_UNLOCK());
+        /* Get CACHE status */
+        u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+        /* Disable CACHE */
+        CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+        /* Set single program mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+        /* OTP latch */
+        RW_MEM32(u32Addr) = (uint32_t)0UL;
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(0U, EFM_ERASE_TIMEOUT);
+        /* Set read only mode. */
+        MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+        /* Recover CACHE */
+        MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get chip ID.
+ * @param  None
+ * @retval Returns the value of the Chip ID
+ */
+uint32_t EFM_GetCID(void)
+{
+    return READ_REG32(CM_EFM->CHIPID);
+}
+/**
+ * @brief  EFM OTP operate unlock.
+ * @param  None
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_OTP_WP_Unlock(void)
+{
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    WRITE_REG32(CM_EFM->KEY2, EFM_OTP_UNLOCK_KEY1);
+    WRITE_REG32(CM_EFM->KEY2, EFM_OTP_UNLOCK_KEY2);
+}
+
+/**
+ * @brief  EFM OTP write protect lock.
+ * @param  None
+ * @retval None
+ */
+void EFM_OTP_WP_Lock(void)
+{
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    SET_REG32_BIT(CM_EFM->FWMC, EFM_FWMC_KEY2LOCK);
+}
+
+int32_t EFM_OTP_Enable(void)
+{
+    uint32_t u32Tmp;
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_EFM_OTP_UNLOCK());
+
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+
+    /* Set single program mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+
+    if (0xFFFFFFFFUL == RW_MEM32(EFM_OTP_ENABLE_ADDR)) {
+        /* Enable OTP */
+        RW_MEM32(EFM_OTP_ENABLE_ADDR) = (uint32_t)0UL;
+        /* Wait operate end. */
+        i32Ret = EFM_WaitEnd(0U, EFM_PGM_TIMEOUT);
+    }
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+
+    /* Recover CACHE */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Sector protected register lock.
+ * @param  [in] u32RegLock                      Specifies sector protected register locking.
+ *  @arg   EFM_WRLOCK0 ~ EFM_WRLOCK7
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ */
+void EFM_SectorProtectRegLock(uint32_t u32RegLock)
+{
+    DDL_ASSERT(IS_EFM_SECTOR_PROTECT_REG_LOCK(u32RegLock));
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+
+    SET_REG32_BIT(CM_EFM->WLOCK, u32RegLock);
+}
+
+/**
+ * @brief  Set sector lock or unlock (Single).
+ * @param  [in] u8SectorNum     Specifies sector for unlock.
+ *                              This parameter can be set 0~255.
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ *         If you want to unlock sequence sectors,Please call EFM_SequenceSectorOperateCmd function
+ */
+void EFM_SingleSectorOperateCmd(uint8_t u8SectorNum, en_functional_state_t enNewState)
+{
+    __IO uint32_t *EFM_FxNWPRTy;
+    uint8_t u8RegIndex;
+    uint8_t u8BitPos;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (SET == EFM_GetSwapStatus()) {
+        if (0xFFFFFFFFUL != RW_MEM32(EFM_OTP_ENABLE_ADDR)) {
+            if (u8SectorNum > EFM_SWAP_FLASH1_END_SECTOR_NUM) {
+                u8SectorNum -= EFM_FLASH1_START_SECTOR_NUM;
+            } else if ((u8SectorNum > EFM_OTP_END_SECTOR_NUM) && (u8SectorNum < EFM_FLASH1_START_SECTOR_NUM)) {
+                u8SectorNum += EFM_FLASH1_START_SECTOR_NUM;
+            } else {
+                /* rsvd */
+            }
+        } else {
+            if (u8SectorNum >= EFM_FLASH1_START_SECTOR_NUM) {
+                u8SectorNum -= EFM_FLASH1_START_SECTOR_NUM;
+            } else {
+                u8SectorNum += EFM_FLASH1_START_SECTOR_NUM;
+            }
+        }
+    }
+
+    u8BitPos = u8SectorNum % REG_LEN;
+    u8RegIndex = u8SectorNum / REG_LEN;
+    EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u8RegIndex << EFM_FNWPRT_REG_OFFSET));
+    MODIFY_REG32(*EFM_FxNWPRTy, 1UL << u8BitPos, (uint32_t)enNewState << u8BitPos);
+}
+
+/**
+ * @brief  Set sector lock or unlock (Sequence).
+ * @param  [in] u32StartSectorNum   Specifies start sector to unlock.
+ *                                  This parameter can be set 0~255.
+ * @param  [in] u16Count            Specifies count of sectors to unlock.
+ *                                  This parameter can be set 1~256.
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call EFM_REG_Unlock() unlock EFM register first.
+ *         If you want to unlock only one sector,Please call EFM_SingleSectorOperateCmd function
+ */
+void EFM_SequenceSectorOperateCmd(uint32_t u32StartSectorNum, uint16_t u16Count, en_functional_state_t enNewState)
+{
+    __IO uint32_t *EFM_FxNWPRTy;
+    uint32_t u32EndSectorNum;
+    uint16_t u16StartRegIndex;
+    uint16_t u16StartBitPos;
+    uint16_t u16EndRegIndex;
+    uint16_t u16EndBitPos;
+    uint32_t u32RegValue;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_SECTOR_IDX(u32StartSectorNum));
+    DDL_ASSERT(IS_EFM_SECTOR_NUM(u32StartSectorNum + u16Count));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (SET == EFM_GetSwapStatus()) {
+        if (0xFFFFFFFFUL != RW_MEM32(EFM_OTP_ENABLE_ADDR)) {
+            if (u32StartSectorNum > EFM_SWAP_FLASH1_END_SECTOR_NUM) {
+                u32StartSectorNum -= EFM_FLASH1_START_SECTOR_NUM;
+            } else if ((u32StartSectorNum > EFM_OTP_END_SECTOR_NUM) && (u32StartSectorNum < EFM_FLASH1_START_SECTOR_NUM)) {
+                u32StartSectorNum += EFM_FLASH1_START_SECTOR_NUM;
+            } else {
+                /* rsvd */
+            }
+        } else {
+            if (u32StartSectorNum >= EFM_FLASH1_START_SECTOR_NUM) {
+                u32StartSectorNum -= EFM_FLASH1_START_SECTOR_NUM;
+            } else {
+                u32StartSectorNum += EFM_FLASH1_START_SECTOR_NUM;
+            }
+        }
+    }
+
+    u16StartRegIndex = (uint16_t)(u32StartSectorNum / REG_LEN);            /* Register offset for the start sector */
+    u16StartBitPos = (uint16_t)(u32StartSectorNum % REG_LEN);              /* Bit offset for the start sector */
+    u32EndSectorNum = (uint16_t)(u32StartSectorNum + u16Count - 1U);       /* Calculate the end sector */
+    u16EndRegIndex = (uint16_t)(u32EndSectorNum / REG_LEN);                /* Register offset for the end sector */
+    u16EndBitPos = (uint16_t)(u32EndSectorNum % REG_LEN);                  /* Bit offset for the end sector */
+
+    if ((u16StartBitPos == 0U) && (u16EndBitPos == 31U)) {
+        while (u16StartRegIndex <= u16EndRegIndex) {
+            EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+            if (EFM_FxNWPRTy > EFM_FNWPRT_REG_END_ADDR) {
+                EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + (((uint32_t)u16StartRegIndex - EFM_FNWPRT_REG_NUM) << EFM_FNWPRT_REG_OFFSET));
+            }
+            if (enNewState == ENABLE) {
+                WRITE_REG32(*EFM_FxNWPRTy, 0xFFFFFFFFUL);
+            } else {
+                WRITE_REG32(*EFM_FxNWPRTy, 0x0UL);
+            }
+            u16StartRegIndex += 1U;
+        }
+    } else {
+        EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+        if (u16StartRegIndex == u16EndRegIndex) {
+            u32RegValue = ((1UL << u16EndBitPos) - (1UL << u16StartBitPos)) | (1UL << u16EndBitPos);
+            if (enNewState == ENABLE) {
+                SET_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+            } else {
+                CLR_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+            }
+        } else {
+            u32RegValue = ((1UL << 31U) - (1UL << u16StartBitPos)) | (1UL << 31U);
+            if (enNewState == ENABLE) {
+                SET_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+                while (u16StartRegIndex < (u16EndRegIndex - 1U)) {
+                    u16StartRegIndex += 1U;
+                    EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+                    if (EFM_FxNWPRTy > EFM_FNWPRT_REG_END_ADDR) {
+                        EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + (((uint32_t)u16StartRegIndex - EFM_FNWPRT_REG_NUM) << EFM_FNWPRT_REG_OFFSET));
+                    }
+                    WRITE_REG32(*EFM_FxNWPRTy, 0xFFFFFFFFUL);
+                }
+                u16StartRegIndex += 1U;
+                u32RegValue = ((1UL << u16EndBitPos) - 1UL) | (1UL << u16EndBitPos);
+                EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+                if (EFM_FxNWPRTy > EFM_FNWPRT_REG_END_ADDR) {
+                    EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + (((uint32_t)u16EndRegIndex - EFM_FNWPRT_REG_NUM) << EFM_FNWPRT_REG_OFFSET));
+                }
+                SET_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+            } else {
+                CLR_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+                while (u16StartRegIndex < (u16EndRegIndex - 1U)) {
+                    u16StartRegIndex += 1U;
+                    EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+                    if (EFM_FxNWPRTy > EFM_FNWPRT_REG_END_ADDR) {
+                        EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + (((uint32_t)u16StartRegIndex - EFM_FNWPRT_REG_NUM) << EFM_FNWPRT_REG_OFFSET));
+                    }
+                    WRITE_REG32(*EFM_FxNWPRTy, 0x0UL);
+                }
+                u32RegValue = ((1UL << u16EndBitPos) - 1UL) | (1UL << u16EndBitPos);
+                EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + ((uint32_t)u16StartRegIndex << EFM_FNWPRT_REG_OFFSET));
+                if (EFM_FxNWPRTy > EFM_FNWPRT_REG_END_ADDR) {
+                    EFM_FxNWPRTy = (__IO uint32_t *)((uint32_t)(&FNWPRT_REG) + (((uint32_t)u16EndRegIndex - EFM_FNWPRT_REG_NUM) << EFM_FNWPRT_REG_OFFSET));
+                }
+                CLR_REG32_BIT(*EFM_FxNWPRTy, u32RegValue);
+            }
+        }
+    }
+}
+
+/**
+ * @brief  Get unique ID.
+ * @param  [out] pstcUID     Unique ID struct
+ * @retval Returns the value of the unique ID
+ */
+void EFM_GetUID(stc_efm_unique_id_t *pstcUID)
+{
+    if (NULL != pstcUID) {
+        pstcUID->u32UniqueID0 = READ_REG32(CM_EFM->UQID0);
+        pstcUID->u32UniqueID1 = READ_REG32(CM_EFM->UQID1);
+        pstcUID->u32UniqueID2 = READ_REG32(CM_EFM->UQID2);
+    }
+}
+
+/**
+ * @brief  Init REMAP initial structure with default value.
+ * @param  [in] pstcEfmRemapInit specifies the Parameter of REMAP.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EFM_REMAP_StructInit(stc_efm_remap_init_t *pstcEfmRemapInit)
+{
+    int32_t i32Ret = LL_OK;
+    if (NULL == pstcEfmRemapInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcEfmRemapInit->u32State = EFM_REMAP_OFF;
+        pstcEfmRemapInit->u32Addr = 0UL;
+        pstcEfmRemapInit->u32Size = EFM_REMAP_4K;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  REMAP initialize.
+ * @param  [in] u8RemapIdx      Specifies the remap ID.
+ * @param  [in] pstcEfmRemapInit specifies the Parameter of REMAP.
+ * @retval int32_t:
+ *         - LL_OK: Initialize success
+ *         - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EFM_REMAP_Init(uint8_t u8RemapIdx, stc_efm_remap_init_t *pstcEfmRemapInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *REMCRx;
+
+    if (NULL == pstcEfmRemapInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_EFM_REMAP_UNLOCK());
+        DDL_ASSERT(IS_EFM_REMAP_IDX(u8RemapIdx));
+        DDL_ASSERT(IS_EFM_REMAP_SIZE(pstcEfmRemapInit->u32Size));
+        DDL_ASSERT(IS_EFM_REMAP_ADDR(pstcEfmRemapInit->u32Addr));
+        DDL_ASSERT(IS_EFM_REMAP_STATE(pstcEfmRemapInit->u32State));
+        if ((pstcEfmRemapInit->u32Addr % (1UL << pstcEfmRemapInit->u32Size)) != 0U) {
+            i32Ret = LL_ERR_INVD_PARAM;
+        } else {
+            REMCRx = &REMCR_REG(u8RemapIdx);
+            MODIFY_REG32(*REMCRx, EFM_MMF_REMCR_EN | EFM_MMF_REMCR_RMTADDR | EFM_MMF_REMCR_RMSIZE, \
+                         pstcEfmRemapInit->u32State | pstcEfmRemapInit->u32Addr | pstcEfmRemapInit->u32Size);
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  EFM REMAP de-initialize.
+ * @param  None
+ * @retval None
+ */
+void EFM_REMAP_DeInit(void)
+{
+    DDL_ASSERT(IS_EFM_REMAP_UNLOCK());
+
+    WRITE_REG32(CM_EFM->MMF_REMCR0, 0UL);
+    WRITE_REG32(CM_EFM->MMF_REMCR1, 0UL);
+}
+
+/**
+ * @brief  Enable or disable REMAP function.
+ * @param  [in] u8RemapIdx      Specifies the remap ID.
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EFM_REMAP_Cmd(uint8_t u8RemapIdx, en_functional_state_t enNewState)
+{
+    __IO uint32_t *REMCRx;
+
+    DDL_ASSERT(IS_EFM_REMAP_UNLOCK());
+    DDL_ASSERT(IS_EFM_REMAP_IDX(u8RemapIdx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    REMCRx = &REMCR_REG(u8RemapIdx);
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*REMCRx, EFM_MMF_REMCR_EN);
+    } else {
+        CLR_REG32_BIT(*REMCRx, EFM_MMF_REMCR_EN);
+    }
+}
+
+/**
+ * @brief  Set specified REMAP target address.
+ * @param  [in] u8RemapIdx      Specifies the remap ID.
+ * @param  [in] u32Addr         Specifies the target address.
+ * @retval None
+ */
+void EFM_REMAP_SetAddr(uint8_t u8RemapIdx, uint32_t u32Addr)
+{
+    __IO uint32_t *REMCRx;
+
+    DDL_ASSERT(IS_EFM_REMAP_UNLOCK());
+    DDL_ASSERT(IS_EFM_REMAP_IDX(u8RemapIdx));
+    DDL_ASSERT(IS_EFM_REMAP_ADDR(u32Addr));
+
+    REMCRx = &REMCR_REG(u8RemapIdx);
+    MODIFY_REG32(*REMCRx, EFM_MMF_REMCR_RMTADDR, u32Addr);
+}
+
+/**
+ * @brief  Set specified REMAP size.
+ * @param  [in] u8RemapIdx      Specifies the remap ID.
+ * @param  [in] u32Size         Specifies the remap size.
+ * @retval None
+ */
+void EFM_REMAP_SetSize(uint8_t u8RemapIdx, uint32_t u32Size)
+{
+    __IO uint32_t *REMCRx;
+
+    DDL_ASSERT(IS_EFM_REMAP_UNLOCK());
+    DDL_ASSERT(IS_EFM_REMAP_IDX(u8RemapIdx));
+    DDL_ASSERT(IS_EFM_REMAP_SIZE(u32Size));
+
+    REMCRx = &REMCR_REG(u8RemapIdx);
+    MODIFY_REG32(*REMCRx, EFM_MMF_REMCR_RMSIZE, u32Size);
+}
+
+/**
+ * @brief  Enable efm protect.
+ * @param  [in] u8Level      Specifies the protect level. @ref EFM_Protect_Level
+ * @retval None
+ */
+void EFM_Protect_Enable(uint8_t u8Level)
+{
+
+    if (SET == EFM_GetSwapStatus()) {
+        (void)EFM_SingleSectorOperateCmd(EFM_SWAP_ON_PROTECT_SECTOR_NUM, ENABLE);
+    } else {
+        (void)EFM_SingleSectorOperateCmd(0U, ENABLE);
+    }
+    if (EFM_PROTECT_LEVEL1 == u8Level) {
+        (void)EFM_ProgramWord(EFM_PROTECT1_ADDR, EFM_PROTECT1_KEY);
+    } else if (EFM_PROTECT_LEVEL2 == u8Level) {
+        (void)EFM_ProgramWord(EFM_PROTECT2_ADDR, EFM_PROTECT2_KEY);
+    } else if (EFM_PROTECT_LEVEL3 == u8Level) {
+        (void)EFM_ProgramWord(EFM_PROTECT3_ADDR1, EFM_PROTECT3_KEY);
+        (void)EFM_ProgramWord(EFM_PROTECT3_ADDR2, EFM_PROTECT3_KEY);
+        (void)EFM_ProgramWord(EFM_PROTECT3_ADDR3, EFM_PROTECT3_KEY);
+    } else {
+        /* rsvd */
+    }
+}
+
+/**
+ * @brief  Write the security code.
+ * @param  [in] pu8Buf       Specifies the security code.
+ * @param  [in] u32Len       Specified the length of the security code.
+ * @retval int32_t
+ */
+int32_t EFM_WriteSecurityCode(const uint8_t *pu8Buf, uint32_t u32Len)
+{
+    int32_t i32Ret;
+    uint32_t u32Tmp;
+    uint32_t u32LoopWords = u32Len >> 2UL;
+    uint32_t *u32pSource = (uint32_t *)(uint32_t)pu8Buf;
+    uint32_t *u32pDest = (uint32_t *)EFM_SECURITY_ADDR;
+
+    DDL_ASSERT(IS_EFM_REG_UNLOCK());
+    DDL_ASSERT(IS_EFM_FWMC_UNLOCK());
+    DDL_ASSERT(IS_EFM_SECURITY_CODE_LEN(u32Len));
+
+    /* Clear the error flag. */
+    EFM_ClearStatus(EFM_FLAG_ALL);
+    /* Get CACHE status */
+    u32Tmp = READ_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+    /* Disable CACHE */
+    CLR_REG32_BIT(CM_EFM->FRMC, EFM_CACHE_ALL);
+
+    /* Set sector erase mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_ERASE_SECTOR);
+    /* Erase */
+    RW_MEM32(EFM_SECURITY_ADDR) = 0UL;
+    /* Wait operate end */
+    i32Ret = EFM_WaitEnd(0U, EFM_PGM_TIMEOUT);
+
+    /* Set single program mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_PGM_SINGLE);
+    while ((u32LoopWords-- > 0UL) && (LL_OK == i32Ret)) {
+        /* program data. */
+        *u32pDest++ = *u32pSource++;
+        /* Wait operate end */
+        i32Ret = EFM_WaitEnd(0U, EFM_PGM_TIMEOUT);
+    }
+
+    /* Set read only mode. */
+    MODIFY_REG32(CM_EFM->FWMC, EFM_FWMC_PEMOD, EFM_MD_READONLY);
+
+    /* Recover CACHE function */
+    MODIFY_REG32(CM_EFM->FRMC, EFM_CACHE_ALL, u32Tmp);
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif  /* LL_EFM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_emb.c
+++ b/hc32f4a2/src/hc32_ll_emb.c
@@ -1,0 +1,713 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_emb.c
+ * @brief This file provides firmware functions to manage the EMB
+ *        (Emergency Brake).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Optimize function: EMB_TMR4_Init
+                                    Optimize function: EMB_TMR6_Init
+   2023-06-30       CDT             Function EMB_TMR4_Init don't call EMB_DeInit
+                                    Function EMB_TMR6_Init don't call EMB_DeInit
+                                    Function EMB_DeInit set register EMB_RLSSEL to reset value
+   2024-06-30       CDT             Modify assert IS_EMB_MONITOR_EVT
+                                    Optimize EMB_ClearStatus function
+                                    Rename macro-definition: IS_VALID_EMB_INT -> IS_EMB_INT
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_emb.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EMB EMB
+ * @brief Emergency Brake Driver Library
+ * @{
+ */
+
+#if (LL_EMB_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EMB_Local_Macros EMB Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup EMB_Check_Parameters_Validity EMB Check Parameters Validity
+ * @{
+ */
+#define IS_EMB_GROUP(x)                                                        \
+(   ((x) == CM_EMB0)                        ||                                 \
+    ((x) == CM_EMB1)                        ||                                 \
+    ((x) == CM_EMB2)                        ||                                 \
+    ((x) == CM_EMB3)                        ||                                 \
+    ((x) == CM_EMB4)                        ||                                 \
+    ((x) == CM_EMB5)                        ||                                 \
+    ((x) == CM_EMB6))
+#define IS_EMB_TMR4_GROUP(x)                                                   \
+(   ((x) == CM_EMB4)                        ||                                 \
+    ((x) == CM_EMB5)                        ||                                 \
+    ((x) == CM_EMB6))
+#define IS_EMB_TMR6_GROUP(x)                                                   \
+(   ((x) == CM_EMB0)                        ||                                 \
+    ((x) == CM_EMB1)                        ||                                 \
+    ((x) == CM_EMB2)                        ||                                 \
+    ((x) == CM_EMB3))
+
+#define IS_EMB_OSC_STAT(x)                                                     \
+(   ((x) == EMB_OSC_ENABLE)                 ||                                 \
+    ((x) == EMB_OSC_DISABLE))
+
+#define IS_EMB_TMR4_PWM_W_STAT(x)                                              \
+(   ((x) == EMB_TMR4_PWM_W_ENABLE)          ||                                 \
+    ((x) == EMB_TMR4_PWM_W_DISABLE))
+
+#define IS_EMB_DETECT_TMR4_PWM_W_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR4_PWM_W_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR4_PWM_W_BOTH_HIGH))
+
+#define IS_EMB_TMR4_PWM_V_STAT(x)                                              \
+(   ((x) == EMB_TMR4_PWM_V_ENABLE)          ||                                 \
+    ((x) == EMB_TMR4_PWM_V_DISABLE))
+
+#define IS_EMB_DETECT_TMR4_PWM_V_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR4_PWM_V_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR4_PWM_V_BOTH_HIGH))
+
+#define IS_EMB_TMR4_PWM_U_STAT(x)                                              \
+(   ((x) == EMB_TMR4_PWM_U_ENABLE)          ||                                 \
+    ((x) == EMB_TMR4_PWM_U_DISABLE))
+
+#define IS_EMB_DETECT_TMR4_PWM_U_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR4_PWM_U_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR4_PWM_U_BOTH_HIGH))
+
+#define IS_EMB_CMP1_STAT(x)                                                    \
+(   ((x) == EMB_CMP1_ENABLE)                ||                                 \
+    ((x) == EMB_CMP1_DISABLE))
+
+#define IS_EMB_CMP2_STAT(x)                                                    \
+(   ((x) == EMB_CMP2_ENABLE)                ||                                 \
+    ((x) == EMB_CMP2_DISABLE))
+
+#define IS_EMB_CMP3_STAT(x)                                                    \
+(   ((x) == EMB_CMP3_ENABLE)                ||                                 \
+    ((x) == EMB_CMP3_DISABLE))
+#define IS_EMB_CMP4_STAT(x)                                                    \
+(   ((x) == EMB_CMP4_ENABLE)                ||                                 \
+    ((x) == EMB_CMP4_DISABLE))
+
+#define IS_EMB_PORT1_STAT(x)                                                   \
+(   ((x) == EMB_PORT1_ENABLE)               ||                                 \
+    ((x) == EMB_PORT1_DISABLE))
+
+#define IS_EMB_PORT1_DETECT_LVL(x)                                             \
+(   ((x) == EMB_PORT1_DETECT_LVL_LOW)       ||                                 \
+    ((x) == EMB_PORT1_DETECT_LVL_HIGH))
+
+#define IS_EMB_PORT1_FILTER_STAT(x)                                            \
+(   ((x) == EMB_PORT1_FILTER_ENABLE)        ||                                 \
+    ((x) == EMB_PORT1_FILTER_DISABLE))
+
+#define IS_EMB_PORT1_FILTER_DIV(x)          (((x) & (~EMB_PORT1_FILTER_CLK_DIV_MASK)) == 0UL)
+#define IS_EMB_PORT2_STAT(x)                                                   \
+(   ((x) == EMB_PORT2_ENABLE)               ||                                 \
+    ((x) == EMB_PORT2_DISABLE))
+
+#define IS_EMB_PORT2_DETECT_LVL(x)                                             \
+(   ((x) == EMB_PORT2_DETECT_LVL_LOW)       ||                                 \
+    ((x) == EMB_PORT2_DETECT_LVL_HIGH))
+
+#define IS_EMB_PORT2_FILTER_STAT(x)                                            \
+(   ((x) == EMB_PORT2_FILTER_ENABLE)        ||                                 \
+    ((x) == EMB_PORT2_FILTER_DISABLE))
+
+#define IS_EMB_PORT2_FILTER_DIV(x)          (((x) & (~EMB_PORT2_FILTER_CLK_DIV_MASK)) == 0UL)
+
+#define IS_EMB_PORT3_STAT(x)                                                   \
+(   ((x) == EMB_PORT3_ENABLE)               ||                                 \
+    ((x) == EMB_PORT3_DISABLE))
+
+#define IS_EMB_PORT3_DETECT_LVL(x)                                             \
+(   ((x) == EMB_PORT3_DETECT_LVL_LOW)       ||                                 \
+    ((x) == EMB_PORT3_DETECT_LVL_HIGH))
+
+#define IS_EMB_PORT3_FILTER_STAT(x)                                            \
+(   ((x) == EMB_PORT3_FILTER_ENABLE)        ||                                 \
+    ((x) == EMB_PORT3_FILTER_DISABLE))
+
+#define IS_EMB_PORT3_FILTER_DIV(x)          (((x) & (~EMB_PORT3_FILTER_CLK_DIV_MASK)) == 0UL)
+#define IS_EMB_PORT4_STAT(x)                                                   \
+(   ((x) == EMB_PORT4_ENABLE)               ||                                 \
+    ((x) == EMB_PORT4_DISABLE))
+
+#define IS_EMB_PORT4_DETECT_LVL(x)                                             \
+(   ((x) == EMB_PORT4_DETECT_LVL_LOW)       ||                                 \
+    ((x) == EMB_PORT4_DETECT_LVL_HIGH))
+
+#define IS_EMB_PORT4_FILTER_STAT(x)                                            \
+(   ((x) == EMB_PORT4_FILTER_ENABLE)        ||                                 \
+    ((x) == EMB_PORT4_FILTER_DISABLE))
+
+#define IS_EMB_PORT4_FILTER_DIV(x)          (((x) & (~EMB_PORT4_FILTER_CLK_DIV_MASK)) == 0UL)
+
+#define IS_EMB_TMR6_1_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_1_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_1_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_1_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_1_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_1_PWM_BOTH_HIGH))
+
+#define IS_EMB_TMR6_2_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_2_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_2_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_2_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_2_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_2_PWM_BOTH_HIGH))
+#define IS_EMB_TMR6_3_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_3_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_3_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_3_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_3_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_3_PWM_BOTH_HIGH))
+#define IS_EMB_TMR6_4_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_4_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_4_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_4_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_4_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_4_PWM_BOTH_HIGH))
+#define IS_EMB_TMR6_5_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_5_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_5_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_5_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_5_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_5_PWM_BOTH_HIGH))
+
+#define IS_EMB_TMR6_6_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_6_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_6_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_6_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_6_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_6_PWM_BOTH_HIGH))
+
+#define IS_EMB_TMR6_7_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_7_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_7_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_7_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_7_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_7_PWM_BOTH_HIGH))
+
+#define IS_EMB_TMR6_8_PWM_STAT(x)                                              \
+(   ((x) == EMB_TMR6_8_PWM_ENABLE)          ||                                 \
+    ((x) == EMB_TMR6_8_PWM_DISABLE))
+
+#define IS_EMB_DETECT_TMR6_8_PWM_LVL(x)                                        \
+(   ((x) == EMB_DETECT_TMR6_8_PWM_BOTH_LOW) ||                                 \
+    ((x) == EMB_DETECT_TMR6_8_PWM_BOTH_HIGH))
+
+#define IS_EMB_INT(x)                                                          \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EMB_INT_ALL) == EMB_INT_ALL))
+
+#define IS_EMB_FLAG(x)                                                         \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EMB_FLAG_ALL) == EMB_FLAG_ALL))
+
+#define IS_EMB_CLR_FLAG(x)                                                     \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EMB_FLAG_CLR_ALL) == EMB_FLAG_CLR_ALL))
+
+#define IS_EMB_RELEASE_PWM_COND(x)                                             \
+(   ((x) == EMB_RELEASE_PWM_COND_FLAG_ZERO) ||                                 \
+    ((x) == EMB_RELEASE_PWM_COND_STAT_ZERO))
+
+#define IS_EMB_MONITOR_EVT(x)                                                  \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EMB_EVT_ALL) == EMB_EVT_ALL))
+
+/**
+ * @}
+ */
+
+#define EMB_PORT1_FILTER_CLK_DIV_MASK       EMB_PORT1_FILTER_CLK_DIV128
+#define EMB_PORT2_FILTER_CLK_DIV_MASK       EMB_PORT2_FILTER_CLK_DIV128
+#define EMB_PORT3_FILTER_CLK_DIV_MASK       EMB_PORT3_FILTER_CLK_DIV128
+#define EMB_PORT4_FILTER_CLK_DIV_MASK       EMB_PORT4_FILTER_CLK_DIV128
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup EMB_Global_Functions EMB Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_emb_tmr4_init_t to default values
+ * @param  [out] pstcEmbInit           Pointer to a @ref stc_emb_tmr4_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcEmbInit value is NULL.
+ */
+int32_t EMB_TMR4_StructInit(stc_emb_tmr4_init_t *pstcEmbInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcEmbInit) {
+        /* OSC */
+        pstcEmbInit->stcOsc.u32OscState = EMB_OSC_DISABLE;
+
+        /* CMP */
+        pstcEmbInit->stcCmp.u32Cmp1State = EMB_CMP1_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp2State = EMB_CMP2_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp3State = EMB_CMP3_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp4State = EMB_CMP4_DISABLE;
+
+        /* Port */
+        pstcEmbInit->stcPort.stcPort1.u32PortState = EMB_PORT1_DISABLE;
+        pstcEmbInit->stcPort.stcPort1.u32PortLevel = EMB_PORT1_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv = EMB_PORT1_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort1.u32PortFilterState = EMB_PORT1_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort2.u32PortState = EMB_PORT2_DISABLE;
+        pstcEmbInit->stcPort.stcPort2.u32PortLevel = EMB_PORT2_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv = EMB_PORT2_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort2.u32PortFilterState = EMB_PORT2_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort3.u32PortState = EMB_PORT3_DISABLE;
+        pstcEmbInit->stcPort.stcPort3.u32PortLevel = EMB_PORT3_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv = EMB_PORT3_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort3.u32PortFilterState = EMB_PORT3_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort4.u32PortState = EMB_PORT4_DISABLE;
+        pstcEmbInit->stcPort.stcPort4.u32PortLevel = EMB_PORT4_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv = EMB_PORT4_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort4.u32PortFilterState = EMB_PORT4_FILTER_DISABLE;
+
+        /* PWM */
+        pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmState = EMB_TMR4_PWM_U_DISABLE;
+        pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmLevel = EMB_DETECT_TMR4_PWM_U_BOTH_LOW;
+        pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmState = EMB_TMR4_PWM_V_DISABLE;
+        pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmLevel = EMB_DETECT_TMR4_PWM_V_BOTH_LOW;
+        pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmState = EMB_TMR4_PWM_W_DISABLE;
+        pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmLevel = EMB_DETECT_TMR4_PWM_W_BOTH_LOW;
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize EMB for TMR4.
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] pstcEmbInit             Pointer to a @ref stc_emb_tmr4_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcEmbInit value is NULL.
+ */
+int32_t EMB_TMR4_Init(CM_EMB_TypeDef *EMBx, const stc_emb_tmr4_init_t *pstcEmbInit)
+{
+    uint32_t u32Reg1Value;
+    uint32_t u32Reg2Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcEmbInit) {
+        DDL_ASSERT(IS_EMB_TMR4_GROUP(EMBx));
+        DDL_ASSERT(IS_EMB_OSC_STAT(pstcEmbInit->stcOsc.u32OscState));
+        DDL_ASSERT(IS_EMB_CMP1_STAT(pstcEmbInit->stcCmp.u32Cmp1State));
+        DDL_ASSERT(IS_EMB_CMP2_STAT(pstcEmbInit->stcCmp.u32Cmp2State));
+        DDL_ASSERT(IS_EMB_CMP3_STAT(pstcEmbInit->stcCmp.u32Cmp3State));
+        DDL_ASSERT(IS_EMB_CMP4_STAT(pstcEmbInit->stcCmp.u32Cmp4State));
+        DDL_ASSERT(IS_EMB_PORT1_STAT(pstcEmbInit->stcPort.stcPort1.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT1_DETECT_LVL(pstcEmbInit->stcPort.stcPort1.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT1_FILTER_DIV(pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT1_FILTER_STAT(pstcEmbInit->stcPort.stcPort1.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT2_STAT(pstcEmbInit->stcPort.stcPort2.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT2_DETECT_LVL(pstcEmbInit->stcPort.stcPort2.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT2_FILTER_DIV(pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT2_FILTER_STAT(pstcEmbInit->stcPort.stcPort2.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT3_STAT(pstcEmbInit->stcPort.stcPort3.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT3_DETECT_LVL(pstcEmbInit->stcPort.stcPort3.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT3_FILTER_DIV(pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT3_FILTER_STAT(pstcEmbInit->stcPort.stcPort3.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT4_STAT(pstcEmbInit->stcPort.stcPort4.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT4_DETECT_LVL(pstcEmbInit->stcPort.stcPort4.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT4_FILTER_DIV(pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT4_FILTER_STAT(pstcEmbInit->stcPort.stcPort4.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_TMR4_PWM_U_STAT(pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR4_PWM_U_LVL(pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR4_PWM_V_STAT(pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR4_PWM_V_LVL(pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR4_PWM_W_STAT(pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR4_PWM_W_LVL(pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmLevel));
+
+        /* OSC */
+        u32Reg1Value = pstcEmbInit->stcOsc.u32OscState;
+        u32Reg2Value = 0UL;
+
+        /* PWM */
+        u32Reg1Value |= (pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmState | pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmState | \
+                         pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmState);
+        u32Reg2Value |= (pstcEmbInit->stcTmr4.stcTmr4PwmU.u32PwmLevel | pstcEmbInit->stcTmr4.stcTmr4PwmV.u32PwmLevel | \
+                         pstcEmbInit->stcTmr4.stcTmr4PwmW.u32PwmLevel);
+
+        /* CMP */
+        u32Reg1Value |= (pstcEmbInit->stcCmp.u32Cmp1State | pstcEmbInit->stcCmp.u32Cmp2State | \
+                         pstcEmbInit->stcCmp.u32Cmp3State | pstcEmbInit->stcCmp.u32Cmp4State);
+
+        /* PORT */
+        u32Reg1Value |= (pstcEmbInit->stcPort.stcPort1.u32PortState | pstcEmbInit->stcPort.stcPort1.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort2.u32PortState | pstcEmbInit->stcPort.stcPort2.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort3.u32PortState | pstcEmbInit->stcPort.stcPort3.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort4.u32PortState | pstcEmbInit->stcPort.stcPort4.u32PortLevel);
+        u32Reg2Value |= (pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort1.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort2.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort3.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort4.u32PortFilterState);
+
+        WRITE_REG32(EMBx->CTL2, u32Reg2Value);
+        WRITE_REG32(EMBx->CTL1, u32Reg1Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_emb_tmr6_init_t to default values
+ * @param  [out] pstcEmbInit            Pointer to a @ref stc_emb_tmr6_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcEmbInit value is NULL.
+ */
+int32_t EMB_TMR6_StructInit(stc_emb_tmr6_init_t *pstcEmbInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcEmbInit) {
+        /* OSC */
+        pstcEmbInit->stcOsc.u32OscState = EMB_OSC_DISABLE;
+
+        /* CMP */
+        pstcEmbInit->stcCmp.u32Cmp1State = EMB_CMP1_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp2State = EMB_CMP2_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp3State = EMB_CMP3_DISABLE;
+        pstcEmbInit->stcCmp.u32Cmp4State = EMB_CMP4_DISABLE;
+
+        /* Port */
+        pstcEmbInit->stcPort.stcPort1.u32PortState = EMB_PORT1_DISABLE;
+        pstcEmbInit->stcPort.stcPort1.u32PortLevel = EMB_PORT1_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv = EMB_PORT1_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort1.u32PortFilterState = EMB_PORT1_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort2.u32PortState = EMB_PORT2_DISABLE;
+        pstcEmbInit->stcPort.stcPort2.u32PortLevel = EMB_PORT2_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv = EMB_PORT2_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort2.u32PortFilterState = EMB_PORT2_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort3.u32PortState = EMB_PORT3_DISABLE;
+        pstcEmbInit->stcPort.stcPort3.u32PortLevel = EMB_PORT3_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv = EMB_PORT3_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort3.u32PortFilterState = EMB_PORT3_FILTER_DISABLE;
+        pstcEmbInit->stcPort.stcPort4.u32PortState = EMB_PORT4_DISABLE;
+        pstcEmbInit->stcPort.stcPort4.u32PortLevel = EMB_PORT4_DETECT_LVL_HIGH;
+        pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv = EMB_PORT4_FILTER_CLK_DIV1;
+        pstcEmbInit->stcPort.stcPort4.u32PortFilterState = EMB_PORT4_FILTER_DISABLE;
+        /* PWM */
+        pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmLevel = EMB_DETECT_TMR6_1_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmState = EMB_TMR6_1_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmLevel = EMB_DETECT_TMR6_2_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmState = EMB_TMR6_2_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmLevel = EMB_DETECT_TMR6_3_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmState = EMB_TMR6_3_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmLevel = EMB_DETECT_TMR6_4_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmState = EMB_TMR6_4_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmLevel = EMB_DETECT_TMR6_6_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmState = EMB_TMR6_5_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmLevel = EMB_DETECT_TMR6_6_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmState = EMB_TMR6_6_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmLevel = EMB_DETECT_TMR6_7_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmState = EMB_TMR6_7_PWM_DISABLE;
+        pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmLevel = EMB_DETECT_TMR6_8_PWM_BOTH_LOW;
+        pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmState = EMB_TMR6_8_PWM_DISABLE;
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize EMB for TMR6.
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] pstcEmbInit             Pointer to a @ref stc_emb_tmr6_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcEmbInit value is NULL.
+ */
+int32_t EMB_TMR6_Init(CM_EMB_TypeDef *EMBx, const stc_emb_tmr6_init_t *pstcEmbInit)
+{
+    uint32_t u32Reg1Value;
+    uint32_t u32Reg2Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcEmbInit) {
+        DDL_ASSERT(IS_EMB_TMR6_GROUP(EMBx));
+        DDL_ASSERT(IS_EMB_OSC_STAT(pstcEmbInit->stcOsc.u32OscState));
+        DDL_ASSERT(IS_EMB_CMP1_STAT(pstcEmbInit->stcCmp.u32Cmp1State));
+        DDL_ASSERT(IS_EMB_CMP2_STAT(pstcEmbInit->stcCmp.u32Cmp2State));
+        DDL_ASSERT(IS_EMB_CMP3_STAT(pstcEmbInit->stcCmp.u32Cmp3State));
+        DDL_ASSERT(IS_EMB_CMP4_STAT(pstcEmbInit->stcCmp.u32Cmp4State));
+        DDL_ASSERT(IS_EMB_PORT1_STAT(pstcEmbInit->stcPort.stcPort1.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT1_DETECT_LVL(pstcEmbInit->stcPort.stcPort1.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT1_FILTER_DIV(pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT1_FILTER_STAT(pstcEmbInit->stcPort.stcPort1.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT2_STAT(pstcEmbInit->stcPort.stcPort2.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT2_DETECT_LVL(pstcEmbInit->stcPort.stcPort2.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT2_FILTER_DIV(pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT2_FILTER_STAT(pstcEmbInit->stcPort.stcPort2.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT3_STAT(pstcEmbInit->stcPort.stcPort3.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT3_DETECT_LVL(pstcEmbInit->stcPort.stcPort3.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT3_FILTER_DIV(pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT3_FILTER_STAT(pstcEmbInit->stcPort.stcPort3.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_PORT4_STAT(pstcEmbInit->stcPort.stcPort4.u32PortState));
+        DDL_ASSERT(IS_EMB_PORT4_DETECT_LVL(pstcEmbInit->stcPort.stcPort4.u32PortLevel));
+        DDL_ASSERT(IS_EMB_PORT4_FILTER_DIV(pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv));
+        DDL_ASSERT(IS_EMB_PORT4_FILTER_STAT(pstcEmbInit->stcPort.stcPort4.u32PortFilterState));
+        DDL_ASSERT(IS_EMB_TMR6_1_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_1_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_2_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_2_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_3_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_3_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_4_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_4_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_5_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_5_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_6_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_6_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_7_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_7_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmLevel));
+        DDL_ASSERT(IS_EMB_TMR6_8_PWM_STAT(pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmState));
+        DDL_ASSERT(IS_EMB_DETECT_TMR6_8_PWM_LVL(pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmLevel));
+
+        u32Reg2Value = 0UL;
+        /* OSC */
+        u32Reg1Value = pstcEmbInit->stcOsc.u32OscState;
+
+        /* PWM */
+        u32Reg1Value |= (pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmState | pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmState | \
+                         pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmState | pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmState | \
+                         pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmState | pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmState | \
+                         pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmState | pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmState);
+        u32Reg2Value |= (pstcEmbInit->stcTmr6.stcTmr6_1.u32PwmLevel | pstcEmbInit->stcTmr6.stcTmr6_2.u32PwmLevel | \
+                         pstcEmbInit->stcTmr6.stcTmr6_3.u32PwmLevel | pstcEmbInit->stcTmr6.stcTmr6_4.u32PwmLevel | \
+                         pstcEmbInit->stcTmr6.stcTmr6_5.u32PwmLevel | pstcEmbInit->stcTmr6.stcTmr6_6.u32PwmLevel | \
+                         pstcEmbInit->stcTmr6.stcTmr6_7.u32PwmLevel | pstcEmbInit->stcTmr6.stcTmr6_8.u32PwmLevel);
+
+        /* CMP */
+        u32Reg1Value |= (pstcEmbInit->stcCmp.u32Cmp1State | pstcEmbInit->stcCmp.u32Cmp2State | \
+                         pstcEmbInit->stcCmp.u32Cmp3State | pstcEmbInit->stcCmp.u32Cmp4State);
+
+        /* PORT */
+        u32Reg1Value |= (pstcEmbInit->stcPort.stcPort1.u32PortState | pstcEmbInit->stcPort.stcPort1.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort2.u32PortState | pstcEmbInit->stcPort.stcPort2.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort3.u32PortState | pstcEmbInit->stcPort.stcPort3.u32PortLevel | \
+                         pstcEmbInit->stcPort.stcPort4.u32PortState | pstcEmbInit->stcPort.stcPort4.u32PortLevel);
+        u32Reg2Value |= (pstcEmbInit->stcPort.stcPort1.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort1.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort2.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort2.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort3.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort3.u32PortFilterState | \
+                         pstcEmbInit->stcPort.stcPort4.u32PortFilterDiv | pstcEmbInit->stcPort.stcPort4.u32PortFilterState);
+
+        WRITE_REG32(EMBx->CTL2, u32Reg2Value);
+        WRITE_REG32(EMBx->CTL1, u32Reg1Value);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize EMB function
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @retval None
+ */
+void EMB_DeInit(CM_EMB_TypeDef *EMBx)
+{
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+
+    WRITE_REG32(EMBx->SOE, 0x00UL);
+    WRITE_REG32(EMBx->INTEN, 0x00UL);
+    WRITE_REG32(EMBx->RLSSEL, 0x00UL);
+}
+
+/**
+ * @brief  Set the EMB interrupt function
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] u32IntType              EMB interrupt source
+ *         This parameter can be any composed value of the macros group @ref EMB_Interrupt.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EMB_IntCmd(CM_EMB_TypeDef *EMBx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+    DDL_ASSERT(IS_EMB_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(EMBx->INTEN, u32IntType);
+    } else {
+        CLR_REG32_BIT(EMBx->INTEN, u32IntType);
+    }
+}
+
+/**
+ * @brief  Clear EMB flag status.
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] u32Flag                 EMB flag
+ *         This parameter can be any composed value(prefix with EMB_FLAG) of the macros group @ref EMB_Flag_State.
+ * @retval None
+ * @note This parameter u32Flag prefix with EMB_FLAG(eg EMB_FLAG_CMP) of the macros group @ref EMB_Flag_State.
+ */
+void EMB_ClearStatus(CM_EMB_TypeDef *EMBx, uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+    DDL_ASSERT(IS_EMB_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(EMBx->STATCLR, u32Flag);
+}
+
+/**
+ * @brief  Get EMB flag status.
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] u32Flag                 EMB flag
+ *         This parameter can be any composed value of the macros group @ref EMB_Flag_State.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EMB_GetStatus(const CM_EMB_TypeDef *EMBx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+    DDL_ASSERT(IS_EMB_FLAG(u32Flag));
+
+    return (READ_REG32_BIT(EMBx->STAT, u32Flag) == 0UL) ? RESET : SET;
+}
+
+/**
+ * @brief  Start/stop EMB brake by software control
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EMB_SWBrake(CM_EMB_TypeDef *EMBx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(EMBx->SOE, enNewState);
+}
+
+/**
+ * @brief  Set EMB release PWM condition for the specified event.
+ * @param  [in] EMBx                    Pointer to EMB instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_EMBx:              EMB group instance register base
+ * @param  [in] u32Event                Monitor event
+ *         This parameter can be any composed value of the macros group @ref EMB_Monitor_Event.
+ * @param  [in] u32Cond                 Release PWM condition
+ *         This parameter can be one of the macros group @ref EMB_Release_TMR_PWM_Condition
+ *           @arg EMB_RELEASE_PWM_COND_FLAG_ZERO: Release PWM when flag bit of the specified event is zero
+ *           @arg EMB_RELEASE_PWM_COND_STAT_ZERO: Release PWM when state bit of the specified event is zero
+ * @retval None
+ */
+void EMB_SetReleasePwmCond(CM_EMB_TypeDef *EMBx, uint32_t u32Event, uint32_t u32Cond)
+{
+    DDL_ASSERT(IS_EMB_GROUP(EMBx));
+    DDL_ASSERT(IS_EMB_MONITOR_EVT(u32Event));
+    DDL_ASSERT(IS_EMB_RELEASE_PWM_COND(u32Cond));
+
+    if (EMB_RELEASE_PWM_COND_FLAG_ZERO == u32Cond) {
+        CLR_REG32_BIT(EMBx->RLSSEL, u32Event);
+    } else {
+        SET_REG32_BIT(EMBx->RLSSEL, u32Event);
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_EMB_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_eth.c
+++ b/hc32f4a2/src/hc32_ll_eth.c
@@ -1,0 +1,4051 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_eth.c
+ * @brief This file provides firmware functions to manage the Ethernet MAC
+ *        Controller(ETH).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Optimize ETH start and stop timing
+                                    Modify the process of obtaining PHY status
+                                    Modify the process of auto-negotiation disable
+                                    Modify ETH_PTP_UpdateBasicAddend function
+                                    Modify typo
+                                    Modify the clock division of SMIC
+                                    Modify operation sequence of ETH_DeInit function
+                                    Add ETH_MAC_SetInterface function
+   2024-06-30       CDT             Add assert IS_ETH_MAC_SMI_CLK(), IS_ETH_PPS_CH_OUTPUT_FREQ(), IS_ETH_PPS_OUTPUT_MD_FREQ
+                                    Optimize the process of ETH_Start() & ETH_Stop()
+                                    Optimize ETH_MAC_SetInterface(), ETH_PTP_UpdateBasicAddend(), ETH_PTP_SysTimeInit(), ETH_PPS_Init()
+                                    Fixed bug of ETH_PMT_EnterPowerDown() # modify && as || logic
+   2024-08-31       CDT             Modify ETH_PPS_SetPps0OutputFreq() as ETH_PPS_SetPpsOutputFreq()
+                                    Add API ETH_MAC_SetMdcClock()
+   2024-09-13       CDT             Modify comment of API ETH_PPS_SetPpsOutputFreq()
+   2024-11-08       CDT             Extract the relevant code of PHY
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_eth.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_ETH ETH
+ * @brief Initial Configuration Driver Library
+ * @{
+ */
+
+#if (LL_ETH_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ETH_Local_Macros ETH Local Macros
+ * @{
+ */
+
+/* Ethernet register Mask */
+#define ETH_MAC_IFCONFR_CLR_MASK                    (ETH_MAC_IFCONFR_RCKINV | ETH_MAC_IFCONFR_TCKINV)
+#define ETH_MAC_CONFIGR_CLR_MASK                    (0x72CF7EF0UL)
+#define ETH_MAC_FLOCTLR_CLR_MASK                    (0xFFFF00BEUL)
+#define ETH_MAC_FLTCTLR_CLR_MASK                    (0x802107FFUL)
+#define ETH_MAC_SMIADDR_CLR_MASK                    (0x0000FFC3UL)
+#define ETH_DMA_BUSMODR_CLR_MASK                    (0x0FFFFFFEUL)
+#define ETH_DMA_OPRMODR_CLR_MASK                    (0x0721C0FCUL)
+#define ETH_PTP_TSPCTLR_CLR_MASK                    (0x0007FF02UL)
+
+/* Ethernet MAC Address byte length */
+#define ETH_MAC_ADDR_BYTE_LEN                       (6U)
+/* Ethernet DMA Tx descriptors Collision Count Shift */
+#define ETH_DMA_TXDESC_COLLISION_CNT_SHIFT          (3UL)
+/* Ethernet DMA Rx descriptors Frame Length Shift */
+#define ETH_DMA_RXDESC_FRAME_LEN_SHIFT              (16UL)
+/* Ethernet DMA Tx/Rx descriptors Buffer2 Size Shift */
+#define ETH_DMA_DESC_BUF2_SIZE_SHIFT                (16UL)
+/* Ethernet Remote Wake-up frame register length */
+#define ETH_WAKEUP_REG_LEN                          (8U)
+/* Ethernet PTP PPS channel 1 time register address Shift */
+#define ETH_PTP_PPS1_TIME_REG_ADDR_SHIFT            (0x64U)
+
+/* Wait timeout(ms) */
+#define ETH_WR_REG_TIMEOUT                          (50UL)
+#define ETH_SW_RST_TIMEOUT                          (200UL)
+#define ETH_PHY_RD_TIMEOUT                          (100UL)
+#define ETH_PHY_WR_TIMEOUT                          (100UL)
+
+/* Clock frequency */
+#define ETH_CLK_FREQ_20M                            (20UL * 1000UL * 1000UL)
+#define ETH_CLK_FREQ_35M                            (35UL * 1000UL * 1000UL)
+#define ETH_CLK_FREQ_60M                            (60UL * 1000UL * 1000UL)
+#define ETH_CLK_FREQ_100M                           (100UL * 1000UL * 1000UL)
+#define ETH_CLK_FREQ_120M                           (120UL * 1000UL * 1000UL)
+
+/** Get the specified register address */
+#define ETH_MAC_MACADHR_ADDR(__SHIFT__)             (__IO uint32_t *)((uint32_t)(&(CM_ETH->MAC_MACADHR0)) + \
+                                                                      (uint32_t)(__SHIFT__))
+#define ETH_MAC_MACADLR_ADDR(__SHIFT__)             (__IO uint32_t *)((uint32_t)(&(CM_ETH->MAC_MACADLR0)) + \
+                                                                      (uint32_t)(__SHIFT__))
+#define ETH_PTP_TMTSECR_ADDR(__SHIFT__)             (__IO uint32_t *)((uint32_t)(&(CM_ETH->PTP_TMTSECR0)) + \
+                                                                      (uint32_t)(__SHIFT__))
+#define ETH_PTP_TMTNSER_ADDR(__SHIFT__)             (__IO uint32_t *)((uint32_t)(&(CM_ETH->PTP_TMTNSER0)) + \
+                                                                      (uint32_t)(__SHIFT__))
+
+/**
+ * @defgroup ETH_Check_Parameters_Validity ETH Check Parameters Validity
+ * @{
+ */
+#define IS_ETH_PHY_ADDR(x)                                  ((x) < 0x20U)
+#define IS_ETH_PHY_REG(x)                                   ((x) < 0x20U)
+
+#define IS_ETH_MAC_IF(x)                                                       \
+(   ((x) == ETH_MAC_IF_MII)                                 ||                 \
+    ((x) == ETH_MAC_IF_RMII))
+
+#define IS_ETH_MAC_SPEED(x)                                                    \
+(   ((x) == ETH_MAC_SPEED_10M)                              ||                 \
+    ((x) == ETH_MAC_SPEED_100M))
+
+#define IS_ETH_MAC_DUPLEX_MD(x)                                                \
+(   ((x) == ETH_MAC_DUPLEX_MD_HALF)                         ||                 \
+    ((x) == ETH_MAC_DUPLEX_MD_FULL))
+
+#define IS_ETH_MAC_CHECKSUM_MD(x)                                              \
+(   ((x) == ETH_MAC_CHECKSUM_MD_SW)                         ||                 \
+    ((x) == ETH_MAC_CHECKSUM_MD_HW))
+
+#define IS_ETH_MAC_SMI_CLK(x)                               (((x) >= ETH_CLK_FREQ_20M) && ((x) <= ETH_CLK_FREQ_120M))
+
+#define IS_ETH_RX_MD(x)                                                        \
+(   ((x) == ETH_RX_MD_POLLING)                              ||                 \
+    ((x) == ETH_RX_MD_INT))
+
+#define IS_ETH_MAC_TX_CLK_POLARITY(x)                                          \
+(   ((x) == ETH_MAC_TX_CLK_POLARITY_KEEP)                   ||                 \
+    ((x) == ETH_MAC_TX_CLK_POLARITY_INVERSE))
+
+#define IS_ETH_MAC_RX_CLK_POLARITY(x)                                          \
+(   ((x) == ETH_MAC_RX_CLK_POLARITY_KEEP)                   ||                 \
+    ((x) == ETH_MAC_RX_CLK_POLARITY_INVERSE))
+
+#define IS_ETH_MAC_SRC_ADDR_MD(x)                                              \
+(   ((x) == ETH_MAC_SRC_ADDR_MD_BY_DMA_TXDESC)              ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_MD_INSERT_MACADDR0)            ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_MD_REPLACE_MACADDR0)           ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_MD_INSERT_MACADDR1)            ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_MD_REPLACE_MACADDR1))
+
+#define IS_ETH_MAC_TYPE_FRAME_STRIP_FCS(x)                                     \
+(   ((x) == ETH_MAC_TYPE_FRAME_STRIP_FCS_DISABLE)           ||                 \
+    ((x) == ETH_MAC_TYPE_FRAME_STRIP_FCS_ENABLE))
+
+#define IS_ETH_MAC_WDT(x)                                                      \
+(   ((x) == ETH_MAC_WDT_DISABLE)                            ||                 \
+    ((x) == ETH_MAC_WDT_ENABLE))
+
+#define IS_ETH_MAC_JABBER(x)                                                   \
+(   ((x) == ETH_MAC_JABBER_DISABLE)                         ||                 \
+    ((x) == ETH_MAC_JABBER_ENABLE))
+
+#define IS_ETH_MAC_INTERFRAME_GAP(x)                                           \
+(   ((x) == ETH_MAC_INTERFRAME_GAP_96BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_88BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_80BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_72BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_64BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_56BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_48BIT)                   ||                 \
+    ((x) == ETH_MAC_INTERFRAME_GAP_40BIT))
+
+#define IS_ETH_MAC_CARRIER_SENSE(x)                                            \
+(   ((x) == ETH_MAC_CARRIER_SENSE_DISABLE)                  ||                 \
+    ((x) == ETH_MAC_CARRIER_SENSE_ENABLE))
+
+#define IS_ETH_MAC_RX_OWN(x)                                                   \
+(   ((x) == ETH_MAC_RX_OWN_DISABLE)                         ||                 \
+    ((x) == ETH_MAC_RX_OWN_ENABLE))
+
+#define IS_ETH_MAC_CHECKSUM_OFFLOAD(x)                                         \
+(   ((x) == ETH_MAC_CHECKSUM_OFFLOAD_DISABLE)               ||                 \
+    ((x) == ETH_MAC_CHECKSUM_OFFLOAD_ENABLE))
+
+#define IS_ETH_MAC_RETRY_TRANS(x)                                              \
+(   ((x) == ETH_MAC_RETRY_TRANS_DISABLE)                    ||                 \
+    ((x) == ETH_MAC_RETRY_TRANS_ENABLE))
+
+#define IS_ETH_MAC_AUTO_STRIP_PAD_FCS(x)                                       \
+(   ((x) == ETH_MAC_AUTO_STRIP_PAD_FCS_DISABLE)             ||                 \
+    ((x) == ETH_MAC_AUTO_STRIP_PAD_FCS_ENABLE))
+
+#define IS_ETH_MAC_BACKOFF_LIMIT(x)                                            \
+(   ((x) == ETH_MAC_BACKOFF_LIMIT10)                        ||                 \
+    ((x) == ETH_MAC_BACKOFF_LIMIT8)                         ||                 \
+    ((x) == ETH_MAC_BACKOFF_LIMIT4)                         ||                 \
+    ((x) == ETH_MAC_BACKOFF_LIMIT1))
+
+#define IS_ETH_MAC_DEFERRAL_CHECK(x)                                           \
+(   ((x) == ETH_MAC_DEFERRAL_CHECK_DISABLE)                 ||                 \
+    ((x) == ETH_MAC_DEFERRAL_CHECK_ENABLE))
+
+#define IS_ETH_MAC_ZERO_QUANTA_PAUSE(x)                                        \
+(   ((x) == ETH_MAC_ZERO_QUANTA_PAUSE_DISABLE)              ||                 \
+    ((x) == ETH_MAC_ZERO_QUANTA_PAUSE_ENABLE))
+
+#define IS_ETH_MAC_PAUSE_LOW_THRESHOLD(x)                                      \
+(   ((x) == ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS4)             ||                 \
+    ((x) == ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS28)            ||                 \
+    ((x) == ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS144)           ||                 \
+    ((x) == ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS256))
+
+#define IS_ETH_MAC_UNICAST_PAUSE_FRAME_DETECT(x)                               \
+(   ((x) == ETH_MAC_UNICAST_PAUSE_FRAME_DETECT_DISABLE)     ||                 \
+    ((x) == ETH_MAC_UNICAST_PAUSE_FRAME_DETECT_ENABLE))
+
+#define IS_ETH_MAC_RX_FLOW_CTRL(x)                                             \
+(   ((x) == ETH_MAC_RX_FLOW_CTRL_DISABLE)                   ||                 \
+    ((x) == ETH_MAC_RX_FLOW_CTRL_ENABLE))
+
+#define IS_ETH_MAC_TRANS_FLOW_CTRL(x)                                          \
+(   ((x) == ETH_MAC_TRANS_FLOW_CTRL_DISABLE)                ||                 \
+    ((x) == ETH_MAC_TRANS_FLOW_CTRL_ENABLE))
+
+#define IS_ETH_MAC_RX_ALL(x)                                                   \
+(   ((x) == ETH_MAC_RX_ALL_DISABLE)                         ||                 \
+    ((x) == ETH_MAC_RX_ALL_ENABLE))
+
+#define IS_ETH_MAC_DROP_NOT_TCPUDP(x)                                          \
+(   ((x) == ETH_MAC_DROP_NOT_TCPUDP_DISABLE)                ||                 \
+    ((x) == ETH_MAC_DROP_NOT_TCPUDP_ENABLE))
+
+#define IS_ETH_MAC_VLAN_TAG_FILTER(x)                                          \
+(   ((x) == ETH_MAC_VLAN_TAG_FILTER_DISABLE)                ||                 \
+    ((x) == ETH_MAC_VLAN_TAG_FILTER_ENABLE))
+
+#define IS_ETH_MAC_SRC_ADDR_FILTER(x)                                          \
+(   ((x) == ETH_MAC_SRC_ADDR_FILTER_DISABLE)                ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_FILTER_NORMAL)                 ||                 \
+    ((x) == ETH_MAC_SRC_ADDR_FILTER_INVERSE))
+
+#define IS_ETH_MAC_PASS_CTRL_FRAME(x)                                          \
+(   ((x) == ETH_MAC_PASS_CTRL_FRAME_BLOCK_ALL)              ||                 \
+    ((x) == ETH_MAC_PASS_CTRL_FRAME_FORWARD_NOT_PAUSE)      ||                 \
+    ((x) == ETH_MAC_PASS_CTRL_FRAME_FORWARD_ALL)            ||                 \
+    ((x) == ETH_MAC_PASS_CTRL_FRAME_FORWARD_PASS_FILTER))
+
+#define IS_ETH_MAC_BROADCAST_FRAME(x)                                          \
+(   ((x) == ETH_MAC_RX_BROADCAST_FRAME_DISABLE)             ||                 \
+    ((x) == ETH_MAC_RX_BROADCAST_FRAME_ENABLE))
+
+#define IS_ETH_MAC_DEST_ADDR_FILTER(x)                                         \
+(   ((x) == ETH_MAC_DEST_ADDR_FILTER_NORMAL)                ||                 \
+    ((x) == ETH_MAC_DEST_ADDR_FILTER_INVERSE))
+
+#define IS_ETH_MAC_MULTICAST_FRAME_FILTER(x)                                   \
+(   ((x) == ETH_MAC_MULTICAST_FRAME_FILTER_NONE)            ||                 \
+    ((x) == ETH_MAC_MULTICAST_FRAME_FILTER_PERFECT)         ||                 \
+    ((x) == ETH_MAC_MULTICAST_FRAME_FILTER_HASHTABLE)       ||                 \
+    ((x) == ETH_MAC_MULTICAST_FRAME_FILTER_PERFECT_HASHTABLE))
+
+#define IS_ETH_MAC_UNICAST_FRAME_FILTER(x)                                     \
+(   ((x) == ETH_MAC_UNICAST_FRAME_FILTER_PERFECT)           ||                 \
+    ((x) == ETH_MAC_UNICAST_FRAME_FILTER_HASHTABLE)         ||                 \
+    ((x) == ETH_MAC_UNICAST_FRAME_FILTER_PERFECT_HASHTABLE))
+
+#define IS_ETH_MAC_PROMISCUOUS_MD(x)                                           \
+(   ((x) == ETH_MAC_PROMISCUOUS_MD_DISABLE)                 ||                 \
+    ((x) == ETH_MAC_PROMISCUOUS_MD_ENABLE))
+
+#define IS_ETH_MAC_TXVLAN_MD(x)                                                \
+(   ((x) == ETH_MAC_TXVLAN_MD_BY_DMA_TXDESC)                ||                 \
+    ((x) == ETH_MAC_TXVLAN_MD_BYPASS)                       ||                 \
+    ((x) == ETH_MAC_TXVLAN_MD_REMOVE_TAG)                   ||                 \
+    ((x) == ETH_MAC_TXVLAN_MD_INSERT_TAG)                   ||                 \
+    ((x) == ETH_MAC_TXVLAN_MD_REPLACE_TAG))
+
+#define IS_ETH_MAC_RXVLAN_FILTER(x)                                            \
+(   ((x) == ETH_MAC_RXVLAN_FILTER_NORMAL)                   ||                 \
+    ((x) == ETH_MAC_RXVLAN_FILTER_INVERSE)                  ||                 \
+    ((x) == ETH_MAC_RXVLAN_FILTER_NORMAL_HASHTABLE)         ||                 \
+    ((x) == ETH_MAC_RXVLAN_FILTER_INVERSE_HASHTABLE))
+
+#define IS_ETH_MAC_RXVLAN_CMP(x)                                               \
+(   ((x) == ETH_MAC_RXVLAN_CMP_16BIT)                       ||                 \
+    ((x) == ETH_MAC_RXVLAN_CMP_12BIT))
+
+#define IS_ETH_MAC_L4_DEST_PORT_FILTER(x)                                      \
+(   ((x) == ETH_MAC_L4_DEST_PORT_FILTER_DISABLE)            ||                 \
+    ((x) == ETH_MAC_L4_DEST_PORT_FILTER_NORMAL)             ||                 \
+    ((x) == ETH_MAC_L4_DEST_PORT_FILTER_INVERSE))
+
+#define IS_ETH_MAC_L4_SRC_PORT_FILTER(x)                                       \
+(   ((x) == ETH_MAC_L4_SRC_PORT_FILTER_DISABLE)             ||                 \
+    ((x) == ETH_MAC_L4_SRC_PORT_FILTER_NORMAL)              ||                 \
+    ((x) == ETH_MAC_L4_SRC_PORT_FILTER_INVERSE))
+
+#define IS_ETH_MAC_L4_PORT_FILTER_PROTOCOL(x)                                  \
+(   ((x) == ETH_MAC_L4_PORT_FILTER_PROTOCOL_TCP)            ||                 \
+    ((x) == ETH_MAC_L4_PORT_FILTER_PROTOCOL_UDP))
+
+#define IS_ETH_MAC_L3_DEST_ADDR_FILTER_MASK(x)                                 \
+(   ((x) | ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT30_0) ==                        \
+    ETH_MAC_L3_DEST_ADDR_FILTER_MASK_BIT30_0)
+
+#define IS_ETH_MAC_L3_SRC_ADDR_FILTER_MASK(x)                                  \
+(   ((x) | ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT30_0) ==                         \
+    ETH_MAC_L3_SRC_ADDR_FILTER_MASK_BIT30_0)
+
+#define IS_ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK(x)                             \
+(   ((x) | ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT126_0) ==                   \
+    ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_BIT126_0)
+
+#define IS_ETH_MAC_L3_DEST_ADDR_FILTER(x)                                      \
+(   ((x) == ETH_MAC_L3_DEST_ADDR_FILTER_DISABLE)            ||                 \
+    ((x) == ETH_MAC_L3_DEST_ADDR_FILTER_NORMAL)             ||                 \
+    ((x) == ETH_MAC_L3_DEST_ADDR_FILTER_INVERSE))
+
+#define IS_ETH_MAC_L3_SRC_ADDR_FILTER(x)                                       \
+(   ((x) == ETH_MAC_L3_SRC_ADDR_FILTER_DISABLE)             ||                 \
+    ((x) == ETH_MAC_L3_SRC_ADDR_FILTER_NORMAL)              ||                 \
+    ((x) == ETH_MAC_L3_SRC_ADDR_FILTER_INVERSE))
+
+#define IS_ETH_MAC_L3_ADDR_FILTER_PROTOCOL(x)                                  \
+(   ((x) == ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV4)           ||                 \
+    ((x) == ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV6))
+
+#define IS_ETH_MAC_ADDR_NORMAL_INDEX(x)                                        \
+(   ((x) == ETH_MAC_ADDR_IDX0)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX1)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX2)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX3)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX4))
+
+#define IS_ETH_MAC_ADDR_SPEC_INDEX(x)                                          \
+(   ((x) == ETH_MAC_ADDR_IDX1)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX2)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX3)                              ||                 \
+    ((x) == ETH_MAC_ADDR_IDX4))
+
+#define IS_ETH_MAC_ADDR_FILTER(x)                                              \
+(   ((x) == ETH_MAC_ADDR_FILTER_DISABLE)                    ||                 \
+    ((x) == ETH_MAC_ADDR_FILTER_PERFECT_DEST_ADDR)          ||                 \
+    ((x) == ETH_MAC_ADDR_FILTER_PERFECT_SRC_ADDR))
+
+#define IS_ETH_MAC_ADDR_MASK(x)                                                \
+(   ((x) | ETH_MAC_ADDR_MASK_ALL) == ETH_MAC_ADDR_MASK_ALL)
+
+#define IS_ETH_MAC_INT_FLAG(x)                                                 \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MAC_INT_FLAG_ALL) == ETH_MAC_INT_FLAG_ALL))
+
+#define IS_ETH_MAC_INT(x)                                                      \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MAC_INT_ALL) == ETH_MAC_INT_ALL))
+
+#define IS_ETH_DMA_BURST_MD(x)                                                 \
+(   ((x) == ETH_DMA_BURST_MD_NORMAL)                        ||                 \
+    ((x) == ETH_DMA_BURST_MD_FIXED)                         ||                 \
+    ((x) == ETH_DMA_BURST_MD_MIXED))
+
+#define IS_ETH_DMA_ADDR_ALIGN(x)                                               \
+(   ((x) == ETH_DMA_ADDR_ALIGN_DISABLE)                     ||                 \
+    ((x) == ETH_DMA_ADDR_ALIGN_ENABLE))
+
+#define IS_ETH_DMA_RX_BURST_LEN(x)                                             \
+(   ((x) == ETH_DMA_RX_BURST_LEN_1BEAT)                     ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_2BEAT)                     ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_4BEAT)                     ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8BEAT)                     ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_16BEAT)                    ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_32BEAT)                    ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_8BEAT)               ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_16BEAT)              ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_32BEAT)              ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_64BEAT)              ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_128BEAT)             ||                 \
+    ((x) == ETH_DMA_RX_BURST_LEN_8XPBL_256BEAT))
+
+#define IS_ETH_DMA_TX_BURST_LEN(x)                                             \
+(   ((x) == ETH_DMA_TX_BURST_LEN_1BEAT)                     ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_2BEAT)                     ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_4BEAT)                     ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8BEAT)                     ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_16BEAT)                    ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_32BEAT)                    ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_8BEAT)               ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_16BEAT)              ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_32BEAT)              ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_64BEAT)              ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_128BEAT)             ||                 \
+    ((x) == ETH_DMA_TX_BURST_LEN_8XPBL_256BEAT))
+
+#define IS_ETH_DMA_ENHANCE_DESC(x)                                             \
+(   ((x) == ETH_DMA_ENHANCE_DESC_DISABLE)                   ||                 \
+    ((x) == ETH_DMA_ENHANCE_DESC_ENABLE))
+
+#define IS_ETH_DMA_DESC_SKIP_LEN(x)                         ((x) < 0x20U)
+
+#define IS_ETH_DMA_PRIO_ARBITRATION(x)                                         \
+(   ((x) == ETH_DMA_ARBITRATION_LOOP_RXTX_1_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_RXTX_2_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_RXTX_3_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_RXTX_4_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_TXRX_1_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_TXRX_2_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_TXRX_3_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_LOOP_TXRX_4_1)              ||                 \
+    ((x) == ETH_DMA_ARBITRATION_FIXED_RX_PRIOR_TX)          ||                 \
+    ((x) == ETH_DMA_ARBITRATION_FIXED_TX_PRIOR_RX))
+
+#define IS_ETH_DMA_DROP_CHECKSUM_ERR_FRAME(x)                                  \
+(   ((x) == ETH_DMA_DROP_CHECKSUM_ERR_FRAME_DISABLE)        ||                 \
+    ((x) == ETH_DMA_DROP_CHECKSUM_ERR_FRAME_ENABLE))
+
+#define IS_ETH_DMA_RX_STORE_FORWARD(x)                                         \
+(   ((x) == ETH_DMA_RX_STORE_FORWARD_DISABLE)               ||                 \
+    ((x) == ETH_DMA_RX_STORE_FORWARD_ENABLE))
+
+#define IS_ETH_DMA_FLUSH_RX_FRAME(x)                                           \
+(   ((x) == ETH_DMA_FLUSH_RX_FRAME_DISABLE)                 ||                 \
+    ((x) == ETH_DMA_FLUSH_RX_FRAME_ENABLE))
+
+#define IS_ETH_DMA_TRANS_STORE_FORWARD(x)                                      \
+(   ((x) == ETH_DMA_TRANS_STORE_FORWARD_DISABLE)            ||                 \
+    ((x) == ETH_DMA_TRANS_STORE_FORWARD_ENABLE))
+
+#define IS_ETH_DMA_TRANS_THRESHOLD(x)                                          \
+(   ((x) == ETH_DMA_TRANS_THRESHOLD_64BYTE)                 ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_128BYTE)                ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_192BYTE)                ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_256BYTE)                ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_40BYTE)                 ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_32BYTE)                 ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_24BYTE)                 ||                 \
+    ((x) == ETH_DMA_TRANS_THRESHOLD_16BYTE))
+
+#define IS_ETH_DMA_FORWARD_ERR_FRAME(x)                                        \
+(   ((x) == ETH_DMA_FORWARD_ERR_FRAME_DISABLE)              ||                 \
+    ((x) == ETH_DMA_FORWARD_ERR_FRAME_ENABLE))
+
+#define IS_ETH_DMA_FORWARD_UNDERSIZE_FRAME(x)                                  \
+(   ((x) == ETH_DMA_FORWARD_UNDERSIZE_FRAME_DISABLE)        ||                 \
+    ((x) == ETH_DMA_FORWARD_UNDERSIZE_FRAME_ENABLE))
+
+#define IS_ETH_DMA_DROP_JUMBO_FRAME(x)                                         \
+(   ((x) == ETH_DMA_DROP_JUMBO_FRAME_DISABLE)               ||                 \
+    ((x) == ETH_DMA_DROP_JUMBO_FRAME_ENABLE))
+
+#define IS_ETH_DMA_RX_THRESHOLD(x)                                             \
+(   ((x) == ETH_DMA_RX_THRESHOLD_64BYTE)                    ||                 \
+    ((x) == ETH_DMA_RX_THRESHOLD_32BYTE)                    ||                 \
+    ((x) == ETH_DMA_RX_THRESHOLD_96BYTE)                    ||                 \
+    ((x) == ETH_DMA_RX_THRESHOLD_128BYTE))
+
+#define IS_ETH_DMA_SEC_FRAME_OP(x)                                             \
+(   ((x) == ETH_DMA_SEC_FRAME_OP_DISABLE)                   ||                 \
+    ((x) == ETH_DMA_SEC_FRAME_OP_ENABLE))
+
+#define IS_ETH_DMA_FLAG(x)                                                     \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_FLAG_ALL) == ETH_DMA_FLAG_ALL))
+
+#define IS_ETH_DMA_CLR_FLAG(x)                                                 \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_FLAG_CLR_ALL) == ETH_DMA_FLAG_CLR_ALL))
+
+#define IS_ETH_DMA_INT(x)                                                      \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_INT_ALL) == ETH_DMA_INT_ALL))
+
+#define IS_ETH_DMA_MISS_FRAME_TYPE(x)                                          \
+(   ((x) == ETH_DMA_OVF_RXFIFO_CNT)                         ||                 \
+    ((x) == ETH_DMA_OVF_MISS_FRAME_CNT))
+
+#define IS_ETH_DMA_DESC_OWN(x)                                                 \
+(   ((x) == ETH_DMA_DESC_OWN_CPU)                           ||                 \
+    ((x) == ETH_DMA_DESC_OWN_DMA))
+
+#define IS_ETH_DMA_DESC_BUF(x)                                                 \
+(   ((x) == ETH_DMA_DESC_BUF1)                              ||                 \
+    ((x) == ETH_DMA_DESC_BUF2))
+
+#define IS_ETH_DMA_TXDESC_BUF_SIZE(x)                       ((x) <= 0x1FFFFFFFUL)
+
+#define IS_ETH_DMA_TXDESC_CHECKSUM_CTRL(x)                                     \
+(   ((x) == ETH_DMA_TXDESC_CHECKSUM_BYPASS)                 ||                 \
+    ((x) == ETH_DMA_TXDESC_CHECKSUM_IPV4_HEADER)            ||                 \
+    ((x) == ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_SEGMENT)     ||                 \
+    ((x) == ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_FULL))
+
+#define IS_ETH_DMA_TXDESC_VLAN_CTRL(x)                                         \
+(   ((x) == ETH_DMA_TXDESC_VLAN_BYPASS)                     ||                 \
+    ((x) == ETH_DMA_TXDESC_VLAN_REMOVE_TAG)                 ||                 \
+    ((x) == ETH_DMA_TXDESC_VLAN_INSERT_TAG)                 ||                 \
+    ((x) == ETH_DMA_TXDESC_VLAN_REPLACE_TAG))
+
+#define IS_ETH_DMA_TXDESC_SRC_ADDR_CTRL(x)                                     \
+(   ((x) == ETH_DMA_TXDESC_SRC_ADDR_BYPASS)                 ||                 \
+    ((x) == ETH_DMA_TXDESC_SRC_ADDR_INSERT_MACADDR0)        ||                 \
+    ((x) == ETH_DMA_TXDESC_SRC_ADDR_REPLACE_MACADDR0)       ||                 \
+    ((x) == ETH_DMA_TXDESC_SRC_ADDR_INSERT_MACADDR1)        ||                 \
+    ((x) == ETH_DMA_TXDESC_SRC_ADDR_REPLACE_MACADDR1))
+
+#define IS_ETH_PMT_FLAG(x)                                                     \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_PMT_FLAG_ALL) == ETH_PMT_FLAG_ALL))
+
+#define IS_ETH_PMT_WAKEUP_SRC(x)                                               \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_PMT_WAKEUP_SRC_ALL) == ETH_PMT_WAKEUP_SRC_ALL))
+
+#define IS_ETH_MMC_CNT_PRESET_MD(x)                                            \
+(   ((x) == ETH_MMC_CNT_PRESET_MD_DISABLE)                  ||                 \
+    ((x) == ETH_MMC_CNT_PRESET_MD_HALF_VALUE)               ||                 \
+    ((x) == ETH_MMC_CNT_PRESET_MD_FULL_VALUE))
+
+#define IS_ETH_MMC_RD_RST(x)                                                   \
+(   ((x) == ETH_MMC_RD_RST_DISABLE)                         ||                 \
+    ((x) == ETH_MMC_RD_RST_ENABLE))
+
+#define IS_ETH_MMC_CNT_RELOAD(x)                                               \
+(   ((x) == ETH_MMC_CNT_RELOAD_DISABLE)                     ||                 \
+    ((x) == ETH_MMC_CNT_RELOAD_ENABLE))
+
+#define IS_ETH_MMC_TX_FLAG(x)                                                  \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MMC_FLAG_TX_ALL) == ETH_MMC_FLAG_TX_ALL))
+
+#define IS_ETH_MMC_RX_FLAG(x)                                                  \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MMC_FLAG_RX_ALL) == ETH_MMC_FLAG_RX_ALL))
+
+#define IS_ETH_MMC_TX_INT(x)                                                   \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MMC_INT_TX_ALL) == ETH_MMC_INT_TX_ALL))
+
+#define IS_ETH_MMC_RX_INT(x)                                                   \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_MMC_INT_RX_ALL) == ETH_MMC_INT_RX_ALL))
+
+#define IS_ETH_MMC_REG(x)                                                      \
+(   ((x) == ETH_MMC_REG_TXBRGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXMUGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXDEEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXLCEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXECEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXCAEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXUNGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_TXEDEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXBRGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXMUGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXCREFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXALEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXRUEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXUNGFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXLEEFR)                            ||                 \
+    ((x) == ETH_MMC_REG_RXOREFR))
+
+#define IS_ETH_PTP_DEST_ADDR_FILTER(x)                                         \
+(   ((x) == ETH_PTP_DEST_ADDR_FILTER_DISABLE)               ||                 \
+    ((x) == ETH_PTP_DEST_ADDR_FILTER_ENABLE))
+
+#define IS_ETH_PTP_DATAGRAM_TYPE(x)                                            \
+(   ((x) == ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY)        ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_SYNC)                     ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_DELAY)                    ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY_PDELAY) ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_SYNC_PDELAY)              ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_DELAY_PDELAY)             ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_SYNC_DELAY)               ||                 \
+    ((x) == ETH_PTP_DATAGRAM_TYPE_PDELAY))
+
+#define IS_ETH_PTP_FRAME_TYPE(x)                                               \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_PTP_FRAME_TYPE_ALL) == ETH_PTP_FRAME_TYPE_ALL))
+
+#define IS_ETH_PTP_DATAGRAM_VER(x)                                             \
+(   ((x) == ETH_PTP_DATAGRAM_VER_IEEE1588V1)                ||                 \
+    ((x) == ETH_PTP_DATAGRAM_VER_IEEE1588V2))
+
+#define IS_ETH_PTP_SUBSEC_SCALE(x)                                             \
+(   ((x) == ETH_PTP_SUBSEC_SCALE_HEX)                       ||                 \
+    ((x) == ETH_PTP_SUBSEC_SCALE_DEC))
+
+#define IS_ETH_PTP_CALIB_MD(x)                                                 \
+(   ((x) == ETH_PTP_CALIB_MD_COARSE)                        ||                 \
+    ((x) == ETH_PTP_CALIB_MD_FINE))
+
+#define IS_ETH_PTP_TIME_UPDATE_SIGN(x)                                         \
+(   ((x) == ETH_PTP_TIME_UPDATE_SIGN_MINUS)                 ||                 \
+    ((x) == ETH_PTP_TIME_UPDATE_SIGN_PLUS))
+
+#define IS_ETH_PTP_FLAG(x)                                                     \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_PTP_FLAG_ALL) == ETH_PTP_FLAG_ALL))
+
+#define IS_ETH_PPS_CH(x)                                                       \
+(   ((x) == ETH_PPS_CH0)                                    ||                 \
+    ((x) == ETH_PPS_CH1))
+
+#define IS_ETH_PPS_TRIG_FUNC(x)                                                \
+(   ((x) == ETH_PPS_TRIG_FUNC_INT_EVT)                      ||                 \
+    ((x) == ETH_PPS_TRIG_FUNC_INT_PPS_EVT)                  ||                 \
+    ((x) == ETH_PPS_TRIG_FUNC_PPS_EVT))
+
+#define IS_ETH_PPS_OUTPUT_MD(x)                                                \
+(   ((x) == ETH_PPS_OUTPUT_MD_CONT)                         ||                 \
+    ((x) == ETH_PPS_OUTPUT_MD_ONCE))
+
+#define IS_ETH_PPS_CH_OUTPUT_FREQ(ch, freq)                                    \
+(   (((ch) == ETH_PPS_CH0) && ((freq) <= ETH_PPS_OUTPUT_FREQ_32768HZ))  ||     \
+    (((ch) == ETH_PPS_CH1) && ((freq) == ETH_PPS_OUTPUT_ONE_PULSE)))
+
+#define IS_ETH_PPS_OUTPUT_MD_FREQ(mode, freq)                                  \
+(   (((mode) == ETH_PPS_OUTPUT_MD_CONT) && ((freq) <= ETH_PPS_OUTPUT_FREQ_32768HZ)) || \
+    (((mode) == ETH_PPS_OUTPUT_MD_ONCE) && ((freq) == ETH_PPS_OUTPUT_ONE_PULSE)))
+
+#define IS_ETH_PTP_SUB_SEC(x)                               ((x) <= 0x7FFFFFFFUL)
+
+#define IS_ETH_DMA_TXDESC_STATUS(x)                                            \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_TXDESC_STATUS_ALL) == ETH_DMA_TXDESC_STATUS_ALL))
+
+#define IS_ETH_DMA_RXDESC_STATUS(x)                                             \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_RXDESC_STATUS_ALL) == ETH_DMA_RXDESC_STATUS_ALL))
+
+#define IS_ETH_DMA_RXDESC_EXTEND_STATUS(x)                                     \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | ETH_DMA_RXDESC_EXTEND_STATUS_ALL) ==                               \
+    ETH_DMA_RXDESC_EXTEND_STATUS_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup ETH_Global_Functions ETH Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-Initialize ETH.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: De-Initialize success
+ *           - LL_ERR_TIMEOUT: De-Initialize timeout
+ */
+int32_t ETH_DeInit(void)
+{
+    int32_t i32Ret;
+
+    i32Ret = ETH_DMA_SoftwareReset();
+    if (LL_OK == i32Ret) {
+        ETH_DMA_DeInit();
+        ETH_MAC_DeInit();
+        ETH_MACADDR_DeInit(ETH_MAC_ADDR_IDX0);
+        ETH_MACADDR_DeInit(ETH_MAC_ADDR_IDX1);
+        ETH_MACADDR_DeInit(ETH_MAC_ADDR_IDX2);
+        ETH_MACADDR_DeInit(ETH_MAC_ADDR_IDX3);
+        ETH_MACADDR_DeInit(ETH_MAC_ADDR_IDX4);
+        ETH_MAC_L3L4FilterDeInit();
+        ETH_PTP_DeInit();
+        ETH_PPS_DeInit(ETH_PPS_CH0);
+        ETH_PPS_DeInit(ETH_PPS_CH1);
+        i32Ret = ETH_MMC_DeInit();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize ETH.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @param  [in] pstcEthInit             Pointer to a @ref stc_eth_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: ETH Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL or pstcEthInit == NULL
+ *           - LL_ERR_TIMEOUT: Initialize timeout
+ */
+int32_t ETH_Init(stc_eth_handle_t *pstcEthHandle, stc_eth_init_t *pstcEthInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcEthHandle) || (NULL == pstcEthInit)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_CHECKSUM_MD(pstcEthHandle->stcCommInit.u32ChecksumMode));
+        DDL_ASSERT(IS_ETH_RX_MD(pstcEthHandle->stcCommInit.u32ReceiveMode));
+        DDL_ASSERT(IS_ETH_MAC_IF(pstcEthHandle->stcCommInit.u32Interface));
+
+        /* Select MII or RMII Mode */
+        MODIFY_REG32(CM_ETH->MAC_IFCONFR, ETH_MAC_IFCONFR_IFSEL, pstcEthHandle->stcCommInit.u32Interface);
+        /* ETH software reset */
+        if (LL_OK != ETH_DMA_SoftwareReset()) {
+            i32Ret = LL_ERR_TIMEOUT;
+        } else {
+            /* Config checksum offload */
+            if (ETH_MAC_CHECKSUM_MD_HW == pstcEthHandle->stcCommInit.u32ChecksumMode) {
+                pstcEthInit->stcMacInit.u32ChecksumOffload = ETH_MAC_CHECKSUM_OFFLOAD_ENABLE;
+            } else {
+                pstcEthInit->stcMacInit.u32ChecksumOffload = ETH_MAC_CHECKSUM_OFFLOAD_DISABLE;
+            }
+            /* Config MAC,DMA,MMC and PTP */
+            (void)ETH_MAC_Init(pstcEthHandle, &pstcEthInit->stcMacInit);
+            (void)ETH_DMA_Init(&pstcEthInit->stcDmaInit);
+            /* Mask all MMC interrupts */
+            ETH_MMC_TxIntCmd(ETH_MMC_INT_TX_ALL, DISABLE);
+            ETH_MMC_RxIntCmd(ETH_MMC_INT_RX_ALL, DISABLE);
+            /* Enable the ETH Rx Interrupt */
+            if (ETH_RX_MD_INT == pstcEthHandle->stcCommInit.u32ReceiveMode) {
+                ETH_DMA_IntCmd(ETH_DMA_INT_NIE | ETH_DMA_INT_RIE, ENABLE);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_comm_init_t to default values.
+ * @param  [out] pstcCommInit           Pointer to a @ref stc_eth_comm_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcCommInit == NULL
+ */
+int32_t ETH_CommStructInit(stc_eth_comm_init_t *pstcCommInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcCommInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcCommInit->au8MacAddr[0]     = ETH_MAC_ADDR0;
+        pstcCommInit->au8MacAddr[1]     = ETH_MAC_ADDR1;
+        pstcCommInit->au8MacAddr[2]     = ETH_MAC_ADDR2;
+        pstcCommInit->au8MacAddr[3]     = ETH_MAC_ADDR3;
+        pstcCommInit->au8MacAddr[4]     = ETH_MAC_ADDR4;
+        pstcCommInit->au8MacAddr[5]     = ETH_MAC_ADDR5;
+        pstcCommInit->u32Interface      = ETH_MAC_IF_MII;
+        pstcCommInit->u32Speed          = ETH_MAC_SPEED_100M;
+        pstcCommInit->u32DuplexMode     = ETH_MAC_DUPLEX_MD_FULL;
+        pstcCommInit->u32ChecksumMode   = ETH_MAC_CHECKSUM_MD_HW;
+        pstcCommInit->u32ReceiveMode    = ETH_RX_MD_POLLING;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_init_t to default values.
+ * @param  [out] pstcEthInit            Pointer to a @ref stc_eth_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcEthInit == NULL
+ */
+int32_t ETH_StructInit(stc_eth_init_t *pstcEthInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcEthInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        (void)ETH_MAC_StructInit(&pstcEthInit->stcMacInit);
+        (void)ETH_DMA_StructInit(&pstcEthInit->stcDmaInit);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable MAC and DMA Transmission/Reception
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Enable success
+ *           - LL_ERR_TIMEOUT: Enable timeout
+ */
+int32_t ETH_Start(void)
+{
+    int32_t i32Ret;
+
+    /* Flush Transmit FIFO */
+    i32Ret = ETH_DMA_FlushTransFIFO();
+    if (LL_OK == i32Ret) {
+        /* Enable MAC Transmit & Receive */
+        SET_REG32_BIT(CM_ETH->MAC_CONFIGR, ETH_MAC_CONFIGR_RE | ETH_MAC_CONFIGR_TE);
+        DDL_DelayUS(300U);
+        /* Enable DMA Transmit & Receive */
+        SET_REG32_BIT(CM_ETH->DMA_OPRMODR, ETH_DMA_OPRMODR_STR | ETH_DMA_OPRMODR_STT);
+        DDL_DelayUS(300U);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Disable MAC and DMA Transmission/Reception
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Disable success
+ *           - LL_ERR_TIMEOUT: Disable timeout
+ */
+int32_t ETH_Stop(void)
+{
+    int32_t i32Ret;
+
+    /* Disable DMA Receive/Transmit */
+    CLR_REG32_BIT(CM_ETH->DMA_OPRMODR, ETH_DMA_OPRMODR_STR | ETH_DMA_OPRMODR_STT);
+    DDL_DelayUS(300U);
+    /* Disable MAC Transmit/Receive */
+    CLR_REG32_BIT(CM_ETH->MAC_CONFIGR, ETH_MAC_CONFIGR_RE | ETH_MAC_CONFIGR_TE);
+    DDL_DelayUS(300U);
+    /* Flush Transmit FIFO */
+    i32Ret = ETH_DMA_FlushTransFIFO();
+
+    return i32Ret;
+}
+
+/******************************************************************************/
+/*                             PHY Functions                                  */
+/******************************************************************************/
+/**
+ * @brief  Write PHY register
+ * @note   More PHY register could be written depending on the used PHY.
+ * @param  [in] u16PhyAddr              PHY port address, The value range from 0 to 31
+ * @param  [in] u16Reg                  PHY register address, The value range from 0 to 31
+ * @param  [in] u16Value                PHY register value
+ * @retval int32_t:
+ *           - LL_OK: Write register success
+ *           - LL_ERR_TIMEOUT: Write timeout
+ */
+int32_t ETH_PHY_WriteReg(uint16_t u16PhyAddr, uint16_t u16Reg, uint16_t u16Value)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PHY_ADDR(u16PhyAddr));
+    DDL_ASSERT(IS_ETH_PHY_REG(u16Reg));
+
+    /* Set the MAC_SMIDATR register */
+    WRITE_REG32(CM_ETH->MAC_SMIDATR, u16Value);
+    /* Set the MAC_SMIADDR register */
+    /* Keep only the MDC Clock Range SMIC[3:0] bits value */
+    MODIFY_REG32(CM_ETH->MAC_SMIADDR, ETH_MAC_SMIADDR_CLR_MASK,
+                 (((uint32_t)u16PhyAddr << ETH_MAC_SMIADDR_SMIA_POS) |
+                  ((uint32_t)u16Reg << ETH_MAC_SMIADDR_SMIR_POS) | ETH_MAC_SMIADDR_SMIW | ETH_MAC_SMIADDR_SMIB));
+    /* Check for the Busy flag */
+    u32Count = ETH_PHY_WR_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32_BIT(CM_ETH->MAC_SMIADDR, ETH_MAC_SMIADDR_SMIB)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Read PHY register.
+ * @note   More PHY register could be read depending on the used PHY.
+ * @param  [in] u16PhyAddr              PHY port address, The value range from 0 to 31
+ * @param  [in] u16Reg                  PHY register address, The value range from 0 to 31
+ * @param  [out] pu16Value              Pointer to PHY register value
+ * @retval int32_t:
+ *           - LL_OK: Read register success
+ *           - LL_ERR_INVD_PARAM: pu16Value == NULL
+ *           - LL_ERR_TIMEOUT: Read timeout
+ */
+int32_t ETH_PHY_ReadReg(uint16_t u16PhyAddr, uint16_t u16Reg, uint16_t *pu16Value)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pu16Value) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_PHY_ADDR(u16PhyAddr));
+        DDL_ASSERT(IS_ETH_PHY_REG(u16Reg));
+
+        *pu16Value = 0U;
+        /* Set the MAC_SMIADDR register */
+        /* Keep only the MDC Clock Range SMIC[3:0] bits value */
+        MODIFY_REG32(CM_ETH->MAC_SMIADDR, ETH_MAC_SMIADDR_CLR_MASK,
+                     (((uint32_t)u16PhyAddr << ETH_MAC_SMIADDR_SMIA_POS) |
+                      ((uint32_t)u16Reg << ETH_MAC_SMIADDR_SMIR_POS) | ETH_MAC_SMIADDR_SMIB));
+        /* Check for the Busy flag */
+        u32Count = ETH_PHY_RD_TIMEOUT * (HCLK_VALUE / 20000UL);
+        while (0UL != READ_REG32_BIT(CM_ETH->MAC_SMIADDR, ETH_MAC_SMIADDR_SMIB)) {
+            if (0UL == u32Count) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+            u32Count--;
+        }
+        if (LL_ERR_TIMEOUT != i32Ret) {
+            /* Get the MAC_SMIDATR value */
+            *pu16Value = (uint16_t)(READ_REG32(CM_ETH->MAC_SMIDATR));
+        }
+    }
+
+    return i32Ret;
+}
+
+/******************************************************************************/
+/*                             MAC Functions                                  */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize MAC.
+ * @param  None
+ * @retval None
+ */
+void ETH_MAC_DeInit(void)
+{
+    WRITE_REG32(CM_ETH->MAC_IFCONFR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_CONFIGR,  0x00008000UL);
+    MODIFY_REG32(CM_ETH->MAC_FLTCTLR, ETH_MAC_FLTCTLR_CLR_MASK, 0UL);
+    WRITE_REG32(CM_ETH->MAC_FLOCTLR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_INTMSKR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_SMIADDR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_SMIDATR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_RTWKFFR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_PMTCTLR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_HASHTLR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_HASHTHR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_VTACTLR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_VTAFLTR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_VLAHTBR,  0UL);
+}
+
+/**
+ * @brief  Initialize MAC.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @param  [in] pstcMacInit             Pointer to a @ref stc_eth_mac_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: MAC Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL or pstcMacInit == NULL
+ */
+int32_t ETH_MAC_Init(stc_eth_handle_t *pstcEthHandle, const stc_eth_mac_init_t *pstcMacInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcEthHandle) || (NULL == pstcMacInit)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_TX_CLK_POLARITY(pstcMacInit->u32TxClockPolarity));
+        DDL_ASSERT(IS_ETH_MAC_RX_CLK_POLARITY(pstcMacInit->u32RxClockPolarity));
+        DDL_ASSERT(IS_ETH_MAC_SRC_ADDR_MD(pstcMacInit->u32SrcAddrMode));
+        DDL_ASSERT(IS_ETH_MAC_TYPE_FRAME_STRIP_FCS(pstcMacInit->u32TypeFrameStripFCS));
+        DDL_ASSERT(IS_ETH_MAC_WDT(pstcMacInit->u32Watchdog));
+        DDL_ASSERT(IS_ETH_MAC_JABBER(pstcMacInit->u32Jabber));
+        DDL_ASSERT(IS_ETH_MAC_INTERFRAME_GAP(pstcMacInit->u32InterframeGap));
+        DDL_ASSERT(IS_ETH_MAC_CARRIER_SENSE(pstcMacInit->u32CarrierSense));
+        DDL_ASSERT(IS_ETH_MAC_SPEED(pstcEthHandle->stcCommInit.u32Speed));
+        DDL_ASSERT(IS_ETH_MAC_RX_OWN(pstcMacInit->u32ReceiveOwn));
+        DDL_ASSERT(IS_ETH_MAC_DUPLEX_MD(pstcEthHandle->stcCommInit.u32DuplexMode));
+        DDL_ASSERT(IS_ETH_MAC_CHECKSUM_OFFLOAD(pstcMacInit->u32ChecksumOffload));
+        DDL_ASSERT(IS_ETH_MAC_RETRY_TRANS(pstcMacInit->u32RetryTrans));
+        DDL_ASSERT(IS_ETH_MAC_AUTO_STRIP_PAD_FCS(pstcMacInit->u32AutoStripPadFCS));
+        DDL_ASSERT(IS_ETH_MAC_BACKOFF_LIMIT(pstcMacInit->u32BackOffLimit));
+        DDL_ASSERT(IS_ETH_MAC_DEFERRAL_CHECK(pstcMacInit->u32DeferralCheck));
+        DDL_ASSERT(IS_ETH_MAC_ZERO_QUANTA_PAUSE(pstcMacInit->u32ZeroQuantaPause));
+        DDL_ASSERT(IS_ETH_MAC_PAUSE_LOW_THRESHOLD(pstcMacInit->u32PauseLowThreshold));
+        DDL_ASSERT(IS_ETH_MAC_UNICAST_PAUSE_FRAME_DETECT(pstcMacInit->u32UnicastPauseFrame));
+        DDL_ASSERT(IS_ETH_MAC_RX_FLOW_CTRL(pstcMacInit->u32ReceiveFlowControl));
+        DDL_ASSERT(IS_ETH_MAC_TRANS_FLOW_CTRL(pstcMacInit->u32TransFlowControl));
+        DDL_ASSERT(IS_ETH_MAC_RX_ALL(pstcMacInit->u32ReceiveAll));
+        DDL_ASSERT(IS_ETH_MAC_DROP_NOT_TCPUDP(pstcMacInit->u32DropNotTcpUdp));
+        DDL_ASSERT(IS_ETH_MAC_VLAN_TAG_FILTER(pstcMacInit->u32VlanTagFilter));
+        DDL_ASSERT(IS_ETH_MAC_SRC_ADDR_FILTER(pstcMacInit->u32SrcAddrFilter));
+        DDL_ASSERT(IS_ETH_MAC_PASS_CTRL_FRAME(pstcMacInit->u32PassControlFrame));
+        DDL_ASSERT(IS_ETH_MAC_BROADCAST_FRAME(pstcMacInit->u32BroadcastFrame));
+        DDL_ASSERT(IS_ETH_MAC_DEST_ADDR_FILTER(pstcMacInit->u32DestAddrFilter));
+        DDL_ASSERT(IS_ETH_MAC_MULTICAST_FRAME_FILTER(pstcMacInit->u32MulticastFrameFilter));
+        DDL_ASSERT(IS_ETH_MAC_UNICAST_FRAME_FILTER(pstcMacInit->u32UnicastFrameFilter));
+        DDL_ASSERT(IS_ETH_MAC_PROMISCUOUS_MD(pstcMacInit->u32PromiscuousMode));
+        DDL_ASSERT(IS_ETH_MAC_TXVLAN_MD(pstcMacInit->u32TxVlanMode));
+        DDL_ASSERT(IS_ETH_MAC_RXVLAN_FILTER(pstcMacInit->u32RxVlanFilter));
+        DDL_ASSERT(IS_ETH_MAC_RXVLAN_CMP(pstcMacInit->u32RxVlanCompare));
+
+        /* Set MAC_IFCONFR register */
+        MODIFY_REG32(CM_ETH->MAC_IFCONFR, ETH_MAC_IFCONFR_CLR_MASK,
+                     (pstcMacInit->u32TxClockPolarity | pstcMacInit->u32RxClockPolarity));
+        /* Set MAC_CONFIGR register */
+        MODIFY_REG32(CM_ETH->MAC_CONFIGR, ETH_MAC_CONFIGR_CLR_MASK,
+                     (pstcMacInit->u32SrcAddrMode         | pstcMacInit->u32TypeFrameStripFCS        |
+                      pstcMacInit->u32Watchdog            | pstcMacInit->u32Jabber                   |
+                      pstcMacInit->u32InterframeGap       | pstcMacInit->u32CarrierSense             |
+                      pstcEthHandle->stcCommInit.u32Speed | pstcMacInit->u32ReceiveOwn               |
+                      pstcMacInit->u32DeferralCheck       | pstcEthHandle->stcCommInit.u32DuplexMode |
+                      pstcMacInit->u32ChecksumOffload     | pstcMacInit->u32RetryTrans               |
+                      pstcMacInit->u32AutoStripPadFCS     | pstcMacInit->u32BackOffLimit));
+        /* Set MAC_FLOCTLR register */
+        MODIFY_REG32(CM_ETH->MAC_FLOCTLR, ETH_MAC_FLOCTLR_CLR_MASK,
+                     ((((uint32_t)pstcMacInit->u16PauseTime) << 16U) | pstcMacInit->u32ZeroQuantaPause   |
+                      pstcMacInit->u32PauseLowThreshold              | pstcMacInit->u32UnicastPauseFrame |
+                      pstcMacInit->u32ReceiveFlowControl             | pstcMacInit->u32TransFlowControl));
+        /* Set MAC_FLTCTLR register */
+        MODIFY_REG32(CM_ETH->MAC_FLTCTLR, ETH_MAC_FLTCTLR_CLR_MASK,
+                     (pstcMacInit->u32ReceiveAll           | pstcMacInit->u32DropNotTcpUdp    |
+                      pstcMacInit->u32PromiscuousMode      | pstcMacInit->u32VlanTagFilter    |
+                      pstcMacInit->u32SrcAddrFilter        | pstcMacInit->u32PassControlFrame |
+                      pstcMacInit->u32BroadcastFrame       | pstcMacInit->u32DestAddrFilter   |
+                      pstcMacInit->u32MulticastFrameFilter | pstcMacInit->u32UnicastFrameFilter));
+        /* Set Hash table register */
+        WRITE_REG32(CM_ETH->MAC_HASHTLR, pstcMacInit->u32HashTableLow);
+        WRITE_REG32(CM_ETH->MAC_HASHTHR, pstcMacInit->u32HashTableHigh);
+        /* Set Tx VLAN register */
+        WRITE_REG32(CM_ETH->MAC_VTACTLR, (pstcMacInit->u32TxVlanMode | pstcMacInit->u16TxVlanTag));
+        /* Set Rx VLAN register */
+        WRITE_REG32(CM_ETH->MAC_VTAFLTR, (pstcMacInit->u32RxVlanFilter | pstcMacInit->u32RxVlanCompare |
+                                          pstcMacInit->u16RxVlanTag));
+        WRITE_REG32(CM_ETH->MAC_VLAHTBR, pstcMacInit->u16RxVlanHashTable);
+        /* Config MAC address in ETH MAC0 */
+        (void)ETH_MACADDR_SetAddr(ETH_MAC_ADDR_IDX0, pstcEthHandle->stcCommInit.au8MacAddr);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_mac_init_t to default values.
+ * @param  [out] pstcMacInit            Pointer to a @ref stc_eth_mac_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcMacInit == NULL
+ */
+int32_t ETH_MAC_StructInit(stc_eth_mac_init_t *pstcMacInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcMacInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcMacInit->u32TxClockPolarity     = ETH_MAC_TX_CLK_POLARITY_KEEP;
+        pstcMacInit->u32RxClockPolarity     = ETH_MAC_RX_CLK_POLARITY_KEEP;
+        pstcMacInit->u32SrcAddrMode         = ETH_MAC_SRC_ADDR_MD_BY_DMA_TXDESC;
+        pstcMacInit->u32TypeFrameStripFCS   = ETH_MAC_TYPE_FRAME_STRIP_FCS_DISABLE;
+        pstcMacInit->u32Watchdog            = ETH_MAC_WDT_ENABLE;
+        pstcMacInit->u32Jabber              = ETH_MAC_JABBER_ENABLE;
+        pstcMacInit->u32InterframeGap       = ETH_MAC_INTERFRAME_GAP_96BIT;
+        pstcMacInit->u32CarrierSense        = ETH_MAC_CARRIER_SENSE_ENABLE;
+        pstcMacInit->u32ReceiveOwn          = ETH_MAC_RX_OWN_ENABLE;
+        pstcMacInit->u32ChecksumOffload     = ETH_MAC_CHECKSUM_OFFLOAD_DISABLE;
+        pstcMacInit->u32RetryTrans          = ETH_MAC_RETRY_TRANS_DISABLE;
+        pstcMacInit->u32AutoStripPadFCS     = ETH_MAC_AUTO_STRIP_PAD_FCS_DISABLE;
+        pstcMacInit->u32BackOffLimit        = ETH_MAC_BACKOFF_LIMIT10;
+        pstcMacInit->u32DeferralCheck       = ETH_MAC_DEFERRAL_CHECK_DISABLE;
+        pstcMacInit->u16PauseTime           = 0U;
+        pstcMacInit->u32ZeroQuantaPause     = ETH_MAC_ZERO_QUANTA_PAUSE_DISABLE;
+        pstcMacInit->u32PauseLowThreshold   = ETH_MAC_PAUSE_LOW_THRESHOLD_MINUS4;
+        pstcMacInit->u32UnicastPauseFrame   = ETH_MAC_UNICAST_PAUSE_FRAME_DETECT_DISABLE;
+        pstcMacInit->u32ReceiveFlowControl  = ETH_MAC_RX_FLOW_CTRL_DISABLE;
+        pstcMacInit->u32TransFlowControl    = ETH_MAC_TRANS_FLOW_CTRL_DISABLE;
+        pstcMacInit->u32ReceiveAll          = ETH_MAC_RX_ALL_DISABLE;
+        pstcMacInit->u32DropNotTcpUdp       = ETH_MAC_DROP_NOT_TCPUDP_DISABLE;
+
+        pstcMacInit->u32VlanTagFilter           = ETH_MAC_VLAN_TAG_FILTER_DISABLE;
+        pstcMacInit->u32SrcAddrFilter           = ETH_MAC_SRC_ADDR_FILTER_DISABLE;
+        pstcMacInit->u32PassControlFrame        = ETH_MAC_PASS_CTRL_FRAME_FORWARD_NOT_PAUSE;
+        pstcMacInit->u32BroadcastFrame          = ETH_MAC_RX_BROADCAST_FRAME_ENABLE;
+        pstcMacInit->u32DestAddrFilter          = ETH_MAC_DEST_ADDR_FILTER_NORMAL;
+        pstcMacInit->u32MulticastFrameFilter    = ETH_MAC_MULTICAST_FRAME_FILTER_PERFECT;
+        pstcMacInit->u32UnicastFrameFilter      = ETH_MAC_UNICAST_FRAME_FILTER_PERFECT;
+        pstcMacInit->u32PromiscuousMode         = ETH_MAC_PROMISCUOUS_MD_DISABLE;
+        pstcMacInit->u32HashTableHigh           = 0UL;
+        pstcMacInit->u32HashTableLow            = 0UL;
+        pstcMacInit->u32TxVlanMode              = ETH_MAC_TXVLAN_MD_BYPASS;
+        pstcMacInit->u16TxVlanTag               = 0U;
+        pstcMacInit->u32RxVlanFilter            = ETH_MAC_RXVLAN_FILTER_NORMAL;
+        pstcMacInit->u32RxVlanCompare           = ETH_MAC_RXVLAN_CMP_16BIT;
+        pstcMacInit->u16RxVlanTag               = 0U;
+        pstcMacInit->u16RxVlanHashTable         = 0U;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set MDC clock
+ * @param  None
+ * @retval None
+ * @note   The MDC clock frequency depends on PCLK1 frequency
+ */
+void ETH_MAC_SetMdcClock(void)
+{
+    uint32_t u32BusClock;
+    uint32_t u32Temp;
+
+    /* Get ETH frequency value */
+    u32BusClock = SystemCoreClock / (0x01UL << (READ_REG32_BIT(CM_CMU->SCFGR,
+                                                               CMU_SCFGR_PCLK1S) >> CMU_SCFGR_PCLK1S_POS));
+    /* Check bus clock range [20~120] */
+    DDL_ASSERT(IS_ETH_MAC_SMI_CLK(u32BusClock));
+    /* Set SMIC bits depending on PCLK1 clock value */
+    if ((u32BusClock >= ETH_CLK_FREQ_20M) && (u32BusClock <= ETH_CLK_FREQ_35M)) {
+        /* PCLK1 Clock Range between 20-35 MHz */
+        u32Temp = ETH_SMI_CLK_DIV16;
+    } else if ((u32BusClock > ETH_CLK_FREQ_35M) && (u32BusClock <= ETH_CLK_FREQ_60M)) {
+        /* PCLK1 Clock Range between 35-60 MHz */
+        u32Temp = ETH_SMI_CLK_DIV26;
+    } else if ((u32BusClock > ETH_CLK_FREQ_60M) && (u32BusClock <= ETH_CLK_FREQ_100M)) {
+        /* PCLK1 Clock Range between 60-100 MHz */
+        u32Temp = ETH_SMI_CLK_DIV42;
+    } else {
+        /* PCLK1 Clock Range between 100-120 MHz */
+        u32Temp = ETH_SMI_CLK_DIV62;
+    }
+    /* Configure the ETH MDC Clock Range */
+    MODIFY_REG32(CM_ETH->MAC_SMIADDR, ETH_MAC_SMIADDR_SMIC, u32Temp);
+}
+
+/**
+ * @brief  Set MAC interface.
+ * @param  [in] u32Interface            The media interface.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_IF_MII:       MII interface
+ *           @arg ETH_MAC_IF_RMII:      RMII interface
+ * @retval None
+ */
+void ETH_MAC_SetInterface(uint32_t u32Interface)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_IF(u32Interface));
+
+    WRITE_REG32(bCM_ETH->MAC_IFCONFR_b.IFSEL, u32Interface);
+}
+
+/**
+ * @brief  Set MAC duplex mode and speed.
+ * @param  [in] u32Mode                 MAC duplex mode
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MAC_DUPLEX_MD_HALF:   Half duplex mode
+ *           @arg ETH_MAC_DUPLEX_MD_FULL:   Full duplex mode
+ * @param  [in] u32Speed                MAC speed
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MAC_SPEED_10M:    10Mbps
+ *           @arg ETH_MAC_SPEED_100M:   100Mbps
+ * @retval None
+ */
+void ETH_MAC_SetDuplexSpeed(uint32_t u32Mode, uint32_t u32Speed)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_DUPLEX_MD(u32Mode));
+    DDL_ASSERT(IS_ETH_MAC_SPEED(u32Speed));
+
+    MODIFY_REG32(CM_ETH->MAC_CONFIGR, (ETH_MAC_CONFIGR_FES | ETH_MAC_CONFIGR_DM), (u32Mode | u32Speed));
+}
+
+/**
+ * @brief  Set MAC hash table.
+ * @param  [in] u32HashHigh             Hash table high value.
+ * @param  [in] u32HashLow              Hash table low value.
+ * @retval None
+ */
+void ETH_MAC_SetHashTable(uint32_t u32HashHigh, uint32_t u32HashLow)
+{
+    WRITE_REG32(CM_ETH->MAC_HASHTLR, u32HashLow);
+    WRITE_REG32(CM_ETH->MAC_HASHTHR, u32HashHigh);
+}
+
+/**
+ * @brief  Set MAC Tx VLAN tag value.
+ * @param  [in] u16TxTag                The tag value of Tx VLAN.
+ * @retval None
+ */
+void ETH_MAC_SetTxVlanTagValue(uint16_t u16TxTag)
+{
+    MODIFY_REG32(CM_ETH->MAC_VTACTLR, ETH_MAC_VTACTLR_VLANV, u16TxTag);
+}
+
+/**
+ * @brief  Set MAC Rx VLAN tag value.
+ * @param  [in] u16RxTag                The tag value of Rx VLAN.
+ * @retval None
+ */
+void ETH_MAC_SetRxVlanTagValue(uint16_t u16RxTag)
+{
+    MODIFY_REG32(CM_ETH->MAC_VTAFLTR, ETH_MAC_VTAFLTR_VLFLT, u16RxTag);
+}
+
+/**
+ * @brief  Set MAC Rx VLAN hash table.
+ * @param  [in] u16HashValue            The value of Rx VLAN hash table.
+ * @retval None
+ */
+void ETH_MAC_SetRxVlanHashTable(uint16_t u16HashValue)
+{
+    WRITE_REG32(CM_ETH->MAC_VLAHTBR, u16HashValue);
+}
+
+/**
+ * @brief  Enable or disable MAC loopback.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_LoopBackCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_CONFIGR_b.LM, enNewState);
+}
+
+/**
+ * @brief  Enable or disable MAC Back Pressure.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_BackPressureCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_FLOCTLR_b.FCA_BPA, enNewState);
+}
+
+/**
+ * @brief  Enable or disable MAC Transmit.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_TransCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_CONFIGR_b.TE, enNewState);
+    DDL_DelayUS(300);
+}
+
+/**
+ * @brief  Enable or disable MAC Receive.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_ReceiveCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_CONFIGR_b.RE, enNewState);
+    DDL_DelayUS(300);
+}
+
+/**
+ * @brief  Enable or disable MAC interrupt.
+ * @param  [in] u32IntType              MAC interrupt source type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MAC_INT_TSPIM:    Time stamp trigger interrupt (on MAC)
+ *           @arg ETH_MAC_INT_PMTIM:    PMT interrupt (on MAC)
+ *           @arg ETH_MAC_INT_ALL:      All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        CLR_REG32_BIT(CM_ETH->MAC_INTMSKR, u32IntType);
+    } else {
+        SET_REG32_BIT(CM_ETH->MAC_INTMSKR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get MAC interrupt status.
+ * @param  [in] u32Flag                 MAC interrupt flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MAC_INT_FLAG_TSPIS:   Time stamp trigger flag (on MAC)
+ *           @arg ETH_MAC_INT_FLAG_MMCTXIS: MMC transmit flag
+ *           @arg ETH_MAC_INT_FLAG_MMCRXIS: MMC receive flag
+ *           @arg ETH_MAC_INT_FLAG_MMCIS:   MMC flag (on MAC)
+ *           @arg ETH_MAC_INT_FLAG_PMTIS:   PMT flag (on MAC)
+ *           @arg ETH_MAC_INT_FLAG_ALL:     All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_MAC_GetIntStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_INT_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->MAC_INTSTSR, u32Flag)) ? SET : RESET);
+}
+
+/******************************************************************************/
+/*                          MAC Address Functions                             */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize MAC Address.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX0:    MAC address 0
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @retval None
+ */
+void ETH_MACADDR_DeInit(uint32_t u32Index)
+{
+    __IO uint32_t *MACADHR;
+    __IO uint32_t *MACADLR;
+    uint32_t u32MacHigh = 0x0000FFFFUL;
+
+    DDL_ASSERT(IS_ETH_MAC_ADDR_NORMAL_INDEX(u32Index));
+
+    MACADHR = ETH_MAC_MACADHR_ADDR(u32Index);
+    MACADLR = ETH_MAC_MACADLR_ADDR(u32Index);
+    if (ETH_MAC_ADDR_IDX0 == u32Index) {
+        u32MacHigh |= 0x80000000UL;
+    }
+    WRITE_REG32(*MACADHR, u32MacHigh);
+    WRITE_REG32(*MACADLR, 0xFFFFFFFFUL);
+}
+
+/**
+ * @brief  Initialize MAC Address.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX0:    MAC address 0
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @param  [in] pstcMacAddrInit         Pointer to a @ref stc_eth_mac_addr_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: MAC Address Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcMacAddrInit == NULL
+ */
+int32_t ETH_MACADDR_Init(uint32_t u32Index, const stc_eth_mac_addr_config_t *pstcMacAddrInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *MACADHR;
+    __IO uint32_t *MACADLR;
+    uint32_t u32TempReg;
+    uint32_t *pu32AddrLow;
+
+    if (NULL == pstcMacAddrInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_ADDR_NORMAL_INDEX(u32Index));
+        DDL_ASSERT(IS_ETH_MAC_ADDR_FILTER(pstcMacAddrInit->u32MacAddrFilter));
+        DDL_ASSERT(IS_ETH_MAC_ADDR_MASK(pstcMacAddrInit->u32MacAddrMask));
+
+        MACADHR = ETH_MAC_MACADHR_ADDR(u32Index);
+        MACADLR = ETH_MAC_MACADLR_ADDR(u32Index);
+        /* Set MAC address high register */
+        u32TempReg = ((uint32_t)pstcMacAddrInit->au8MacAddr[5] << 8U) | (uint32_t)pstcMacAddrInit->au8MacAddr[4];
+        if (ETH_MAC_ADDR_IDX0 != u32Index) {
+            u32TempReg |= pstcMacAddrInit->u32MacAddrFilter | pstcMacAddrInit->u32MacAddrMask;
+        }
+        WRITE_REG32(*MACADHR, u32TempReg);
+        /* Set MAC address low register */
+        pu32AddrLow = (uint32_t *)((uint32_t) & (pstcMacAddrInit->au8MacAddr[0]));
+        WRITE_REG32(*MACADLR, *pu32AddrLow);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_mac_addr_config_t to default values.
+ * @param  [out] pstcMacAddrInit        Pointer to a @ref stc_eth_mac_addr_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcMacAddrInit == NULL
+ */
+int32_t ETH_MACADDR_StructInit(stc_eth_mac_addr_config_t *pstcMacAddrInit)
+{
+    int32_t i32Ret = LL_OK;
+    uint8_t i;
+
+    if (NULL == pstcMacAddrInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcMacAddrInit->u32MacAddrFilter = ETH_MAC_ADDR_FILTER_DISABLE;
+        pstcMacAddrInit->u32MacAddrMask   = ETH_MAC_ADDR_MASK_DISABLE;
+        for (i = 0U; i < ETH_MAC_ADDR_BYTE_LEN; i++) {
+            pstcMacAddrInit->au8MacAddr[i] = 0x00U;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set MAC Address.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX0:    MAC address 0
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @param  [in] au8Addr                 Pointer to MAC address buffer(6 bytes).
+ * @retval int32_t:
+ *           - LL_OK: Set address success
+ *           - LL_ERR_INVD_PARAM: au8Addr == NULL
+ */
+int32_t ETH_MACADDR_SetAddr(uint32_t u32Index, uint8_t au8Addr[])
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *MACADHR;
+    __IO uint32_t *MACADLR;
+    uint32_t u32TempReg;
+    uint32_t *pu32AddrLow;
+
+    if (NULL == au8Addr) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_ADDR_NORMAL_INDEX(u32Index));
+
+        MACADHR = ETH_MAC_MACADHR_ADDR(u32Index);
+        MACADLR = ETH_MAC_MACADLR_ADDR(u32Index);
+        /* Set MAC address high register */
+        u32TempReg = ((uint32_t)au8Addr[5] << 8U) | (uint32_t)au8Addr[4];
+        WRITE_REG32(*MACADHR, u32TempReg);
+        /* Set MAC address low register */
+        pu32AddrLow = (uint32_t *)((uint32_t) & (au8Addr[0]));
+        WRITE_REG32(*MACADLR, *pu32AddrLow);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get MAC Address.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX0:    MAC address 0
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @param  [out] au8Addr                Pointer to MAC address buffer(6 bytes).
+ * @retval int32_t:
+ *           - LL_OK: Set address success
+ *           - LL_ERR_INVD_PARAM: au8Addr == NULL
+ */
+int32_t ETH_MACADDR_GetAddr(uint32_t u32Index, uint8_t au8Addr[])
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *MACADHR;
+    __IO uint32_t *MACADLR;
+    uint32_t u32TempReg;
+    uint32_t *pu32AddrLow;
+
+    if (NULL == au8Addr) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_ADDR_NORMAL_INDEX(u32Index));
+
+        MACADHR    = ETH_MAC_MACADHR_ADDR(u32Index);
+        MACADLR    = ETH_MAC_MACADLR_ADDR(u32Index);
+        /* Get MAC address high */
+        u32TempReg = READ_REG32(*MACADHR);
+        au8Addr[5] = (uint8_t)((u32TempReg >> 8U) & 0x000000FFUL);
+        au8Addr[4] = (uint8_t)(u32TempReg & 0x000000FFUL);
+        /* Get MAC address low */
+        pu32AddrLow = (uint32_t *)((uint32_t) & (au8Addr[0]));
+        *pu32AddrLow = READ_REG32(*MACADLR);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set MAC Address filter mode.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @param  [in] u32Mode                 MAC address filter mode.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_FILTER_DISABLE:              Disable perfect filter with MAC address.
+ *           @arg ETH_MAC_ADDR_FILTER_PERFECT_DEST_ADDR:    Filter the DA address of the received frame with MAC address.
+ *           @arg ETH_MAC_ADDR_FILTER_PERFECT_SRC_ADDR:     Filter the SA address of the received frame with MAC address.
+ * @retval None
+ */
+void ETH_MACADDR_SetFilterMode(uint32_t u32Index, uint32_t u32Mode)
+{
+    __IO uint32_t *MACADHR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_ADDR_SPEC_INDEX(u32Index));
+    DDL_ASSERT(IS_ETH_MAC_ADDR_FILTER(u32Mode));
+
+    MACADHR = ETH_MAC_MACADHR_ADDR(u32Index);
+    MODIFY_REG32(*MACADHR, (ETH_MAC_MACADHR1_SA1 | ETH_MAC_MACADHR1_AE1), u32Mode);
+}
+
+/**
+ * @brief  Set MAC Address Transmit priority ratio.
+ * @param  [in] u32Index                MAC address index.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_ADDR_IDX1:    MAC address 1
+ *           @arg ETH_MAC_ADDR_IDX2:    MAC address 2
+ *           @arg ETH_MAC_ADDR_IDX3:    MAC address 3
+ *           @arg ETH_MAC_ADDR_IDX4:    MAC address 4
+ * @param  [in] u32Mask                 MAC address filter mask.
+ *         This parameter can be one of the following values or any combination of BYTE1 through BYTE6:
+ *           @arg ETH_MAC_ADDR_MASK_DISABLE: Disable MAC Address Mask
+ *           @arg ETH_MAC_ADDR_MASK_BYTE6:   Mask MAC Address high reg bits [15:8]
+ *           @arg ETH_MAC_ADDR_MASK_BYTE5:   Mask MAC Address high reg bits [7:0]
+ *           @arg ETH_MAC_ADDR_MASK_BYTE4:   Mask MAC Address low reg bits [31:24]
+ *           @arg ETH_MAC_ADDR_MASK_BYTE3:   Mask MAC Address low reg bits [23:16]
+ *           @arg ETH_MAC_ADDR_MASK_BYTE2:   Mask MAC Address low reg bits [15:8]
+ *           @arg ETH_MAC_ADDR_MASK_BYTE1:   Mask MAC Address low reg bits [7:0]
+ *           @arg ETH_MAC_ADDR_MASK_ALL:     Mask MAC Address low reg bits [31:0] and low high bits [15:0]
+ * @retval None
+ */
+void ETH_MACADDR_SetFilterMask(uint32_t u32Index, uint32_t u32Mask)
+{
+    __IO uint32_t *MACADHR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_ADDR_SPEC_INDEX(u32Index));
+    DDL_ASSERT(IS_ETH_MAC_ADDR_MASK(u32Mask));
+
+    MACADHR = ETH_MAC_MACADHR_ADDR(u32Index);
+    MODIFY_REG32(*MACADHR, ETH_MAC_MACADHR1_MBC1, u32Mask);
+}
+
+/******************************************************************************/
+/*                        MAC L3L4 Filter Functions                           */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize MAC L3L4 Filter.
+ * @param  None
+ * @retval None
+ */
+void ETH_MAC_L3L4FilterDeInit(void)
+{
+    WRITE_REG32(bCM_ETH->MAC_FLTCTLR_b.IPFE, DISABLE);
+    WRITE_REG32(CM_ETH->MAC_L34CTLR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_L4PORTR,  0UL);
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR0, 0UL);
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR1, 0UL);
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR2, 0UL);
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR3, 0UL);
+}
+
+/**
+ * @brief  Initialize MAC L3L4 Filter.
+ * @param  [in] pstcL3L4FilterInit      Pointer to a @ref stc_eth_l3l4_filter_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: MAC L3L4 Filter Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcL3L4FilterInit == NULL
+ */
+int32_t ETH_MAC_L3L4FilterInit(const stc_eth_l3l4_filter_config_t *pstcL3L4FilterInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcL3L4FilterInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MAC_L4_DEST_PORT_FILTER(pstcL3L4FilterInit->u32DestPortFilter));
+        DDL_ASSERT(IS_ETH_MAC_L4_SRC_PORT_FILTER(pstcL3L4FilterInit->u32SrcPortFilter));
+        DDL_ASSERT(IS_ETH_MAC_L4_PORT_FILTER_PROTOCOL(pstcL3L4FilterInit->u32PortFilterProtocol));
+        DDL_ASSERT(IS_ETH_MAC_L3_DEST_ADDR_FILTER_MASK(pstcL3L4FilterInit->u32Ip4DestAddrFilterMask));
+        DDL_ASSERT(IS_ETH_MAC_L3_SRC_ADDR_FILTER_MASK(pstcL3L4FilterInit->u32Ip4SrcAddrFilterMask));
+        DDL_ASSERT(IS_ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK(pstcL3L4FilterInit->u32Ip6AddrFilterMask));
+        DDL_ASSERT(IS_ETH_MAC_L3_DEST_ADDR_FILTER(pstcL3L4FilterInit->u32DestAddrFilter));
+        DDL_ASSERT(IS_ETH_MAC_L3_SRC_ADDR_FILTER(pstcL3L4FilterInit->u32SrcAddrFilter));
+        DDL_ASSERT(IS_ETH_MAC_L3_ADDR_FILTER_PROTOCOL(pstcL3L4FilterInit->u32AddrFilterProtocol));
+
+        /* Set L3/L4 control register */
+        if (ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV4 != pstcL3L4FilterInit->u32AddrFilterProtocol) {
+            WRITE_REG32(CM_ETH->MAC_L34CTLR,
+                        (pstcL3L4FilterInit->u32DestPortFilter     | pstcL3L4FilterInit->u32SrcPortFilter     |
+                         pstcL3L4FilterInit->u32PortFilterProtocol | pstcL3L4FilterInit->u32Ip6AddrFilterMask |
+                         pstcL3L4FilterInit->u32DestAddrFilter     | pstcL3L4FilterInit->u32SrcAddrFilter     |
+                         pstcL3L4FilterInit->u32AddrFilterProtocol));
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR0, pstcL3L4FilterInit->au32Ip6AddrFilterValue[0]);
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR1, pstcL3L4FilterInit->au32Ip6AddrFilterValue[1]);
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR2, pstcL3L4FilterInit->au32Ip6AddrFilterValue[2]);
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR3, pstcL3L4FilterInit->au32Ip6AddrFilterValue[3]);
+        } else {    /* IPv4 protocol*/
+            WRITE_REG32(CM_ETH->MAC_L34CTLR,
+                        (pstcL3L4FilterInit->u32DestPortFilter       | pstcL3L4FilterInit->u32SrcPortFilter         |
+                         pstcL3L4FilterInit->u32PortFilterProtocol   | pstcL3L4FilterInit->u32Ip4DestAddrFilterMask |
+                         pstcL3L4FilterInit->u32Ip4SrcAddrFilterMask | pstcL3L4FilterInit->u32DestAddrFilter        |
+                         pstcL3L4FilterInit->u32SrcAddrFilter        | pstcL3L4FilterInit->u32AddrFilterProtocol));
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR0, pstcL3L4FilterInit->u32Ip4SrcAddrFilterValue);
+            WRITE_REG32(CM_ETH->MAC_L3ADDRR1, pstcL3L4FilterInit->u32Ip4DestAddrFilterValue);
+        }
+        WRITE_REG32(CM_ETH->MAC_L4PORTR, ((((uint32_t)pstcL3L4FilterInit->u16DestProtFilterValue) <<
+                                           ETH_MAC_L4PORTR_L4DPVAL_POS) | pstcL3L4FilterInit->u16SrcProtFilterValue));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_l3l4_filter_config_t to default values.
+ * @param  [out] pstcL3L4FilterInit     Pointer to a @ref stc_eth_l3l4_filter_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcL3L4FilterInit == NULL
+ */
+int32_t ETH_MAC_L3L4FilterStructInit(stc_eth_l3l4_filter_config_t *pstcL3L4FilterInit)
+{
+    int32_t i32Ret = LL_OK;
+    uint8_t i;
+
+    if (NULL == pstcL3L4FilterInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcL3L4FilterInit->u32DestPortFilter           = ETH_MAC_L4_DEST_PORT_FILTER_DISABLE;
+        pstcL3L4FilterInit->u32SrcPortFilter            = ETH_MAC_L4_SRC_PORT_FILTER_DISABLE;
+        pstcL3L4FilterInit->u32PortFilterProtocol       = ETH_MAC_L4_PORT_FILTER_PROTOCOL_TCP;
+        pstcL3L4FilterInit->u32Ip4DestAddrFilterMask    = ETH_MAC_L3_DEST_ADDR_FILTER_MASK_NONE;
+        pstcL3L4FilterInit->u32Ip4SrcAddrFilterMask     = ETH_MAC_L3_SRC_ADDR_FILTER_MASK_NONE;
+        pstcL3L4FilterInit->u32Ip6AddrFilterMask        = ETH_MAC_L3_DEST_SRC_ADDR_FILTER_MASK_NONE;
+        pstcL3L4FilterInit->u32DestAddrFilter           = ETH_MAC_L3_DEST_ADDR_FILTER_DISABLE;
+        pstcL3L4FilterInit->u32SrcAddrFilter            = ETH_MAC_SRC_ADDR_FILTER_DISABLE;
+        pstcL3L4FilterInit->u32AddrFilterProtocol       = ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV4;
+        pstcL3L4FilterInit->u16DestProtFilterValue      = 0U;
+        pstcL3L4FilterInit->u16SrcProtFilterValue       = 0U;
+        pstcL3L4FilterInit->u32Ip4DestAddrFilterValue   = 0UL;
+        pstcL3L4FilterInit->u32Ip4SrcAddrFilterValue    = 0UL;
+        for (i = 0U; i < 4U; i++) {
+            pstcL3L4FilterInit->au32Ip6AddrFilterValue[i] = 0UL;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable MAC L3L4 Filter function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MAC_L3L4FilterCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_FLTCTLR_b.IPFE, enNewState);
+}
+
+/**
+ * @brief  Set L4 port filter protocol.
+ * @param  [in] u32Protocol             MAC L4 port filter protocol.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_L4_PORT_FILTER_PROTOCOL_TCP:  Port filter for TCP frame
+ *           @arg ETH_MAC_L4_PORT_FILTER_PROTOCOL_UDP:  Port filter for UDP frame
+ * @retval None
+ */
+void ETH_MAC_SetPortFilterProtocol(uint32_t u32Protocol)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_L4_PORT_FILTER_PROTOCOL(u32Protocol));
+
+    WRITE_REG32(bCM_ETH->MAC_L34CTLR_b.L4PEN, (u32Protocol >> ETH_MAC_L34CTLR_L4PEN_POS));
+}
+
+/**
+ * @brief  Set L4 Destination port filter value.
+ * @param  [in] u16Port                 The value of Destination port.
+ * @retval None
+ */
+void ETH_MAC_SetDestPortFilterValue(uint16_t u16Port)
+{
+    MODIFY_REG32(CM_ETH->MAC_L4PORTR, ETH_MAC_L4PORTR_L4DPVAL, ((uint32_t)u16Port << ETH_MAC_L4PORTR_L4DPVAL_POS));
+}
+
+/**
+ * @brief  Set L4 Source port filter value.
+ * @param  [in] u16Port                 The value of Source port.
+ * @retval None
+ */
+void ETH_MAC_SetSrcPortFilterValue(uint16_t u16Port)
+{
+    MODIFY_REG32(CM_ETH->MAC_L4PORTR, ETH_MAC_L4PORTR_L4SPVAL, u16Port);
+}
+
+/**
+ * @brief  Set L3 address filter protocol.
+ * @param  [in] u32Protocol             MAC L3 address filter protocol.
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV4: Ip Address filter for IPv4
+ *           @arg ETH_MAC_L3_ADDR_FILTER_PROTOCOL_IPV6: Ip Address filter for IPv6
+ * @retval None
+ */
+void ETH_MAC_SetAddrFilterProtocol(uint32_t u32Protocol)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MAC_L3_ADDR_FILTER_PROTOCOL(u32Protocol));
+
+    WRITE_REG32(bCM_ETH->MAC_L34CTLR_b.L3PEN, u32Protocol);
+}
+
+/**
+ * @brief  Set L3 Destination address filter value of IPv4.
+ * @param  [in] u32Addr                 The value of Destination address.
+ * @retval None
+ */
+void ETH_MAC_SetIpv4DestAddrFilterValue(uint32_t u32Addr)
+{
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR1, u32Addr);
+}
+
+/**
+ * @brief  Set L3 Source address filter value of IPv4.
+ * @param  [in] u32Addr                 The value of Source address.
+ * @retval None
+ */
+void ETH_MAC_SetIpv4SrcAddrFilterValue(uint32_t u32Addr)
+{
+    WRITE_REG32(CM_ETH->MAC_L3ADDRR0, u32Addr);
+}
+
+/**
+ * @brief  Set L3 Destination/Source Address filter value of IPv6.
+ * @param  [in] au32Addr                Pointer to Destination/Source Address buffer(4 words).
+ * @retval int32_t:
+ *           - LL_OK: Set Address filter value success
+ *           - LL_ERR_INVD_PARAM: au32Addr == NULL
+ */
+int32_t ETH_MAC_SetIpv6AddrFilterValue(const uint32_t au32Addr[])
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == au32Addr) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        WRITE_REG32(CM_ETH->MAC_L3ADDRR0, au32Addr[0]);
+        WRITE_REG32(CM_ETH->MAC_L3ADDRR1, au32Addr[1]);
+        WRITE_REG32(CM_ETH->MAC_L3ADDRR2, au32Addr[2]);
+        WRITE_REG32(CM_ETH->MAC_L3ADDRR3, au32Addr[3]);
+    }
+
+    return i32Ret;
+}
+
+/******************************************************************************/
+/*                              DMA Functions                                 */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize DMA.
+ * @param  None
+ * @retval None
+ */
+void ETH_DMA_DeInit(void)
+{
+    WRITE_REG32(CM_ETH->DMA_BUSMODR, 0x00020101UL);
+    WRITE_REG32(CM_ETH->DMA_OPRMODR, 0U);
+    WRITE_REG32(CM_ETH->DMA_INTENAR, 0U);
+    WRITE_REG32(CM_ETH->DMA_REVWDTR, 0U);
+    WRITE_REG32(CM_ETH->DMA_TXDLADR, 0U);
+    WRITE_REG32(CM_ETH->DMA_RXDLADR, 0U);
+}
+
+/**
+ * @brief  Initialize DMA.
+ * @param  [in] pstcDmaInit             Pointer to a @ref stc_eth_dma_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: DMA Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcDmaInit == NULL
+ */
+int32_t ETH_DMA_Init(const stc_eth_dma_init_t *pstcDmaInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_BURST_MD(pstcDmaInit->u32BurstMode));
+        DDL_ASSERT(IS_ETH_DMA_ADDR_ALIGN(pstcDmaInit->u32AddrAlign));
+        DDL_ASSERT(IS_ETH_DMA_RX_BURST_LEN(pstcDmaInit->u32RxBurstLen));
+        DDL_ASSERT(IS_ETH_DMA_TX_BURST_LEN(pstcDmaInit->u32TxBurstLen));
+        DDL_ASSERT(IS_ETH_DMA_ENHANCE_DESC(pstcDmaInit->u32EnhanceDesc));
+        DDL_ASSERT(IS_ETH_DMA_DESC_SKIP_LEN(pstcDmaInit->u32DescSkipLen));
+        DDL_ASSERT(IS_ETH_DMA_PRIO_ARBITRATION(pstcDmaInit->u32Arbitration));
+        DDL_ASSERT(IS_ETH_DMA_DROP_CHECKSUM_ERR_FRAME(pstcDmaInit->u32DropChecksumErrorFrame));
+        DDL_ASSERT(IS_ETH_DMA_RX_STORE_FORWARD(pstcDmaInit->u32ReceiveStoreForward));
+        DDL_ASSERT(IS_ETH_DMA_FLUSH_RX_FRAME(pstcDmaInit->u32FlushReceiveFrame));
+        DDL_ASSERT(IS_ETH_DMA_TRANS_STORE_FORWARD(pstcDmaInit->u32TransStoreForward));
+        DDL_ASSERT(IS_ETH_DMA_TRANS_THRESHOLD(pstcDmaInit->u32TransThreshold));
+        DDL_ASSERT(IS_ETH_DMA_FORWARD_ERR_FRAME(pstcDmaInit->u32ForwardErrorFrame));
+        DDL_ASSERT(IS_ETH_DMA_FORWARD_UNDERSIZE_FRAME(pstcDmaInit->u32ForwardUndersizeFrame));
+        DDL_ASSERT(IS_ETH_DMA_DROP_JUMBO_FRAME(pstcDmaInit->u32DropJumboFrame));
+        DDL_ASSERT(IS_ETH_DMA_RX_THRESHOLD(pstcDmaInit->u32ReceiveThreshold));
+        DDL_ASSERT(IS_ETH_DMA_SEC_FRAME_OP(pstcDmaInit->u32SecFrameOperate));
+
+        /* Set Bus mode register */
+        MODIFY_REG32(CM_ETH->DMA_BUSMODR, ETH_DMA_BUSMODR_CLR_MASK,
+                     (pstcDmaInit->u32BurstMode   | pstcDmaInit->u32AddrAlign   | pstcDmaInit->u32RxBurstLen  |
+                      pstcDmaInit->u32TxBurstLen  | pstcDmaInit->u32EnhanceDesc | pstcDmaInit->u32DescSkipLen |
+                      pstcDmaInit->u32Arbitration | ETH_DMA_BUSMODR_SPBL));
+        /* Set Operation mode register */
+        MODIFY_REG32(CM_ETH->DMA_OPRMODR, ETH_DMA_OPRMODR_CLR_MASK,
+                     (pstcDmaInit->u32DropChecksumErrorFrame | pstcDmaInit->u32ReceiveStoreForward |
+                      pstcDmaInit->u32FlushReceiveFrame      | pstcDmaInit->u32TransStoreForward   |
+                      pstcDmaInit->u32TransThreshold         | pstcDmaInit->u32ForwardErrorFrame   |
+                      pstcDmaInit->u32ForwardUndersizeFrame  | pstcDmaInit->u32DropJumboFrame      |
+                      pstcDmaInit->u32ReceiveThreshold       | pstcDmaInit->u32SecFrameOperate));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_dma_init_t to default values.
+ * @param  [out] pstcDmaInit            Pointer to a @ref stc_eth_dma_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcDmaInit == NULL
+ */
+int32_t ETH_DMA_StructInit(stc_eth_dma_init_t *pstcDmaInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDmaInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDmaInit->u32BurstMode               = ETH_DMA_BURST_MD_FIXED;
+        pstcDmaInit->u32AddrAlign               = ETH_DMA_ADDR_ALIGN_ENABLE;
+        pstcDmaInit->u32RxBurstLen              = ETH_DMA_RX_BURST_LEN_32BEAT;
+        pstcDmaInit->u32TxBurstLen              = ETH_DMA_TX_BURST_LEN_32BEAT;
+        pstcDmaInit->u32EnhanceDesc             = ETH_DMA_ENHANCE_DESC_ENABLE;
+        pstcDmaInit->u32DescSkipLen             = 0U;
+        pstcDmaInit->u32Arbitration             = ETH_DMA_ARBITRATION_LOOP_RXTX_1_1;
+        pstcDmaInit->u32DropChecksumErrorFrame  = ETH_DMA_DROP_CHECKSUM_ERR_FRAME_ENABLE;
+        pstcDmaInit->u32ReceiveStoreForward     = ETH_DMA_RX_STORE_FORWARD_ENABLE;
+        pstcDmaInit->u32FlushReceiveFrame       = ETH_DMA_FLUSH_RX_FRAME_ENABLE;
+        pstcDmaInit->u32TransStoreForward       = ETH_DMA_TRANS_STORE_FORWARD_ENABLE;
+        pstcDmaInit->u32TransThreshold          = ETH_DMA_TRANS_THRESHOLD_64BYTE;
+        pstcDmaInit->u32ForwardErrorFrame       = ETH_DMA_FORWARD_ERR_FRAME_DISABLE;
+        pstcDmaInit->u32ForwardUndersizeFrame   = ETH_DMA_FORWARD_UNDERSIZE_FRAME_DISABLE;
+        pstcDmaInit->u32DropJumboFrame          = ETH_DMA_DROP_JUMBO_FRAME_DISABLE;
+        pstcDmaInit->u32ReceiveThreshold        = ETH_DMA_RX_THRESHOLD_64BYTE;
+        pstcDmaInit->u32SecFrameOperate         = ETH_DMA_SEC_FRAME_OP_ENABLE;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA software reset.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Software reset success
+ *           - LL_ERR_TIMEOUT: Reset timeout
+ */
+int32_t ETH_DMA_SoftwareReset(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(bCM_ETH->DMA_BUSMODR_b.SWR, 1U);
+    u32Count = ETH_SW_RST_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32(bCM_ETH->DMA_BUSMODR_b.SWR)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA Transmit priority ratio.
+ * @param  [in] u32Ratio                Priority ratio
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_ARBITRATION_LOOP_RXTX_1_1:        Rx:Tx = 1:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_RXTX_2_1:        Rx:Tx = 2:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_RXTX_3_1:        Rx:Tx = 3:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_RXTX_4_1:        Rx:Tx = 4:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_TXRX_1_1:        Tx:Rx = 1:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_TXRX_2_1:        Tx:Rx = 2:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_TXRX_3_1:        Tx:Rx = 3:1
+ *           @arg ETH_DMA_ARBITRATION_LOOP_TXRX_4_1:        Tx:Rx = 4:1
+ *           @arg ETH_DMA_ARBITRATION_FIXED_RX_PRIOR_TX:    Fixed priority: Rx is higher than Tx
+ *           @arg ETH_DMA_ARBITRATION_FIXED_TX_PRIOR_RX:    Fixed priority: Tx is higher than Rx
+ * @retval None
+ */
+void ETH_DMA_SetTransPriorityRatio(uint32_t u32Ratio)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_PRIO_ARBITRATION(u32Ratio));
+
+    MODIFY_REG32(CM_ETH->DMA_BUSMODR, (ETH_DMA_BUSMODR_TXPR | ETH_DMA_BUSMODR_PRAT | ETH_DMA_BUSMODR_DMAA), u32Ratio);
+}
+
+/**
+ * @brief  Set DMA Rx watchdog counter.
+ * @param  [in] u8Value                 The value of Watchdog timer
+ * @retval None
+ */
+void ETH_DMA_SetRxWatchdogCounter(uint8_t u8Value)
+{
+    WRITE_REG32(CM_ETH->DMA_REVWDTR, u8Value);
+}
+
+/**
+ * @brief  Flush transmit FIFO.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Flush transmit FIFO success
+ *           - LL_ERR_TIMEOUT: Flush timeout
+ */
+int32_t ETH_DMA_FlushTransFIFO(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(bCM_ETH->DMA_OPRMODR_b.FTF, 1U);
+    u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32(bCM_ETH->DMA_OPRMODR_b.FTF)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA transmit.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_DMA_TransCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->DMA_OPRMODR_b.STT, enNewState);
+    DDL_DelayUS(300);
+}
+
+/**
+ * @brief  Enable or disable DMA receive.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_DMA_ReceiveCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->DMA_OPRMODR_b.STR, enNewState);
+    DDL_DelayUS(300);
+}
+
+/**
+ * @brief  Enable or disable DMA interrupt.
+ * @param  [in] u32IntType              DMA interrupt source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_INT_NIE:      Normal interrupt summary
+ *           @arg ETH_DMA_INT_AIE:      Abnormal interrupt summary
+ *           @arg ETH_DMA_INT_ERE:      Early receive interrupt
+ *           @arg ETH_DMA_INT_FBE:      Fatal bus error interrupt
+ *           @arg ETH_DMA_INT_ETE:      Early transmit interrupt
+ *           @arg ETH_DMA_INT_RWE:      Receive watchdog timeout interrupt
+ *           @arg ETH_DMA_INT_RSE:      Receive process stopped interrupt
+ *           @arg ETH_DMA_INT_RUE:      Receive buffer unavailable interrupt
+ *           @arg ETH_DMA_INT_RIE:      Receive interrupt
+ *           @arg ETH_DMA_INT_UNE:      Transmit Underflow interrupt
+ *           @arg ETH_DMA_INT_OVE:      Receive Overflow interrupt
+ *           @arg ETH_DMA_INT_TJE:      Transmit jabber timeout interrupt
+ *           @arg ETH_DMA_INT_TUE:      Transmit buffer unavailable interrupt
+ *           @arg ETH_DMA_INT_TSE:      Transmit process stopped interrupt
+ *           @arg ETH_DMA_INT_TIE:      Transmit interrupt
+ *           @arg ETH_DMA_INT_ALL:      All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_DMA_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG32_BIT(CM_ETH->DMA_INTENAR, u32IntType);
+    } else {
+        CLR_REG32_BIT(CM_ETH->DMA_INTENAR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get DMA flag status.
+ * @param  [in] u32Flag                 DMA flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_FLAG_PTPS:    Time-stamp trigger status
+ *           @arg ETH_DMA_FLAG_PMTS:    PMT trigger status
+ *           @arg ETH_DMA_FLAG_MMCS:    MMC trigger status
+ *           @arg ETH_DMA_FLAG_NIS:     Normal interrupt summary flag
+ *           @arg ETH_DMA_FLAG_AIS:     Abnormal interrupt summary flag
+ *           @arg ETH_DMA_FLAG_ERS:     Early receive flag
+ *           @arg ETH_DMA_FLAG_FBS:     Fatal bus error flag
+ *           @arg ETH_DMA_FLAG_ETS:     Early transmit flag
+ *           @arg ETH_DMA_FLAG_RWS:     Receive watchdog timeout flag
+ *           @arg ETH_DMA_FLAG_RSS:     Receive stopped flag
+ *           @arg ETH_DMA_FLAG_RUS:     Receive buffer unavailable flag
+ *           @arg ETH_DMA_FLAG_RIS:     Receive flag
+ *           @arg ETH_DMA_FLAG_UNS:     Transmit Underflow flag
+ *           @arg ETH_DMA_FLAG_OVS:     Receive Overflow flag
+ *           @arg ETH_DMA_FLAG_TJS:     Transmit jabber timeout flag
+ *           @arg ETH_DMA_FLAG_TUS:     Transmit buffer unavailable flag
+ *           @arg ETH_DMA_FLAG_TSS:     Transmit stopped flag
+ *           @arg ETH_DMA_FLAG_TIS:     Transmit interrupt flag
+ *           @arg ETH_DMA_FLAG_ALL:     All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_DMA_GetStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->DMA_DMASTSR, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear DMA flag.
+ * @param  [in] u32Flag                 DMA flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_FLAG_NIS:     Normal interrupt summary flag
+ *           @arg ETH_DMA_FLAG_AIS:     Abnormal interrupt summary flag
+ *           @arg ETH_DMA_FLAG_ERS:     Early receive flag
+ *           @arg ETH_DMA_FLAG_FBS:     Fatal bus error flag
+ *           @arg ETH_DMA_FLAG_ETS:     Early transmit flag
+ *           @arg ETH_DMA_FLAG_RWS:     Receive watchdog timeout flag
+ *           @arg ETH_DMA_FLAG_RSS:     Receive stopped flag
+ *           @arg ETH_DMA_FLAG_RUS:     Receive buffer unavailable flag
+ *           @arg ETH_DMA_FLAG_RIS:     Receive flag
+ *           @arg ETH_DMA_FLAG_UNS:     Transmit Underflow flag
+ *           @arg ETH_DMA_FLAG_OVS:     Receive Overflow flag
+ *           @arg ETH_DMA_FLAG_TJS:     Transmit jabber timeout flag
+ *           @arg ETH_DMA_FLAG_TUS:     Transmit buffer unavailable flag
+ *           @arg ETH_DMA_FLAG_TSS:     Transmit stopped flag
+ *           @arg ETH_DMA_FLAG_TIS:     Transmit interrupt flag
+ *           @arg ETH_DMA_FLAG_CLR_ALL: All of the above
+ * @retval None
+ */
+void ETH_DMA_ClearStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(CM_ETH->DMA_DMASTSR, u32Flag);
+}
+
+/**
+ * @brief  Get DMA overflow flag status.
+ * @param  [in] u32Flag                 DMA overflow flag type
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_OVF_RXFIFO_CNT:       Overflow bit for FIFO overflow counter
+ *           @arg ETH_DMA_OVF_MISS_FRAME_CNT:   Overflow bit for miss frame counter
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_DMA_GetOvfStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_MISS_FRAME_TYPE(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->DMA_RFRCNTR, u32Flag)) ? SET : RESET);
+}
+
+/******************************************************************************/
+/*                          DMA descriptor Functions                          */
+/******************************************************************************/
+/**
+ * @brief  Initializes DMA Tx descriptor in chain mode.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @param  [in] astcTxDescTab           Pointer to the first Tx desc list
+ * @param  [in] au8TxBuf                Pointer to the first TxBuffer list
+ * @param  [in] u32TxBufCnt             Number of the Tx desc in the list
+ * @retval int32_t:
+ *           - LL_OK: Initializes Tx chain mode success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL or astcTxDescTab == NULL or au8TxBuf == NULL or u32TxBufCnt == 0
+ */
+int32_t ETH_DMA_TxDescListInit(stc_eth_handle_t *pstcEthHandle, stc_eth_dma_desc_t astcTxDescTab[],
+                               const uint8_t au8TxBuf[], uint32_t u32TxBufCnt)
+{
+    uint32_t i;
+    stc_eth_dma_desc_t *pstcTxDesc;
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcEthHandle) || (NULL == astcTxDescTab) || (NULL == au8TxBuf) || (0UL == u32TxBufCnt)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Set the DMATxDesc pointer with the first in the astcTxDescTab list */
+        pstcEthHandle->stcTxDesc = astcTxDescTab;
+        /* Fill each DMATxDesc descriptor */
+        for (i = 0U; i < u32TxBufCnt; i++) {
+            pstcTxDesc = &astcTxDescTab[i];
+            /* Set Second Address Chained */
+            pstcTxDesc->u32ControlStatus = ETH_DMA_TXDESC_TSAC;
+            /* Set Buffer1 address pointer */
+            pstcTxDesc->u32Buf1Addr = (uint32_t)(&au8TxBuf[i * ETH_TX_BUF_SIZE]);
+            /* Set the DMA Tx descriptors checksum insertion */
+            if (ETH_MAC_CHECKSUM_MD_HW == pstcEthHandle->stcCommInit.u32ChecksumMode) {
+                SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_CIC_TCPUDPICMP_FULL);
+            }
+            /* Initialize the next descriptor with the Next Descriptor Polling */
+            if (i < (u32TxBufCnt - 1U)) {
+                pstcTxDesc->u32Buf2NextDescAddr = (uint32_t)(&astcTxDescTab[i + 1U]);
+            } else {
+                pstcTxDesc->u32Buf2NextDescAddr = (uint32_t)astcTxDescTab;
+            }
+        }
+        /* Set Transmit Descriptor List Address Register */
+        WRITE_REG32(CM_ETH->DMA_TXDLADR, (uint32_t)astcTxDescTab);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initializes DMA Rx descriptor in chain mode.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @param  [in] astcRxDescTab           Pointer to the first Rx desc list
+ * @param  [in] au8RxBuf                Pointer to the first RxBuffer list
+ * @param  [in] u32RxBufCnt             Number of the Rx desc in the list
+ * @retval int32_t:
+ *           - LL_OK: Initializes Rx chain mode success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL or astcRxDescTab == NULL or au8RxBuf == NULL or u32RxBufCnt == 0
+ */
+int32_t ETH_DMA_RxDescListInit(stc_eth_handle_t *pstcEthHandle, stc_eth_dma_desc_t astcRxDescTab[],
+                               const uint8_t au8RxBuf[], uint32_t u32RxBufCnt)
+{
+    uint32_t i;
+    stc_eth_dma_desc_t *pstcRxDesc;
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcEthHandle) || (NULL == astcRxDescTab) || (NULL == au8RxBuf) || (0UL == u32RxBufCnt)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Set the DMARxDesc pointer with the first in the astcRxDescTab list */
+        pstcEthHandle->stcRxDesc = astcRxDescTab;
+        /* Fill each DMARxDesc descriptor */
+        for (i = 0UL; i < u32RxBufCnt; i++) {
+            pstcRxDesc = &astcRxDescTab[i];
+            /* Set Own bit of the Rx descriptor */
+            pstcRxDesc->u32ControlStatus  = ETH_DMA_RXDESC_OWN;
+            /* Set Buffer1 size and Second Address Chained */
+            pstcRxDesc->u32ControlBufSize = ETH_RX_BUF_SIZE | ETH_DMA_RXDESC_RSAC;
+            /* Set Buffer1 address pointer */
+            pstcRxDesc->u32Buf1Addr       = (uint32_t)(&au8RxBuf[i * ETH_RX_BUF_SIZE]);
+            /* Set the DMA Rx Descriptor interrupt */
+            if (ETH_RX_MD_INT == pstcEthHandle->stcCommInit.u32ReceiveMode) {
+                CLR_REG32_BIT(pstcRxDesc->u32ControlBufSize, ETH_DMA_RXDESC_DIC);
+            }
+            /* Initialize the next descriptor with the Next Descriptor Polling */
+            if (i < (u32RxBufCnt - 1U)) {
+                pstcRxDesc->u32Buf2NextDescAddr = (uint32_t)(&astcRxDescTab[i + 1U]);
+            } else {
+                pstcRxDesc->u32Buf2NextDescAddr = (uint32_t)astcRxDescTab;
+            }
+        }
+        /* Set Receive Descriptor List Address Register */
+        WRITE_REG32(CM_ETH->DMA_RXDLADR, (uint32_t)astcRxDescTab);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA transmit frame.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @param  [in] u32FrameLen             Total of data to be transmit
+ * @retval int32_t:
+ *           - LL_OK: Set transmit frame success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL
+ *           - LL_ERR_INVD_MD: Descriptor is owned by the DMA
+ */
+int32_t ETH_DMA_SetTransFrame(stc_eth_handle_t *pstcEthHandle, uint32_t u32FrameLen)
+{
+    uint32_t i;
+    uint32_t u32BufCnt;
+    uint32_t u32Size;
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcEthHandle) || (0U == u32FrameLen)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check if the descriptor is owned by the CPU */
+        if (0UL != (pstcEthHandle->stcTxDesc->u32ControlStatus & ETH_DMA_TXDESC_OWN)) {
+            i32Ret = LL_ERR_INVD_MD;
+        } else {
+            /* Get the number of needed Tx buffers for the current frame */
+            if (u32FrameLen > ETH_TX_BUF_SIZE) {
+                u32BufCnt = u32FrameLen / ETH_TX_BUF_SIZE;
+                if (0UL != (u32FrameLen % ETH_TX_BUF_SIZE)) {
+                    u32BufCnt++;
+                }
+            } else {
+                u32BufCnt = 1U;
+            }
+
+            if (1U == u32BufCnt) {
+                /* Set FIRST and LAST segment */
+                SET_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus, (ETH_DMA_TXDESC_TFS | ETH_DMA_TXDESC_TLS));
+                /* Set frame size */
+                MODIFY_REG32(pstcEthHandle->stcTxDesc->u32ControlBufSize, ETH_DMA_TXDESC_TBS1,
+                             (u32FrameLen & ETH_DMA_TXDESC_TBS1));
+                /* Set Own bit of the Tx descriptor */
+                SET_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_OWN);
+                /* Point to next descriptor */
+                pstcEthHandle->stcTxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcTxDesc->u32Buf2NextDescAddr);
+            } else {
+                for (i = 0U; i < u32BufCnt; i++) {
+                    /* Clear FIRST and LAST segment bits */
+                    CLR_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus,
+                                  (ETH_DMA_TXDESC_TFS | ETH_DMA_TXDESC_TLS));
+                    if (0U == i) {
+                        /* Set the FIRST segment bit */
+                        SET_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_TFS);
+                    }
+                    if ((u32BufCnt - 1U) == i) {
+                        /* Set the last segment bit */
+                        SET_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_TLS);
+                        u32Size = u32FrameLen - ((u32BufCnt - 1U) * ETH_TX_BUF_SIZE);
+                        MODIFY_REG32(pstcEthHandle->stcTxDesc->u32ControlBufSize, ETH_DMA_TXDESC_TBS1,
+                                     (u32Size & ETH_DMA_TXDESC_TBS1));
+                    } else {
+                        /* Set frame size */
+                        MODIFY_REG32(pstcEthHandle->stcTxDesc->u32ControlBufSize, ETH_DMA_TXDESC_TBS1,
+                                     (ETH_TX_BUF_SIZE & ETH_DMA_TXDESC_TBS1));
+                    }
+
+                    /* Set Own bit of the Tx descriptor */
+                    SET_REG32_BIT(pstcEthHandle->stcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_OWN);
+                    /* Pointer to next descriptor */
+                    pstcEthHandle->stcTxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcTxDesc->u32Buf2NextDescAddr);
+                }
+            }
+
+            /* When Tx Buffer unavailable flag is set: clear it and resume transmission */
+            if (0UL != (READ_REG32_BIT(CM_ETH->DMA_DMASTSR, ETH_DMA_FLAG_TUS))) {
+                /* Clear DMA TUS flag */
+                WRITE_REG32(CM_ETH->DMA_DMASTSR, ETH_DMA_FLAG_TUS);
+                /* Resume DMA transmission */
+                WRITE_REG32(CM_ETH->DMA_TXPOLLR, 0UL);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA receive frame.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get receive frame success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL
+ *           - LL_ERR: Not completed frame received
+ */
+int32_t ETH_DMA_GetReceiveFrame(stc_eth_handle_t *pstcEthHandle)
+{
+    int32_t i32Ret = LL_ERR;
+
+    if (NULL == pstcEthHandle) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check if segment is not owned by DMA */
+        if (0UL == (pstcEthHandle->stcRxDesc->u32ControlStatus & ETH_DMA_RXDESC_OWN)) {
+            /* Check if last segment */
+            if (0UL != (pstcEthHandle->stcRxDesc->u32ControlStatus & ETH_DMA_RXDESC_RLS)) {
+                pstcEthHandle->stcRxFrame.u32SegCount++;
+                pstcEthHandle->stcRxFrame.pstcLSDesc = pstcEthHandle->stcRxDesc;
+                /* Check if last segment is first segment */
+                if (1U == pstcEthHandle->stcRxFrame.u32SegCount) {
+                    pstcEthHandle->stcRxFrame.pstcFSDesc = pstcEthHandle->stcRxDesc;
+                }
+
+                /* Get the Frame Length of the received packet: Strip FCS */
+                pstcEthHandle->stcRxFrame.u32Len = ((pstcEthHandle->stcRxDesc->u32ControlStatus &
+                                                     ETH_DMA_RXDESC_FRAL) >> ETH_DMA_RXDESC_FRAME_LEN_SHIFT) - 4U;
+                /* Get the address of the buffer start address */
+                pstcEthHandle->stcRxFrame.u32Buf = (pstcEthHandle->stcRxFrame.pstcFSDesc)->u32Buf1Addr;
+                /* Pointer to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+                /* Get success */
+                i32Ret = LL_OK;
+            } else if (0UL != (pstcEthHandle->stcRxDesc->u32ControlStatus & ETH_DMA_RXDESC_RFS)) {  /* Check if first segment */
+                pstcEthHandle->stcRxFrame.pstcFSDesc  = pstcEthHandle->stcRxDesc;
+                pstcEthHandle->stcRxFrame.pstcLSDesc  = NULL;
+                pstcEthHandle->stcRxFrame.u32SegCount = 1U;
+                /* Point to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+            } else {    /* Check if intermediate segment */
+                pstcEthHandle->stcRxFrame.u32SegCount++;
+                /* Point to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA receive frame in interrupt mode.
+ * @param  [in] pstcEthHandle           Pointer to a @ref stc_eth_handle_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get receive frame success
+ *           - LL_ERR_INVD_PARAM: pstcEthHandle == NULL
+ *           - LL_ERR: Not completed frame received
+ */
+int32_t ETH_DMA_GetReceiveFrame_Int(stc_eth_handle_t *pstcEthHandle)
+{
+    uint32_t u32DescCnt = 0U;
+    int32_t i32Ret = LL_ERR;
+
+    if (NULL == pstcEthHandle) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Scan descriptor owned by CPU */
+        while ((0UL == (pstcEthHandle->stcRxDesc->u32ControlStatus & ETH_DMA_RXDESC_OWN)) &&
+               (u32DescCnt < ETH_RX_BUF_SIZE)) {
+            u32DescCnt++;
+            /* Check if first segment in frame */
+            if (ETH_DMA_RXDESC_RFS == (pstcEthHandle->stcRxDesc->u32ControlStatus &
+                                       (ETH_DMA_RXDESC_RFS | ETH_DMA_RXDESC_RLS))) {
+                pstcEthHandle->stcRxFrame.pstcFSDesc  = pstcEthHandle->stcRxDesc;
+                pstcEthHandle->stcRxFrame.pstcLSDesc  = NULL;
+                pstcEthHandle->stcRxFrame.u32SegCount = 1U;
+                /* Point to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+            } else if (0UL == (pstcEthHandle->stcRxDesc->u32ControlStatus & (ETH_DMA_RXDESC_RFS | ETH_DMA_RXDESC_RLS))) {
+                /* Check if intermediate segment */
+                pstcEthHandle->stcRxFrame.u32SegCount++;
+                /* Point to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+            } else {    /* Last segment */
+                pstcEthHandle->stcRxFrame.u32SegCount++;
+                /* Last segment */
+                pstcEthHandle->stcRxFrame.pstcLSDesc = pstcEthHandle->stcRxDesc;
+                /* Check if last segment is first segment */
+                if (1U == pstcEthHandle->stcRxFrame.u32SegCount) {
+                    pstcEthHandle->stcRxFrame.pstcFSDesc = pstcEthHandle->stcRxDesc;
+                }
+
+                /* Get the Frame Length of the received packet: Strip FCS */
+                pstcEthHandle->stcRxFrame.u32Len = ((pstcEthHandle->stcRxDesc->u32ControlStatus &
+                                                     ETH_DMA_RXDESC_FRAL) >> ETH_DMA_RXDESC_FRAME_LEN_SHIFT) - 4U;
+                /* Get the address of the buffer start address */
+                pstcEthHandle->stcRxFrame.u32Buf = (pstcEthHandle->stcRxFrame.pstcFSDesc)->u32Buf1Addr;
+                /* Pointer to next descriptor */
+                pstcEthHandle->stcRxDesc = (stc_eth_dma_desc_t *)(pstcEthHandle->stcRxDesc->u32Buf2NextDescAddr);
+                /* Get success */
+                i32Ret = LL_OK;
+                break;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA Tx descriptor own bit.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Owner                DMA Tx descriptor owner
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_DESC_OWN_CPU: Descriptor is owned by CPU
+ *           @arg ETH_DMA_DESC_OWN_DMA: Descriptor is owned by DMA
+ * @retval int32_t:
+ *           - LL_OK: Set Tx descriptor own bit success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_SetTxDescOwn(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Owner)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_DESC_OWN(u32Owner));
+
+        if (ETH_DMA_DESC_OWN_CPU != u32Owner) {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_OWN);
+        } else {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_OWN);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA Tx descriptor buffer size.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u8BufNum                Buffer sequence number
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_DESC_BUF1:    DMA Tx Desc Buffer1
+ *           @arg ETH_DMA_DESC_BUF2:    DMA Tx Desc Buffer2
+ * @param  [in] u32BufSize              DMA Tx buffer size
+ * @retval int32_t:
+ *           - LL_OK: Set Tx descriptor buffer size success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_SetTxDescBufSize(stc_eth_dma_desc_t *pstcTxDesc, uint8_t u8BufNum, uint32_t u32BufSize)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32ShiftBit = 0UL;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_DESC_BUF(u8BufNum));
+        DDL_ASSERT(IS_ETH_DMA_TXDESC_BUF_SIZE(u32BufSize));
+
+        /* DMA Tx Desc buffer2 */
+        if (ETH_DMA_DESC_BUF1 != u8BufNum) {
+            u32ShiftBit = ETH_DMA_DESC_BUF2_SIZE_SHIFT;
+        }
+        MODIFY_REG32(pstcTxDesc->u32ControlBufSize, (ETH_DMA_TXDESC_TBS1 << u32ShiftBit),
+                     (u32BufSize << u32ShiftBit));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configure DMA Tx descriptor checksum insert.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32ChecksumMode         Checksum insert mode
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_TXDESC_CHECKSUM_BYPASS:               Checksum Engine is bypassed
+ *           @arg ETH_DMA_TXDESC_CHECKSUM_IPV4_HEADER:          IPv4 header checksum insertion
+ *           @arg ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_SEGMENT:   TCP/UDP/ICMP Checksum Insertion calculated over segment only
+ *           @arg ETH_DMA_TXDESC_CHECKSUM_TCPUDPICMP_FULL:      TCP/UDP/ICMP Checksum Insertion fully calculated
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx descriptor checksum insert success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescChecksumInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32ChecksumMode)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_TXDESC_CHECKSUM_CTRL(u32ChecksumMode));
+
+        MODIFY_REG32(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_CIC, u32ChecksumMode);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configure DMA Tx descriptor VLAN insert.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32VlanMode             VLAN insert mode
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_TXDESC_VLAN_BYPASS:       VLAN Insertion is bypassed
+ *           @arg ETH_DMA_TXDESC_VLAN_REMOVE_TAG:   Remove Tag and Type fields in VLAN frame
+ *           @arg ETH_DMA_TXDESC_VLAN_INSERT_TAG:   Insert VLAN Tag value in ETH_MAC_VTACTLR Register into transmit frame
+ *           @arg ETH_DMA_TXDESC_VLAN_REPLACE_TAG:  Replace VLAN tag value in transmit frame with VLAN tag value in ETH_MAC_VTACTLR register
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx descriptor VLAN insert success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescVlanInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32VlanMode)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_TXDESC_VLAN_CTRL(u32VlanMode));
+
+        MODIFY_REG32(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_VLANC, u32VlanMode);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configure DMA Tx descriptor SA insert.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Mode                 SA insert mode
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_TXDESC_SAIRC_BYPASS:              Source Address Insertion or Replace Control is bypassed
+ *           @arg ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR0:     Insert address value in MAC address register 0 into transmit frame as SA address
+ *           @arg ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR0:    Replace SA address in transmit frame with address value in MAC address register 0
+ *           @arg ETH_DMA_TXDESC_SAIRC_INSERT_MACADDR1:     Insert address value in MAC address register 1 into transmit frame as SA address
+ *           @arg ETH_DMA_TXDESC_SAIRC_REPLACE_MACADDR1:    Replace SA address in transmit frame with address value in MAC address register 1
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx descriptor SA insert success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescSrcAddrInsertConfig(stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Mode)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_TXDESC_SRC_ADDR_CTRL(u32Mode));
+
+        MODIFY_REG32(pstcTxDesc->u32ControlBufSize, ETH_DMA_TXDESC_SAIRC, u32Mode);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Tx descriptor add CRC.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx add CRC success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescCrcCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_DCRC);
+        } else {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_DCRC);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Tx descriptor padding.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx padding success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescPadCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_DPAD);
+        } else {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_DPAD);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Tx descriptor timestamp.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx padding success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescTimestamp(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_TTSE);
+        } else {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_TTSE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Tx descriptor replace CRC.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx replace CRC success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescReplaceCrcCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_CRCR);
+        } else {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_CRCR);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Tx finished interrupt.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Configure Tx interrupt configure success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL
+ */
+int32_t ETH_DMA_TxDescIntCmd(stc_eth_dma_desc_t *pstcTxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            SET_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_IOC);
+        } else {
+            CLR_REG32_BIT(pstcTxDesc->u32ControlStatus, ETH_DMA_TXDESC_IOC);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Tx descriptor flag status.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Flag                 DMA Tx descriptor flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_TXDESC_OWN:   OWN bit
+ *           @arg ETH_DMA_TXDESC_IOC:   Interrupt on Completion
+ *           @arg ETH_DMA_TXDESC_TLS:   Transmit Last Segment
+ *           @arg ETH_DMA_TXDESC_TFS:   Transmit First Segment
+ *           @arg ETH_DMA_TXDESC_DCRC:  Disable CRC
+ *           @arg ETH_DMA_TXDESC_DPAD:  Disable Padding
+ *           @arg ETH_DMA_TXDESC_TTSE:  Transmit Time Stamp Enable
+ *           @arg ETH_DMA_TXDESC_CRCR:  CRC Replace Control
+ *           @arg ETH_DMA_TXDESC_TER:   Transmit End of Ring
+ *           @arg ETH_DMA_TXDESC_TSAC:  Second Address Chained
+ *           @arg ETH_DMA_TXDESC_TTSS:  Tx Time Stamp Status
+ *           @arg ETH_DMA_TXDESC_IHE:   IP Header Error
+ *           @arg ETH_DMA_TXDESC_ETSUM: Tx Error summary
+ *           @arg ETH_DMA_TXDESC_JTE:   Jabber Timeout Error
+ *           @arg ETH_DMA_TXDESC_FFF:   Frame Flushed
+ *           @arg ETH_DMA_TXDESC_TPCE:  Payload Checksum Error
+ *           @arg ETH_DMA_TXDESC_LOCE:  Loss Carrier Error
+ *           @arg ETH_DMA_TXDESC_NCE:   No Carrier Error
+ *           @arg ETH_DMA_TXDESC_TLCE:  Late Collision Error
+ *           @arg ETH_DMA_TXDESC_ECE:   Excessive Collision Error
+ *           @arg ETH_DMA_TXDESC_VLF:   VLAN Frame
+ *           @arg ETH_DMA_TXDESC_EDE:   Excessive Deferral Error
+ *           @arg ETH_DMA_TXDESC_UDE:   Underflow Error
+ *           @arg ETH_DMA_TXDESC_DEE:   Deferred Error
+ *           @arg ETH_DMA_TXDESC_STATUS_ALL:    All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_DMA_GetTxDescStatus(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagStatus = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_TXDESC_STATUS(u32Flag));
+
+    if (NULL != pstcTxDesc) {
+        if (0UL != (pstcTxDesc->u32ControlStatus & u32Flag)) {
+            enFlagStatus = SET;
+        }
+    }
+
+    return enFlagStatus;
+}
+
+/**
+ * @brief  Get DMA Tx descriptor collision count
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32Count              Pointer to DMA Tx collision count
+ * @retval int32_t:
+ *           - LL_OK: Get collision count success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL or pu32Count == NULL
+ */
+int32_t ETH_DMA_GetTxDescCollisionCount(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t *pu32Count)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcTxDesc) || (NULL == pu32Count)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32Count = (pstcTxDesc->u32ControlStatus >> ETH_DMA_TXDESC_COLLISION_CNT_SHIFT) & ((uint32_t)0x0000000FUL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Tx descriptor timestamp.
+ * @param  [in] pstcTxDesc              Pointer to a DMA Tx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32High               Timestamp high bit time
+ * @param  [out] pu32Low                Timestamp low bit time
+ * @retval int32_t:
+ *           - LL_OK: Get timestamp success
+ *           - LL_ERR_INVD_PARAM: pstcTxDesc == NULL or pu32High == NULL or pu32Low == NULL
+ */
+int32_t ETH_DMA_GetTxDescTimeStamp(const stc_eth_dma_desc_t *pstcTxDesc, uint32_t *pu32High, uint32_t *pu32Low)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcTxDesc) || (NULL == pu32High) || (NULL == pu32Low)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32Low  = pstcTxDesc->u32TimestampLow;
+        *pu32High = pstcTxDesc->u32TimestampHigh;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set DMA Rx descriptor own bit.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Owner                DMA Rx descriptor owner
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_DESC_OWN_CPU: Descriptor is owned by CPU
+ *           @arg ETH_DMA_DESC_OWN_DMA: Descriptor is owned by DMA
+ * @retval int32_t:
+ *           - LL_OK: Set Rx descriptor own bit success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL
+ */
+int32_t ETH_DMA_SetRxDescOwn(stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Owner)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_DESC_OWN(u32Owner));
+
+        if (ETH_DMA_DESC_OWN_CPU != u32Owner) {
+            SET_REG32_BIT(pstcRxDesc->u32ControlStatus, ETH_DMA_RXDESC_OWN);
+        } else {
+            CLR_REG32_BIT(pstcRxDesc->u32ControlStatus, ETH_DMA_RXDESC_OWN);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable DMA Rx finished interrupt.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Rx interrupt configure success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL
+ */
+int32_t ETH_DMA_RxDescIntCmd(stc_eth_dma_desc_t *pstcRxDesc, en_functional_state_t enNewState)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRxDesc) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+        if (DISABLE != enNewState) {
+            CLR_REG32_BIT(pstcRxDesc->u32ControlBufSize, ETH_DMA_RXDESC_DIC);
+        } else {
+            SET_REG32_BIT(pstcRxDesc->u32ControlBufSize, ETH_DMA_RXDESC_DIC);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor flag status.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Flag                 DMA Rx descriptor flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_RXDESC_OWN:           OWN bit
+ *           @arg ETH_DMA_RXDESC_DAF:           DA Filter Fail for the received frame
+ *           @arg ETH_DMA_RXDESC_ERSUM:         Rx Error summary
+ *           @arg ETH_DMA_RXDESC_DPE:           Descriptor Error
+ *           @arg ETH_DMA_RXDESC_SAF:           SA Filter Fail for the received frame
+ *           @arg ETH_DMA_RXDESC_LEE:           Length Error
+ *           @arg ETH_DMA_RXDESC_OVE:           Overflow Error
+ *           @arg ETH_DMA_RXDESC_VLAT           VLAN Tag
+ *           @arg ETH_DMA_RXDESC_RFS:           First descriptor
+ *           @arg ETH_DMA_RXDESC_RLS:           Last descriptor
+ *           @arg ETH_DMA_RXDESC_IPE_TSPA_GF:   COE Error or Time stamp valid or jumbo frame
+ *           @arg ETH_DMA_RXDESC_RLCE:          Late collision Error
+ *           @arg ETH_DMA_RXDESC_FRAT:          Frame type
+ *           @arg ETH_DMA_RXDESC_WTE:           Receive Watchdog Timeout
+ *           @arg ETH_DMA_RXDESC_REE:           Receive error
+ *           @arg ETH_DMA_RXDESC_DBE:           Dribble bit error
+ *           @arg ETH_DMA_RXDESC_CRE:           CRC error
+ *           @arg ETH_DMA_RXDESC_DAS_ESA:       MAC Address Filter/Status bit extension
+ *           @arg ETH_DMA_RXDESC_STATUS_ALL:    All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_DMA_GetRxDescStatus(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagStatus = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_RXDESC_STATUS(u32Flag));
+
+    if (NULL != pstcRxDesc) {
+        if (0UL != (pstcRxDesc->u32ControlStatus & u32Flag)) {
+            enFlagStatus = SET;
+        }
+    }
+
+    return enFlagStatus;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor extend flag status.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u32Flag                 DMA Rx descriptor extend flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_DMA_RXDESC_L4FMS:     L4 Port Filter Status
+ *           @arg ETH_DMA_RXDESC_L3FMS:     L3 Address Filter Status
+ *           @arg ETH_DMA_RXDESC_TSPD:      Discard Time Stamp
+ *           @arg ETH_DMA_RXDESC_PTPV:      PTP Version
+ *           @arg ETH_DMA_RXDESC_PTPFT:     PTP Frame Type
+ *           @arg ETH_DMA_RXDESC_IPV6DR:    IPv6 Packet Received
+ *           @arg ETH_DMA_RXDESC_IPV4DR:    IPv4 Packet Received
+ *           @arg ETH_DMA_RXDESC_IPCB:      COE engine Bypassed
+ *           @arg ETH_DMA_RXDESC_IPPE:      IP Payload Error
+ *           @arg ETH_DMA_RXDESC_IPHE:      IP Header Error
+ *           @arg ETH_DMA_RXDESC_EXTEND_STATUS_ALL: All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_DMA_GetRxDescExtendStatus(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagStatus = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_DMA_RXDESC_EXTEND_STATUS(u32Flag));
+
+    if (NULL != pstcRxDesc) {
+        if (0UL != (pstcRxDesc->u32ExtendStatus & u32Flag)) {
+            enFlagStatus = SET;
+        }
+    }
+
+    return enFlagStatus;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor payload type.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32PayloadType        Pointer to DMA Rx payload type
+ *           The payload type may be one of the following values:
+ *           - ETH_DMA_RXDESC_IPPT_UNKNOWN: Unknown
+ *           - ETH_DMA_RXDESC_IPPT_UDP:     UDP
+ *           - ETH_DMA_RXDESC_IPPT_TCP:     TCP
+ *           - ETH_DMA_RXDESC_IPPT_ICMP:    ICMP
+ * @retval int32_t:
+ *           - LL_OK: Get payload type success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL or pu32PayloadType == NULL
+ */
+int32_t ETH_DMA_GetRxDescPayloadType(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32PayloadType)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcRxDesc) || (NULL == pu32PayloadType)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32PayloadType = pstcRxDesc->u32ExtendStatus & ETH_DMA_RXDESC_IPPT;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor datagram type.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32DatagramType       Pointer to DMA Rx datagram type
+ *           The payload type may be one of the following values:
+ *           - ETH_DMA_RXDESC_MTP_NONE:                     No PTP messages
+ *           - ETH_DMA_RXDESC_MTP_SYNC:                     SYNC message (all clock types)
+ *           - ETH_DMA_RXDESC_MTP_FOLLOW_UP:                Follow_Up message (all clock types)
+ *           - ETH_DMA_RXDESC_MTP_DELAY_REQ:                Delay_Req message (all clock types)
+ *           - ETH_DMA_RXDESC_MTP_DELAY_RESP:               Delay_Resp message (all clock types)
+ *           - ETH_DMA_RXDESC_MTP_PDELAY_REQ:               Pdelay_Req message (peer-to-peer transparent clock)
+ *           - ETH_DMA_RXDESC_MTP_PDELAY_RESP:              Pdelay_Resp message (peer-to-peer transparent clock)
+ *           - ETH_DMA_RXDESC_MTP_PDELAY_RESP_FOLLOW_UP:    Pdelay_Resp_Follow_Up message (peer-to-peer transparent clock)
+ *           - ETH_DMA_RXDESC_MTP_ANNOUNCE:                 Announce message (Ordinary or Boundary clock)
+ *           - ETH_DMA_RXDESC_MTP_MANAGEMENT:               Management message (Ordinary or Boundary clock)
+ *           - ETH_DMA_RXDESC_MTP_SIGNALING:                Signaling message (Ordinary or Boundary clock)
+ *           - ETH_DMA_RXDESC_MTP_DEFAULT:                  Default Datagram Type
+ * @retval int32_t:
+ *           - LL_OK: Get datagram type success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL or pu32DatagramType == NULL
+ */
+int32_t ETH_DMA_GetRxDescDatagramType(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32DatagramType)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcRxDesc) || (NULL == pu32DatagramType)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32DatagramType = pstcRxDesc->u32ExtendStatus & ETH_DMA_RXDESC_MTP;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor frame length.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32FrameLen           Pointer to DMA Rx frame length
+ * @retval int32_t:
+ *           - LL_OK: Get frame length success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL or pu32FrameLen == NULL
+ */
+int32_t ETH_DMA_GetRxDescFrameLen(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32FrameLen)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcRxDesc) || (NULL == pu32FrameLen)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32FrameLen = (pstcRxDesc->u32ControlStatus >> ETH_DMA_RXDESC_FRAME_LEN_SHIFT) & ((uint32_t)0x00003FFFUL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor buffer size.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [in] u8BufNum                Buffer sequence number
+ *         This parameter can be one of the following values:
+ *           @arg ETH_DMA_DESC_BUF1:    DMA Rx Desc Buffer1
+ *           @arg ETH_DMA_DESC_BUF2:    DMA Rx Desc Buffer2
+ * @param  [out] pu32BufSize            Pointer to DMA Rx buffer size
+ * @retval int32_t:
+ *           - LL_OK: Get buffer size success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL or pu32BufSize == NULL
+ */
+int32_t ETH_DMA_GetRxDescBufSize(const stc_eth_dma_desc_t *pstcRxDesc, uint8_t u8BufNum, uint32_t *pu32BufSize)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32ShiftBit = 0UL;
+
+    if ((NULL == pstcRxDesc) || (NULL == pu32BufSize)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_DMA_DESC_BUF(u8BufNum));
+
+        /* DMA Rx Desc buffer2 */
+        if (ETH_DMA_DESC_BUF1 != u8BufNum) {
+            u32ShiftBit = ETH_DMA_DESC_BUF2_SIZE_SHIFT;
+        }
+        *pu32BufSize = (pstcRxDesc->u32ControlBufSize >> u32ShiftBit) & ((uint32_t)0x00001FFFUL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get DMA Rx descriptor timestamp.
+ * @param  [in] pstcRxDesc              Pointer to a DMA Rx descriptor @ref stc_eth_dma_desc_t
+ * @param  [out] pu32High               Timestamp high bit time
+ * @param  [out] pu32Low                Timestamp low bit time
+ * @retval int32_t:
+ *           - LL_OK: Get timestamp success
+ *           - LL_ERR_INVD_PARAM: pstcRxDesc == NULL or pu32High == NULL or pu32Low == NULL
+ */
+int32_t ETH_DMA_GetRxDescTimeStamp(const stc_eth_dma_desc_t *pstcRxDesc, uint32_t *pu32High, uint32_t *pu32Low)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pstcRxDesc) || (NULL == pu32High) || (NULL == pu32Low)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32Low  = pstcRxDesc->u32TimestampLow;
+        *pu32High = pstcRxDesc->u32TimestampHigh;
+    }
+
+    return i32Ret;
+}
+
+/******************************************************************************/
+/*                                PMT Functions                               */
+/******************************************************************************/
+/**
+ * @brief  Reset PMT wakeup frame pointer.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Reset pointer success
+ *           - LL_ERR_TIMEOUT: Reset timeout
+ */
+int32_t ETH_PMT_ResetWakeupFramePointer(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(bCM_ETH->MAC_PMTCTLR_b.RTWKFR, 1U);
+    u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32(bCM_ETH->MAC_PMTCTLR_b.RTWKFR)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+/**
+ * @brief  Write PMT wakeup frame register.
+ * @param  [in] au32RegBuf              Pointer to wakeup frame filter register buffer(8 words).
+ * @retval int32_t:
+ *           - LL_OK: Write register success
+ *           - LL_ERR_INVD_PARAM: au32RegBuf == NULL
+ */
+int32_t ETH_PMT_WriteWakeupFrameReg(const uint32_t au32RegBuf[])
+{
+    uint32_t i;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == au32RegBuf) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        for (i = 0U; i < ETH_WAKEUP_REG_LEN; i++) {
+            WRITE_REG32(CM_ETH->MAC_RTWKFFR, au32RegBuf[i]);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable PMT forward wakeup frame.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_PMT_ForwardWakeupFrameCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MAC_PMTCTLR_b.RTWKTR, enNewState);
+}
+
+/**
+ * @brief  Enable or disable PMT wakeup source.
+ * @param  [in] u32WakeupSrc            Wakeup source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_PMT_WAKEUP_SRC_GLOBAL_UNICAST:    Global unicast
+ *           @arg ETH_PMT_WAKEUP_SRC_WAKEUP_FRAME:      Wake-Up Frame
+ *           @arg ETH_PMT_WAKEUP_SRC_MAGIC_PACKET:      Magic Packet
+ *           @arg ETH_PMT_WAKEUP_SRC_ALL:               All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_PMT_WakeupSrcCmd(uint32_t u32WakeupSrc, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PMT_WAKEUP_SRC(u32WakeupSrc));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG32_BIT(CM_ETH->MAC_PMTCTLR, u32WakeupSrc);
+    } else {
+        CLR_REG32_BIT(CM_ETH->MAC_PMTCTLR, u32WakeupSrc);
+    }
+}
+
+/**
+ * @brief  Enable or disable PMT powerdown mode.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Set powerdown mode success
+ *           - LL_ERR: Set powerdown mode failed
+ */
+int32_t ETH_PMT_EnterPowerDown(void)
+{
+    int32_t i32Ret = LL_ERR;
+    uint32_t u32Temp1, u32Temp2;
+
+    u32Temp1 = READ_REG32(bCM_ETH->MAC_PMTCTLR_b.MPEN);
+    u32Temp2 = READ_REG32(bCM_ETH->MAC_PMTCTLR_b.WKEN);
+
+    if ((0UL != u32Temp1) || (0UL != u32Temp2)) {
+        WRITE_REG32(bCM_ETH->MAC_PMTCTLR_b.PWDN, ENABLE);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get PMT flag status.
+ * @param  [in] u32Flag                 PMT flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_PMT_FLAG_RTWKFR:  Wake-Up Frame Filter Register Pointer Reset
+ *           @arg ETH_PMT_FLAG_WKFR:    Wake-Up Frame Received
+ *           @arg ETH_PMT_FLAG_MPFR:    Magic Packet Received
+ *           @arg ETH_PMT_FLAG_ALL:     All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_PMT_GetStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PMT_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->MAC_PMTCTLR, u32Flag)) ? SET : RESET);
+}
+
+/******************************************************************************/
+/*                                MMC Functions                               */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize MMC.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: MMC De-Initialize success
+*           - LL_ERR_TIMEOUT: De-Initialize timeout
+ */
+int32_t ETH_MMC_DeInit(void)
+{
+    WRITE_REG32(CM_ETH->MMC_MMCCTLR, 0UL);
+    WRITE_REG32(CM_ETH->MMC_RITCTLR, 0UL);
+    WRITE_REG32(CM_ETH->MMC_TITCTLR, 0UL);
+
+    return ETH_MMC_CounterReset();
+}
+
+/**
+ * @brief  Initialize MMC.
+ * @param  [in] pstcMmcInit             Pointer to a @ref stc_eth_mmc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: MMC Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcMmcInit == NULL
+ */
+int32_t ETH_MMC_Init(const stc_eth_mmc_init_t *pstcMmcInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcMmcInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_MMC_CNT_PRESET_MD(pstcMmcInit->u32PresetMode));
+        DDL_ASSERT(IS_ETH_MMC_RD_RST(pstcMmcInit->u32ReadReset));
+        DDL_ASSERT(IS_ETH_MMC_CNT_RELOAD(pstcMmcInit->u32Reload));
+
+        MODIFY_REG32(CM_ETH->MMC_MMCCTLR,
+                     (ETH_MMC_MMCCTLR_MCPSEL | ETH_MMC_MMCCTLR_MCPSET |
+                      ETH_MMC_MMCCTLR_ROR    | ETH_MMC_MMCCTLR_COS),
+                     (pstcMmcInit->u32PresetMode | pstcMmcInit->u32ReadReset |
+                      pstcMmcInit->u32Reload));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_mmc_init_t to default values.
+ * @param  [out] pstcMmcInit            Pointer to a @ref stc_eth_mmc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcMmcInit == NULL
+ */
+int32_t ETH_MMC_StructInit(stc_eth_mmc_init_t *pstcMmcInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcMmcInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcMmcInit->u32PresetMode = ETH_MMC_CNT_PRESET_MD_DISABLE;
+        pstcMmcInit->u32ReadReset  = ETH_MMC_RD_RST_ENABLE;
+        pstcMmcInit->u32Reload = ETH_MMC_CNT_RELOAD_ENABLE;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  MMC all counter software reset.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Reset success
+ *           - LL_ERR_TIMEOUT: Reset timeout
+ */
+int32_t ETH_MMC_CounterReset(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(bCM_ETH->MMC_MMCCTLR_b.CRST, 1U);
+    u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32(bCM_ETH->MMC_MMCCTLR_b.CRST)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the reset of all MMC counter after reading.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MMC_ResetAfterReadCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->MMC_MMCCTLR_b.ROR, enNewState);
+}
+
+/**
+ * @brief  Enable or disable MMC function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MMC_Cmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        WRITE_REG32(bCM_ETH->MMC_MMCCTLR_b.MCF, DISABLE);
+    } else {
+        WRITE_REG32(bCM_ETH->MMC_MMCCTLR_b.MCF, ENABLE);
+    }
+}
+
+/**
+ * @brief  Enable or disable MMC transmit interrupt.
+ * @param  [in] u32IntType              MMC interrupt source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MMC_INT_TXEDEIM:  Tx excessive deferral error frame interrupt
+ *           @arg ETH_MMC_INT_TXUGIM:   Tx unicast good frame interrupt
+ *           @arg ETH_MMC_INT_TXCAEIM:  Tx carrier error frame interrupt
+ *           @arg ETH_MMC_INT_TXECEIM:  Tx excessive collision error frame interrupt
+ *           @arg ETH_MMC_INT_TXLCEIM:  Tx deferral collision error frame interrupt
+ *           @arg ETH_MMC_INT_TXDEEIM:  Tx deferral error frame interrupt
+ *           @arg ETH_MMC_INT_TXMGIM:   Tx multicast good frame interrupt
+ *           @arg ETH_MMC_INT_TXBGIM:   Tx broadcast good frame interrupt
+ *           @arg ETH_MMC_INT_TX_ALL:   All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MMC_TxIntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MMC_TX_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        CLR_REG32_BIT(CM_ETH->MMC_TITCTLR, u32IntType);
+    } else {
+        SET_REG32_BIT(CM_ETH->MMC_TITCTLR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Enable or disable MMC receive interrupt.
+ * @param  [in] u32IntType              MMC interrupt source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MMC_INT_RXOEIM:   Rx out of scope error frame interrupt
+ *           @arg ETH_MMC_INT_RXLEIM:   Rx length error frame interrupt
+ *           @arg ETH_MMC_INT_RXUGIM:   Rx unicast good frame interrupt
+ *           @arg ETH_MMC_INT_RXREIM:   Rx short error frame interrupt
+ *           @arg ETH_MMC_INT_RXAEIM:   Rx alignment error frame interrupt
+ *           @arg ETH_MMC_INT_RXCEIM:   Rx crc error frame interrupt
+ *           @arg ETH_MMC_INT_RXMGIM:   Rx multicast good frame interrupt
+ *           @arg ETH_MMC_INT_RXBGIM:   Rx broadcast good frame interrupt
+ *           @arg ETH_MMC_INT_RX_ALL:   All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_MMC_RxIntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MMC_RX_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        CLR_REG32_BIT(CM_ETH->MMC_RITCTLR, u32IntType);
+    } else {
+        SET_REG32_BIT(CM_ETH->MMC_RITCTLR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get MMC flag transmit status.
+ * @param  [in] u32Flag                 MMC flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MMC_FLAG_TXEDEIS: Tx excessive deferral error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXUGIS:  Tx unicast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXCAEIS: Tx carrier error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXECEIS: Tx excessive collision error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXLCEIS: Tx deferral collision error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXDEEIS: Tx deferral error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXMGIS:  Tx multicast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TXBGIS:  Tx broadcast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_TX_ALL:  All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_MMC_GetTxStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MMC_TX_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->MMC_TRSSTSR, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Get MMC receive flag status.
+ * @param  [in] u32Flag                 MMC flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_MMC_FLAG_RXOEIS:  Rx out of scope error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXLEIS:  Rx length error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXUGIS:  Rx unicast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXREIS:  Rx short error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXAEIS:  Rx alignment error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXCEIS:  Rx crc error frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXMGIS:  Rx multicast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RXBGIS:  Rx broadcast good frame counter reaches half or all the maximum value
+ *           @arg ETH_MMC_FLAG_RX_ALL:  All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_MMC_GetRxStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MMC_RX_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->MMC_REVSTSR, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Get MMC register.
+ * @param  [in] u32Reg                  MMC statistics register
+ *         This parameter can be one of the following values:
+ *           @arg ETH_MMC_REG_TXBRGFR:  Tx broadcast good frame Statistical Register
+ *           @arg ETH_MMC_REG_TXMUGFR:  Tx multicast good frame Statistical Register
+ *           @arg ETH_MMC_REG_TXDEEFR:  Tx deferral error frame Statistical Register
+ *           @arg ETH_MMC_REG_TXLCEFR:  Tx deferral collision error frame Statistical Register
+ *           @arg ETH_MMC_REG_TXECEFR:  Tx excessive collision error frame Statistical Register
+ *           @arg ETH_MMC_REG_TXCAEFR:  Tx carrier error frame Statistical Register
+ *           @arg ETH_MMC_REG_TXUNGFR:  Tx unicast good frame Statistical Register
+ *           @arg ETH_MMC_REG_TXEDEFR:  Tx excessive deferral error frame Statistical Register
+ *           @arg ETH_MMC_REG_RXBRGFR:  Rx broadcast good frame Statistical Register
+ *           @arg ETH_MMC_REG_RXMUGFR:  Rx multicast good frame Statistical Register
+ *           @arg ETH_MMC_REG_RXCREFR:  Rx crc error frame Statistical Register
+ *           @arg ETH_MMC_REG_RXALEFR:  Rx alignment error frame Statistical Register
+ *           @arg ETH_MMC_REG_RXRUEFR:  Rx short error frame Statistical Register
+ *           @arg ETH_MMC_REG_RXUNGFR:  Rx unicast good frame Statistical Register
+ *           @arg ETH_MMC_REG_RXLEEFR:  Rx length error frame Statistical Register
+ *           @arg ETH_MMC_REG_RXOREFR:  Rx out of scope error frame Statistical Register
+ * @retval uint32_t                     MMC statistics Register value
+ */
+uint32_t ETH_MMC_GetReg(uint32_t u32Reg)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_MMC_REG(u32Reg));
+
+    return (*(__IO uint32_t *)((uint32_t)(&CM_ETH->MAC_CONFIGR) + u32Reg));
+}
+
+/******************************************************************************/
+/*                                PTP Functions                               */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize PTP.
+ * @param  None
+ * @retval None
+ */
+void ETH_PTP_DeInit(void)
+{
+    WRITE_REG32(CM_ETH->PTP_TSPCTLR, 0x00002000UL);
+    WRITE_REG32(CM_ETH->PTP_TSPADDR, 0UL);
+    WRITE_REG32(CM_ETH->PTP_TSPNSAR, 0UL);
+    WRITE_REG32(CM_ETH->PTP_TMUSECR, 0UL);
+    WRITE_REG32(CM_ETH->PTP_TMUNSER, 0UL);
+}
+
+/**
+ * @brief  Initialize PTP.
+ * @param  [in] pstcPtpInit             Pointer to a @ref stc_eth_ptp_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: PTP Initialize success
+ *           - LL_ERR: PTP Initialize failed
+ *           - LL_ERR_TIMEOUT: PTP Initialize timeout
+ *           - LL_ERR_INVD_PARAM: pstcPtpInit == NULL
+ */
+int32_t ETH_PTP_Init(const stc_eth_ptp_init_t *pstcPtpInit)
+{
+    int32_t i32Ret;
+
+    if (NULL == pstcPtpInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_PTP_DEST_ADDR_FILTER(pstcPtpInit->u32DestAddrFilter));
+        DDL_ASSERT(IS_ETH_PTP_DATAGRAM_VER(pstcPtpInit->u32DatagramVersion));
+        DDL_ASSERT(IS_ETH_PTP_SUBSEC_SCALE(pstcPtpInit->u32SubsecScale));
+        DDL_ASSERT(IS_ETH_PTP_DATAGRAM_TYPE(pstcPtpInit->u32SnapDatagramType));
+        DDL_ASSERT(IS_ETH_PTP_FRAME_TYPE(pstcPtpInit->u32SnapFrameType));
+        DDL_ASSERT(IS_ETH_PTP_CALIB_MD(pstcPtpInit->u32CalibMode));
+        DDL_ASSERT(IS_ETH_PTP_SUB_SEC(pstcPtpInit->u32SubsecInitValue));
+
+        /* Enable timestamp function */
+        WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPEN, (uint32_t)ENABLE);
+        /* Set addend value registers */
+        WRITE_REG32(CM_ETH->PTP_TSPNSAR, pstcPtpInit->u8SubsecAddend);
+        WRITE_REG32(CM_ETH->PTP_TSPADDR, pstcPtpInit->u32BasicAddend);
+        i32Ret = ETH_PTP_UpdateBasicAddend();
+        if (LL_OK == i32Ret) {
+            /* Set timestamp control register */
+            MODIFY_REG32(CM_ETH->PTP_TSPCTLR, ETH_PTP_TSPCTLR_CLR_MASK,
+                         (pstcPtpInit->u32DestAddrFilter | pstcPtpInit->u32SnapDatagramType |
+                          pstcPtpInit->u32SnapFrameType  | pstcPtpInit->u32DatagramVersion  |
+                          pstcPtpInit->u32SubsecScale    | pstcPtpInit->u32CalibMode));
+            /* Set initialize value */
+            WRITE_REG32(CM_ETH->PTP_TMUSECR, pstcPtpInit->u32SecInitValue);
+            WRITE_REG32(CM_ETH->PTP_TMUNSER, pstcPtpInit->u32SubsecInitValue);
+            i32Ret = ETH_PTP_SysTimeInit();
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_ptp_init_t to default values.
+ * @param  [out] pstcPtpInit            Pointer to a @ref stc_eth_ptp_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcPtpInit == NULL
+ */
+int32_t ETH_PTP_StructInit(stc_eth_ptp_init_t *pstcPtpInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcPtpInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcPtpInit->u32DestAddrFilter      = ETH_PTP_DEST_ADDR_FILTER_DISABLE;
+        pstcPtpInit->u32SnapDatagramType    = ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY;
+        pstcPtpInit->u32SnapFrameType       = ETH_PTP_FRAME_TYPE_IPV4_FRAME;
+        pstcPtpInit->u32DatagramVersion     = ETH_PTP_DATAGRAM_VER_IEEE1588V1;
+        pstcPtpInit->u32SubsecScale         = ETH_PTP_SUBSEC_SCALE_HEX;
+        pstcPtpInit->u32CalibMode           = ETH_PTP_CALIB_MD_COARSE;
+        pstcPtpInit->u32BasicAddend         = 0UL;
+        pstcPtpInit->u8SubsecAddend         = 0U;
+        pstcPtpInit->u32SecInitValue        = 0UL;
+        pstcPtpInit->u32SubsecInitValue     = 0UL;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set PTP snapshot datagram type.
+ * @param  [in] u32DatagramType         Snapshot datagram type
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY:         SYNC Follow_Up Delay_Req Delay_Resp
+ *           @arg ETH_PTP_DATAGRAM_TYPE_SYNC:                      SYNC
+ *           @arg ETH_PTP_DATAGRAM_TYPE_DELAY:                     Delay_Req
+ *           @arg ETH_PTP_DATAGRAM_TYPE_SYNC_FOLLOW_DELAY_PDELAY:  SYNC Follow_Up Delay_Req Delay_Resp Pdelay_Req Pdelay_Resp Pdelay_Resp_Follow_Up
+ *           @arg ETH_PTP_DATAGRAM_TYPE_SYNC_PDELAY:               SYNC Pdelay_Req Pdelay_Resp
+ *           @arg ETH_PTP_DATAGRAM_TYPE_DELAY_PDELAY:              Delay_Req Pdelay_Req Pdelay_Resp
+ *           @arg ETH_PTP_DATAGRAM_TYPE_SYNC_DELAY:                SYNC Delay_Req
+ *           @arg ETH_PTP_DATAGRAM_TYPE_PDELAY:                    Pdelay_Req Pdelay_Resp
+ * @retval None
+ */
+void ETH_PTP_SetSnapDatagramType(uint32_t u32DatagramType)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PTP_DATAGRAM_TYPE(u32DatagramType));
+
+    MODIFY_REG32(CM_ETH->PTP_TSPCTLR, ETH_PTP_TSPCTLR_TSPMTSEL, u32DatagramType);
+}
+
+/**
+ * @brief  Set PTP snapshot frame type.
+ * @param  [in] u32FrameType            Snapshot frame type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_PTP_FRAME_TYPE_IPV4_FRAME:    snapshot of IPv4 frame
+ *           @arg ETH_PTP_FRAME_TYPE_IPV6_FRAME:    snapshot of IPv6 frame
+ *           @arg ETH_PTP_FRAME_TYPE_ETH_FRAME:     snapshot of PTP over ethernet frame
+ *           @arg ETH_PTP_FRAME_TYPE_RX_FRAME:      snapshot of all received frame
+ *           @arg ETH_PTP_FRAME_TYPE_ALL:           All of the above
+ * @retval None
+ */
+void ETH_PTP_SetSnapFrameType(uint32_t u32FrameType)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PTP_FRAME_TYPE(u32FrameType));
+
+    MODIFY_REG32(CM_ETH->PTP_TSPCTLR,
+                 (ETH_PTP_TSPCTLR_TSPOVIPV4 | ETH_PTP_TSPCTLR_TSPOVIPV6 | ETH_PTP_TSPCTLR_TSPOVETH |
+                  ETH_PTP_TSPCTLR_TSPEALL), u32FrameType);
+}
+
+/**
+ * @brief  Set PTP timestamp calibration mode.
+ * @param  [in] u32CalibMode            Timestamp calibration mode
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PTP_CALIB_MD_COARSE:  Coarse calibration
+ *           @arg ETH_PTP_CALIB_MD_FINE:    Fine calibration
+ * @retval None
+ */
+void ETH_PTP_SetCalibMode(uint32_t u32CalibMode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PTP_CALIB_MD(u32CalibMode));
+
+    WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPUPSEL, u32CalibMode >> ETH_PTP_TSPCTLR_TSPUPSEL_POS);
+}
+
+/**
+ * @brief  Update PTP timestamp basic addend value.
+ * @note   Update Timestamp addend value by basic addend register.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Update timestamp addend value success
+ *           - LL_ERR: Current state cannot be updated
+ *           - LL_ERR_TIMEOUT: Update timeout
+ */
+int32_t ETH_PTP_UpdateBasicAddend(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    if (0UL == READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPADUP)) {
+        WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPADUP, 1U);
+        u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+        while (0UL != READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPADUP)) {
+            if (0UL == u32Count) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+            u32Count--;
+        }
+    } else {
+        i32Ret = LL_ERR;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Update PTP timestamp system time.
+ * @note   Update Timestamp system time by update second and update subsecond registers.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Update timestamp system time success
+ *           - LL_ERR: Current state cannot be updated
+ *           - LL_ERR_TIMEOUT: Update timeout
+ */
+int32_t ETH_PTP_UpdateSysTime(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_ERR;
+
+    if (0UL == READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPINI)) {
+        if (0UL == READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPUP)) {
+            WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPUP, 1U);
+            u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+            while (0UL != READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPUP)) {
+                if (0UL == u32Count) {
+                    i32Ret = LL_ERR_TIMEOUT;
+                    break;
+                }
+                u32Count--;
+            }
+            if (LL_ERR_TIMEOUT != i32Ret) {
+                i32Ret = LL_OK;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize PTP timestamp system time.
+ * @note   Initialize Timestamp system time by update second and update subsecond registers.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Initialize timestamp system time success
+ *           - LL_ERR: Current state cannot be initialized
+ *           - LL_ERR_TIMEOUT: Initialize timeout
+ */
+int32_t ETH_PTP_SysTimeInit(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    if (0UL == READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPINI)) {
+        WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPINI, 1U);
+        u32Count = ETH_WR_REG_TIMEOUT * (HCLK_VALUE / 20000UL);
+        while (0UL != READ_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPINI)) {
+            if (0UL == u32Count) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+            u32Count--;
+        }
+    } else {
+        i32Ret = LL_ERR;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get PTP timestamp system time.
+ * @param  [out] pu32Sec                Pointer to Timestamp system time of Second
+ * @param  [out] pu32Subsec             Pointer to Timestamp system time of Subsecond
+ * @retval int32_t:
+ *           - LL_OK: Get timestamp system time success
+ *           - LL_ERR_INVD_PARAM: pu32Sec == NULL or pu32Subsec == NULL
+ */
+int32_t ETH_PTP_GetSysTime(uint32_t *pu32Sec, uint32_t *pu32Subsec)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pu32Sec) || (NULL == pu32Subsec)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32Sec    = READ_REG32(CM_ETH->PTP_TMSSECR);
+        *pu32Subsec = READ_REG32(CM_ETH->PTP_TMSNSER);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set PTP timestamp addend value.
+ * @param  [in] u32BasicAddend          Timestamp basic addend value (Between 0x0 and 0xFFFFFFFF)
+ * @param  [in] u8SubsecAddend          Timestamp subsecond addend value (Between 0x0 and 0xFF)
+ * @retval None
+ */
+void ETH_PTP_SetBasicAddend(uint32_t u32BasicAddend, uint8_t u8SubsecAddend)
+{
+    WRITE_REG32(CM_ETH->PTP_TSPADDR, u32BasicAddend);
+    WRITE_REG32(CM_ETH->PTP_TSPNSAR, u8SubsecAddend);
+}
+
+/**
+ * @brief  Get PTP timestamp addend value.
+ * @param  [out] pu32BasicAddend        Pointer to basic addend value
+ * @param  [out] pu8SubsecAddend        Pointer to subsecond addend value
+ * @retval int32_t:
+ *           - LL_OK: Get timestamp addend value success
+ *           - LL_ERR_INVD_PARAM: pu32BasicAddend == NULL or pu8SubsecAddend == NULL
+ */
+int32_t ETH_PTP_GetBasicAddend(uint32_t *pu32BasicAddend, uint8_t *pu8SubsecAddend)
+{
+    int32_t i32Ret = LL_OK;
+
+    if ((NULL == pu32BasicAddend) || (NULL == pu8SubsecAddend)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32BasicAddend = READ_REG32(CM_ETH->PTP_TSPADDR);
+        *pu8SubsecAddend = (uint8_t)(READ_REG32(CM_ETH->PTP_TSPNSAR) & ETH_PTP_TSPNSAR_TSPNSEADD);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set PTP timestamp update time.
+ * @param  [in] u32Sign                 Timestamp Update Sign
+ *           @arg ETH_PTP_TIME_UPDATE_SIGN_MINUS:   Minus
+ *           @arg ETH_PTP_TIME_UPDATE_SIGN_PLUS:    Plus
+ * @param  [in] u32Sec                  Update time of Second (Between 0x0 and 0xFFFFFFFF)
+ * @param  [in] u32Subsec               Update time of Subsecond (Between 0x0 and 0x7FFFFFFF)
+ * @retval None
+ */
+void ETH_PTP_SetUpdateTime(uint32_t u32Sign, uint32_t u32Sec, uint32_t u32Subsec)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PTP_TIME_UPDATE_SIGN(u32Sign));
+    DDL_ASSERT(IS_ETH_PTP_SUB_SEC(u32Subsec));
+
+    WRITE_REG32(CM_ETH->PTP_TMUSECR, u32Sec);
+    WRITE_REG32(CM_ETH->PTP_TMUNSER, (u32Sign | u32Subsec));
+}
+
+/**
+ * @brief  Enable or disable PTP function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_PTP_Cmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPEN, enNewState);
+}
+
+/**
+ * @brief  Enable or disable PTP interrupt.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void ETH_PTP_IntCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_ETH->PTP_TSPCTLR_b.TSPINT, enNewState);
+}
+
+/**
+ * @brief  Get PTP flag status.
+ * @param  [in] u32Flag                 PTP flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg ETH_PTP_FLAG_TSERR1:  Target time 1 error
+ *           @arg ETH_PTP_FLAG_TSTAR1:  Target time 1 reached
+ *           @arg ETH_PTP_FLAG_TSERR0:  Target time 0 error
+ *           @arg ETH_PTP_FLAG_TSTAR0:  Target time 0 reached
+ *           @arg ETH_PTP_FLAG_TSOVF:   System time overflow
+ *           @arg ETH_PTP_FLAG_ALL:     All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t ETH_PTP_GetStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PTP_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(CM_ETH->PTP_TSPSTSR, u32Flag)) ? SET : RESET);
+}
+
+/******************************************************************************/
+/*                            PTP PPS Functions                               */
+/******************************************************************************/
+/**
+ * @brief  De-Initialize PTP PPS.
+ * @param  [in] u8Ch                    PPS output channel
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_CH0:          PPS Channel 0
+ *           @arg ETH_PPS_CH1:          PPS Channel 1
+ * @retval None
+ */
+void ETH_PPS_DeInit(uint8_t u8Ch)
+{
+    uint32_t u32ShiftStep = 0UL;
+    uint32_t u32ShiftBit = 0UL;
+    __IO uint32_t *PTP_TMTSECR;
+    __IO uint32_t *PTP_TMTNSER;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PPS_CH(u8Ch));
+
+    if (ETH_PPS_CH1 == u8Ch) {
+        u32ShiftBit  = ETH_PTP_PPSCTLR_PPSFRE1_POS;
+        u32ShiftStep = ETH_PTP_PPS1_TIME_REG_ADDR_SHIFT;
+    }
+    CLR_REG32_BIT(CM_ETH->PTP_PPSCTLR,
+                  ((ETH_PTP_PPSCTLR_PPSFRE0 | ETH_PTP_PPSCTLR_PPSOMD | ETH_PTP_PPSCTLR_TT0SEL) << u32ShiftBit));
+    /* Clear target time registers */
+    PTP_TMTSECR = ETH_PTP_TMTSECR_ADDR(u32ShiftStep);
+    PTP_TMTNSER = ETH_PTP_TMTNSER_ADDR(u32ShiftStep);
+    WRITE_REG32(*PTP_TMTSECR, 0UL);
+    WRITE_REG32(*PTP_TMTNSER, 0UL);
+}
+
+/**
+ * @brief  Initialize PTP PPS.
+ * @param  [in] u8Ch                    PPS output channel
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_CH0:          PPS Channel 0
+ *           @arg ETH_PPS_CH1:          PPS Channel 1
+ * @param  [in] pstcPpsInit             Pointer to a @ref stc_eth_pps_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: PPS Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcPpsInit == NULL
+ */
+int32_t ETH_PPS_Init(uint8_t u8Ch, const stc_eth_pps_config_t *pstcPpsInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcPpsInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_ETH_PPS_CH_OUTPUT_FREQ(u8Ch, pstcPpsInit->u32OutputFreq));
+        DDL_ASSERT(IS_ETH_PTP_SUB_SEC(pstcPpsInit->u32SubsecValue));
+        DDL_ASSERT(IS_ETH_PPS_TRIG_FUNC(pstcPpsInit->u32TriggerFunc));
+
+        /* Set target time registers */
+        if (ETH_PPS_CH1 == u8Ch) {
+            WRITE_REG32(CM_ETH->PTP_TMTSECR1, pstcPpsInit->u32SecValue);
+            WRITE_REG32(CM_ETH->PTP_TMTNSER1, pstcPpsInit->u32SubsecValue);
+            MODIFY_REG32(CM_ETH->PTP_PPSCTLR, (ETH_PTP_PPSCTLR_PPSFRE1 | ETH_PTP_PPSCTLR_TT1SEL),
+                         (pstcPpsInit->u32TriggerFunc | pstcPpsInit->u32OutputFreq) << ETH_PTP_PPSCTLR_PPSFRE1_POS);
+        } else {
+            DDL_ASSERT(IS_ETH_PPS_OUTPUT_MD_FREQ(pstcPpsInit->u32OutputMode, pstcPpsInit->u32OutputFreq));
+
+            WRITE_REG32(CM_ETH->PTP_TMTSECR0, pstcPpsInit->u32SecValue);
+            WRITE_REG32(CM_ETH->PTP_TMTNSER0, pstcPpsInit->u32SubsecValue);
+            MODIFY_REG32(CM_ETH->PTP_PPSCTLR,
+                         (ETH_PTP_PPSCTLR_PPSFRE0 | ETH_PTP_PPSCTLR_PPSOMD | ETH_PTP_PPSCTLR_TT0SEL),
+                         (pstcPpsInit->u32OutputFreq | pstcPpsInit->u32TriggerFunc | pstcPpsInit->u32OutputMode));
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_eth_pps_config_t to default values.
+ * @param  [out] pstcPpsInit            Pointer to a @ref stc_eth_pps_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcPpsInit == NULL
+ */
+int32_t ETH_PPS_StructInit(stc_eth_pps_config_t *pstcPpsInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcPpsInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcPpsInit->u32TriggerFunc = ETH_PPS_TRIG_FUNC_INT_EVT;
+        pstcPpsInit->u32OutputMode  = ETH_PPS_OUTPUT_MD_ONCE;
+        pstcPpsInit->u32OutputFreq  = ETH_PPS_OUTPUT_ONE_PULSE;
+        pstcPpsInit->u32SecValue    = 0UL;
+        pstcPpsInit->u32SubsecValue = 0UL;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set PTP Target time function.
+ * @param  [in] u8Ch                    PPS output channel
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_CH0:          PPS Channel 0
+ *           @arg ETH_PPS_CH1:          PPS Channel 1
+ * @param  [in] u32Sec                  Target time of Second (Between 0x0 and 0xFFFFFFFF)
+ * @param  [in] u32Subsec               Target time of Subsecond (Between 0x0 and 0x7FFFFFFF)
+ * @retval None
+ */
+void ETH_PPS_SetTargetTime(uint8_t u8Ch, uint32_t u32Sec, uint32_t u32Subsec)
+{
+    uint32_t u32ShiftStep = 0UL;
+    __IO uint32_t *PTP_TMTSECR;
+    __IO uint32_t *PTP_TMTNSER;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PPS_CH(u8Ch));
+    DDL_ASSERT(IS_ETH_PTP_SUB_SEC(u32Subsec));
+
+    if (ETH_PPS_CH1 == u8Ch) {
+        u32ShiftStep = ETH_PTP_PPS1_TIME_REG_ADDR_SHIFT;
+    }
+    PTP_TMTSECR = ETH_PTP_TMTSECR_ADDR(u32ShiftStep);
+    PTP_TMTNSER = ETH_PTP_TMTNSER_ADDR(u32ShiftStep);
+    WRITE_REG32(*PTP_TMTSECR, u32Sec);
+    WRITE_REG32(*PTP_TMTNSER, u32Subsec);
+}
+
+/**
+ * @brief  Set PTP Target time function.
+ * @param  [in] u8Ch                    PPS output channel
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_CH0:          PPS Channel 0
+ *           @arg ETH_PPS_CH1:          PPS Channel 1
+ * @param  [in] u32Func                 Arrival time trigger the function
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_TRIG_FUNC_INT_EVT:      Interrupt output event
+ *           @arg ETH_PPS_TRIG_FUNC_INT_PPS_EVT:  Interrupt out event and PPS single output event
+ *           @arg ETH_PPS_TRIG_FUNC_PPS_EVT:      PPS Single output event
+ * @retval None
+ */
+void ETH_PPS_SetTriggerFunc(uint8_t u8Ch, uint32_t u32Func)
+{
+    uint32_t u32ShiftBit = 0UL;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PPS_CH(u8Ch));
+    DDL_ASSERT(IS_ETH_PPS_TRIG_FUNC(u32Func));
+
+    if (ETH_PPS_CH1 == u8Ch) {
+        u32ShiftBit = ETH_PTP_PPSCTLR_PPSFRE1_POS;
+    }
+    MODIFY_REG32(CM_ETH->PTP_PPSCTLR, (ETH_PTP_PPSCTLR_TT0SEL << u32ShiftBit), (u32Func << u32ShiftBit));
+}
+
+/**
+ * @brief  Set PTP PPS0 output mode.
+ * @param  [in] u32Mode                 PPS output mode
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_OUTPUT_MD_CONT:       Continuous output mode
+ *           @arg ETH_PPS_OUTPUT_MD_ONCE:       Single output mode
+ * @retval None
+ */
+void ETH_PPS_SetPps0OutputMode(uint32_t u32Mode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PPS_OUTPUT_MD(u32Mode));
+
+    WRITE_REG32(bCM_ETH->PTP_PPSCTLR_b.PPSOMD, u32Mode >> ETH_PTP_PPSCTLR_PPSOMD_POS);
+}
+
+/**
+ * @brief  Set PTP PPS output frequency.
+ * @param  [in] u8Ch                    PPS output channel
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_CH0:          PPS Channel 0
+ *           @arg ETH_PPS_CH1:          PPS Channel 1
+ * @param  [in] u32Freq                 PPS output frequency
+ *         This parameter can be one of the following values:
+ *           @arg ETH_PPS_OUTPUT_PULSE_1HZ:     Output 1HZ pulse signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_2HZ:      Output 2HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_4HZ:      Output 4HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_8HZ:      Output 8HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_16HZ:     Output 16HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_32HZ:     Output 32HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_64HZ:     Output 64HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_128HZ:    Output 128HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_256HZ:    Output 256HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_512HZ:    Output 512HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_1024HZ:   Output 1024HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_2048HZ:   Output 2048HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_4096HZ:   Output 4096HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_8192HZ:   Output 8192HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_16384HZ:  Output 16384HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_FREQ_32768HZ:  Output 32768HZ square signal in continuous output mode
+ *           @arg ETH_PPS_OUTPUT_ONE_PULSE:     One pulse is generated in single output mode
+ * @retval None
+ * @note   u32Freq should be ETH_PPS_OUTPUT_ONE_PULSE while ETH_PPS_CH1
+ */
+void ETH_PPS_SetPpsOutputFreq(uint8_t u8Ch, uint32_t u32Freq)
+{
+    uint32_t u32ShiftBit = 0UL;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_ETH_PPS_CH_OUTPUT_FREQ(u8Ch, u32Freq));
+
+    if (ETH_PPS_CH1 == u8Ch) {
+        u32ShiftBit = ETH_PTP_PPSCTLR_PPSFRE1_POS;
+    }
+
+    MODIFY_REG32(CM_ETH->PTP_PPSCTLR, ETH_PTP_PPSCTLR_PPSFRE0 << u32ShiftBit, u32Freq << u32ShiftBit);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_ETH_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_event_port.c
+++ b/hc32f4a2/src/hc32_ll_event_port.c
@@ -1,0 +1,444 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_event_port.c
+ * @brief This file provides firmware functions to manage the Event Port (EP).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+                                    Modify for new head file
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_event_port.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EVENT_PORT EVENT_PORT
+ * @brief Event Port Driver Library
+ * @{
+ */
+
+#if (LL_EVENT_PORT_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EP_Local_Macros Event Port Local Macros
+ * @{
+ */
+#define EP_OFFSET               (0x1CUL)
+#define PEVNTDIR_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTDIRR1) + (EP_OFFSET * (x))))
+#define PEVNTIDR_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTIDR1) + (EP_OFFSET * (x))))
+#define PEVNTODR_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTODR1) + (EP_OFFSET * (x))))
+#define PEVNTORR_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTORR1) + (EP_OFFSET * (x))))
+#define PEVNTOSR_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTOSR1) + (EP_OFFSET * (x))))
+#define PEVNTRIS_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTRISR1) + (EP_OFFSET * (x))))
+#define PEVNTFAL_REG(x)         (*(__IO uint32_t *)((uint32_t)(&CM_AOS->PEVNTFALR1) + (EP_OFFSET * (x))))
+#define PEVNTTRGSR_RST_VALUE    (0x1FFUL)
+#define EP_PIN_MAX              (16U)
+
+/**
+ * @defgroup EP_Check_Parameters_Validity Event Port Check Parameters Validity
+ * @{
+ */
+/*! Parameter validity check for port group. */
+#define IS_EVENT_PORT(port)                                                     \
+(   ((port) == EVT_PORT_1)                      ||                              \
+    ((port) == EVT_PORT_2)                      ||                              \
+    ((port) == EVT_PORT_3)                      ||                              \
+    ((port) == EVT_PORT_4))
+
+/*! Parameter valid check for event port trigger edge. */
+#define IS_EP_TRIG_EDGE(edge)                                                   \
+(   ((edge) == EP_TRIG_NONE)                    ||                              \
+    ((edge) == EP_TRIG_FALLING)                 ||                              \
+    ((edge) == EP_TRIG_RISING)                  ||                              \
+    ((edge) == EP_TRIG_BOTH))
+
+/*! Parameter valid check for event port initial output state. */
+#define IS_EP_STATE(state)                                                      \
+(   ((state) == EVT_PIN_RESET)                  ||                              \
+    ((state) == EVT_PIN_SET))
+
+/*! Parameter valid check for event port filter function. */
+#define IS_EP_FILTER(filter)                                                    \
+(   ((filter) == EP_FILTER_OFF)                 ||                              \
+    ((filter) == EP_FILTER_ON))
+
+/*! Parameter validity check for pin. */
+#define IS_EVENT_PIN(pin)               (((pin) & EVT_PIN_MASK) != 0x0000U)
+
+/*! Parameter valid check for event port operation after triggered. */
+#define IS_EP_OPS(ops)                                                          \
+(   ((ops) == EP_OPS_NONE)                      ||                              \
+    ((ops) == EP_OPS_LOW)                       ||                              \
+    ((ops) == EP_OPS_HIGH)                      ||                              \
+    ((ops) == EP_OPS_TOGGLE))
+
+/*! Parameter valid check for event port direction. */
+#define IS_EP_DIR(dir)                                                          \
+(   ((dir) == EP_DIR_IN)                        ||                              \
+    ((dir) == EP_DIR_OUT))
+
+/*! Parameter valid check for event port filter clock div. */
+#define IS_EP_FILTER_CLK(clk)                                                   \
+(   ((clk) == EP_FCLK_DIV1)                     ||                              \
+    ((clk) == EP_FCLK_DIV8)                     ||                              \
+    ((clk) == EP_FCLK_DIV32)                    ||                              \
+    ((clk) == EP_FCLK_DIV64))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup EP_Global_Functions Event Port Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initialize Event Port.
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP port peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @param  [in] pstcEventPortInit Pointer to a stc_ep_init_t structure that
+ *                                contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: Event Port initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EP_Init(uint8_t u8EventPort, uint16_t u16EventPin, const stc_ep_init_t *pstcEventPortInit)
+{
+    uint16_t u16PinPos;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcEventPortInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+        DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+        DDL_ASSERT(IS_EP_OPS(pstcEventPortInit->u32PinTriggerOps));
+        DDL_ASSERT(IS_EP_DIR(pstcEventPortInit->u32PinDir));
+        DDL_ASSERT(IS_EP_STATE(pstcEventPortInit->enPinState));
+        DDL_ASSERT(IS_EP_TRIG_EDGE(pstcEventPortInit->u32Edge));
+        DDL_ASSERT(IS_EP_FILTER(pstcEventPortInit->u32Filter));
+        DDL_ASSERT(IS_EP_FILTER_CLK(pstcEventPortInit->u32FilterClock));
+
+        for (u16PinPos = 0U; u16PinPos < EP_PIN_MAX; u16PinPos++) {
+            if ((u16EventPin & (1UL << u16PinPos)) != 0U) {
+                /* Direction config */
+                if (EP_DIR_OUT == pstcEventPortInit->u32PinDir) {
+                    SET_REG32_BIT(PEVNTDIR_REG(u8EventPort), u16EventPin);
+                } else {
+                    CLR_REG32_BIT(PEVNTDIR_REG(u8EventPort), u16EventPin);
+                }
+                /* Set pin initial output value */
+                if (EVT_PIN_SET == pstcEventPortInit->enPinState) {
+                    SET_REG32_BIT(PEVNTODR_REG(u8EventPort), u16EventPin);
+                } else {
+                    CLR_REG32_BIT(PEVNTODR_REG(u8EventPort), u16EventPin);
+                }
+                /* Set Pin operation after triggered */
+                (void)EP_SetTriggerOps(u8EventPort, u16EventPin, pstcEventPortInit->u32PinTriggerOps);
+                /* Set trigger edge */
+                (void)EP_SetTriggerEdge(u8EventPort, u16EventPin, pstcEventPortInit->u32Edge);
+            }
+            MODIFY_REG32(CM_AOS->PEVNTNFCR, \
+                         ((AOS_PEVNTNFCR_NFEN1 | AOS_PEVNTNFCR_DIVS1) << (u8EventPort * 8UL)), \
+                         ((pstcEventPortInit->u32Filter | pstcEventPortInit->u32FilterClock) << (u8EventPort * 8UL)));
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-init Event Port register to default value
+ * @param  None
+ * @retval None
+ */
+void EP_DeInit(void)
+{
+    uint8_t u8EventPort;
+
+    /* Restore all registers to default value */
+    WRITE_REG32(CM_AOS->PEVNT_TRGSEL12, PEVNTTRGSR_RST_VALUE);
+    WRITE_REG32(CM_AOS->PEVNT_TRGSEL34, PEVNTTRGSR_RST_VALUE);
+    WRITE_REG32(CM_AOS->PEVNTNFCR, 0UL);
+    for (u8EventPort = EVT_PORT_1; u8EventPort < EVT_PORT_4; u8EventPort++) {
+        WRITE_REG32(PEVNTDIR_REG(u8EventPort), 0UL);
+        WRITE_REG32(PEVNTODR_REG(u8EventPort), 0UL);
+        WRITE_REG32(PEVNTORR_REG(u8EventPort), 0UL);
+        WRITE_REG32(PEVNTOSR_REG(u8EventPort), 0UL);
+        WRITE_REG32(PEVNTRIS_REG(u8EventPort), 0UL);
+        WRITE_REG32(PEVNTFAL_REG(u8EventPort), 0UL);
+    }
+}
+
+/**
+ * @brief  Initialize Event Port config structure. Fill each pstcEventPortInit with default value
+ * @param  [in] pstcEventPortInit: Pointer to a stc_ep_init_t structure that
+ *                                 contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: Event Port structure initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EP_StructInit(stc_ep_init_t *pstcEventPortInit)
+{
+    int32_t i32Ret = LL_OK;
+    /* Check if pointer is NULL */
+    if (NULL == pstcEventPortInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Reset Event Port init structure parameters values */
+        pstcEventPortInit->u32PinDir        = EP_DIR_IN;
+        pstcEventPortInit->enPinState       = EVT_PIN_RESET;
+        pstcEventPortInit->u32PinTriggerOps = EP_OPS_NONE;
+        pstcEventPortInit->u32Edge  = EP_TRIG_NONE;
+        pstcEventPortInit->u32Filter = EP_FILTER_OFF;
+        pstcEventPortInit->u32FilterClock = EP_FCLK_DIV1;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set event port trigger edge.
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP port peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @param  [in] u32Edge: Trigger edge, @ref EP_Trigger_Sel for details
+ * @retval int32_t:
+ *           - LL_OK: Trigger edge set successful
+ *           - LL_ERR_INVD_PARAM: Undefined edge
+ */
+int32_t EP_SetTriggerEdge(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Edge)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+    DDL_ASSERT(IS_EP_TRIG_EDGE(u32Edge));
+
+    /* Set trigger edge */
+    switch (u32Edge) {
+        case EP_TRIG_NONE:
+            CLR_REG32_BIT(PEVNTFAL_REG(u8EventPort), u16EventPin);
+            CLR_REG32_BIT(PEVNTRIS_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_TRIG_FALLING:
+            SET_REG32_BIT(PEVNTFAL_REG(u8EventPort), u16EventPin);
+            CLR_REG32_BIT(PEVNTRIS_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_TRIG_RISING:
+            CLR_REG32_BIT(PEVNTFAL_REG(u8EventPort), u16EventPin);
+            SET_REG32_BIT(PEVNTRIS_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_TRIG_BOTH:
+            SET_REG32_BIT(PEVNTFAL_REG(u8EventPort), u16EventPin);
+            SET_REG32_BIT(PEVNTRIS_REG(u8EventPort), u16EventPin);
+            break;
+        default:
+            i32Ret = LL_ERR_INVD_PARAM;
+            break;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set event port operation after triggered
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @param  [in] u32Ops: The operation after triggered, @ref EP_TriggerOps_Sel for details
+ * @retval Specified Event port pin input value
+ */
+int32_t EP_SetTriggerOps(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Ops)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+    DDL_ASSERT(IS_EP_OPS(u32Ops));
+
+    switch (u32Ops) {
+        case EP_OPS_NONE:
+            CLR_REG32_BIT(PEVNTORR_REG(u8EventPort), u16EventPin);
+            CLR_REG32_BIT(PEVNTOSR_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_OPS_LOW:
+            SET_REG32_BIT(PEVNTORR_REG(u8EventPort), u16EventPin);
+            CLR_REG32_BIT(PEVNTOSR_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_OPS_HIGH:
+            CLR_REG32_BIT(PEVNTORR_REG(u8EventPort), u16EventPin);
+            SET_REG32_BIT(PEVNTOSR_REG(u8EventPort), u16EventPin);
+            break;
+        case EP_OPS_TOGGLE:
+            SET_REG32_BIT(PEVNTORR_REG(u8EventPort), u16EventPin);
+            SET_REG32_BIT(PEVNTOSR_REG(u8EventPort), u16EventPin);
+            break;
+        default:
+            i32Ret = LL_ERR_INVD_PARAM;
+            break;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Read specified Event port input data port pins
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @retval Specified Event port pin input value
+ */
+en_ep_state_t EP_ReadInputPins(uint8_t u8EventPort, uint16_t u16EventPin)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+
+    return ((READ_REG32(PEVNTIDR_REG(u8EventPort)) & (u16EventPin)) != 0UL) ? EVT_PIN_SET : EVT_PIN_RESET;
+}
+
+/**
+ * @brief  Read specified Event port input data port
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the Event Port peripheral
+ * @retval Specified Event Port input value
+ */
+uint16_t EP_ReadInputPort(uint8_t u8EventPort)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+
+    return (uint16_t)(READ_REG32(PEVNTIDR_REG(u8EventPort)) & 0xFFFFUL);
+}
+
+/**
+ * @brief  Read specified Event port output data port pins
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @retval Specified Event port pin output value
+ */
+en_ep_state_t EP_ReadOutputPins(uint8_t u8EventPort, uint16_t u16EventPin)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+
+    return ((READ_REG32(PEVNTODR_REG(u8EventPort)) & (u16EventPin)) != 0UL) ? EVT_PIN_SET : EVT_PIN_RESET;
+}
+
+/**
+ * @brief  Read specified Event port output data port
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the Event Port peripheral
+ * @retval Specified Event Port output value
+ */
+uint16_t EP_ReadOutputPort(uint8_t u8EventPort)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+
+    return (uint16_t)(READ_REG32(PEVNTODR_REG(u8EventPort)) & 0xFFFFUL);
+}
+
+/**
+ * @brief  Set specified Event port output data port pins
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @retval None
+ */
+void EP_SetPins(uint8_t u8EventPort, uint16_t u16EventPin)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+
+    SET_REG32_BIT(PEVNTODR_REG(u8EventPort), u16EventPin);
+}
+
+/**
+ * @brief  Reset specified Event port output data port pins
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @retval None
+ */
+void EP_ResetPins(uint8_t u8EventPort, uint16_t u16EventPin)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+
+    CLR_REG32_BIT(PEVNTODR_REG(u8EventPort), u16EventPin);
+}
+
+/**
+ * @brief  Set specified Event port pins direction
+ * @param  [in] u8EventPort: EVENT_PORT_x, x can be (1~4) to select the EP peripheral
+ * @param  [in] u16EventPin: EVENT_PIN_x, x can be (00~15) to select the EP pin index
+ * @param  [in] u32Dir: Pin direction
+ *   @arg  EP_DIR_IN
+ *   @arg  EP_DIR_OUT
+ * @retval None
+ */
+void EP_SetDir(uint8_t u8EventPort, uint16_t u16EventPin, uint32_t u32Dir)
+{
+    DDL_ASSERT(IS_EVENT_PORT(u8EventPort));
+    DDL_ASSERT(IS_EVENT_PIN(u16EventPin));
+    DDL_ASSERT(IS_EP_DIR(u32Dir));
+
+    if (EP_DIR_OUT == u32Dir) {
+        SET_REG32_BIT(PEVNTDIR_REG(u8EventPort), u16EventPin);
+    } else {
+        CLR_REG32_BIT(PEVNTDIR_REG(u8EventPort), u16EventPin);
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_EVENT_PORT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_fcg.c
+++ b/hc32f4a2/src/hc32_ll_fcg.c
@@ -1,0 +1,194 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fcg.c
+ * @brief This file provides firmware functions to manage the Function Clock
+ *        Gate (FCG).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_fcg.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_FCG FCG
+ * @brief FCG Driver Library
+ * @{
+ */
+
+#if (LL_FCG_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup FCG_Local_Macros FCG Local Macros
+ * @{
+ */
+#define IS_FCG0_UNLOCKED()      ((CM_PWC->FCG0PC & PWC_FCG0PC_PRT0) == PWC_FCG0PC_PRT0)
+
+/**
+ * @defgroup FCG_Check_Parameters_Validity FCG Check Parameters Validity
+ * @{
+ */
+/* Parameter validity check for peripheral in fcg0. */
+#define IS_FCG0_PERIPH(per)                                 \
+(   ((per) != 0x00UL)                           &&          \
+    (((per) | FCG_FCG0_PERIPH_MASK) == FCG_FCG0_PERIPH_MASK))
+
+/* Parameter validity check for peripheral in fcg1. */
+#define IS_FCG1_PERIPH(per)                                 \
+(   ((per) != 0x00UL)                           &&          \
+    (((per) | FCG_FCG1_PERIPH_MASK) == FCG_FCG1_PERIPH_MASK))
+
+/* Parameter validity check for peripheral in fcg2. */
+#define IS_FCG2_PERIPH(per)                                 \
+(   ((per) != 0x00UL)                           &&          \
+    (((per) | FCG_FCG2_PERIPH_MASK) == FCG_FCG2_PERIPH_MASK))
+
+/* Parameter validity check for peripheral in fcg3. */
+#define IS_FCG3_PERIPH(per)                                 \
+(   ((per) != 0x00UL)                           &&          \
+    (((per) | FCG_FCG3_PERIPH_MASK) == FCG_FCG3_PERIPH_MASK))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup FCG_Global_Functions FCG Global Functions
+ * @{
+ */
+
+/**
+ * @brief Enable or disable the FCG0 peripheral clock.
+ * @param [in] u32Fcg0Periph The peripheral in FCG0 @ref FCG_FCG0_Peripheral.
+ * @param [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCG_Fcg0PeriphClockCmd(uint32_t u32Fcg0Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCG0_PERIPH(u32Fcg0Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_FCG0_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_PWC->FCG0, u32Fcg0Periph);
+    } else {
+        SET_REG32_BIT(CM_PWC->FCG0, u32Fcg0Periph);
+    }
+}
+
+/**
+ * @brief  Enable or disable the FCG1 peripheral clock.
+ * @param [in] u32Fcg1Periph The peripheral in FCG1 @ref FCG_FCG1_Peripheral.
+ * @param [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCG_Fcg1PeriphClockCmd(uint32_t u32Fcg1Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCG1_PERIPH(u32Fcg1Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_PWC->FCG1, u32Fcg1Periph);
+    } else {
+        SET_REG32_BIT(CM_PWC->FCG1, u32Fcg1Periph);
+    }
+}
+
+/**
+ * @brief  Enable or disable the FCG2 peripheral clock.
+ * @param [in] u32Fcg2Periph The peripheral in FCG2 @ref FCG_FCG2_Peripheral.
+ * @param [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCG_Fcg2PeriphClockCmd(uint32_t u32Fcg2Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCG2_PERIPH(u32Fcg2Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_PWC->FCG2, u32Fcg2Periph);
+    } else {
+        SET_REG32_BIT(CM_PWC->FCG2, u32Fcg2Periph);
+    }
+}
+
+/**
+ * @brief  Enable or disable the FCG3 peripheral clock.
+ * @param [in] u32Fcg3Periph The peripheral in FCG3 @ref FCG_FCG3_Peripheral.
+ * @param [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCG_Fcg3PeriphClockCmd(uint32_t u32Fcg3Periph, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCG3_PERIPH(u32Fcg3Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_PWC->FCG3, u32Fcg3Periph);
+    } else {
+        SET_REG32_BIT(CM_PWC->FCG3, u32Fcg3Periph);
+    }
+}
+
+#endif /* LL_FCG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_fcm.c
+++ b/hc32f4a2/src/hc32_ll_fcm.c
@@ -1,0 +1,423 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fcm.c
+ * @brief This file provides firmware functions to manage the Frequency Clock
+ *        Measurement (FCM).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Modify parameter check for reference clock source
+   2023-06-30       CDT             Modify API FCM_DeInit()
+   2024-06-30       CDT             Interface add instance
+                                    Modify API FCM_ClearStatus(), Clear status by write instruction
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_fcm.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_FCM FCM
+ * @brief FCM Driver Library
+ * @{
+ */
+
+#if (LL_FCM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup FCM_Local_Macros FCM Local Macros
+ * @{
+ */
+
+/* FCM Registers RESET Value */
+#define FCM_REG_RST_VALUE       (0x00000000UL)
+
+/* FCM interrupt mask */
+#define FCM_INT_MASK            (FCM_INT_OVF | FCM_INT_END | FCM_INT_ERR)
+/* FCM status flag mask */
+#define FCM_FLAG_MASK           (FCM_SR_ERRF | FCM_SR_MENDF | FCM_SR_OVF)
+
+/**
+ * @defgroup FCM_Check_Parameters_Validity FCM Check Parameters Validity
+ * @{
+ */
+
+/* Parameters validity check for FCM Unit */
+#define IS_FCM_UNIT(x)          ((x) == CM_FCM)
+
+/* Parameter validity check for FCM target and reference clock source. */
+#define IS_FCM_TARGET_SRC(x)                                                 \
+(   ((x) == FCM_TARGET_CLK_XTAL)          ||                                 \
+    ((x) == FCM_TARGET_CLK_XTAL32)        ||                                 \
+    ((x) == FCM_TARGET_CLK_HRC)           ||                                 \
+    ((x) == FCM_TARGET_CLK_LRC)           ||                                 \
+    ((x) == FCM_TARGET_CLK_SWDTLRC)       ||                                 \
+    ((x) == FCM_TARGET_CLK_PCLK1)         ||                                 \
+    ((x) == FCM_TARGET_CLK_PLLAP)         ||                                 \
+    ((x) == FCM_TARGET_CLK_MRC)           ||                                 \
+    ((x) == FCM_TARGET_CLK_PLLHP)         ||                                 \
+    ((x) == FCM_TARGET_CLK_RTCLRC))
+
+#define IS_FCM_REF_SRC(x)                                                    \
+(   ((x) == FCM_REF_CLK_EXTCLK)           ||                                 \
+    ((x) == FCM_REF_CLK_XTAL)             ||                                 \
+    ((x) == FCM_REF_CLK_XTAL32)           ||                                 \
+    ((x) == FCM_REF_CLK_HRC)              ||                                 \
+    ((x) == FCM_REF_CLK_LRC)              ||                                 \
+    ((x) == FCM_REF_CLK_SWDTLRC)          ||                                 \
+    ((x) == FCM_REF_CLK_PCLK1)            ||                                 \
+    ((x) == FCM_REF_CLK_PLLAP)            ||                                 \
+    ((x) == FCM_REF_CLK_MRC)              ||                                 \
+    ((x) == FCM_REF_CLK_PLLHP)            ||                                 \
+    ((x) == FCM_REF_CLK_RTCLRC))
+
+/* Parameter validity check for FCM target clock division. */
+#define IS_FCM_TARGET_DIV(x)                                                 \
+(   ((x) == FCM_TARGET_CLK_DIV1)          ||                                 \
+    ((x) == FCM_TARGET_CLK_DIV4)          ||                                 \
+    ((x) == FCM_TARGET_CLK_DIV8)          ||                                 \
+    ((x) == FCM_TARGET_CLK_DIV32))
+
+/* Parameter validity check for FCM external reference input function. */
+#define IS_FCM_EXT_REF_FUNC(x)                                               \
+(   ((x) == FCM_EXT_REF_OFF)              ||                                 \
+    ((x) == FCM_EXT_REF_ON))
+
+/* Parameter validity check for FCM reference clock edge. */
+#define IS_FCM_REF_EDGE(x)                                                   \
+(   ((x) == FCM_REF_CLK_RISING)           ||                                 \
+    ((x) == FCM_REF_CLK_FALLING)          ||                                 \
+    ((x) == FCM_REF_CLK_BOTH))
+
+/* Parameter validity check for FCM digital filter function. */
+#define IS_FCM_DIG_FILTER(x)                                                 \
+(   ((x) == FCM_DIG_FILTER_OFF)           ||                                 \
+    ((x) == FCM_DIG_FILTER_DIV1)          ||                                 \
+    ((x) == FCM_DIG_FILTER_DIV4)          ||                                 \
+    ((x) == FCM_DIG_FILTER_DIV16))
+
+/* Parameter validity check for FCM reference clock division. */
+#define IS_FCM_REF_DIV(x)                                                    \
+(   ((x) == FCM_REF_CLK_DIV32)            ||                                 \
+    ((x) == FCM_REF_CLK_DIV128)           ||                                 \
+    ((x) == FCM_REF_CLK_DIV1024)          ||                                 \
+    ((x) == FCM_REF_CLK_DIV8192))
+
+/* Parameter validity check for FCM exception type function. */
+#define IS_FCM_EXP_TYPE(x)                                                   \
+(   ((x) == FCM_EXP_TYPE_INT)             ||                                 \
+    ((x) == FCM_EXP_TYPE_RST))
+
+/* Parameter validity check for FCM interrupt. */
+#define IS_FCM_INT(x)           (((x) | FCM_INT_MASK) == FCM_INT_MASK)
+
+/* Parameter validity check for FCM flag state. */
+#define IS_FCM_FLAG(x)                                                       \
+(   ((x) != 0x00UL)                       &&                                 \
+    (((x) | FCM_FLAG_MASK) == FCM_FLAG_MASK))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup FCM_Global_Functions FCM Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initialize FCM.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] pstcFcmInit         Pointer to a @ref stc_fcm_init_t structure
+ *                                  that contains configuration information.
+ * @retval int32_t:
+ *       - LL_OK:                   FCM initialize successful
+ *       - LL_ERR_INVD_PARAM:       Invalid parameter
+ */
+int32_t FCM_Init(CM_FCM_TypeDef *FCMx, const stc_fcm_init_t *pstcFcmInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    /* Check if pointer is NULL */
+    if (NULL == pstcFcmInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Parameter validity checking */
+        DDL_ASSERT(IS_FCM_TARGET_SRC(pstcFcmInit->u32TargetClock));
+        DDL_ASSERT(IS_FCM_TARGET_DIV(pstcFcmInit->u32TargetClockDiv));
+        DDL_ASSERT(IS_FCM_EXT_REF_FUNC(pstcFcmInit->u32ExtRefClockEnable));
+        DDL_ASSERT(IS_FCM_REF_EDGE(pstcFcmInit->u32RefClockEdge));
+        DDL_ASSERT(IS_FCM_DIG_FILTER(pstcFcmInit->u32DigitalFilter));
+        DDL_ASSERT(IS_FCM_REF_SRC(pstcFcmInit->u32RefClock));
+        DDL_ASSERT(IS_FCM_REF_DIV(pstcFcmInit->u32RefClockDiv));
+        DDL_ASSERT(IS_FCM_EXP_TYPE(pstcFcmInit->u32ExceptionType));
+
+        WRITE_REG32(FCMx->LVR, pstcFcmInit->u16LowerLimit);
+        WRITE_REG32(FCMx->UVR, pstcFcmInit->u16UpperLimit);
+        WRITE_REG32(FCMx->MCCR, (pstcFcmInit->u32TargetClock | pstcFcmInit->u32TargetClockDiv));
+        WRITE_REG32(FCMx->RCCR, (pstcFcmInit->u32ExtRefClockEnable | pstcFcmInit->u32RefClockEdge |
+                                 pstcFcmInit->u32DigitalFilter | pstcFcmInit->u32RefClock |
+                                 pstcFcmInit->u32RefClockDiv));
+        MODIFY_REG32(FCMx->RIER, FCM_RIER_ERRINTRS, pstcFcmInit->u32ExceptionType);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize FCM structure. Fill each pstcFcmInit with default value.
+ * @param  [in] pstcFcmInit         Pointer to a @ref stc_fcm_init_t structure
+ *                                  that contains configuration information.
+ * @retval int32_t:
+ *       - LL_OK:                   FCM structure initialize successful
+ *       - LL_ERR_INVD_PARAM:       Invalid parameter
+ */
+int32_t FCM_StructInit(stc_fcm_init_t *pstcFcmInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcFcmInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* RESET FCM init structure parameters values */
+        pstcFcmInit->u16LowerLimit = 0U;
+        pstcFcmInit->u16UpperLimit = 0U;
+        pstcFcmInit->u32TargetClock = FCM_TARGET_CLK_XTAL;
+        pstcFcmInit->u32TargetClockDiv = FCM_TARGET_CLK_DIV1;
+        pstcFcmInit->u32ExtRefClockEnable = FCM_EXT_REF_OFF;
+        pstcFcmInit->u32RefClockEdge = FCM_REF_CLK_RISING;
+        pstcFcmInit->u32DigitalFilter = FCM_DIG_FILTER_OFF;
+        pstcFcmInit->u32RefClock = FCM_REF_CLK_XTAL;
+        pstcFcmInit->u32RefClockDiv = FCM_REF_CLK_DIV32;
+        pstcFcmInit->u32ExceptionType = FCM_EXP_TYPE_INT;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize FCM.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t FCM_DeInit(CM_FCM_TypeDef *FCMx)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    WRITE_REG32(FCMx->STR, FCM_REG_RST_VALUE);
+    WRITE_REG32(FCMx->CLR, FCM_FLAG_MASK);
+    WRITE_REG32(FCMx->LVR, FCM_REG_RST_VALUE);
+    WRITE_REG32(FCMx->UVR, FCM_REG_RST_VALUE);
+    WRITE_REG32(FCMx->MCCR, FCM_REG_RST_VALUE);
+    WRITE_REG32(FCMx->RCCR, FCM_REG_RST_VALUE);
+    WRITE_REG32(FCMx->RIER, FCM_REG_RST_VALUE);
+    return LL_OK;
+}
+
+/**
+ * @brief  Get FCM state, get FCM overflow, complete, error flag.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] u32Flag         FCM flags.This parameter can be one or any
+ *                              combination of the following values: @ref FCM_Flag_Sel
+ *   @arg  FCM_FLAG_ERR:        FCM error.
+ *   @arg  FCM_FLAG_END:        FCM measure end.
+ *   @arg  FCM_FLAG_OVF:        FCM overflow.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t FCM_GetStatus(CM_FCM_TypeDef *FCMx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FCM_FLAG(u32Flag));
+
+    return ((READ_REG32_BIT(FCMx->SR, u32Flag) != 0UL) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear FCM state, Clear FCM overflow, complete, error flag.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] u32Flag     FCM flags.This parameter can be one or any
+ *                          combination of the following values: @ref FCM_Flag_Sel
+ *   @arg  FCM_FLAG_ERR:    FCM error.
+ *   @arg  FCM_FLAG_END:    FCM measure end.
+ *   @arg  FCM_FLAG_OVF:    FCM overflow.
+ * @retval None.
+ */
+void FCM_ClearStatus(CM_FCM_TypeDef *FCMx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FCM_FLAG(u32Flag));
+
+    WRITE_REG32(FCMx->CLR, u32Flag);
+}
+
+/**
+ * @brief  Get FCM counter value.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @retval FCM counter value.
+ */
+uint16_t FCM_GetCountValue(CM_FCM_TypeDef *FCMx)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    return (uint16_t)(READ_REG32(FCMx->CNTR) & 0xFFFFU);
+}
+
+/**
+ * @brief  FCM target clock type and division config.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] u32ClockSrc Target clock type. @ref FCM_Target_Clock_Src
+ * @param  [in] u32Div Target clock division. @ref FCM_Target_Clock_Div
+ *   @arg  FCM_TARGET_CLK_DIV1
+ *   @arg  FCM_TARGET_CLK_DIV4
+ *   @arg  FCM_TARGET_CLK_DIV8
+ *   @arg  FCM_TARGET_CLK_DIV32
+ * @retval None.
+ */
+void FCM_SetTargetClock(CM_FCM_TypeDef *FCMx, uint32_t u32ClockSrc, uint32_t u32Div)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FCM_TARGET_SRC(u32ClockSrc));
+    DDL_ASSERT(IS_FCM_TARGET_DIV(u32Div));
+    WRITE_REG32(FCMx->MCCR, (u32ClockSrc | u32Div));
+}
+
+/**
+ * @brief  FCM reference clock type and division config.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] u32ClockSrc Reference clock type. @ref FCM_Ref_Clock_Src
+ * @param  [in] u32Div Reference clock division. @ref FCM_Ref_Clock_Div
+ *   @arg  FCM_REF_CLK_DIV32
+ *   @arg  FCM_REF_CLK_DIV128
+ *   @arg  FCM_REF_CLK_DIV1024
+ *   @arg  FCM_REF_CLK_DIV8192
+ * @retval None.
+ */
+void FCM_SetRefClock(CM_FCM_TypeDef *FCMx, uint32_t u32ClockSrc, uint32_t u32Div)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FCM_REF_SRC(u32ClockSrc));
+    DDL_ASSERT(IS_FCM_REF_DIV(u32Div));
+    MODIFY_REG32(FCMx->RCCR, (FCM_RCCR_INEXS | FCM_RCCR_RCKS | FCM_RCCR_RDIVS), (u32ClockSrc | u32Div));
+}
+
+/**
+ * @brief  Enable or disable the FCM reset
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCM_ResetCmd(CM_FCM_TypeDef *FCMx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_FCM->RIER_b.ERRE, enNewState);
+}
+
+/**
+ * @brief  Enable or disable the FCM interrupt
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] u32IntType      The FCM interrupt type. This parameter can be
+ *                              one or any combination @ref FCM_Int_Type
+ *    @arg FCM_INT_OVF:         FCM overflow interrupt
+ *    @arg FCM_INT_END:         FCM calculate end interrupt
+ *    @arg FCM_INT_ERR:         FCM frequency abnormal interrupt
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FCM_IntCmd(CM_FCM_TypeDef *FCMx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FCM_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(FCMx->RIER, u32IntType);
+    } else {
+        CLR_REG32_BIT(FCMx->RIER, u32IntType);
+    }
+}
+
+/**
+ * @brief  FCM function config.
+ * @param  [in] FCMx FCM unit instance.
+ *   @arg  CM_FCMx or CM_FCM
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None.
+ */
+void FCM_Cmd(CM_FCM_TypeDef *FCMx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FCM_UNIT(FCMx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    WRITE_REG32(bCM_FCM->STR_b.START, enNewState);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_FCM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_fmac.c
+++ b/hc32f4a2/src/hc32_ll_fmac.c
@@ -1,0 +1,355 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_fmac.c
+ * @brief This file provides firmware functions to manage the Filter Math
+ *        Accelerate (FMAC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Modify API FMAC_DeInit()
+   2024-06-30       CDT             All parameter assert add module name
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_fmac.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_FMAC FMAC
+ * @brief FMAC Driver Library
+ * @{
+ */
+
+#if (LL_FMAC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup FMAC_Local_Macros FMAC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup FMAC_Check_Parameters_Validity FMAC Check Parameters Validity
+ * @{
+ */
+#define IS_FMAC_FIR_SHIFT(x)                    ((x) <= FMAC_FIR_SHIFT_21BIT)
+
+#define IS_FMAC_FIR_STAGE(x)                    ((x) <= FMAC_FIR_STAGE_16)
+
+#define IS_FMAC_INT_FUNC(x)                                                     \
+(   ((x) == FMAC_INT_ENABLE)                    ||                              \
+    ((x) == FMAC_INT_DISABLE))
+
+#define IS_FMAC_UNIT(x)                                                         \
+(   ((x) == CM_FMAC1)                           ||                              \
+    ((x) == CM_FMAC2)                           ||                              \
+    ((x) == CM_FMAC3)                           ||                              \
+    ((x) == CM_FMAC4))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup FMAC_Global_Functions FMAC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  FMAC peripheral initialization structure clear
+ * @param  [in] pstcFmacInit      FMAC function structure
+ *   @arg  See the structure definition for @ref stc_fmac_init_t
+ * @retval int32_t:
+ *           - LL_OK: Success
+ *           - LL_ERR_INVD_PARAM: Parameter error
+ */
+int32_t FMAC_StructInit(stc_fmac_init_t *pstcFmacInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcFmacInit != NULL) {
+        pstcFmacInit->u32Stage   = FMAC_FIR_STAGE_0;
+        pstcFmacInit->u32Shift   = FMAC_FIR_SHIFT_0BIT;
+        pstcFmacInit->pi16Factor = NULL;
+        pstcFmacInit->u32IntCmd  = FMAC_INT_DISABLE;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize FMAC function
+ * @param  [in] FMACx            Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:             FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:             FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:             FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:             FMAC unit 4 instance register base
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t FMAC_DeInit(CM_FMAC_TypeDef *FMACx)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+
+    WRITE_REG32(FMACx->CTR, 0UL);
+    WRITE_REG32(FMACx->IER, 0UL);
+    WRITE_REG32(FMACx->DTR, 0UL);
+    WRITE_REG32(FMACx->RTR0, 0UL);
+    WRITE_REG32(FMACx->RTR1, 0UL);
+    WRITE_REG32(FMACx->STR, 0UL);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  FMAC peripheral function initialize
+ * @param  [in] FMACx            Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:             FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:             FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:             FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:             FMAC unit 4 instance register base
+ * @param  [in] pstcFmacInit     FMAC function base parameter structure
+ *   @arg  See the structure definition for @ref stc_fmac_init_t
+ * @retval int32_t:
+ *           - LL_OK: Success
+ *           - LL_ERR_INVD_PARAM: Parameter error
+ */
+int32_t FMAC_Init(CM_FMAC_TypeDef *FMACx, const stc_fmac_init_t *pstcFmacInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    int16_t *pi16Factor;
+    __IO uint32_t *FMAC_CORx;
+    uint32_t i;
+    if ((pstcFmacInit != NULL) && (pstcFmacInit->pi16Factor != NULL)) {
+        DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+        DDL_ASSERT(IS_FMAC_FIR_SHIFT(pstcFmacInit->u32Shift));
+        DDL_ASSERT(IS_FMAC_FIR_STAGE(pstcFmacInit->u32Stage));
+        DDL_ASSERT(IS_FMAC_INT_FUNC(pstcFmacInit->u32IntCmd));
+
+        pi16Factor = (pstcFmacInit->pi16Factor);
+        /* Configure filter stage and results right shift bits */
+        WRITE_REG32(FMACx->CTR, (pstcFmacInit->u32Stage | (pstcFmacInit->u32Shift << FMAC_CTR_SHIFT_POS)));
+        /* Configure interrupt command */
+        WRITE_REG32(FMACx->IER, pstcFmacInit->u32IntCmd);
+        for (i = 0U; i < pstcFmacInit->u32Stage + 1U; i++) {
+            FMAC_CORx = (__IO uint32_t *)((uint32_t)(&FMACx->COR0) + (i << 2UL));
+            WRITE_REG32(*FMAC_CORx, *pi16Factor++);
+        }
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or Disable FMAC
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FMAC_Cmd(CM_FMAC_TypeDef *FMACx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(FMACx->ENR, enNewState);
+}
+
+/**
+ * @brief  Set Filter result shift bits.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:             FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:             FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:             FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:             FMAC unit 4 instance register base
+ * @param  [in] u32ShiftNum      Result shift times.
+ * This parameter can be one of @ref FMAC_Filter_Shift
+ * @retval None
+ */
+void FMAC_SetResultShift(CM_FMAC_TypeDef *FMACx, uint32_t u32ShiftNum)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    DDL_ASSERT(IS_FMAC_FIR_SHIFT(u32ShiftNum));
+    /* Set Filter result shift bits */
+    MODIFY_REG32(FMACx->CTR, FMAC_CTR_SHIFT, u32ShiftNum << FMAC_CTR_SHIFT_POS);
+}
+
+/**
+ * @brief  Set filter stage and filter factor.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @param  [in] u32FilterStage  FMAC filter stage.
+ * This parameter can be one of @ref FMAC_Filter_Stage
+ * @param  [in] pi16Factor       FMAC filter factor.
+ * This parameter can be set -32768 ~ 32767
+ * @retval None
+ */
+void FMAC_SetStageFactor(CM_FMAC_TypeDef *FMACx, uint32_t u32FilterStage, int16_t *pi16Factor)
+{
+    __IO uint32_t *FMAC_CORx;
+    uint8_t i;
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    DDL_ASSERT(IS_FMAC_FIR_STAGE(u32FilterStage));
+    /* FMAC Software reset */
+    CLR_REG32_BIT(FMACx->ENR, FMAC_ENR_FMACEN);
+    SET_REG32_BIT(FMACx->ENR, FMAC_ENR_FMACEN);
+    /* Set the filter stage  */
+    MODIFY_REG32(FMACx->CTR, FMAC_CTR_STAGE_NUM, u32FilterStage);
+    for (i = 0U; i < (u32FilterStage + 1UL); i++) {
+        FMAC_CORx = (__IO uint32_t *)((uint32_t)(&FMACx->COR0) + ((uint32_t)i << 2UL));
+        WRITE_REG32(*FMAC_CORx, *pi16Factor++);
+    }
+}
+
+/**
+ * @brief  Configure interrupt command.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void FMAC_IntCmd(CM_FMAC_TypeDef *FMACx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(FMACx->IER, enNewState);
+}
+
+/**
+ * @brief  Data input.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @param  [in] i16Factor       Data that needs to be processed.
+ * @retval None
+ */
+void FMAC_FIRInput(CM_FMAC_TypeDef *FMACx, int16_t i16Factor)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    WRITE_REG32(FMACx->DTR, i16Factor);
+}
+
+/**
+ * @brief  Get FMAC status.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @retval An @ref en_flag_status_t enumeration type value.
+ *              - SET           Calculate complete
+ *              - RESET         Calculation in progress
+ */
+en_flag_status_t FMAC_GetStatus(const CM_FMAC_TypeDef *FMACx)
+{
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+    return ((READ_REG32_BIT(FMACx->STR, FMAC_STR_READY) != 0UL) ? SET : RESET);
+}
+
+/**
+ * @brief  Get calculation results.
+ * @param  [in] FMACx           Pointer to FMAC instance register base.
+ * This parameter can be a value of the following:
+ *   @arg  CM_FMAC1:            FMAC unit 1 instance register base
+ *   @arg  CM_FMAC2:            FMAC unit 2 instance register base
+ *   @arg  CM_FMAC3:            FMAC unit 3 instance register base
+ *   @arg  CM_FMAC4:            FMAC unit 4 instance register base
+ * @param  [out] pstcResult     Get result.
+ *         u32ResultHigh:       The high value of the result
+ *         u32ResultLow:        The low value of the result
+ * @retval int32_t:
+ *           - LL_OK: Success
+ *           - LL_ERR_INVD_PARAM: pstcResult == NULL
+ */
+int32_t FMAC_GetResult(const CM_FMAC_TypeDef *FMACx, stc_fmac_result_t *pstcResult)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    DDL_ASSERT(IS_FMAC_UNIT(FMACx));
+
+    if (pstcResult != NULL) {
+        pstcResult->u32ResultHigh = READ_REG32(FMACx->RTR0);
+        pstcResult->u32ResultLow  = READ_REG32(FMACx->RTR1);
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_FMAC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/
+

--- a/hc32f4a2/src/hc32_ll_gpio.c
+++ b/hc32f4a2/src/hc32_ll_gpio.c
@@ -1,0 +1,738 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_gpio.c
+ * @brief This file provides firmware functions to manage the General Purpose
+ *        Input/Output(GPIO).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add API GPIO_AnalogCmd() and GPIO_ExIntCmd()
+   2023-06-30       CDT             Modify GPIO_SetFunc()
+                                    Rename GPIO_ExIntCmd() as GPIO_ExtIntCmd
+                                    Optimize API: GPIO_Init(), GPIO_SetFunc(), GPIO_SubFuncCmd(), GPIO_InputMOSCmd(), GPIO_AnalogCmd(), GPIO_ExtIntCmd()
+   2023-12-15       CDT             Add assert for GPIO register lock status in API GPIO_AnalogCmd(), GPIO_ExtIntCmd()
+   2024-06-30       CDT             clear EFEN bit or NOCEN bit in GPIO_ExtIntCmd() before enable interrupt
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_gpio.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_GPIO GPIO
+ * @brief GPIO Driver Library
+ * @{
+ */
+
+#if (LL_GPIO_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Local_Types GPIO Local Types
+ * @{
+ */
+/**
+ * @brief  GPIO port pin table definition
+ */
+typedef struct {
+    uint8_t u8Port;             /*!< GPIO Port Source, @ref GPIO_Port_Source for details       */
+    uint16_t u16PinMask;        /*!< Pin active or inactive, @ref GPIO_All_Pins_Define for details       */
+} stc_gpio_port_pin_tbl_t;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Local_Macros GPIO Local Macros
+ * @{
+ */
+/**
+ * @defgroup GPIO_Registers_Setting_definition GPIO Registers setting definition
+ * @{
+ */
+#define GPIO_PSPCR_RST_VALUE            (0x001FU)
+#define GPIO_PCCR_RST_VALUE             (0x1000U)
+#define GPIO_PINAER_RST_VALUE           (0x0000U)
+#define GPIO_PIN_NUM_MAX                (16U)
+#define GPIO_PORT_OFFSET                (0x40UL)
+#define GPIO_PIN_OFFSET                 (0x04UL)
+#define GPIO_REG_OFFSET                 (0x10UL)
+#define GPIO_REG_TYPE                   uint16_t
+#define GPIO_PIDR_BASE                  ((uint32_t)(&CM_GPIO->PIDRA))
+#define GPIO_PODR_BASE                  ((uint32_t)(&CM_GPIO->PODRA))
+#define GPIO_POSR_BASE                  ((uint32_t)(&CM_GPIO->POSRA))
+#define GPIO_PORR_BASE                  ((uint32_t)(&CM_GPIO->PORRA))
+#define GPIO_POTR_BASE                  ((uint32_t)(&CM_GPIO->POTRA))
+#define GPIO_POER_BASE                  ((uint32_t)(&CM_GPIO->POERA))
+#define GPIO_PCR_BASE                   ((uint32_t)(&CM_GPIO->PCRA0))
+#define GPIO_PFSR_BASE                  ((uint32_t)(&CM_GPIO->PFSRA0))
+
+#define PIDR_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_PIDR_BASE + GPIO_REG_OFFSET * (x)))
+#define PODR_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_PODR_BASE + GPIO_REG_OFFSET * (x)))
+#define POSR_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_POSR_BASE + GPIO_REG_OFFSET * (x)))
+#define PORR_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_PORR_BASE + GPIO_REG_OFFSET * (x)))
+#define POTR_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_POTR_BASE + GPIO_REG_OFFSET * (x)))
+#define POER_REG(x)     (*(__IO GPIO_REG_TYPE *)(GPIO_POER_BASE + GPIO_REG_OFFSET * (x)))
+#define PCR_REG(x, y)   (*(__IO uint16_t *)(GPIO_PCR_BASE +  (uint32_t)((x) * GPIO_PORT_OFFSET) + (y) * GPIO_PIN_OFFSET))
+#define PFSR_REG(x, y)  (*(__IO uint16_t *)(GPIO_PFSR_BASE + (uint32_t)((x) * GPIO_PORT_OFFSET) + (y) * GPIO_PIN_OFFSET))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup GPIO_Check_Parameters_Validity GPIO Check Parameters Validity
+ * @{
+ */
+/*! Parameter validity check for pin state. */
+#define IS_GPIO_PIN_STATE(state)                                                \
+(   ((state) == PIN_STAT_RST)                   ||                              \
+    ((state) == PIN_STAT_SET))
+
+/*! Parameter validity check for pin direction. */
+#define IS_GPIO_DIR(dir)                                                        \
+(   ((dir) == PIN_DIR_IN)                       ||                              \
+    ((dir) == PIN_DIR_OUT))
+
+/*! Parameter validity check for pin output type. */
+#define IS_GPIO_OUT_TYPE(type)                                                  \
+(   ((type) == PIN_OUT_TYPE_CMOS)               ||                              \
+    ((type) == PIN_OUT_TYPE_NMOS))
+
+/*! Parameter validity check for pin driver capacity. */
+#define IS_GPIO_PIN_DRV(drv)                                                    \
+(   ((drv) == PIN_LOW_DRV)                      ||                              \
+    ((drv) == PIN_MID_DRV)                      ||                              \
+    ((drv) == PIN_HIGH_DRV))
+
+/*! Parameter validity check for pin attribute. */
+#define IS_GPIO_ATTR(attr)                                                      \
+(   ((attr) == PIN_ATTR_DIGITAL)                ||                              \
+    ((attr) == PIN_ATTR_ANALOG))
+
+/*! Parameter validity check for pin latch function. */
+#define IS_GPIO_LATCH(latch)                                                    \
+(   ((latch) == PIN_LATCH_OFF)                  ||                              \
+    ((latch) == PIN_LATCH_ON))
+
+/*! Parameter validity check for internal pull-up resistor. */
+#define IS_GPIO_PIN_PU(pu)                                                      \
+(   ((pu) == PIN_PU_OFF)                        ||                              \
+    ((pu) == PIN_PU_ON))
+
+/*! Parameter validity check for pin state invert. */
+#define IS_GPIO_PIN_INVERT(invert)                                              \
+(   ((invert) == PIN_INVT_OFF)                  ||                              \
+    ((invert) == PIN_INVT_ON))
+
+/*! Parameter validity check for pin input type. */
+#define IS_GPIO_IN_TYPE(type)                                                   \
+(   ((type) == PIN_IN_TYPE_SMT)                 ||                              \
+    ((type) == PIN_IN_TYPE_CMOS))
+
+/*! Parameter validity check for external interrupt function. */
+#define IS_GPIO_EXTINT(extint)                                                  \
+(   ((extint) == PIN_EXTINT_OFF)                ||                              \
+    ((extint) == PIN_EXTINT_ON))
+
+/*! Parameter validity check for pin number. */
+#define IS_GPIO_PIN(pin)                                                        \
+(   ((pin) != 0U)                               &&                              \
+    (((pin) & GPIO_PIN_ALL) != 0U))
+
+/*! Parameter validity check for port source. */
+#define IS_GPIO_PORT(port)                                                      \
+(   ((port) == GPIO_PORT_A)                     ||                              \
+    ((port) == GPIO_PORT_B)                     ||                              \
+    ((port) == GPIO_PORT_C)                     ||                              \
+    ((port) == GPIO_PORT_D)                     ||                              \
+    ((port) == GPIO_PORT_E)                     ||                              \
+    ((port) == GPIO_PORT_F)                     ||                              \
+    ((port) == GPIO_PORT_G)                     ||                              \
+    ((port) == GPIO_PORT_H)                     ||                              \
+    ((port) == GPIO_PORT_I))
+
+/*! Parameter validity check for pin function. */
+#define IS_GPIO_FUNC(func)                                                      \
+(   ((func) <= GPIO_FUNC_20)                    ||                              \
+    (((func) >= GPIO_FUNC_32) && ((func) <= GPIO_FUNC_63)))
+
+/*! Parameter validity check for debug pin definition. */
+#define IS_GPIO_DEBUG_PORT(port)                                                \
+(   ((port) != 0U)                              &&                              \
+    (((port) | GPIO_PIN_DEBUG) == GPIO_PIN_DEBUG))
+
+/*! Parameter validity check for pin read wait cycle. */
+#define IS_GPIO_READ_WAIT(wait)                                                 \
+(   ((wait) == GPIO_RD_WAIT0)                   ||                              \
+    ((wait) == GPIO_RD_WAIT1)                   ||                              \
+    ((wait) == GPIO_RD_WAIT2)                   ||                              \
+    ((wait) == GPIO_RD_WAIT3)                   ||                              \
+    ((wait) == GPIO_RD_WAIT4)                   ||                              \
+    ((wait) == GPIO_RD_WAIT5)                   ||                              \
+    ((wait) == GPIO_RD_WAIT6)                   ||                              \
+    ((wait) == GPIO_RD_WAIT7))
+
+/*  Check GPIO register lock status. */
+#define IS_GPIO_UNLOCK()      (GPIO_PWPR_WE == (CM_GPIO->PWPR & GPIO_PWPR_WE))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Local_Variables GPIO Local Variables
+ * @{
+ */
+static const stc_gpio_port_pin_tbl_t m_astcGpioPortPinTbl[] = {
+    {GPIO_PORT_A, GPIO_PIN_A_ALL},
+    {GPIO_PORT_B, GPIO_PIN_B_ALL},
+    {GPIO_PORT_C, GPIO_PIN_C_ALL},
+    {GPIO_PORT_D, GPIO_PIN_D_ALL},
+    {GPIO_PORT_E, GPIO_PIN_E_ALL},
+    {GPIO_PORT_F, GPIO_PIN_F_ALL},
+    {GPIO_PORT_G, GPIO_PIN_G_ALL},
+    {GPIO_PORT_H, GPIO_PIN_H_ALL},
+    {GPIO_PORT_I, GPIO_PIN_I_ALL},
+
+};
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup GPIO_Global_Functions GPIO Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initialize GPIO.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] pstcGpioInit: Pointer to a stc_gpio_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: GPIO initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t GPIO_Init(uint8_t u8Port, uint16_t u16Pin, const stc_gpio_init_t *pstcGpioInit)
+{
+    uint8_t u8PinPos;
+    uint16_t u16PCRVal;
+    uint16_t u16PCRMask;
+    int32_t i32Ret = LL_OK;
+    __IO uint16_t *PCRx;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcGpioInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Parameter validity checking */
+        DDL_ASSERT(IS_GPIO_UNLOCK());
+        DDL_ASSERT(IS_GPIO_PORT(u8Port));
+        DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+        DDL_ASSERT(IS_GPIO_PIN_STATE(pstcGpioInit->u16PinState));
+        DDL_ASSERT(IS_GPIO_DIR(pstcGpioInit->u16PinDir));
+        DDL_ASSERT(IS_GPIO_OUT_TYPE(pstcGpioInit->u16PinOutputType));
+        DDL_ASSERT(IS_GPIO_PIN_DRV(pstcGpioInit->u16PinDrv));
+        DDL_ASSERT(IS_GPIO_LATCH(pstcGpioInit->u16Latch));
+        DDL_ASSERT(IS_GPIO_PIN_PU(pstcGpioInit->u16PullUp));
+        DDL_ASSERT(IS_GPIO_PIN_INVERT(pstcGpioInit->u16Invert));
+        DDL_ASSERT(IS_GPIO_EXTINT(pstcGpioInit->u16ExtInt));
+        DDL_ASSERT(IS_GPIO_IN_TYPE(pstcGpioInit->u16PinInputType));
+        DDL_ASSERT(IS_GPIO_ATTR(pstcGpioInit->u16PinAttr));
+
+        for (u8PinPos = 0U; u8PinPos < GPIO_PIN_NUM_MAX; u8PinPos++) {
+            if ((u16Pin & 1U) != 0U) {
+                u16PCRVal = pstcGpioInit->u16PinState | pstcGpioInit->u16PinDir | pstcGpioInit->u16PinOutputType |  \
+                            pstcGpioInit->u16PinDrv   | pstcGpioInit->u16PullUp | pstcGpioInit->u16Invert        |  \
+                            pstcGpioInit->u16ExtInt   | pstcGpioInit->u16Latch;
+
+                u16PCRMask = GPIO_PCR_POUT            | GPIO_PCR_POUTE          | GPIO_PCR_NOD                   |  \
+                             GPIO_PCR_DRV             | GPIO_PCR_PUU            | GPIO_PCR_INVE                  |  \
+                             GPIO_PCR_INTE            | GPIO_PCR_LTE ;
+                u16PCRVal |= pstcGpioInit->u16PinAttr;
+                u16PCRMask |= GPIO_PCR_DDIS;
+
+                u16PCRVal |= pstcGpioInit->u16PinInputType;
+                u16PCRMask |= GPIO_PCR_CINSEL;
+                PCRx = &PCR_REG(u8Port, u8PinPos);
+                MODIFY_REG16(*PCRx, u16PCRMask, u16PCRVal);
+            }
+            u16Pin >>= 1U;
+            if (0U == u16Pin) {
+                break;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-init GPIO register to default value
+ * @param  None
+ * @retval None
+ */
+void GPIO_DeInit(void)
+{
+    stc_gpio_init_t stcGpioInit;
+    uint8_t i;
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    (void)GPIO_StructInit(&stcGpioInit);
+
+    for (i = 0U; i < ARRAY_SZ(m_astcGpioPortPinTbl); i++) {
+        (void)GPIO_Init(m_astcGpioPortPinTbl[i].u8Port, m_astcGpioPortPinTbl[i].u16PinMask, &stcGpioInit);
+    }
+    /* GPIO global register reset */
+    WRITE_REG16(CM_GPIO->PSPCR, GPIO_PSPCR_RST_VALUE);
+    WRITE_REG16(CM_GPIO->PCCR, GPIO_PCCR_RST_VALUE);
+
+    WRITE_REG16(CM_GPIO->PINAER, GPIO_PINAER_RST_VALUE);
+}
+
+/**
+ * @brief  Initialize GPIO config structure. Fill each pstcGpioInit with default value
+ * @param  [in] pstcGpioInit: Pointer to a stc_gpio_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: GPIO structure initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t GPIO_StructInit(stc_gpio_init_t *pstcGpioInit)
+{
+    int32_t i32Ret = LL_OK;
+    /* Check if pointer is NULL */
+    if (NULL == pstcGpioInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Reset GPIO init structure parameters values */
+        pstcGpioInit->u16PinState       = PIN_STAT_RST;
+        pstcGpioInit->u16PinDir         = PIN_DIR_IN;
+        pstcGpioInit->u16PinDrv         = PIN_LOW_DRV;
+        pstcGpioInit->u16PinAttr        = PIN_ATTR_DIGITAL;
+        pstcGpioInit->u16Latch          = PIN_LATCH_OFF;
+        pstcGpioInit->u16PullUp         = PIN_PU_OFF;
+        pstcGpioInit->u16Invert         = PIN_INVT_OFF;
+        pstcGpioInit->u16ExtInt         = PIN_EXTINT_OFF;
+        pstcGpioInit->u16PinOutputType  = PIN_OUT_TYPE_CMOS;
+        pstcGpioInit->u16PinInputType   = PIN_IN_TYPE_SMT;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  GPIO debug port configure. Set debug pins to GPIO
+ * @param  [in] u8DebugPort: @ref GPIO_DebugPin_Sel for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ *   @arg  ENABLE: set to debug port (SWD/JTAG)
+ *   @arg  DISABLE: set to GPIO
+ * @retval None
+ */
+void GPIO_SetDebugPort(uint8_t u8DebugPort, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_DEBUG_PORT(u8DebugPort));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(CM_GPIO->PSPCR, ((uint16_t)u8DebugPort & GPIO_PSPCR_SPFE));
+    } else {
+        CLR_REG16_BIT(CM_GPIO->PSPCR, ((uint16_t)u8DebugPort & GPIO_PSPCR_SPFE));
+    }
+}
+
+/**
+ * @brief  Set specified Port Pin function
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] u16Func: GPIO_FUNC_x, x can be the suffix in @ref GPIO_Function_Sel for each product
+ * @retval None
+ */
+void GPIO_SetFunc(uint8_t u8Port, uint16_t u16Pin, uint16_t u16Func)
+{
+    uint8_t u8PinPos;
+    __IO uint16_t *PFSRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+    DDL_ASSERT(IS_GPIO_FUNC(u16Func));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    for (u8PinPos = 0U; u8PinPos < GPIO_PIN_NUM_MAX; u8PinPos++) {
+        if ((u16Pin & 1U) != 0U) {
+            PFSRx = &PFSR_REG(u8Port, u8PinPos);
+            MODIFY_REG16(*PFSRx, GPIO_PFSR_FSEL, u16Func);
+        }
+        u16Pin >>= 1U;
+        if (0U == u16Pin) {
+            break;
+        }
+    }
+}
+
+/**
+ * @brief  GPIO pin sub-function ENABLE.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void GPIO_SubFuncCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState)
+{
+    uint8_t u8PinPos;
+    __IO uint16_t *PFSRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    for (u8PinPos = 0U; u8PinPos < GPIO_PIN_NUM_MAX; u8PinPos++) {
+        if ((u16Pin & 1U) != 0U) {
+            PFSRx = &PFSR_REG(u8Port, u8PinPos);
+            if (ENABLE == enNewState) {
+                SET_REG16_BIT(*PFSRx, PIN_SUBFUNC_ENABLE);
+            } else {
+                CLR_REG16_BIT(*PFSRx, PIN_SUBFUNC_ENABLE);
+            }
+        }
+        u16Pin >>= 1U;
+        if (0U == u16Pin) {
+            break;
+        }
+    }
+}
+
+/**
+ * @brief  Set the sub-function, it's a global configuration
+ * @param  [in] u8Func: GPIO_FUNC_x, x can be the suffix in @ref GPIO_Function_Sel for each product
+ * @retval None
+ */
+void GPIO_SetSubFunc(uint8_t u8Func)
+{
+    DDL_ASSERT(IS_GPIO_FUNC(u8Func));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    MODIFY_REG16(CM_GPIO->PCCR, GPIO_PCCR_BFSEL, u8Func);
+}
+
+/**
+ * @brief  GPIO output ENABLE.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void GPIO_OutputCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState)
+{
+    __IO GPIO_REG_TYPE *POERx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    POERx = &POER_REG(u8Port);
+    if (ENABLE == enNewState) {
+        SET_REG_BIT(*POERx, (GPIO_REG_TYPE)u16Pin);
+    } else {
+        CLR_REG_BIT(*POERx, (GPIO_REG_TYPE)u16Pin);
+    }
+}
+
+/**
+ * @brief  GPIO read wait cycle configure.
+ * @param  [in] u16ReadWait: @ref GPIO_ReadCycle_Sel for each product
+ * @retval None
+ */
+void GPIO_SetReadWaitCycle(uint16_t u16ReadWait)
+{
+    DDL_ASSERT(IS_GPIO_READ_WAIT(u16ReadWait));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    MODIFY_REG16(CM_GPIO->PCCR, GPIO_PCCR_RDWT, u16ReadWait);
+}
+
+/**
+ * @brief  GPIO input MOS always ON configure.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ *   @arg  ENABLE: set input MOS always ON
+ *   @arg  DISABLE: set input MOS turns on while read operation
+ * @retval None
+ */
+void GPIO_InputMOSCmd(uint8_t u8Port, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(CM_GPIO->PINAER, (1UL << u8Port));
+    } else {
+        CLR_REG16_BIT(CM_GPIO->PINAER, (1UL << u8Port));
+    }
+}
+
+/**
+ * @brief  Read specified GPIO input data port pins
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @retval Specified GPIO port pin input value
+ */
+en_pin_state_t GPIO_ReadInputPins(uint8_t u8Port, uint16_t u16Pin)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    return ((READ_REG(PIDR_REG(u8Port)) & (u16Pin)) != 0U) ? PIN_SET : PIN_RESET;
+}
+
+/**
+ * @brief  Read specified GPIO input data port
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @retval Specified GPIO port input value
+ */
+uint16_t GPIO_ReadInputPort(uint8_t u8Port)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+
+    return READ_REG(PIDR_REG(u8Port));
+}
+
+/**
+ * @brief  Read specified GPIO output data port pins
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @retval Specified GPIO port pin output value
+ */
+en_pin_state_t GPIO_ReadOutputPins(uint8_t u8Port, uint16_t u16Pin)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    return ((READ_REG(PODR_REG(u8Port)) & (u16Pin)) != 0U) ? PIN_SET : PIN_RESET;
+}
+
+/**
+ * @brief  Read specified GPIO output data port
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @retval Specified GPIO port output value
+ */
+uint16_t GPIO_ReadOutputPort(uint8_t u8Port)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+
+    return READ_REG(PODR_REG(u8Port));
+}
+
+/**
+ * @brief  Set specified GPIO output data port pins
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @retval None
+ */
+void GPIO_SetPins(uint8_t u8Port, uint16_t u16Pin)
+{
+    __IO GPIO_REG_TYPE *POSRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    POSRx = &POSR_REG(u8Port);
+    SET_REG_BIT(*POSRx, (GPIO_REG_TYPE)u16Pin);
+}
+
+/**
+ * @brief  Reset specified GPIO output data port pins
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @retval None
+ */
+void GPIO_ResetPins(uint8_t u8Port, uint16_t u16Pin)
+{
+    __IO GPIO_REG_TYPE *PORRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    PORRx = &PORR_REG(u8Port);
+    SET_REG_BIT(*PORRx, (GPIO_REG_TYPE)u16Pin);
+}
+
+/**
+ * @brief  Write specified GPIO data port
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16PortVal: Pin output value
+ * @retval None
+ */
+void GPIO_WritePort(uint8_t u8Port, uint16_t u16PortVal)
+{
+    __IO GPIO_REG_TYPE *PODRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+
+    PODRx = &PODR_REG(u8Port);
+    WRITE_REG(*PODRx, (GPIO_REG_TYPE)u16PortVal);
+}
+
+/**
+ * @brief  Toggle specified GPIO output data port pin
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @retval None
+ */
+void GPIO_TogglePins(uint8_t u8Port, uint16_t u16Pin)
+{
+    __IO GPIO_REG_TYPE *POTRx;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    POTRx = &POTR_REG(u8Port);
+    SET_REG_BIT(*POTRx, (GPIO_REG_TYPE)u16Pin);
+}
+
+/**
+ * @brief  GPIO Analog command.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void GPIO_AnalogCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState)
+{
+    __IO uint16_t *PCRx;
+    uint8_t u8PinPos;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    for (u8PinPos = 0U; u8PinPos < GPIO_PIN_NUM_MAX; u8PinPos++) {
+        if ((u16Pin & 1U) != 0U) {
+            PCRx = &PCR_REG(u8Port, u8PinPos);
+            if (ENABLE == enNewState) {
+                SET_REG16_BIT(*PCRx, GPIO_PCR_DDIS);
+            } else {
+                CLR_REG16_BIT(*PCRx, GPIO_PCR_DDIS);
+            }
+        }
+        u16Pin >>= 1U;
+        if (0U == u16Pin) {
+            break;
+        }
+    }
+}
+
+/**
+ * @brief  GPIO external interrupt command.
+ * @param  [in] u8Port: GPIO_PORT_x, x can be the suffix in @ref GPIO_Port_Source for each product
+ * @param  [in] u16Pin: GPIO_PIN_x, x can be the suffix in @ref GPIO_Pins_Define for each product
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void GPIO_ExtIntCmd(uint8_t u8Port, uint16_t u16Pin, en_functional_state_t enNewState)
+{
+    __IO uint16_t *PCRx;
+    uint8_t u8PinPos;
+    __IO uint32_t *EIRQCRx;
+    uint32_t EIRQ_Value;
+
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_GPIO_UNLOCK());
+    DDL_ASSERT(IS_GPIO_PORT(u8Port));
+    DDL_ASSERT(IS_GPIO_PIN(u16Pin));
+
+    for (u8PinPos = 0U; u8PinPos < GPIO_PIN_NUM_MAX; u8PinPos++) {
+        if ((u16Pin & 1U) != 0U) {
+            PCRx = &PCR_REG(u8Port, u8PinPos);
+            EIRQCRx = (__IO uint32_t *)((uint32_t)&CM_INTC->EIRQCR0 + 4UL * u8PinPos);
+            if (ENABLE == enNewState) {
+                EIRQ_Value = (uint32_t) * EIRQCRx;
+                /*  disable digital filter A */
+                CLR_REG32_BIT(*EIRQCRx, INTC_EIRQCR_EFEN);
+                /*  disable digital filter B */
+                CLR_REG32_BIT(*EIRQCRx, INTC_EIRQCR_NOCEN);
+                SET_REG16_BIT(*PCRx, GPIO_PCR_INTE);
+                WRITE_REG32(*EIRQCRx, EIRQ_Value);
+            } else {
+                CLR_REG16_BIT(*PCRx, GPIO_PCR_INTE);
+            }
+        }
+        u16Pin >>= 1U;
+        if (0U == u16Pin) {
+            break;
+        }
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_GPIO_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_hash.c
+++ b/hc32f4a2/src/hc32_ll_hash.c
@@ -1,0 +1,641 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_hash.c
+ * @brief This file provides firmware functions to manage the HASH.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add HASH_DeInit function
+   2024-06-30       CDT             Modify API about CR register for couping risk
+   2024-11-08       CDT             Fixed HASH_HMAC_Calculate function
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_hash.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_HASH HASH
+ * @brief HASH Driver Library
+ * @{
+ */
+
+#if (LL_HASH_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup HASH_Local_Macros HASH Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup HASH_Miscellaneous_Macros HASH Miscellaneous Macros
+ * @{
+ */
+#define HASH_GROUP_SIZE                 (64U)
+#define HASH_GROUP_SIZE_WORD            (HASH_GROUP_SIZE / 4U)
+#define HASH_LAST_GROUP_SIZE_MAX        (56U)
+#define HASH_TIMEOUT                    (6000U)
+#define HASH_MSG_DIGEST_SIZE_WORD       (8U)
+
+#define HASH_KEY_LONG_SIZE              (64U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Action HASH Action
+ * @{
+ */
+#define HASH_ACTION_START               (HASH_CR_START)
+#define HASH_ACTION_HMAC_END            (HASH_CR_HMAC_END)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Check_Parameters_Validity HASH Check Parameters Validity
+ * @{
+ */
+#define IS_HASH_BIT_MASK(x, mask)   (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+#define IS_HASH_MD(x)               (((x) == HASH_MD_SHA256) || ((x) == HASH_MD_HMAC))
+
+#define IS_HASH_KEY_SIZE_MD(x)      (((x) == HASH_KEY_MD_LONG_SIZE) || ((x) == HASH_KEY_MD_SHORT_SIZE))
+
+#define IS_HASH_INT(x)              IS_HASH_BIT_MASK(x, HASH_INT_ALL)
+
+#define IS_HASH_FLAG(x)             IS_HASH_BIT_MASK(x, HASH_FLAG_ALL)
+
+#define IS_HASH_FLAG_CLR(x)         IS_HASH_BIT_MASK(x, HASH_FLAG_CLR_ALL)
+
+#define IS_HASH_MSG_GRP(x)                                                     \
+(   ((x) == HASH_MSG_GRP_FIRST)                 ||                             \
+    ((x) == HASH_MSG_GRP_END)                   ||                             \
+    ((x) == HASH_MSG_GRP_ONLY_ONE))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup HASH_Local_Functions HASH Local Functions
+ * @{
+ */
+
+/**
+ * @brief  Writes the input buffer in data register.
+ * @param  [in] pu8Data       The buffer for source data
+ * @retval None
+ */
+static void HASH_WriteData(const uint8_t *pu8Data)
+{
+    uint8_t i;
+    __IO uint32_t *regDR = &CM_HASH->DR15;
+    const uint32_t *pu32Data = (const uint32_t *)((uint32_t)pu8Data);
+
+    for (i = 0U; i < HASH_GROUP_SIZE_WORD; i++) {
+        regDR[i] = __REV(pu32Data[i]);
+    }
+}
+
+/**
+ * @brief  Memory copy.
+ * @param  [in] pu8Dest                 Pointer to a destination address.
+ * @param  [in] pu8Src                  Pointer to a source address.
+ * @param  [in] u32Size                 Data size.
+ * @retval None
+ */
+static void HASH_MemCopy(uint8_t *pu8Dest, const uint8_t *pu8Src, uint32_t u32Size)
+{
+    uint32_t i = 0UL;
+    while (i < u32Size) {
+        pu8Dest[i] = pu8Src[i];
+        i++;
+    }
+}
+
+/**
+ * @brief  Memory set.
+ * @param  [in] pu8Mem                  Pointer to an address.
+ * @param  [in] u8Value                 Data value.
+ * @param  [in] u32Size                 Data size.
+ * @retval None
+ */
+static void HASH_MemSet(uint8_t *pu8Mem, uint8_t u8Value, uint32_t u32Size)
+{
+    uint32_t i = 0UL;
+    while (i < u32Size) {
+        pu8Mem[i] = u8Value;
+        i++;
+    }
+}
+
+/**
+ * @brief  Wait for the HASH to stop
+ * @param  [in]  u32Action              HASH action. This parameter can be a value of @ref HASH_Action.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+static int32_t HASH_Wait(uint32_t u32Action)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32TimeCount = 0UL;
+
+    /* Wait for the HASH to stop */
+    while (READ_REG32_BIT(CM_HASH->CR, u32Action) != 0UL) {
+        if (u32TimeCount++ > HASH_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  HASH Filling data
+ * @param  [in] pu8Data                 The source data buffer
+ * @param  [in] u32DataSize             Length of the input buffer in bytes
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+static int32_t HASH_DoCalc(const uint8_t *pu8Data, uint32_t u32DataSize)
+{
+    uint8_t  u8FillBuffer[HASH_GROUP_SIZE];
+    uint32_t u32BitLenHigh;
+    uint32_t u32BitLenLow;
+    uint32_t u32Index      = 0U;
+    uint8_t  u8FirstGroup  = 1U;
+    uint8_t  u8HashEnd     = 0U;
+    uint8_t  u8DataEndMark = 0U;
+    uint8_t u8LastGroup    = 0U;
+    int32_t i32Ret;
+
+    u32BitLenHigh = (u32DataSize >> 29U) & 0x7U;
+    u32BitLenLow  = (u32DataSize << 3U);
+
+    /* wait hash calculating stop. */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+
+    while ((i32Ret == LL_OK) && (u8HashEnd == 0U)) {
+        if (u32DataSize >= HASH_GROUP_SIZE) {
+            HASH_WriteData(&pu8Data[u32Index]);
+            u32DataSize -= HASH_GROUP_SIZE;
+            u32Index += HASH_GROUP_SIZE;
+        } else if (u32DataSize >= HASH_LAST_GROUP_SIZE_MAX) {
+            HASH_MemSet(u8FillBuffer, 0U, HASH_GROUP_SIZE);
+            HASH_MemCopy(u8FillBuffer, &pu8Data[u32Index], u32DataSize);
+            u8FillBuffer[u32DataSize] = 0x80U;
+            u8DataEndMark = 1U;
+            HASH_WriteData(u8FillBuffer);
+            u32DataSize = 0U;
+        } else {
+            u8HashEnd = 1U;
+        }
+
+        if (u8HashEnd != 0U) {
+            HASH_MemSet(u8FillBuffer, 0U, HASH_GROUP_SIZE);
+            if (u32DataSize > 0U) {
+                HASH_MemCopy(u8FillBuffer, &pu8Data[u32Index], u32DataSize);
+            }
+            if (u8DataEndMark == 0U) {
+                u8FillBuffer[u32DataSize] = 0x80U;
+            }
+            u8FillBuffer[63U] = (uint8_t)(u32BitLenLow);
+            u8FillBuffer[62U] = (uint8_t)(u32BitLenLow >> 8U);
+            u8FillBuffer[61U] = (uint8_t)(u32BitLenLow >> 16U);
+            u8FillBuffer[60U] = (uint8_t)(u32BitLenLow >> 24U);
+            u8FillBuffer[59U] = (uint8_t)(u32BitLenHigh);
+            u8FillBuffer[58U] = (uint8_t)(u32BitLenHigh >> 8U);
+            u8FillBuffer[57U] = (uint8_t)(u32BitLenHigh >> 16U);
+            u8FillBuffer[56U] = (uint8_t)(u32BitLenHigh >> 24U);
+            HASH_WriteData(u8FillBuffer);
+            u8LastGroup = 1U;
+        }
+
+        /* First group and last group check */
+        /* check if first group */
+        if (u8FirstGroup != 0U) {
+            u8FirstGroup = 0U;
+            /* Set first group. */
+            SET_REG32_BIT(CM_HASH->CR, HASH_CR_FST_GRP | HASH_FLAG_CLR_ALL);
+        }
+        /* check if last group */
+        if (u8LastGroup != 0U) {
+            u8LastGroup = 0U;
+            /* Set last group. */
+            SET_REG32_BIT(CM_HASH->CR, HASH_CR_KMSG_END | HASH_FLAG_CLR_ALL);
+        }
+        /* Start hash calculating. */
+        SET_REG32_BIT(CM_HASH->CR, HASH_CR_START | HASH_FLAG_CLR_ALL);
+        i32Ret = HASH_Wait(HASH_ACTION_START);
+    }
+
+    /* Stop hash calculating. */
+    MODIFY_REG32(CM_HASH->CR, HASH_CR_START | HASH_FLAG_CLR_ALL, ~HASH_CR_START);
+    return i32Ret;
+}
+
+/**
+ * @brief  Read message digest.
+ * @param  [out] pu8MsgDigest           Buffer for message digest.
+ * @retval None
+ */
+static void HASH_ReadMsgDigest(uint8_t *pu8MsgDigest)
+{
+    uint8_t i;
+    __IO uint32_t *regHR = &CM_HASH->HR7;
+    uint32_t *pu32MsgDigest = (uint32_t *)((uint32_t)pu8MsgDigest);
+
+    for (i = 0U; i < HASH_MSG_DIGEST_SIZE_WORD; i++) {
+        pu32MsgDigest[i] = __REV(regHR[i]);
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup HASH_Global_Functions HASH Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-initializes HASH.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ */
+int32_t HASH_DeInit(void)
+{
+    uint8_t i;
+    __IO uint32_t *regDR = &CM_HASH->DR15;
+
+    WRITE_REG32(CM_HASH->CR,  0UL);
+    for (i = 0U; i < HASH_GROUP_SIZE_WORD; i++) {
+        WRITE_REG32(regDR[i],  0UL);
+    }
+    return LL_OK;
+}
+
+/**
+ * @brief  HASH calculate.
+ * @param  [in]  pu8SrcData             Pointer to the source data buffer.
+ * @param  [in]  u32SrcDataSize         Length of the source data buffer in bytes.
+ * @param  [out] pu8MsgDigest           Buffer of the digest. The size must be 32 bytes.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       Parameter error.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ */
+int32_t HASH_Calculate(const uint8_t *pu8SrcData, uint32_t u32SrcDataSize, uint8_t *pu8MsgDigest)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pu8SrcData != NULL) && (u32SrcDataSize != 0UL) && (pu8MsgDigest != NULL)) {
+        /* Set HASH mode */
+        (void)HASH_SetMode(HASH_MD_SHA256);
+        i32Ret = HASH_DoCalc(pu8SrcData, u32SrcDataSize);
+        if (i32Ret == LL_OK) {
+            /* Get the message digest result */
+            HASH_ReadMsgDigest(pu8MsgDigest);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Wait for the flag
+ * @param  [in]  u32Action              HASH action. This parameter can be a value of @ref HASH_Action.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+static int32_t FLAG_Wait(uint32_t u32Action)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32TimeCount = 0UL;
+
+    /* Wait for the flag */
+    while (READ_REG32_BIT(CM_HASH->CR, u32Action) == 0UL) {
+        if (u32TimeCount++ > HASH_TIMEOUT) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  HMAC calculate.
+ * @param  [in]  pu8SrcData             Pointer to the source data buffer.
+ * @param  [in]  u32SrcDataSize         Length of the source data buffer in bytes.
+ * @param  [in]  pu8Key                 Buffer of the secret key.
+ * @param  [in]  u32KeySize             Size of the input secret key in bytes.
+ * @param  [out] pu8MsgDigest           Buffer of the digest data buffer. The size must be 32 bytes.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       Parameter error.
+ *           - LL_ERR_BUF_FULL:         Data filling error.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ */
+int32_t HASH_HMAC_Calculate(const uint8_t *pu8SrcData, uint32_t u32SrcDataSize,
+                            const uint8_t *pu8Key, uint32_t u32KeySize,
+                            uint8_t *pu8MsgDigest)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint8_t u8FillBuffer[HASH_GROUP_SIZE] = {0U};
+
+    if ((pu8SrcData != NULL) && (u32SrcDataSize != 0UL) && \
+        (pu8Key != NULL) && (u32KeySize != 0UL) && (pu8MsgDigest != NULL)) {
+        /* Set HMAC Mode */
+        (void)HASH_SetMode(HASH_MD_HMAC);
+        if (u32KeySize > HASH_KEY_LONG_SIZE) {
+            /* Key size longer than 64 bytes. */
+            SET_REG32_BIT(CM_HASH->CR, HASH_CR_LKEY | HASH_FLAG_CLR_ALL);
+            /* Write the key to the data register */
+            i32Ret = HASH_DoCalc(pu8Key, u32KeySize);
+        } else {
+            /* We need the rest of it to be 0 */
+            HASH_MemSet(u8FillBuffer, 0U, HASH_GROUP_SIZE);
+            HASH_MemCopy(u8FillBuffer, pu8Key, u32KeySize);
+            /* Key size equal to or shorter than 64 bytes. */
+            MODIFY_REG32(CM_HASH->CR, HASH_CR_LKEY | HASH_FLAG_CLR_ALL, ~HASH_CR_LKEY);
+            /* Write the key to the data register */
+            HASH_WriteData(u8FillBuffer);
+            /* Only one group. */
+            SET_REG32_BIT(CM_HASH->CR, HASH_MSG_GRP_ONLY_ONE | HASH_FLAG_CLR_ALL);
+            /* Start hash calculating. */
+            SET_REG32_BIT(CM_HASH->CR, HASH_CR_START | HASH_FLAG_CLR_ALL);
+            /* Wait for operation completion */
+            i32Ret = HASH_Wait(HASH_ACTION_START);
+        }
+        /* Clear operation completion flag */
+        MODIFY_REG32(CM_HASH->CR, HASH_FLAG_CLR_ALL, ~HASH_FLAG_CYC_END);
+
+        if (i32Ret == LL_OK) {
+            i32Ret = HASH_DoCalc(pu8SrcData, u32SrcDataSize);
+            /* Write the message to the data register */
+            if (i32Ret == LL_OK) {
+                /* Write hmac Operation complete */
+                i32Ret = FLAG_Wait(HASH_ACTION_HMAC_END);
+                if (i32Ret == LL_OK) {
+                    /* Clear operation completion flag */
+                    CLR_REG32_BIT(CM_HASH->CR, HASH_FLAG_CLR_ALL);
+                    /* Get the message digest result */
+                    HASH_ReadMsgDigest(pu8MsgDigest);
+                }
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable HASH interrupt.
+ * @param  [in] u32HashInt              Specifies the HASH interrupt to check.
+ *                                      This parameter can be values of @ref HASH_Interrupt
+ *   @arg  HASH_INT_GRP:                A set of data operations complete interrupt.
+ *   @arg  HASH_INT_ALL_CPLT:           All data operations complete interrupt.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ */
+int32_t HASH_IntCmd(uint32_t u32HashInt, en_functional_state_t enNewState)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_HASH_INT(u32HashInt));
+
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        if (enNewState == ENABLE) {
+            SET_REG32_BIT(CM_HASH->CR, u32HashInt | HASH_FLAG_CLR_ALL);
+        } else {
+            MODIFY_REG32(CM_HASH->CR, HASH_INT_ALL | HASH_FLAG_CLR_ALL, ~u32HashInt);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get the status of the specified HASH flag.
+ * @param  [in] u32Flag                 HASH status flag.
+ *                                      This parameter can be a value of @ref HASH_Status_Flag
+ *   @arg  HASH_FLAG_START:             Operation in progress.
+ *   @arg  HASH_FLAG_BUSY:              Operation in progress.
+ *   @arg  HASH_FLAG_CYC_END:           key or message operation completed.
+ *   @arg  HASH_FLAG_HMAC_END:          HMAC operation completed.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t HASH_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_HASH_FLAG(u32Flag));
+    if (READ_REG32_BIT(CM_HASH->CR, u32Flag) != 0UL) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified HASH flag.
+ * @param  [in] u32Flag                 HASH status flag.
+ *                                      This parameter can be a value of @ref HASH_Status_Flag
+ *   @arg  HASH_FLAG_CYC_END:           Clear the key or message operation completed flag
+ *   @arg  HASH_FLAG_HMAC_END:          Clear the HMAC operation completed flag
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+int32_t HASH_ClearStatus(uint32_t u32Flag)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_HASH_FLAG_CLR(u32Flag));
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        MODIFY_REG32(CM_HASH->CR, HASH_FLAG_CLR_ALL, ~u32Flag);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Specifies HASH mode: SHA256 mode or HMAC mode.
+ * @param  [in] u32HashMode             HASH mode selection.
+ *                                      This parameter can be a value of @ref HASH_Mode
+ *   @arg  HASH_MD_SHA256:              SHA256 mode
+ *   @arg  HASH_MD_HMAC:                HMAC mode
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+int32_t HASH_SetMode(uint32_t u32HashMode)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_HASH_MD(u32HashMode));
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        MODIFY_REG32(CM_HASH->CR, HASH_CR_MODE | HASH_FLAG_CLR_ALL, u32HashMode | HASH_FLAG_CLR_ALL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set HASH key size mode.
+ * @param  [in] u32SizeMode             Key size mode.
+ *                                      This parameter can be a value of @ref HASH_Key_Size_Mode
+ *   @arg  HASH_KEY_MD_LONG_SIZE:       Key size > 64 Bytes
+ *   @arg  HASH_KEY_MD_SHORT_SIZE:      Key size <= 64 Bytes
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+int32_t HASH_SetKeySizeMode(uint32_t u32SizeMode)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_HASH_KEY_SIZE_MD(u32SizeMode));
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        MODIFY_REG32(CM_HASH->CR, HASH_CR_LKEY | HASH_FLAG_CLR_ALL, u32SizeMode | HASH_FLAG_CLR_ALL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set message group.
+ * @param  [in] u32MsgGroup             First group or Last group of messages.
+ *                                      This parameter can be a value of @ref HASH_Msg_Group
+
+ *   @arg  HASH_MSG_GRP_FIRST:          The first group of messages or keys
+ *   @arg  HASH_MSG_GRP_END:            The last group of messages or keys
+ *   @arg  HASH_MSG_GRP_ONLY_ONE:       Only one set of message or key
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+int32_t HASH_SetMsgGroup(uint32_t u32MsgGroup)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_HASH_MSG_GRP(u32MsgGroup));
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        MODIFY_REG32(CM_HASH->CR, HASH_MSG_GRP_ONLY_ONE | HASH_FLAG_CLR_ALL, u32MsgGroup | HASH_FLAG_CLR_ALL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Start HASH.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred
+ *           - LL_ERR_TIMEOUT:          Works timeout
+ */
+int32_t HASH_Start(void)
+{
+    int32_t i32Ret;
+
+    /* Wait for the HASH to stop */
+    i32Ret = HASH_Wait(HASH_ACTION_START);
+    if (i32Ret == LL_OK) {
+        /* Start hash calculating. */
+        SET_REG32_BIT(CM_HASH->CR, HASH_CR_START | HASH_FLAG_CLR_ALL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Provides the message digest result.
+ * @param  [out] pu8MsgDigest           Buffer for message digest.
+ * @retval None
+ */
+void HASH_GetMsgDigest(uint8_t *pu8MsgDigest)
+{
+    HASH_ReadMsgDigest(pu8MsgDigest);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_HASH_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/src/hc32_ll_hrpwm.c
+++ b/hc32f4a2/src/hc32_ll_hrpwm.c
@@ -1,0 +1,383 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_hrpwm.c
+ * @brief This file provides firmware functions to manage the High Resolution
+ *        Pulse-Width Modulation(HRPWM).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify typo
+   2024-11-08       CDT             unified the abbreviation of Calibrate
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_hrpwm.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_HRPWM HRPWM
+ * @brief HRPWM Driver Library
+ * @{
+ */
+
+#if (LL_HRPWM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup HRPWM_Local_Macros HRPWM Local Macros
+ * @{
+ */
+
+/* About 1mS timeout */
+#define HRPWM_CALIB_TIMEOUT             (HCLK_VALUE/1000UL)
+#define HRPWM_PCLK0_MIN                 (120000000UL)
+
+#define HRPWM_SYSCLKSRC_HRC             (0x00U)
+#define HRPWM_SYSCLKSRC_MRC             (0x01U)
+#define HRPWM_SYSCLKSRC_LRC             (0x02U)
+#define HRPWM_SYSCLKSRC_XTAL            (0x03U)
+#define HRPWM_SYSCLKSRC_XTAL32          (0x04U)
+#define HRPWM_SYSCLKSRC_PLL             (0x05U)
+
+#define HRPWM_PLLSRC_XTAL               (0x00UL)
+#define HRPWM_PLLSRC_HRC                (0x01UL)
+
+/**
+ * @defgroup HRPWM_Check_Param_Validity HRPWM Check Parameters Validity
+ * @{
+ */
+
+/*! Parameter valid check for HRPWM output channel */
+#define IS_HRPWM_CH(x)                                                         \
+(   ((x) >= HRPWM_CH_MIN)                       &&                             \
+    ((x) <= HRPWM_CH_MAX))
+
+/*! Parameter valid check for HRPWM calibration unit */
+#define IS_HRPWM_CALIB_UNIT(x)                                                 \
+(   (HRPWM_CALIB_UNIT0 == (x))                  ||                             \
+    (HRPWM_CALIB_UNIT1 == (x)))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup HRPWM_Global_Functions HRPWM Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Process for getting HRPWM Calibrate function code
+ * @param  [in] u32Unit             Calibrate unit, the parameter should be HRPWM_CALIB_UNIT0 or HRPWM_CALIB_UNIT1
+ * @param  [out] pu8Code            The pointer to get calibrate code.
+ * @retval int32_t:
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Time out
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t HRPWM_CalibProcess(uint32_t u32Unit, uint8_t *pu8Code)
+{
+    __IO uint32_t u32Timeout = HRPWM_CALIB_TIMEOUT;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL != pu8Code) {
+        /* Enable calibrate */
+        HRPWM_CalibCmd(u32Unit, ENABLE);
+        /* Wait calibrate finish flag */
+        while (DISABLE == HRPWM_GetCalibState(u32Unit)) {
+            if (0UL == u32Timeout--) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+        }
+
+        if (LL_OK == i32Ret) {
+            /* Get calibrate code */
+            *pu8Code = HRPWM_GetCalibCode(u32Unit);
+        }
+    } else {
+        i32Ret = LL_ERR_INVD_PARAM;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  HRPWM Calibrate function enable or disable for specified unit
+ * @param  [in] u32Unit             Calibrate unit, the parameter should be HRPWM_CALIB_UNIT0 or HRPWM_CALIB_UNIT1
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void HRPWM_CalibCmd(uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CALCRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CALIB_UNIT(u32Unit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CALCRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CALCR0) + 4UL * u32Unit);
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*CALCRx, HRPWM_CALCR_CALEN);
+    } else {
+        CLR_REG32_BIT(*CALCRx, HRPWM_CALCR_CALEN);
+    }
+}
+
+/**
+ * @brief  HRPWM Calibrate function status get for specified unit
+ * @param  [in] u32Unit             Calibrate unit, the parameter should be HRPWM_CALIB_UNIT0 or HRPWM_CALIB_UNIT1
+ * @retval An @ref en_functional_state_t enumeration value.
+ */
+en_functional_state_t HRPWM_GetCalibState(uint32_t u32Unit)
+{
+    en_functional_state_t enRet;
+    __IO uint32_t *CALCRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CALIB_UNIT(u32Unit));
+
+    CALCRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CALCR0) + 4UL * u32Unit);
+
+    if (0UL != READ_REG32_BIT(*CALCRx, HRPWM_CALCR_ENDF)) {
+        enRet = ENABLE;
+    } else {
+        enRet = DISABLE;
+    }
+    return enRet;
+}
+
+/**
+ * @brief  HRPWM Calibrate code get for specified unit
+ * @param  [in] u32Unit             Calibrate unit, the parameter should be HRPWM_CALIB_UNIT0 or HRPWM_CALIB_UNIT1
+ * @retval uint8_t:                 The calibration code.
+ */
+uint8_t HRPWM_GetCalibCode(uint32_t u32Unit)
+{
+    __IO uint32_t *CALCRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CALIB_UNIT(u32Unit));
+
+    CALCRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CALCR0) + 4UL * u32Unit);
+
+    return ((uint8_t)(READ_REG32(*CALCRx)));
+}
+
+/**
+ * @brief  HRPWM function enable or disable for specified channel
+ * @param  [in] u32Ch               Channel, the parameter should range from HRPWM_CH_MIN to HRPWM_CH_MAX
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void HRPWM_ChCmd(uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CR1) + 4UL * (u32Ch - 1UL));
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*CRx, HRPWM_CR_EN);
+    } else {
+        CLR_REG32_BIT(*CRx, HRPWM_CR_EN);
+    }
+}
+
+/**
+ * @brief  HRPWM positive edge adjust enable or disable for specified channel
+ * @param  [in] u32Ch               Channel, the parameter should range from HRPWM_CH_MIN to HRPWM_CH_MAX
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void HRPWM_ChPositiveAdjustCmd(uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CR1) + 4UL * (u32Ch - 1UL));
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*CRx, HRPWM_CR_PE);
+    } else {
+        CLR_REG32_BIT(*CRx, HRPWM_CR_PE);
+    }
+}
+
+/**
+ * @brief  HRPWM negative edge adjust enable or disable for specified channel
+ * @param  [in] u32Ch               Channel, the parameter should range from HRPWM_CH_MIN to HRPWM_CH_MAX
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void HRPWM_ChNegativeAdjustCmd(uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    CRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CR1) + 4UL * (u32Ch - 1UL));
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*CRx, HRPWM_CR_NE);
+    } else {
+        CLR_REG32_BIT(*CRx, HRPWM_CR_NE);
+    }
+}
+
+/**
+ * @brief  HRPWM positive edge adjust delay counts configuration for specified channel
+ * @param  [in] u32Ch               Channel, the parameter should range from HRPWM_CH_MIN to HRPWM_CH_MAX
+ * @param  [in] u8DelayNum          Delay counts of minimum delay time.
+ * @retval None
+ */
+void HRPWM_ChPositiveAdjustConfig(uint32_t u32Ch, uint8_t u8DelayNum)
+{
+    __IO uint32_t *CRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CH(u32Ch));
+
+    CRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CR1) + 4UL * (u32Ch - 1UL));
+    MODIFY_REG32(*CRx, HRPWM_CR_PSEL, ((uint32_t)u8DelayNum - 1UL) << HRPWM_CR_PSEL_POS);
+}
+
+/**
+ * @brief  HRPWM negative edge adjust delay counts configuration for specified channel
+ * @param  [in] u32Ch               Channel, the parameter should range from HRPWM_CH_MIN to HRPWM_CH_MAX
+ * @param  [in] u8DelayNum          Delay counts of minimum delay time.
+ * @retval None
+ */
+void HRPWM_ChNegativeAdjustConfig(uint32_t u32Ch, uint8_t u8DelayNum)
+{
+    __IO uint32_t *CRx;
+    /* Check parameters */
+    DDL_ASSERT(IS_HRPWM_CH(u32Ch));
+
+    CRx = (__IO uint32_t *)(((uint32_t)&CM_HRPWM->CR1) + 4UL * (u32Ch - 1UL));
+    MODIFY_REG32(*CRx, HRPWM_CR_NSEL, ((uint32_t)u8DelayNum - 1UL) << HRPWM_CR_NSEL_POS);
+}
+
+/**
+ * @brief  HRPWM Judge the condition of calibration function.
+ * @param  None
+ * @retval An @ref en_functional_state_t enumeration value.
+ */
+en_functional_state_t HRPWM_CondConfirm(void)
+{
+    en_functional_state_t enRet = ENABLE;
+    uint32_t plln;
+    uint32_t pllp;
+    uint32_t pllm;
+    uint32_t u32SysclkFreq;
+    uint32_t u32Pclk0Freq;
+
+    switch (READ_REG8_BIT(CM_CMU->CKSWR, CMU_CKSWR_CKSW)) {
+        case HRPWM_SYSCLKSRC_HRC:
+            /* HRC is used to system clock */
+            u32SysclkFreq = HRC_VALUE;
+            break;
+        case HRPWM_SYSCLKSRC_MRC:
+            /* MRC is used to system clock */
+            u32SysclkFreq = MRC_VALUE;
+            break;
+        case HRPWM_SYSCLKSRC_LRC:
+            /* LRC is used to system clock */
+            u32SysclkFreq = LRC_VALUE;
+            break;
+        case HRPWM_SYSCLKSRC_XTAL:
+            /* XTAL is used to system clock */
+            u32SysclkFreq = XTAL_VALUE;
+            break;
+        case HRPWM_SYSCLKSRC_XTAL32:
+            /* XTAL32 is used to system clock */
+            u32SysclkFreq = XTAL32_VALUE;
+            break;
+        case HRPWM_SYSCLKSRC_PLL:
+            /* PLLHP is used as system clock. */
+            pllp = (uint32_t)((CM_CMU->PLLHCFGR >> CMU_PLLHCFGR_PLLHP_POS) & 0x0FUL);
+            plln = (uint32_t)((CM_CMU->PLLHCFGR >> CMU_PLLHCFGR_PLLHN_POS) & 0xFFUL);
+            pllm = (uint32_t)((CM_CMU->PLLHCFGR >> CMU_PLLHCFGR_PLLHM_POS) & 0x03UL);
+
+            /* fpll = ((pllin / pllm) * plln) / pllp */
+            if (HRPWM_PLLSRC_XTAL == READ_REG32_BIT(CM_CMU->PLLHCFGR, CMU_PLLHCFGR_PLLSRC)) {
+                u32SysclkFreq = ((XTAL_VALUE / (pllm + 1UL)) * (plln + 1UL)) / (pllp + 1UL);
+            } else {
+                u32SysclkFreq = ((HRC_VALUE / (pllm + 1UL)) * (plln + 1UL)) / (pllp + 1UL);
+            }
+            break;
+        default:
+            u32SysclkFreq = HRC_VALUE;
+            enRet = DISABLE;
+            break;
+    }
+
+    if (ENABLE == enRet) {
+        /* Get pclk0. */
+        u32Pclk0Freq = u32SysclkFreq >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK0S) >> CMU_SCFGR_PCLK0S_POS);
+
+        if (u32Pclk0Freq < HRPWM_PCLK0_MIN) {
+            enRet = DISABLE;
+        }
+    }
+    return enRet;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_HRPWM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_i2c.c
+++ b/hc32f4a2/src/hc32_ll_i2c.c
@@ -1,0 +1,1235 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_i2c.c
+ * @brief This file provides firmware functions to manage the Inter-Integrated
+ *        Circuit(I2C).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add API I2C_SlaveAddrCmd(), modify API I2C_SlaveAddrConfig()
+   2023-06-30       CDT             Disable slave address function in I2C_Init()
+                                    Move macro define I2C_SRC_CLK to head file
+   2023-12-15       CDT             Modify I2C_Restart()
+                                    Modify macro IS_I2C_INT_FLAG -> IS_I2C_INT
+   2024-06-30       CDT             Modify I2C_CR1_ENGC to I2C_CR1_GCEN
+                                    Modify the I2C_BaudrateConfig func rounding off method
+                                    Modify duty cycle for SCL
+   2024-11-08       CDT             Modify I2C_CCR_FREQ to I2C_CCR_CKDIV
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_i2c.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_I2C I2C
+ * @brief I2C Driver Library
+ * @{
+ */
+
+#if (LL_I2C_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup I2C_Local_Macros I2C Local Macros
+ * @{
+ */
+#define I2C_BAUDRATE_MAX                (400000UL)
+
+#define I2C_SCL_HIGH_LOW_LVL_SUM_MAX    ((float32_t)(0x1F + 0x1F))
+#define I2C_7BIT_MAX                    (0x7FUL)
+#define I2C_10BIT_MAX                   (0x3FFUL)
+
+/**
+ * @defgroup I2C_Check_Parameters_Validity I2C Check Parameters Validity
+ * @{
+ */
+
+#define IS_I2C_UNIT(x)                                                         \
+(   ((x) == CM_I2C1)                        ||                                 \
+    ((x) == CM_I2C2)                        ||                                 \
+    ((x) == CM_I2C3)                        ||                                 \
+    ((x) == CM_I2C4)                        ||                                 \
+    ((x) == CM_I2C5)                        ||                                 \
+    ((x) == CM_I2C6))
+
+#define IS_I2C_DIG_FILTER_CLK(x)        ((x) <= I2C_DIG_FILTER_CLK_DIV4)
+
+#define IS_I2C_7BIT_ADDR(x)             ((x) <= I2C_7BIT_MAX)
+#define IS_I2C_10BIT_ADDR(x)            ((x) <= I2C_10BIT_MAX)
+
+#define IS_I2C_SPEED(x)                                                        \
+(   ((x) != 0U)                                     &&                         \
+    ((x) <= I2C_BAUDRATE_MAX))
+
+#define IS_I2C_FLAG(x)                                                         \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | I2C_FLAG_ALL) == I2C_FLAG_ALL))
+
+#define IS_I2C_CLR_FLAG(x)                                                     \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | I2C_FLAG_CLR_ALL) == I2C_FLAG_CLR_ALL))
+
+#define IS_I2C_INT(x)                                                          \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | I2C_INT_ALL) == I2C_INT_ALL))
+
+#define IS_I2C_SMBUS_CONFIG(x)                                                 \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | I2C_SMBUS_MATCH_ALL) == I2C_SMBUS_MATCH_ALL))
+
+#define IS_I2C_ADDR(mode, addr)                                                \
+(   ((I2C_ADDR_7BIT == (mode)) && ((addr) <= 0x7FU))        ||                 \
+    ((I2C_ADDR_10BIT == (mode)) && ((addr) <= 0x3FFU))      ||                 \
+    (I2C_ADDR_DISABLE == (mode)))
+
+#define IS_I2C_ADDR_NUM(x)                                                     \
+(   ((x) == I2C_ADDR0)                              ||                         \
+    ((x) == I2C_ADDR1))
+
+#define IS_I2C_CLK_DIV(x)                                                      \
+(   (x) <= I2C_CLK_DIV128)
+
+#define IS_I2C_TRANS_DIR(x)                                                    \
+(   ((x) == I2C_DIR_TX)                             ||                         \
+    ((x) == I2C_DIR_RX))
+
+#define IS_I2C_ACK_CONFIG(x)                                                   \
+(   ((x) == I2C_ACK)                                ||                         \
+    ((x) == I2C_NACK))
+
+#define IS_I2C_FLAG_STD(x)                                                     \
+(   ((x) == RESET)                                  ||                         \
+    ((x) == SET))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup I2C_Global_Functions I2C Global Functions
+ * @{
+ */
+
+/**
+ * @brief Try to wait a status of specified flags
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *        @arg CM_I2C or CM_I2Cx:   I2C instance register base.
+ * @param [in] u32Flag              Specify the flags to check, This parameter can be any combination of the member from
+ *                                  @ref I2C_Flag values:
+ * @param [in] enStatus             Expected status @ref en_flag_status_t
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ */
+int32_t I2C_WaitStatus(const CM_I2C_TypeDef *I2Cx, uint32_t u32Flag, en_flag_status_t enStatus, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_TIMEOUT;
+    uint32_t u32RegStatusBit;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_FLAG(u32Flag));
+    DDL_ASSERT(IS_I2C_FLAG_STD(enStatus));
+
+    for (;;) {
+        u32RegStatusBit = (READ_REG32_BIT(I2Cx->SR, u32Flag));
+        if (((enStatus == SET) && (u32Flag == u32RegStatusBit)) || ((enStatus == RESET) && (0UL == u32RegStatusBit))) {
+            i32Ret = LL_OK;
+        }
+
+        if ((LL_OK == i32Ret) || (0UL == u32Timeout)) {
+            break;
+        } else {
+            u32Timeout--;
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief I2C generate start condition
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *        @arg CM_I2C or CM_I2Cx:   I2C instance register base.
+ * @retval None
+ */
+void I2C_GenerateStart(CM_I2C_TypeDef *I2Cx)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    SET_REG32_BIT(I2Cx->CR1, I2C_CR1_START);
+}
+
+/**
+ * @brief I2C generate restart condition
+ * @param [in]  I2Cx                Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *   @arg CM_I2C or CM_I2Cx:        I2C instance register base.
+ * @retval None
+ */
+void I2C_GenerateRestart(CM_I2C_TypeDef *I2Cx)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    SET_REG32_BIT(I2Cx->CR1, I2C_CR1_RESTART);
+}
+
+/**
+ * @brief I2C generate stop condition
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @retval None
+ */
+void I2C_GenerateStop(CM_I2C_TypeDef *I2Cx)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    SET_REG32_BIT(I2Cx->CR1, I2C_CR1_STOP);
+}
+
+/**
+ * @brief Set the baudrate for I2C peripheral.
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] pstcI2cInit          Pointer to I2C config structure  @ref stc_i2c_init_t
+ *         @arg pstcI2cInit->u32ClockDiv: Division of i2c source clock, reference as:
+ * <pre>
+ *              step1: calculate div = (I2cSrcClk/Baudrate/(Imme+2*Dnfsum+SclTime)
+ *                     I2cSrcClk -- I2c source clock
+ *                     Baudrate -- baudrate of i2c
+ *                     SclTime  -- =(SCL rising time + SCL falling time)/period of i2c clock
+ *                                 according to i2c bus hardware parameter.
+ *                     Dnfsum   -- 0 if digital filter off;
+ *                                 Filter capacity if digital filter on(1 ~ 4)
+ *                     Imme     -- An Immediate data, 68
+ *              step2: chose a division item which is similar and bigger than div from @ref I2C_Clock_Division.
+ * </pre>
+ *         @arg pstcI2cInit->u32Baudrate : Baudrate configuration
+ *         @arg pstcI2cInit->u32SclTime : Indicate SCL pin rising and falling
+ *              time, should be number of T(i2c clock period time)
+ * @param [out] pf32Error           Baudrate error
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t I2C_BaudrateConfig(CM_I2C_TypeDef *I2Cx, const stc_i2c_init_t *pstcI2cInit, float32_t *pf32Error)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t I2cSrcClk;
+    uint32_t I2cDivClk;
+    uint32_t SclCnt;
+    uint32_t Baudrate;
+    uint32_t Dnfsum = 0UL;
+    uint32_t Divsum = 2UL;
+    uint32_t TheoryBaudrate;
+    float32_t WidthTotal;
+    float32_t SumTotal;
+    float32_t WidthHL;
+    float32_t fErr = 0.0F;
+    float32_t WidthHLMax;
+
+    if ((NULL == pstcI2cInit) || (NULL == pf32Error)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+        DDL_ASSERT(IS_I2C_SPEED(pstcI2cInit->u32Baudrate));
+        DDL_ASSERT(IS_I2C_CLK_DIV(pstcI2cInit->u32ClockDiv));
+
+        /* Get configuration for i2c */
+        I2cSrcClk = I2C_SRC_CLK;
+        I2cDivClk = 1UL << pstcI2cInit->u32ClockDiv;
+        SclCnt = pstcI2cInit->u32SclTime;
+        Baudrate = pstcI2cInit->u32Baudrate;
+
+        /* Judge digital filter status */
+        if (0U != READ_REG32_BIT(I2Cx->FLTR, I2C_FLTR_DNFEN)) {
+            Dnfsum = (READ_REG32_BIT(I2Cx->FLTR, I2C_FLTR_DNF) >> I2C_FLTR_DNF_POS) + 1U;
+        }
+
+        /* Judge if clock divider on*/
+        if (I2C_CLK_DIV1 == pstcI2cInit->u32ClockDiv) {
+            Divsum = 3UL;
+        }
+
+        if (I2cDivClk != 0UL) { /* Judge for misra */
+            WidthTotal = (float32_t)I2cSrcClk / (float32_t)Baudrate / (float32_t)I2cDivClk;
+            SumTotal = (2.0F * (float32_t)Divsum) + (2.0F * (float32_t)Dnfsum) + (float32_t)SclCnt;
+            WidthHL = WidthTotal - SumTotal;
+
+            /* Integer for WidthTotal, rounding off */
+            if ((WidthTotal - (float32_t)((uint32_t)WidthTotal)) >= 0.5F) {
+                WidthTotal = (float32_t)((uint32_t)WidthTotal) + 1.0F;
+            } else {
+                WidthTotal = (float32_t)((uint32_t)WidthTotal);
+            }
+
+            if (WidthTotal <= SumTotal) {
+                /* Err, Should set a smaller division value for pstcI2cInit->u32ClockDiv */
+                i32Ret = LL_ERR_INVD_PARAM;
+            } else {
+                WidthHLMax = I2C_SCL_HIGH_LOW_LVL_SUM_MAX;
+                if (WidthHL > WidthHLMax) {
+                    /* Err, Should set a bigger division value for pstcI2cInit->u32ClockDiv */
+                    i32Ret = LL_ERR_INVD_PARAM;
+                } else {
+                    TheoryBaudrate = I2cSrcClk / (uint32_t)WidthTotal / I2cDivClk;
+                    fErr = ((float32_t)Baudrate - (float32_t)TheoryBaudrate) / (float32_t)TheoryBaudrate;
+                    WRITE_REG32(I2Cx->CCR,
+                                (pstcI2cInit->u32ClockDiv << I2C_CCR_CKDIV_POS) |
+                                (((uint32_t)WidthHL / 2U) << I2C_CCR_SLOWW_POS) |
+                                (((uint32_t)WidthHL - (((uint32_t)WidthHL) / 2U)) << I2C_CCR_SHIGHW_POS));
+                }
+            }
+        } else {
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+    }
+
+    if ((NULL != pf32Error) && (LL_OK == i32Ret)) {
+        *pf32Error = fErr;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief De-initialize I2C unit
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ */
+int32_t I2C_DeInit(CM_I2C_TypeDef *I2Cx)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    /* RESET peripheral register and internal status*/
+    CLR_REG32_BIT(I2Cx->CR1, I2C_CR1_PE);
+    SET_REG32_BIT(I2Cx->CR1, I2C_CR1_SWRST);
+
+    return LL_OK;
+}
+
+/**
+ * @brief Initialize I2C peripheral according to the structure
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] pstcI2cInit          Pointer to I2C config structure  @ref stc_i2c_init_t
+ *         @arg pstcI2cInit->u32ClockDiv: Division of i2c source clock, reference as:
+ * <pre>
+ *              step1: calculate div = (I2cSrcClk/Baudrate/(Imme+2*Dnfsum+SclTime)
+ *                     I2cSrcClk -- I2c source clock
+ *                     Baudrate -- baudrate of i2c
+ *                     SclTime  -- =(SCL rising time + SCL falling time)/period of i2c clock
+ *                                 according to i2c bus hardware parameter.
+ *                     Dnfsum   -- 0 if digital filter off;
+ *                                 Filter capacity if digital filter on(1 ~ 4)
+ *                     Imme     -- An Immediate data, 68
+ *              step2: chose a division item which is similar and bigger than div
+ *                     from @ref I2C_Clock_Division.
+ * </pre>
+ *         @arg pstcI2cInit->u32Baudrate : Baudrate configuration
+ *         @arg pstcI2cInit->u32SclTime : Indicate SCL pin rising and falling
+ *              time, should be number of T(i2c clock period time)
+ * @param [out] pf32Error           Baudrate error
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t I2C_Init(CM_I2C_TypeDef *I2Cx, const stc_i2c_init_t *pstcI2cInit, float32_t *pf32Error)
+{
+    int32_t i32Ret;
+
+    if (NULL == pstcI2cInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+        DDL_ASSERT(IS_I2C_SPEED(pstcI2cInit->u32Baudrate));
+        DDL_ASSERT(IS_I2C_CLK_DIV(pstcI2cInit->u32ClockDiv));
+
+        /* Register and internal status reset */
+        CLR_REG32_BIT(I2Cx->CR1, I2C_CR1_PE);
+        SET_REG32_BIT(I2Cx->CR1, I2C_CR1_SWRST);
+        SET_REG32_BIT(I2Cx->CR1, I2C_CR1_PE);
+
+        /* I2C baudrate config */
+        i32Ret = I2C_BaudrateConfig(I2Cx, pstcI2cInit, pf32Error);
+
+        /* Disable global broadcast address function */
+        CLR_REG32_BIT(I2Cx->CR1, I2C_CR1_GCEN);
+        /* Release software reset */
+        CLR_REG32_BIT(I2Cx->CR1, I2C_CR1_SWRST);
+        /* Disable I2C peripheral */
+        CLR_REG32_BIT(I2Cx->CR1, I2C_CR1_PE);
+        /* Disable slave address function */
+        CLR_REG32_BIT(I2Cx->SLR0, I2C_SLR0_SLADDR0EN);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief I2C slave address config
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32AddrNum           I2C address 0 or address 1 @ref I2C_Address_Num
+ * @param [in] u32AddrMode          Address mode configuration @ref I2C_Addr_Config
+ * @param [in] u32Addr              The slave address
+ * @retval None
+ */
+void I2C_SlaveAddrConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32AddrNum, uint32_t u32AddrMode, uint32_t u32Addr)
+{
+    __IO uint32_t *const pu32SLRx = (__IO uint32_t *)((uint32_t)&I2Cx->SLR0 + (u32AddrNum * 4UL));
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_ADDR_NUM(u32AddrNum));
+    DDL_ASSERT(IS_I2C_ADDR(u32AddrMode, u32Addr));
+
+    if (I2C_ADDR_DISABLE == u32AddrMode) {
+        CLR_REG32_BIT(*pu32SLRx, I2C_SLR0_SLADDR0EN);
+    } else {
+        if (I2C_ADDR_10BIT == u32AddrMode) {
+            MODIFY_REG32(*pu32SLRx, I2C_SLR0_SLADDR0EN | I2C_SLR0_ADDRMOD0 | I2C_SLR0_SLADDR0,
+                         u32AddrMode | u32Addr);
+        } else {
+            MODIFY_REG32(*pu32SLRx, I2C_SLR0_SLADDR0EN | I2C_SLR0_ADDRMOD0 | I2C_SLR0_SLADDR0,
+                         u32AddrMode | (u32Addr << 1U));
+        }
+    }
+}
+
+/**
+ * @brief I2C slave address config
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32AddrNum           I2C address 0 or address 1 @ref I2C_Address_Num
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SlaveAddrCmd(CM_I2C_TypeDef *I2Cx, uint32_t u32AddrNum, en_functional_state_t enNewState)
+{
+    __IO uint32_t *const pu32SLRx = (__IO uint32_t *)((uint32_t)&I2Cx->SLR0 + (u32AddrNum * 4UL));
+    /* Check parameters */
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_ADDR_NUM(u32AddrNum));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(*pu32SLRx, I2C_SLR0_SLADDR0EN, (uint32_t)enNewState << I2C_SLR0_SLADDR0EN_POS);
+}
+
+/**
+ * @brief I2C function command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_Cmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->CR1, I2C_CR1_PE, (uint32_t)enNewState << I2C_CR1_PE_POS);
+}
+
+/**
+ * @brief I2C fast ACK config
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_FastAckCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(I2Cx->CR3, I2C_CR3_FACKEN);
+    } else {
+        SET_REG32_BIT(I2Cx->CR3, I2C_CR3_FACKEN);
+    }
+}
+
+/**
+ * @brief I2C bus wait function command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_BusWaitCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR4, I2C_CR4_BUSWAIT);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR4, I2C_CR4_BUSWAIT);
+    }
+}
+
+/**
+ * @brief I2C SMBUS function configuration
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32SmbusConfig       Indicate the SMBUS address match function configuration. @ref I2C_Smbus_Match_Config
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SmbusConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32SmbusConfig, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_SMBUS_CONFIG(u32SmbusConfig));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR1, u32SmbusConfig);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR1, u32SmbusConfig);
+    }
+}
+
+/**
+ * @brief I2C SMBUS function command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SmbusCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->CR1, I2C_CR1_SMBUS, (uint32_t)enNewState << I2C_CR1_SMBUS_POS);
+}
+
+/**
+ * @brief I2C digital filter function configuration
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32FilterClock       Chose the digital filter clock, @ref I2C_Digital_Filter_Clock
+ * @retval None
+ */
+void I2C_DigitalFilterConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32FilterClock)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_DIG_FILTER_CLK(u32FilterClock));
+
+    MODIFY_REG32(I2Cx->FLTR, I2C_FLTR_DNF, u32FilterClock);
+}
+
+/**
+ * @brief I2C digital filter command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_DigitalFilterCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->FLTR, I2C_FLTR_DNFEN, (uint32_t)enNewState << I2C_FLTR_DNFEN_POS);
+}
+
+/**
+ * @brief I2C analog filter function command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_AnalogFilterCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->FLTR, I2C_FLTR_ANFEN, (uint32_t)enNewState << I2C_FLTR_ANFEN_POS);
+}
+
+/**
+ * @brief I2C general call command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_GeneralCallCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->CR1, I2C_CR1_GCEN, (uint32_t)enNewState << I2C_CR1_GCEN_POS);
+}
+
+/**
+ * @brief I2C flags status get
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32Flag              Specify the flags to check, This parameter can be any combination of the member from
+ *                                  @ref I2C_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t I2C_GetStatus(const CM_I2C_TypeDef *I2Cx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_FLAG(u32Flag));
+
+    return ((0UL != READ_REG32_BIT(I2Cx->SR, u32Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief Clear I2C flags
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32Flag              Specifies the flag to clear, This parameter can be any combination of the member from
+ *                                  @ref I2C_Flag_Clear
+ * @retval None
+ */
+void I2C_ClearStatus(CM_I2C_TypeDef *I2Cx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(I2Cx->CLR, u32Flag);
+}
+
+/**
+ * @brief I2C software reset function command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SWResetCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(I2Cx->CR1, I2C_CR1_SWRST, (uint32_t)enNewState << I2C_CR1_SWRST_POS);
+}
+
+/**
+ * @brief I2C interrupt command
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32IntType           Specifies the I2C interrupts @ref I2C_Int_Flag
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_IntCmd(CM_I2C_TypeDef *I2Cx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR2, u32IntType);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR2, u32IntType);
+    }
+}
+
+/**
+ * @brief I2C send data
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u8Data               The data to be send
+ * @retval None
+ */
+void I2C_WriteData(CM_I2C_TypeDef *I2Cx, uint8_t u8Data)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    WRITE_REG8(I2Cx->DTR, u8Data);
+}
+
+/**
+ * @brief I2C read data from register
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @retval uint8_t                  The value of the received data
+ */
+uint8_t I2C_ReadData(const CM_I2C_TypeDef *I2Cx)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    return READ_REG8(I2Cx->DRR);
+}
+
+/**
+ * @brief I2C ACK status configuration
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32AckConfig         I2C ACK configure. @ref I2C_Ack_Config
+ * @retval None
+ */
+void I2C_AckConfig(CM_I2C_TypeDef *I2Cx, uint32_t u32AckConfig)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_ACK_CONFIG(u32AckConfig));
+
+    MODIFY_REG32(I2Cx->CR1, I2C_CR1_ACK, u32AckConfig);
+}
+
+/**
+ * @brief I2C SCL high level timeout configuration
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u16TimeoutH          Clock timeout period for high level
+ * @retval None
+ */
+void I2C_SCLHighTimeoutConfig(CM_I2C_TypeDef *I2Cx, uint16_t u16TimeoutH)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    MODIFY_REG32(I2Cx->SLTR, I2C_SLTR_TOUTHIGH, (uint32_t)u16TimeoutH << I2C_SLTR_TOUTHIGH_POS);
+}
+
+/**
+ * @brief I2C SCL low level timeout configuration
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u16TimeoutL          Clock timeout period for low level
+ * @retval None
+ */
+void I2C_SCLLowTimeoutConfig(CM_I2C_TypeDef *I2Cx, uint16_t u16TimeoutL)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    MODIFY_REG32(I2Cx->SLTR, I2C_SLTR_TOUTLOW, u16TimeoutL);
+}
+
+/**
+ * @brief Enable or disable I2C SCL high level timeout function
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SCLHighTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR3, I2C_CR3_HTMOUT);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR3, I2C_CR3_HTMOUT);
+    }
+}
+
+/**
+ * @brief Enable or disable I2C SCL low level timeout function
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SCLLowTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR3, I2C_CR3_LTMOUT);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR3, I2C_CR3_LTMOUT);
+    }
+}
+
+/**
+ * @brief Enable or disable I2C SCL timeout function
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] enNewState           An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2C_SCLTimeoutCmd(CM_I2C_TypeDef *I2Cx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(I2Cx->CR3, I2C_CR3_TMOUTEN);
+    } else {
+        CLR_REG32_BIT(I2Cx->CR3, I2C_CR3_TMOUTEN);
+    }
+}
+
+/**
+ * @brief I2Cx start
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ */
+int32_t I2C_Start(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_BUSY, RESET, u32Timeout);
+
+    if (LL_OK == i32Ret) {
+        /* generate start signal */
+        I2C_GenerateStart(I2Cx);
+        /* Judge if start success*/
+        i32Ret = I2C_WaitStatus(I2Cx, (I2C_FLAG_BUSY | I2C_FLAG_START), SET, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx restart
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ */
+int32_t I2C_Restart(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_BUSY, SET, u32Timeout);
+
+    if (LL_OK == i32Ret) {
+        /* Clear start status flag */
+        I2C_ClearStatus(I2Cx, I2C_FLAG_CLR_START);
+        /* Send restart condition */
+        I2C_GenerateRestart(I2Cx);
+        /* Judge if start success*/
+        i32Ret = I2C_WaitStatus(I2Cx, (I2C_FLAG_BUSY | I2C_FLAG_START), SET, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx send address
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u16Addr              The address to be sent
+ * @param [in] u8Dir                Transfer direction, @ref I2C_Trans_Dir
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR:                NACK received
+ */
+int32_t I2C_TransAddr(CM_I2C_TypeDef *I2Cx, uint16_t u16Addr, uint8_t u8Dir, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_TRANS_DIR(u8Dir));
+    DDL_ASSERT(IS_I2C_7BIT_ADDR(u16Addr));
+
+    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_EMPTY, SET, u32Timeout);
+
+    if (LL_OK == i32Ret) {
+        /* Send I2C address */
+        I2C_WriteData(I2Cx, (uint8_t)(u16Addr << 1U) | u8Dir);
+
+        if (I2C_DIR_TX == u8Dir) {
+            /* If in master transfer process, Need wait transfer end */
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_CPLT, SET, u32Timeout);
+        } else {
+            /* If in master receive process, wait I2C_FLAG_TRA changed to receive */
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TRA, RESET, u32Timeout);
+        }
+
+        if (i32Ret == LL_OK) {
+            if (I2C_GetStatus(I2Cx, I2C_FLAG_NACKF) == SET) {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx send 10 bit address
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u16Addr              The address to be sent
+ * @param [in] u8Dir                Transfer direction @ref I2C_Trans_Dir
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR:                NACK received
+ */
+int32_t I2C_Trans10BitAddr(CM_I2C_TypeDef *I2Cx, uint16_t u16Addr, uint8_t u8Dir, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+    DDL_ASSERT(IS_I2C_TRANS_DIR(u8Dir));
+    DDL_ASSERT(IS_I2C_10BIT_ADDR(u16Addr));
+
+    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_EMPTY, SET, u32Timeout);
+
+    if (LL_OK == i32Ret) {
+        /* Write 11110 + SLA(bit9:8) + W#(1bit) */
+        I2C_WriteData(I2Cx, (uint8_t)((u16Addr >> 7U) & 0x06U) | 0xF0U | I2C_DIR_TX);
+        i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_CPLT, SET, u32Timeout);
+
+        if (LL_OK == i32Ret) {
+            /* If receive ACK */
+            if (I2C_GetStatus(I2Cx, I2C_FLAG_NACKF) == RESET) {
+                /* Write SLA(bit7:0)*/
+                I2C_WriteData(I2Cx, (uint8_t)(u16Addr & 0xFFU));
+                i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_CPLT, SET, u32Timeout);
+
+                if (LL_OK == i32Ret) {
+                    if (I2C_GetStatus(I2Cx, I2C_FLAG_NACKF) == SET) {
+                        i32Ret = LL_ERR;
+                    }
+                }
+            } else {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    if ((u8Dir == I2C_DIR_RX) && (LL_OK == i32Ret)) {
+        /* Restart */
+        I2C_ClearStatus(I2Cx, I2C_FLAG_CLR_START);
+        I2C_GenerateRestart(I2Cx);
+        i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_START, SET, u32Timeout);
+
+        if (LL_OK == i32Ret) {
+            /* Write 11110 + SLA(bit9:8) + R(1bit) */
+            I2C_WriteData(I2Cx, (uint8_t)((u16Addr >> 7U) & 0x06U) | 0xF0U | I2C_DIR_RX);
+            /* If in master receive process, Need wait TRA flag */
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TRA, RESET, u32Timeout);
+
+            if (LL_OK == i32Ret) {
+                /* If receive NACK */
+                if (I2C_GetStatus(I2Cx, I2C_FLAG_NACKF) == SET) {
+                    i32Ret = LL_ERR;
+                }
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx send data
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] au8TxData            The data array to be sent
+ * @param [in] u32Size              Number of data in array au8TxData
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t I2C_TransData(CM_I2C_TypeDef *I2Cx, const uint8_t au8TxData[], uint32_t u32Size, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32Count = 0UL;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    if (au8TxData != NULL) {
+        while ((u32Count != u32Size) && (i32Ret == LL_OK)) {
+            /* Wait tx buffer empty */
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_EMPTY, SET, u32Timeout);
+
+            if (i32Ret == LL_OK) {
+                /* Send one byte data */
+                I2C_WriteData(I2Cx, au8TxData[u32Count]);
+
+                /* Wait transfer end */
+                i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_TX_CPLT, SET, u32Timeout);
+
+                /* If receive NACK */
+                if (I2C_GetStatus(I2Cx, I2C_FLAG_NACKF) == SET) {
+                    break;
+                }
+                u32Count++;
+            }
+        }
+    } else {
+        i32Ret = LL_ERR_INVD_PARAM;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx receive data
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [out] au8RxData           Array to hold the received data
+ * @param [in] u32Size              Number of data to be received
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t I2C_ReceiveData(CM_I2C_TypeDef *I2Cx, uint8_t au8RxData[], uint32_t u32Size, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    if (au8RxData != NULL) {
+        uint32_t u32FastAckDis = READ_REG32_BIT(I2Cx->CR3, I2C_CR3_FACKEN);
+        for (i = 0UL; i < u32Size; i++) {
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_RX_FULL, SET, u32Timeout);
+
+            if (0UL == u32FastAckDis) {
+                if ((u32Size >= 2UL) && (i == (u32Size - 2UL))) {
+                    I2C_AckConfig(I2Cx, I2C_NACK);
+                }
+            } else {
+                if (i != (u32Size - 1UL)) {
+                    I2C_AckConfig(I2Cx, I2C_ACK);
+                } else {
+                    I2C_AckConfig(I2Cx, I2C_NACK);
+                }
+            }
+
+            if (i32Ret == LL_OK) {
+                /* read data from register */
+                au8RxData[i] = I2C_ReadData(I2Cx);
+            } else {
+                break;
+            }
+        }
+        I2C_AckConfig(I2Cx, I2C_ACK);
+    } else {
+        i32Ret = LL_ERR_INVD_PARAM;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx receive data and stop(for master)
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *        @arg CM_I2C or CM_I2Cx:   I2C instance register base.
+ * @param [out] au8RxData           Array to hold the received data
+ * @param [in] u32Size              Number of data to be received
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t I2C_MasterReceiveDataAndStop(CM_I2C_TypeDef *I2Cx, uint8_t au8RxData[], uint32_t u32Size, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    if (au8RxData != NULL) {
+        uint32_t u32FastAckDis = READ_REG32_BIT(I2Cx->CR3, I2C_CR3_FACKEN);
+
+        for (i = 0UL; i < u32Size; i++) {
+            i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_RX_FULL, SET, u32Timeout);
+
+            if (0UL == u32FastAckDis) {
+                if ((u32Size >= 2UL) && (i == (u32Size - 2UL))) {
+                    I2C_AckConfig(I2Cx, I2C_NACK);
+                }
+            } else {
+                if (i != (u32Size - 1UL)) {
+                    I2C_AckConfig(I2Cx, I2C_ACK);
+                } else {
+                    I2C_AckConfig(I2Cx, I2C_NACK);
+                }
+            }
+
+            if (i32Ret == LL_OK) {
+                /* Stop before read last data */
+                if (i == (u32Size - 1UL)) {
+                    I2C_ClearStatus(I2Cx, I2C_FLAG_CLR_STOP);
+                    I2C_GenerateStop(I2Cx);
+                }
+                /* read data from register */
+                au8RxData[i] = I2C_ReadData(I2Cx);
+
+                if (i == (u32Size - 1UL)) {
+                    /* Wait stop flag after DRR read */
+                    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_STOP, SET, u32Timeout);
+                }
+            } else {
+                break;
+            }
+        }
+        I2C_AckConfig(I2Cx, I2C_ACK);
+    } else {
+        i32Ret = LL_ERR_INVD_PARAM;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief I2Cx stop
+ * @param [in] I2Cx                 Pointer to I2C instance register base.
+ *                                  This parameter can be a value of the following:
+ *         @arg CM_I2C or CM_I2Cx:  I2C instance register base.
+ * @param [in] u32Timeout           Maximum count of trying to get a status of a flag in status register
+ * @retval int32_t
+ *         - LL_OK:                 Success
+ *         - LL_ERR_TIMEOUT:        Failed
+ */
+int32_t I2C_Stop(CM_I2C_TypeDef *I2Cx, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_I2C_UNIT(I2Cx));
+
+    /* Clear stop flag */
+    while ((SET == I2C_GetStatus(I2Cx, I2C_FLAG_STOP)) && (u32Timeout > 0UL)) {
+        I2C_ClearStatus(I2Cx, I2C_FLAG_CLR_STOP);
+        u32Timeout--;
+    }
+    I2C_GenerateStop(I2Cx);
+    /* Wait stop flag */
+    i32Ret = I2C_WaitStatus(I2Cx, I2C_FLAG_STOP, SET, u32Timeout);
+
+    return i32Ret;
+}
+
+/**
+ * @brief Initialize structure stc_i2c_init_t variable with default value.
+ * @param [out] pstcI2cInit             Pointer to a stc_i2c_init_t structure variable which will be initialized.
+ *                                      @ref stc_i2c_init_t.
+ * @retval int32_t
+ *         - LL_OK:                     Success
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t I2C_StructInit(stc_i2c_init_t *pstcI2cInit)
+{
+    int32_t i32Ret = LL_OK;
+    if (pstcI2cInit == NULL) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcI2cInit->u32Baudrate = 50000UL;
+        pstcI2cInit->u32SclTime = 0UL;
+        pstcI2cInit->u32ClockDiv = I2C_CLK_DIV1;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_I2C_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_i2s.c
+++ b/hc32f4a2/src/hc32_ll_i2s.c
@@ -1,0 +1,1030 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_i2s.c
+ * @brief This file provides firmware functions to manage the Inter IC Sound Bus
+ *        (I2S).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify I2S_ClearStatus function
+   2024-06-30       CDT             Optimize calculate for I2SDIV and ODD in MCK enabled mode
+   2024-08-31       CDT             Optimize I2S_DeInit()
+                                    Delete needless set data in I2S_Init function
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_i2s.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_I2S I2S
+ * @brief Inter IC Sound Bus Driver Library
+ * @{
+ */
+
+#if (LL_I2S_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup I2S_Local_Macros I2S Local Macros
+ * @{
+ */
+/* CMU registers define */
+#define I2S_CLK_SRC_PCLK                (0x00U << CMU_I2SCKSEL_I2S1CKSEL_POS)
+#define I2S_CLK_SRC_PLLQ                (0x08U << CMU_I2SCKSEL_I2S1CKSEL_POS)
+#define I2S_CLK_SRC_PLLR                (0x09U << CMU_I2SCKSEL_I2S1CKSEL_POS)
+#define I2S_CLK_SRC_PLLXP               (0x0AU << CMU_I2SCKSEL_I2S1CKSEL_POS)
+#define I2S_CLK_SRC_PLLXQ               (0x0BU << CMU_I2SCKSEL_I2S1CKSEL_POS)
+#define I2S_CLK_SRC_PLLXR               (0x0CU << CMU_I2SCKSEL_I2S1CKSEL_POS)
+
+#define I2S_CMU_PLLCFGR                 PLLHCFGR
+#define I2S_CMU_PLLCFGR_PLLSRC          CMU_PLLHCFGR_PLLSRC
+
+#define I2S_CMU_PLLXCFGR                PLLACFGR
+
+#define I2S_CMU_SCFGR                   SCFGR
+#define I2S_CMU_SCFGR_PCLK              CMU_SCFGR_PCLK1S
+#define I2S_CMU_SCFGR_PCLK_POS          CMU_SCFGR_PCLK1S_POS
+
+#define I2S_CMU_PLLCFGR_PLLM            CMU_PLLHCFGR_PLLHM
+#define I2S_CMU_PLLCFGR_PLLM_POS        CMU_PLLHCFGR_PLLHM_POS
+#define I2S_CMU_PLLCFGR_PLLN            CMU_PLLHCFGR_PLLHN
+#define I2S_CMU_PLLCFGR_PLLN_POS        CMU_PLLHCFGR_PLLHN_POS
+#define I2S_CMU_PLLCFGR_PLLP            CMU_PLLHCFGR_PLLHP
+#define I2S_CMU_PLLCFGR_PLLP_POS        CMU_PLLHCFGR_PLLHP_POS
+#define I2S_CMU_PLLCFGR_PLLQ            CMU_PLLHCFGR_PLLHQ
+#define I2S_CMU_PLLCFGR_PLLQ_POS        CMU_PLLHCFGR_PLLHQ_POS
+#define I2S_CMU_PLLCFGR_PLLR            CMU_PLLHCFGR_PLLHR
+#define I2S_CMU_PLLCFGR_PLLR_POS        CMU_PLLHCFGR_PLLHR_POS
+
+#define I2S_CMU_PLLCFGR_PLLXM           CMU_PLLACFGR_PLLAM
+#define I2S_CMU_PLLCFGR_PLLXM_POS       CMU_PLLACFGR_PLLAM_POS
+#define I2S_CMU_PLLCFGR_PLLXN           CMU_PLLACFGR_PLLAN
+#define I2S_CMU_PLLCFGR_PLLXN_POS       CMU_PLLACFGR_PLLAN_POS
+#define I2S_CMU_PLLCFGR_PLLXP           CMU_PLLACFGR_PLLAP
+#define I2S_CMU_PLLCFGR_PLLXP_POS       CMU_PLLACFGR_PLLAP_POS
+#define I2S_CMU_PLLCFGR_PLLXQ           CMU_PLLACFGR_PLLAQ
+#define I2S_CMU_PLLCFGR_PLLXQ_POS       CMU_PLLACFGR_PLLAQ_POS
+#define I2S_CMU_PLLCFGR_PLLXR           CMU_PLLACFGR_PLLAR
+#define I2S_CMU_PLLCFGR_PLLXR_POS       CMU_PLLACFGR_PLLAR_POS
+
+/* I2S CTRL register Mask */
+#define I2S_CTRL_CLR_MASK               (I2S_CTRL_WMS      | I2S_CTRL_ODD      | I2S_CTRL_MCKOE     | \
+                                         I2S_CTRL_TXBIRQWL | I2S_CTRL_RXBIRQWL | I2S_CTRL_I2SPLLSEL | \
+                                         I2S_CTRL_SDOE     | I2S_CTRL_LRCKOE   | I2S_CTRL_CKOE      | \
+                                         I2S_CTRL_DUPLEX   | I2S_CTRL_CLKSEL)
+
+/**
+ * @defgroup I2S_Check_Parameters_Validity I2S Check Parameters Validity
+ * @{
+ */
+#define IS_I2S_UNIT(x)                                                         \
+(   ((x) == CM_I2S1)                            ||                             \
+    ((x) == CM_I2S2)                            ||                             \
+    ((x) == CM_I2S3)                            ||                             \
+    ((x) == CM_I2S4))
+
+#define IS_I2S_CLK_SRC(x)                                                      \
+(   ((x) == I2S_CLK_SRC_PLL)                    ||                             \
+    ((x) == I2S_CLK_SRC_EXT))
+
+#define IS_I2S_MD(x)                                                           \
+(   ((x) == I2S_MD_MASTER)                      ||                             \
+    ((x) == I2S_MD_SLAVE))
+
+#define IS_I2S_PROTOCOL(x)                                                     \
+(   ((x) == I2S_PROTOCOL_PHILLIPS)              ||                             \
+    ((x) == I2S_PROTOCOL_MSB)                   ||                             \
+    ((x) == I2S_PROTOCOL_LSB)                   ||                             \
+    ((x) == I2S_PROTOCOL_PCM_SHORT)             ||                             \
+    ((x) == I2S_PROTOCOL_PCM_LONG))
+
+#define IS_I2S_TRANS_MD(x)                                                     \
+(   ((x) == I2S_TRANS_MD_HALF_DUPLEX_RX)        ||                             \
+    ((x) == I2S_TRANS_MD_HALF_DUPLEX_TX)        ||                             \
+    ((x) == I2S_TRANS_MD_FULL_DUPLEX))
+
+#define IS_I2S_AUDIO_FREQ(x)                                                   \
+(   ((x) == I2S_AUDIO_FREQ_DEFAULT)             ||                             \
+    (((x) >= I2S_AUDIO_FREQ_8K) && ((x) <= I2S_AUDIO_FREQ_192K)))
+
+#define IS_I2S_CH_LEN(x)                                                       \
+(   ((x) == I2S_CH_LEN_16BIT)                   ||                             \
+    ((x) == I2S_CH_LEN_32BIT))
+
+#define IS_I2S_DATA_LEN(x)                                                     \
+(   ((x) == I2S_DATA_LEN_16BIT)                 ||                             \
+    ((x) == I2S_DATA_LEN_24BIT)                 ||                             \
+    ((x) == I2S_DATA_LEN_32BIT))
+
+#define IS_I2S_MCK_OUTPUT(x)                                                   \
+(   ((x) == I2S_MCK_OUTPUT_DISABLE)             ||                             \
+    ((x) == I2S_MCK_OUTPUT_ENABLE))
+
+#define IS_I2S_TRANS_LVL(x)                                                    \
+(   ((x) == I2S_TRANS_LVL0)                     ||                             \
+    ((x) == I2S_TRANS_LVL1)                     ||                             \
+    ((x) == I2S_TRANS_LVL2)                     ||                             \
+    ((x) == I2S_TRANS_LVL3)                     ||                             \
+    ((x) == I2S_TRANS_LVL4))
+
+#define IS_I2S_RECEIVE_LVL(x)                                                  \
+(   ((x) == I2S_RECEIVE_LVL0)                   ||                             \
+    ((x) == I2S_RECEIVE_LVL1)                   ||                             \
+    ((x) == I2S_RECEIVE_LVL2)                   ||                             \
+    ((x) == I2S_RECEIVE_LVL3)                   ||                             \
+    ((x) == I2S_RECEIVE_LVL4))
+
+#define IS_I2S_FUNC(x)                                                         \
+(   ((x) != 0U)                                 &&                             \
+    (((x) | I2S_FUNC_ALL) == I2S_FUNC_ALL))
+
+#define IS_I2S_RST_TYPE(x)                                                     \
+(   ((x) != 0U)                                 &&                             \
+    (((x) | I2S_RST_TYPE_ALL) == I2S_RST_TYPE_ALL))
+
+#define IS_I2S_INT(x)                                                          \
+(   ((x) != 0U)                                 &&                             \
+    (((x) | I2S_INT_ALL) == I2S_INT_ALL))
+
+#define IS_I2S_FLAG(x)                                                         \
+(   ((x) != 0U)                                 &&                             \
+    (((x) | I2S_FLAG_ALL) == I2S_FLAG_ALL))
+
+#define IS_I2S_CLR_FLAG(x)                                                     \
+(   ((x) != 0U)                                 &&                             \
+    (((x) | I2S_FLAG_CLR_ALL) == I2S_FLAG_CLR_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup I2S_Global_Functions I2S Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Get I2S clock frequency.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @retval uint32_t                     The I2S clock frequency
+ */
+static uint32_t I2S_GetClockFreq(const CM_I2S_TypeDef *I2Sx)
+{
+    uint32_t u32ClockShift;
+    uint16_t u16ClockSrc;
+    uint32_t u32ClockFreq;
+    uint32_t u32PllP;
+    uint32_t u32PllQ;
+    uint32_t u32PllR;
+    uint32_t u32PllN;
+    uint32_t u32PllM;
+    uint32_t u32PllIn;
+    uint32_t u32Temp;
+
+    /* Get the offset of the I2S clock source in CMU_I2SCKSEL */
+    if (CM_I2S1 == I2Sx) {
+        u32ClockShift = CMU_I2SCKSEL_I2S1CKSEL_POS;
+    } else if (CM_I2S2 == I2Sx) {
+        u32ClockShift = CMU_I2SCKSEL_I2S2CKSEL_POS;
+    } else if (CM_I2S3 == I2Sx) {
+        u32ClockShift = CMU_I2SCKSEL_I2S3CKSEL_POS;
+    } else if (CM_I2S4 == I2Sx) {
+        u32ClockShift = CMU_I2SCKSEL_I2S4CKSEL_POS;
+    } else {
+        u32ClockShift = 0UL;
+    }
+
+    u16ClockSrc = (READ_REG16(CM_CMU->I2SCKSEL) >> u32ClockShift) & CMU_I2SCKSEL_I2S1CKSEL;
+    if (0UL != READ_REG32_BIT(CM_CMU->I2S_CMU_PLLCFGR, I2S_CMU_PLLCFGR_PLLSRC)) {
+        u32PllIn = HRC_VALUE;
+    } else {
+        u32PllIn = XTAL_VALUE;
+    }
+    /* Calculate the clock frequency */
+    switch (u16ClockSrc) {
+        case I2S_CLK_SRC_PCLK:
+            u32ClockFreq = SystemCoreClock >> ((READ_REG32_BIT(CM_CMU->I2S_CMU_SCFGR,
+                                                               I2S_CMU_SCFGR_PCLK) >> I2S_CMU_SCFGR_PCLK_POS));
+            break;
+        case I2S_CLK_SRC_PLLQ:
+            u32Temp = READ_REG32(CM_CMU->I2S_CMU_PLLCFGR);
+            u32PllM = (u32Temp & I2S_CMU_PLLCFGR_PLLM) >> I2S_CMU_PLLCFGR_PLLM_POS;
+            u32PllN = (u32Temp & I2S_CMU_PLLCFGR_PLLN) >> I2S_CMU_PLLCFGR_PLLN_POS;
+            u32PllQ = (u32Temp & I2S_CMU_PLLCFGR_PLLQ) >> I2S_CMU_PLLCFGR_PLLQ_POS;
+            u32ClockFreq = ((u32PllIn / (u32PllM + 1UL)) * (u32PllN + 1UL)) / (u32PllQ + 1UL);
+            break;
+        case I2S_CLK_SRC_PLLR:
+            u32Temp = READ_REG32(CM_CMU->I2S_CMU_PLLCFGR);
+            u32PllM = (u32Temp & I2S_CMU_PLLCFGR_PLLM) >> I2S_CMU_PLLCFGR_PLLM_POS;
+            u32PllN = (u32Temp & I2S_CMU_PLLCFGR_PLLN) >> I2S_CMU_PLLCFGR_PLLN_POS;
+            u32PllR = (u32Temp & I2S_CMU_PLLCFGR_PLLR) >> I2S_CMU_PLLCFGR_PLLR_POS;
+            u32ClockFreq = ((u32PllIn / (u32PllM + 1UL)) * (u32PllN + 1UL)) / (u32PllR + 1UL);
+            break;
+        case I2S_CLK_SRC_PLLXP:
+            u32Temp = READ_REG32(CM_CMU->I2S_CMU_PLLXCFGR);
+            u32PllM = (u32Temp & I2S_CMU_PLLCFGR_PLLXM) >> I2S_CMU_PLLCFGR_PLLXM_POS;
+            u32PllN = (u32Temp & I2S_CMU_PLLCFGR_PLLXN) >> I2S_CMU_PLLCFGR_PLLXN_POS;
+            u32PllP = (u32Temp & I2S_CMU_PLLCFGR_PLLXP) >> I2S_CMU_PLLCFGR_PLLXP_POS;
+            u32ClockFreq = ((u32PllIn / (u32PllM + 1UL)) * (u32PllN + 1UL)) / (u32PllP + 1UL);
+            break;
+        case I2S_CLK_SRC_PLLXQ:
+            u32Temp = READ_REG32(CM_CMU->I2S_CMU_PLLXCFGR);
+            u32PllM = (u32Temp & I2S_CMU_PLLCFGR_PLLXM) >> I2S_CMU_PLLCFGR_PLLXM_POS;
+            u32PllN = (u32Temp & I2S_CMU_PLLCFGR_PLLXN) >> I2S_CMU_PLLCFGR_PLLXN_POS;
+            u32PllQ = (u32Temp & I2S_CMU_PLLCFGR_PLLXQ) >> I2S_CMU_PLLCFGR_PLLXQ_POS;
+            u32ClockFreq = ((u32PllIn / (u32PllM + 1UL)) * (u32PllN + 1UL)) / (u32PllQ + 1UL);
+            break;
+        case I2S_CLK_SRC_PLLXR:
+            u32Temp = READ_REG32(CM_CMU->I2S_CMU_PLLXCFGR);
+            u32PllM = (u32Temp & I2S_CMU_PLLCFGR_PLLXM) >> I2S_CMU_PLLCFGR_PLLXM_POS;
+            u32PllN = (u32Temp & I2S_CMU_PLLCFGR_PLLXN) >> I2S_CMU_PLLCFGR_PLLXN_POS;
+            u32PllR = (u32Temp & I2S_CMU_PLLCFGR_PLLXR) >> I2S_CMU_PLLCFGR_PLLXR_POS;
+            u32ClockFreq = ((u32PllIn / (u32PllM + 1UL)) * (u32PllN + 1UL)) / (u32PllR + 1UL);
+            break;
+        default:
+            u32ClockFreq = 0UL;
+            break;
+    }
+
+    return u32ClockFreq;
+}
+
+/**
+ * @brief  Wait for the flag status of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Flag                 I2S flag type
+ *         This parameter can be one of the following values:
+ *           @arg I2S_FLAG_TX_ALARM:    Transfer buffer alarm flag
+ *           @arg I2S_FLAG_RX_ALARM:    Receive buffer alarm flag
+ *           @arg I2S_FLAG_TX_EMPTY:    Transfer buffer empty flag
+ *           @arg I2S_FLAG_TX_FULL:     Transfer buffer full flag
+ *           @arg I2S_FLAG_RX_EMPTY:    Receive buffer empty flag
+ *           @arg I2S_FLAG_RX_FULL:     Receive buffer full flag
+ *           @arg I2S_FLAG_TX_ERR:      Transfer overflow or underflow flag
+ *           @arg I2S_FLAG_RX_ERR:      Receive overflow flag
+ * @param  [in] enStatus                The flag status
+ *         This parameter can be one of the following values:
+ *         @arg SET:                    Wait for the flag to set
+ *         @arg RESET:                  Wait for the flag to reset
+ * @param  [in] u32Timeout              Wait the flag timeout(ms)
+ * @retval int32_t:
+ *           - LL_OK: Wait status success
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t I2S_WaitStatus(const CM_I2S_TypeDef *I2Sx, uint32_t u32Flag,
+                              en_flag_status_t enStatus, uint32_t u32Timeout)
+{
+    int32_t i32Ret  = LL_OK;
+    __IO uint32_t u32Count;
+
+    /* Waiting for the flag status to change to the enStatus */
+    u32Count = u32Timeout * (HCLK_VALUE / 20000UL);
+    while (enStatus != I2S_GetStatus(I2Sx, u32Flag)) {
+        if (u32Count == 0UL) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ */
+int32_t I2S_DeInit(CM_I2S_TypeDef *I2Sx)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+
+    /* Reset all registers of I2S */
+    WRITE_REG32(I2Sx->CTRL,   0x00004400UL);
+    WRITE_REG32(I2Sx->ER,     0x00000003UL);
+    WRITE_REG32(I2Sx->CFGR,   0x00000000UL);
+    WRITE_REG32(I2Sx->PR,     0x00000002UL);
+    SET_REG32_BIT(I2Sx->CTRL, I2S_RST_TYPE_ALL);
+    CLR_REG32_BIT(I2Sx->CTRL, I2S_RST_TYPE_ALL);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] pstcI2sInit             Pointer to a @ref stc_i2s_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ *           - LL_ERR: Set frequency failed
+ */
+int32_t I2S_Init(CM_I2S_TypeDef *I2Sx, const stc_i2s_init_t *pstcI2sInit)
+{
+    int32_t i32Ret  = LL_OK;
+    uint32_t u32I2sClk;
+    uint32_t u32Temp;
+    uint32_t u32I2sDiv = 2UL;
+    uint32_t u32I2sOdd = 0UL;
+    uint32_t u32ChWidth;
+
+    if (NULL == pstcI2sInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+        DDL_ASSERT(IS_I2S_CLK_SRC(pstcI2sInit->u32ClockSrc));
+        DDL_ASSERT(IS_I2S_MD(pstcI2sInit->u32Mode));
+        DDL_ASSERT(IS_I2S_PROTOCOL(pstcI2sInit->u32Protocol));
+        DDL_ASSERT(IS_I2S_TRANS_MD(pstcI2sInit->u32TransMode));
+        DDL_ASSERT(IS_I2S_AUDIO_FREQ(pstcI2sInit->u32AudioFreq));
+        DDL_ASSERT(IS_I2S_CH_LEN(pstcI2sInit->u32ChWidth));
+        DDL_ASSERT(IS_I2S_DATA_LEN(pstcI2sInit->u32DataWidth));
+        DDL_ASSERT(IS_I2S_MCK_OUTPUT(pstcI2sInit->u32MCKOutput));
+        DDL_ASSERT(IS_I2S_TRANS_LVL(pstcI2sInit->u32TransFIFOLevel));
+        DDL_ASSERT(IS_I2S_RECEIVE_LVL(pstcI2sInit->u32ReceiveFIFOLevel));
+
+        if (I2S_AUDIO_FREQ_DEFAULT != pstcI2sInit->u32AudioFreq) {
+            /* Get I2S source Clock frequency */
+            if (I2S_CLK_SRC_EXT == pstcI2sInit->u32ClockSrc) {
+                /* If the external clock frequency is different from the default value,
+                   you need to redefine the macro value (I2S_EXT_CLK_FREQ). */
+                u32I2sClk = I2S_EXT_CLK_FREQ;
+            } else {
+                u32I2sClk = I2S_GetClockFreq(I2Sx);
+            }
+            /* The actual frequency division value is calculated according to the output state of MCK */
+            if (I2S_CH_LEN_16BIT != pstcI2sInit->u32ChWidth) {
+                u32ChWidth = 32UL;
+            } else {
+                u32ChWidth = 16UL;
+            }
+
+            if (I2S_MCK_OUTPUT_ENABLE == pstcI2sInit->u32MCKOutput) {
+                u32Temp = (((u32I2sClk / (32U * 2U * 4U)) * 10U) / pstcI2sInit->u32AudioFreq) + 5U;
+            } else {
+                u32Temp = (((u32I2sClk / (u32ChWidth * 2U)) * 10U) / pstcI2sInit->u32AudioFreq) + 5U;
+            }
+            u32Temp   = u32Temp / 10U;
+            u32I2sOdd = u32Temp & 0x01U;
+            u32I2sDiv = (u32Temp - u32I2sOdd) / 2U;
+        }
+
+        if ((u32I2sDiv < 2U) || (u32I2sDiv > 0xFFU)) {
+            /* Set the default values */
+            u32I2sOdd = 0U;
+            u32I2sDiv = 2U;
+            i32Ret     = LL_ERR;
+        }
+        u32Temp = pstcI2sInit->u32ClockSrc         | pstcI2sInit->u32Mode             |
+                  pstcI2sInit->u32TransMode        | pstcI2sInit->u32MCKOutput        |
+                  pstcI2sInit->u32TransFIFOLevel   | pstcI2sInit->u32ReceiveFIFOLevel |
+                  (u32I2sOdd << I2S_CTRL_ODD_POS);
+        if (I2S_MD_MASTER == pstcI2sInit->u32Mode) {
+            u32Temp |= (I2S_CTRL_CKOE | I2S_CTRL_LRCKOE);
+        }
+        /* Set I2S_CFGR register */
+        WRITE_REG32(I2Sx->CFGR, (pstcI2sInit->u32Protocol | pstcI2sInit->u32ChWidth | pstcI2sInit->u32DataWidth));
+        /* set I2S_PR register */
+        WRITE_REG32(I2Sx->PR, u32I2sDiv);
+        /* Set I2S_CTRL register */
+        MODIFY_REG32(I2Sx->CTRL, I2S_CTRL_CLR_MASK, u32Temp);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_i2s_init_t member with default value.
+ * @param  [out] pstcI2sInit            Pointer to a @ref stc_i2s_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_i2s_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t I2S_StructInit(stc_i2s_init_t *pstcI2sInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcI2sInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcI2sInit->u32ClockSrc         = I2S_CLK_SRC_PLL;
+        pstcI2sInit->u32Mode             = I2S_MD_MASTER;
+        pstcI2sInit->u32Protocol         = I2S_PROTOCOL_PHILLIPS;
+        pstcI2sInit->u32TransMode        = I2S_TRANS_MD_HALF_DUPLEX_RX;
+        pstcI2sInit->u32AudioFreq        = I2S_AUDIO_FREQ_DEFAULT;
+        pstcI2sInit->u32ChWidth          = I2S_CH_LEN_16BIT;
+        pstcI2sInit->u32DataWidth        = I2S_DATA_LEN_16BIT;
+        pstcI2sInit->u32MCKOutput        = I2S_MCK_OUTPUT_DISABLE;
+        pstcI2sInit->u32TransFIFOLevel   = I2S_TRANS_LVL2;
+        pstcI2sInit->u32ReceiveFIFOLevel = I2S_RECEIVE_LVL2;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Software reset of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Type                 Software reset type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref I2S_Reset_Type
+ * @retval None
+ */
+void I2S_SWReset(CM_I2S_TypeDef *I2Sx, uint32_t u32Type)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_RST_TYPE(u32Type));
+
+    SET_REG32_BIT(I2Sx->CTRL, u32Type);
+    CLR_REG32_BIT(I2Sx->CTRL, u32Type);
+}
+
+/**
+ * @brief  Set the transfer mode for the I2S communication.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Mode                 Transfer mode
+ *         This parameter can be one of the following values:
+ *           @arg I2S_TRANS_MD_HALF_DUPLEX_RX:  Receive only and half duplex mode
+ *           @arg I2S_TRANS_MD_HALF_DUPLEX_TX:  Send only and half duplex mode
+ *           @arg I2S_TRANS_MD_FULL_DUPLEX:     Full duplex mode
+ * @retval None
+ */
+void I2S_SetTransMode(CM_I2S_TypeDef *I2Sx, uint32_t u32Mode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_TRANS_MD(u32Mode));
+
+    MODIFY_REG32(I2Sx->CTRL, (I2S_CTRL_DUPLEX | I2S_CTRL_SDOE), u32Mode);
+}
+
+/**
+ * @brief  Set the transfer FIFO level of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Level                Transfer FIFO level
+ *         This parameter can be one of the following values:
+ *           @arg @ref I2S_Trans_Level
+ * @retval None
+ */
+void I2S_SetTransFIFOLevel(CM_I2S_TypeDef *I2Sx, uint32_t u32Level)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_TRANS_LVL(u32Level));
+
+    MODIFY_REG32(I2Sx->CTRL, I2S_CTRL_TXBIRQWL, u32Level);
+}
+
+/**
+ * @brief  Set the receive FIFO level of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Level                Receive FIFO level
+ *         This parameter can be one of the following values:
+ *           @arg @ref I2S_Receive_Level
+ * @retval None
+ */
+void I2S_SetReceiveFIFOLevel(CM_I2S_TypeDef *I2Sx, uint32_t u32Level)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_RECEIVE_LVL(u32Level));
+
+    MODIFY_REG32(I2Sx->CTRL, I2S_CTRL_RXBIRQWL, u32Level);
+}
+
+/**
+ * @brief  Set the communication protocol of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Protocol             Communication protocol
+ *         This parameter can be one of the following values:
+ *           @arg I2S_PROTOCOL_PHILLIPS:    Phillips protocol
+ *           @arg I2S_PROTOCOL_MSB:         MSB justified protocol
+ *           @arg I2S_PROTOCOL_LSB:         LSB justified protocol
+ *           @arg I2S_PROTOCOL_PCM_SHORT:   PCM short-frame protocol
+ *           @arg I2S_PROTOCOL_PCM_LONG:    PCM long-frame protocol
+ * @retval None
+ */
+void I2S_SetProtocol(CM_I2S_TypeDef *I2Sx, uint32_t u32Protocol)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_PROTOCOL(u32Protocol));
+
+    MODIFY_REG32(I2Sx->CFGR, (I2S_CFGR_I2SSTD | I2S_CFGR_PCMSYNC), u32Protocol);
+}
+
+/**
+ * @brief  Set the audio frequency for the I2S communication.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Freq                 Audio frequency
+ *         This parameter can be 'I2S_AUDIO_FREQ_DEFAULT' or between
+ *         'I2S_AUDIO_FREQ_8K' and 'I2S_AUDIO_FREQ_192K':
+ *           @arg I2S_AUDIO_FREQ_192K:  FS = 192000Hz
+ *           @arg I2S_AUDIO_FREQ_8K:    FS = 8000Hz
+ *           @arg I2S_AUDIO_FREQ_DEFAULT
+ * @retval int32_t:
+ *           - LL_OK: Set success
+ *           - LL_ERR: Set frequency failed
+ */
+int32_t I2S_SetAudioFreq(CM_I2S_TypeDef *I2Sx, uint32_t u32Freq)
+{
+    int32_t i32Ret  = LL_OK;
+    uint32_t u32I2sClk;
+    uint32_t u32Temp;
+    uint32_t u32I2sDiv = 2UL;
+    uint32_t u32I2sOdd = 0UL;
+    uint32_t u32ChWidth;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_AUDIO_FREQ(u32Freq));
+
+    if (I2S_AUDIO_FREQ_DEFAULT != u32Freq) {
+        /* Get I2S source Clock frequency */
+        if (I2S_CLK_SRC_EXT == READ_REG32_BIT(I2Sx->CTRL, I2S_CTRL_CLKSEL)) {
+            /* If the external clock frequency is different from the default value,
+               you need to redefine the macro value (I2S_EXT_CLK_FREQ). */
+            u32I2sClk = I2S_EXT_CLK_FREQ;
+        } else {
+            u32I2sClk = I2S_GetClockFreq(I2Sx);
+        }
+        /* The actual frequency division value is calculated according to the output state of MCK */
+        if (I2S_CH_LEN_16BIT != READ_REG32_BIT(I2Sx->CFGR, I2S_CFGR_CHLEN)) {
+            u32ChWidth = 32UL;
+        } else {
+            u32ChWidth = 16UL;
+        }
+
+        if (I2S_MCK_OUTPUT_ENABLE == READ_REG32_BIT(I2Sx->CTRL, I2S_CTRL_MCKOE)) {
+            u32Temp = (((u32I2sClk / (32U * 2U * 4U)) * 10U) / u32Freq) + 5U;
+        } else {
+            u32Temp = (((u32I2sClk / (u32ChWidth * 2U)) * 10U) / u32Freq) + 5U;
+        }
+        u32Temp   = u32Temp / 10U;
+        u32I2sOdd = u32Temp & 0x01U;
+        u32I2sDiv = (u32Temp - u32I2sOdd) / 2U;
+    }
+
+    if ((u32I2sDiv < 2U) || (u32I2sDiv > 0xFFU)) {
+        i32Ret = LL_ERR;
+    } else {
+        /* Set clock division */
+        WRITE_REG32(I2Sx->PR, u32I2sDiv);
+        MODIFY_REG32(I2Sx->CTRL, I2S_CTRL_ODD, (u32I2sOdd << I2S_CTRL_ODD_POS));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable MCK clock output.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2S_MCKOutputCmd(CM_I2S_TypeDef *I2Sx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG32_BIT(I2Sx->CTRL, I2S_CTRL_MCKOE);
+    } else {
+        CLR_REG32_BIT(I2Sx->CTRL, I2S_CTRL_MCKOE);
+    }
+}
+
+/**
+ * @brief  Enable or disable the function of I2S.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Func                 I2S function
+ *         This parameter can be one or any combination of the following values:
+ *           @arg I2S_FUNC_TX:          Transfer function
+ *           @arg I2S_FUNC_RX:          Receive function
+ *           @arg I2S_FUNC_ALL:         All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2S_FuncCmd(CM_I2S_TypeDef *I2Sx, uint32_t u32Func, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_FUNC(u32Func));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG32_BIT(I2Sx->CTRL, u32Func);
+    } else {
+        CLR_REG32_BIT(I2Sx->CTRL, u32Func);
+    }
+}
+
+/**
+ * @brief  I2S send data.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Data                 Send data
+ * @retval None
+ */
+void I2S_WriteData(CM_I2S_TypeDef *I2Sx, uint32_t u32Data)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+
+    WRITE_REG32(I2Sx->TXBUF, u32Data);
+}
+
+/**
+ * @brief  I2S receive data.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @retval uint32_t                     Receive data
+ */
+uint32_t I2S_ReadData(const CM_I2S_TypeDef *I2Sx)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+
+    return READ_REG32(I2Sx->RXBUF);
+}
+
+/**
+ * @brief  I2S transmit data in polling mode.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] pvTxBuf                 The pointer to data transmitted buffer
+ * @param  [in] u32Len                  Data length
+ * @param  [in] u32Timeout              Transfer timeout(ms)
+ * @retval int32_t:
+ *           - LL_OK: Transmit data success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ *           - LL_ERR_TIMEOUT: Transmission timeout
+ */
+int32_t I2S_Trans(CM_I2S_TypeDef *I2Sx, const void *pvTxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+    uint32_t u32DataWidth;
+
+    if ((NULL == pvTxBuf) || (0UL == u32Len)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        u32DataWidth = READ_REG32_BIT(I2Sx->CFGR, I2S_CFGR_DATLEN);
+        /* Check parameters */
+        DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+        if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+            DDL_ASSERT(IS_ADDR_ALIGN_HALFWORD(&((const uint16_t *)pvTxBuf)[0]));
+        } else {
+            DDL_ASSERT(IS_ADDR_ALIGN_WORD(&((const uint32_t *)pvTxBuf)[0]));
+        }
+
+        for (i = 0UL; i < u32Len; i++) {
+            i32Ret = I2S_WaitStatus(I2Sx, I2S_FLAG_TX_FULL, RESET, u32Timeout);
+            if (LL_OK != i32Ret) {
+                break;
+            }
+
+            if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+                WRITE_REG32(I2Sx->TXBUF, ((const uint16_t *)pvTxBuf)[i]);
+            } else {
+                WRITE_REG32(I2Sx->TXBUF, ((const uint32_t *)pvTxBuf)[i]);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  I2S receive data in polling mode.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] pvRxBuf                 The pointer to data received buffer
+ * @param  [in] u32Len                  Data length
+ * @param  [in] u32Timeout              Transfer timeout(ms)
+ * @retval int32_t:
+ *           - LL_OK: Receive data success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ *           - LL_ERR_TIMEOUT: Transmission timeout
+ */
+int32_t I2S_Receive(const CM_I2S_TypeDef *I2Sx, void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+    uint32_t u32DataWidth;
+    uint32_t u32Temp;
+
+    if ((NULL == pvRxBuf) || (0UL == u32Len)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+
+        u32DataWidth = READ_REG32_BIT(I2Sx->CFGR, I2S_CFGR_DATLEN);
+        if (((I2S_DATA_LEN_16BIT == u32DataWidth) && IS_ADDR_ALIGN_HALFWORD(&((const uint16_t *)pvRxBuf)[0])) ||
+            (IS_ADDR_ALIGN_WORD(&((const uint32_t *)pvRxBuf)[0]))) {
+            for (i = 0UL; i < u32Len; i++) {
+                i32Ret = I2S_WaitStatus(I2Sx, I2S_FLAG_RX_EMPTY, RESET, u32Timeout);
+                if (LL_OK != i32Ret) {
+                    break;
+                }
+
+                u32Temp = READ_REG32(I2Sx->RXBUF);
+                if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+                    ((uint16_t *)pvRxBuf)[i] = (uint16_t)(u32Temp & 0xFFFFUL);
+                } else if (I2S_DATA_LEN_24BIT == u32DataWidth) {
+                    ((uint32_t *)pvRxBuf)[i] = u32Temp & 0xFFFFFFUL;
+                } else {
+                    ((uint32_t *)pvRxBuf)[i] = u32Temp;
+                }
+            }
+        } else {
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  I2S transmit and receive data in polling mode.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] pvTxBuf                 The pointer to data transmitted buffer
+ * @param  [in] pvRxBuf                 The pointer to data received buffer
+ * @param  [in] u32Len                  Data length
+ * @param  [in] u32Timeout              Transfer timeout(ms)
+ * @retval int32_t:
+ *           - LL_OK: Receive data success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ *           - LL_ERR_TIMEOUT: Transmission timeout
+ */
+int32_t I2S_TransReceive(CM_I2S_TypeDef *I2Sx, const void *pvTxBuf,
+                         void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+    uint32_t u32TxCnt = 0U;
+    uint32_t u32RxCnt = 0U;
+    uint32_t u32DataWidth;
+    uint32_t u32Temp;
+    uint8_t u8BreakFlag = 0U;
+
+    if ((NULL == pvTxBuf) || (NULL == pvRxBuf) || (0UL == u32Len)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+
+        u32DataWidth = READ_REG32_BIT(I2Sx->CFGR, I2S_CFGR_DATLEN);
+        if (((I2S_DATA_LEN_16BIT == u32DataWidth) && IS_ADDR_ALIGN_HALFWORD(&((const uint16_t *)pvTxBuf)[0]) && IS_ADDR_ALIGN_HALFWORD(&((const uint16_t *)pvRxBuf)[0])) ||
+            (IS_ADDR_ALIGN_WORD(&((const uint32_t *)pvTxBuf)[0]) && IS_ADDR_ALIGN_WORD(&((const uint32_t *)pvRxBuf)[0]))) {
+            i32Ret = I2S_WaitStatus(I2Sx, I2S_FLAG_TX_FULL, RESET, u32Timeout);
+            if (LL_OK == i32Ret) {
+                /* Preload data */
+                if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+                    WRITE_REG32(I2Sx->TXBUF, ((const uint16_t *)pvTxBuf)[u32TxCnt]);
+                } else {
+                    WRITE_REG32(I2Sx->TXBUF, ((const uint32_t *)pvTxBuf)[u32TxCnt]);
+                }
+                u32TxCnt++;
+
+                for (;;) {
+                    /* Transmit data */
+                    if (u32TxCnt < u32Len) {
+                        i32Ret = I2S_WaitStatus(I2Sx, I2S_FLAG_TX_FULL, RESET, u32Timeout);
+                        if (LL_OK != i32Ret) {
+                            u8BreakFlag = 1U;
+                        } else {
+                            if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+                                WRITE_REG32(I2Sx->TXBUF, ((const uint16_t *)pvTxBuf)[u32TxCnt]);
+                            } else {
+                                WRITE_REG32(I2Sx->TXBUF, ((const uint32_t *)pvTxBuf)[u32TxCnt]);
+                            }
+                            u32TxCnt++;
+                        }
+                    }
+                    /* Receive data */
+                    if ((1U != u8BreakFlag) && (u32RxCnt < u32Len)) {
+                        i32Ret = I2S_WaitStatus(I2Sx, I2S_FLAG_RX_EMPTY, RESET, u32Timeout);
+                        if (LL_OK != i32Ret) {
+                            u8BreakFlag = 1U;
+                        } else {
+                            u32Temp = READ_REG32(I2Sx->RXBUF);
+                            if (I2S_DATA_LEN_16BIT == u32DataWidth) {
+                                ((uint16_t *)pvRxBuf)[u32RxCnt] = (uint16_t)(u32Temp & 0xFFFFUL);
+                            } else if (I2S_DATA_LEN_24BIT == u32DataWidth) {
+                                ((uint32_t *)pvRxBuf)[u32RxCnt] = u32Temp & 0xFFFFFFUL;
+                            } else {
+                                ((uint32_t *)pvRxBuf)[u32RxCnt] = u32Temp;
+                            }
+                            u32RxCnt++;
+                        }
+                    }
+
+                    /* Complete the transmission */
+                    if ((1U == u8BreakFlag) || ((u32Len == u32TxCnt) && (u32Len == u32RxCnt))) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable specified I2S interrupt.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32IntType              Interrupt type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg I2S_INT_TX:           Transfer interrupt
+ *           @arg I2S_INT_RX:           Receive interrupt
+ *           @arg I2S_INT_ERR:          Communication error interrupt
+ *           @arg I2S_INT_ALL:          All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void I2S_IntCmd(CM_I2S_TypeDef *I2Sx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG32_BIT(I2Sx->CTRL, u32IntType);
+    } else {
+        CLR_REG32_BIT(I2Sx->CTRL, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get I2S flag status.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Flag                 I2S flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg I2S_FLAG_TX_ALARM:    Transfer buffer alarm flag
+ *           @arg I2S_FLAG_RX_ALARM:    Receive buffer alarm flag
+ *           @arg I2S_FLAG_TX_EMPTY:    Transfer buffer empty flag
+ *           @arg I2S_FLAG_TX_FULL:     Transfer buffer full flag
+ *           @arg I2S_FLAG_RX_EMPTY:    Receive buffer empty flag
+ *           @arg I2S_FLAG_RX_FULL:     Receive buffer full flag
+ *           @arg I2S_FLAG_TX_ERR:      Transfer overflow or underflow flag
+ *           @arg I2S_FLAG_RX_ERR:      Receive overflow flag
+ *           @arg I2S_FLAG_ALL:         All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t I2S_GetStatus(const CM_I2S_TypeDef *I2Sx, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+    uint32_t u32NormalFlag;
+    uint32_t u32ErrorFlag;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_FLAG(u32Flag));
+
+    u32NormalFlag = u32Flag & 0xFFFFUL;
+    u32ErrorFlag  = u32Flag >> 16U;
+    if (0UL != u32NormalFlag) {
+        if (0UL != (READ_REG32_BIT(I2Sx->SR, u32NormalFlag))) {
+            enFlagSta = SET;
+        }
+    }
+    if ((RESET == enFlagSta) && (0UL != u32ErrorFlag)) {
+        if (0UL != (READ_REG32_BIT(I2Sx->ER, u32ErrorFlag))) {
+            enFlagSta = SET;
+        }
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear I2S flag.
+ * @param  [in] I2Sx                    Pointer to I2S unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_I2Sx:              I2S unit instance
+ * @param  [in] u32Flag                 I2S flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg I2S_FLAG_TX_ERR:      Transfer overflow or underflow flag
+ *           @arg I2S_FLAG_RX_ERR:      Receive overflow flag
+ *           @arg I2S_FLAG_CLR_ALL:     All of the above
+ * @retval None
+ */
+void I2S_ClearStatus(CM_I2S_TypeDef *I2Sx, uint32_t u32Flag)
+{
+    uint32_t u32ErrorFlag;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_I2S_UNIT(I2Sx));
+    DDL_ASSERT(IS_I2S_CLR_FLAG(u32Flag));
+
+    u32ErrorFlag  = u32Flag >> 16U;
+    WRITE_REG32(I2Sx->ER, u32ErrorFlag);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_I2S_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_icg.c
+++ b/hc32f4a2/src/hc32_ll_icg.c
@@ -1,0 +1,147 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_icg.c
+ * @brief This file provides firmware functions to manage the Initial
+ *        Configuration(ICG).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-06-30       CDT             Delete ICG2 function
+   2024-08-31       CDT             Add __USED for optimize
+  @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_icg.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_ICG ICG
+ * @brief Initial Configuration Driver Library
+ * @{
+ */
+
+#if (LL_ICG_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup ICG_Local_Macros ICG Local Macros
+ * @{
+ */
+
+/**
+ * @brief ICG Start Address
+ */
+#define ICG_START_ADDR                  0x400
+#define ICG_START_ADDR_AC6              ".ARM.__at_0x400"
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/**
+ * @defgroup ICG_Local_Variables ICG Local Variables
+ * @{
+ * @brief ICG parameters configuration
+ */
+
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__USED const uint32_t u32ICGValue[] __attribute__((section(ICG_START_ADDR_AC6))) =
+#elif defined (__GNUC__) && !defined (__CC_ARM)
+__USED const uint32_t u32ICGValue[] __attribute__((section(".icg_sec"))) =
+#elif defined (__CC_ARM)
+__USED const uint32_t u32ICGValue[] __attribute__((at(ICG_START_ADDR))) =
+#elif defined (__ICCARM__)
+#pragma location = ICG_START_ADDR
+__USED __root static const uint32_t u32ICGValue[] =
+#else
+#error "unsupported compiler!!"
+#endif
+{
+    /* ICG 0~1 */
+    ICG_REG_CFG0_CONST,
+    ICG_REG_CFG1_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    /* ICG 3 */
+    ICG_REG_CFG3_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    /* Reserved */
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+    ICG_REG_RESV_CONST,
+};
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+#endif /* LL_ICG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_interrupts.c
+++ b/hc32f4a2/src/hc32_ll_interrupts.c
@@ -1,0 +1,2192 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_interrupts.c
+ * @brief This file provides firmware functions to manage the Interrupt Controller
+ *        (INTC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Delete comment code
+   2023-01-15       CDT             Add macro-definition: EIRQFR_REG/NMIENR_REG/INTWKEN_REG
+   2023-06-30       CDT             IRQxxx_Handler add __DSB for Arm Errata 838869
+   2023-09-30       CDT             Modify micro define EIRQCFR_REG and EIRQFR_REG base RM
+                                    Remove space line
+   2024-06-30       CDT             Modify INTC filter B macros correspond with RM
+                                    Modify API NMI_ClearNmiStatus(),EXTINT_ClearExtIntStatus() Clear status by write instruction
+                                    clear EFEN bit in EXTINT_Init()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_interrupts.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_INTERRUPTS INTERRUPTS
+ * @brief INTC Driver Library
+ * @{
+ */
+
+#if (LL_INTERRUPTS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup INTC_Local_Macros INTC Local Macros
+ * @{
+ */
+/**
+ * @brief   Maximum IRQ handler number
+ */
+#define IRQ_NUM_MAX             (128U)
+#define IRQn_MIN                (INT000_IRQn)
+#define IRQn_MAX                (INT127_IRQn)
+#define IRQn_OFFSET             (0U)
+#define EXTINT_CH_NUM_MAX       (16U)
+#define EIRQCFR_REG             (CM_INTC->EIFCR)
+#define EIRQFR_REG              (CM_INTC->EIFR)
+#define NMIENR_REG              (CM_INTC->NMIENR)
+#define NMICFR_REG              (CM_INTC->NMICFR)
+#define INTSEL_REG              (uint32_t)(&CM_INTC->SEL0)
+#define INTWKEN_REG             (CM_INTC->WUPEN)
+#define INTSEL_RST_VALUE        (0x1FFUL)
+#define IRQ_GRP_MOD             (32UL)
+#define IRQ_GRP_NUM             (6UL)
+#define IRQ_GRP_LOW             (32UL)
+#define IRQ_GRP_HIGH            (37UL)
+#define IRQ_GRP_BASE            (32UL)
+
+/**
+ * @defgroup INTC_Check_Parameters_Validity INTC Check Parameters Validity
+ * @{
+ */
+/*! Parameter validity check for wakeup source from stop mode. */
+#define IS_INTC_WKUP_SRC(src)                                                   \
+(   ((src) != 0x00UL)                           &&                              \
+    (((src) | INTC_WUPEN_ALL) == INTC_WUPEN_ALL))
+
+/*! Parameter validity check for event index. */
+#define IS_INTC_EVT(event)                                                      \
+(   ((event) != 0x00UL)                         &&                              \
+    (((event) | INTC_EVT_ALL) == INTC_EVT_ALL))
+
+/*! Parameter validity check for interrupt index. */
+#define IS_INTC_INT(it)                                                         \
+(   ((it) != 0x00UL)                            &&                              \
+    (((it) | INTC_INT_ALL) == INTC_INT_ALL))
+
+/*! Parameter validity check for software interrupt index. */
+#define IS_INTC_SWI(swi)                                                        \
+(   ((swi) != 0x00UL)                           &&                              \
+    (((swi) | SWINT_ALL) == SWINT_ALL))
+
+/*! Parameter validity check for NMI trigger source. */
+#define IS_NMI_SRC(src)                                                         \
+(   ((src) != 0x00UL)                           &&                              \
+    (((src) | NMI_SRC_ALL) == NMI_SRC_ALL))
+
+/*! Parameter validity check for EXTINT filter A function. */
+#define IS_EXTINT_FAE(fae)                                                      \
+(   ((fae) == EXTINT_FILTER_OFF)                ||                              \
+    ((fae) == EXTINT_FILTER_ON))
+
+/*! Parameter validity check for EXTINT filter A clock division. */
+#define IS_EXTINT_FACLK(faclk)                                                  \
+(   ((faclk) == EXTINT_FCLK_DIV1)               ||                              \
+    ((faclk) == EXTINT_FCLK_DIV8)               ||                              \
+    ((faclk) == EXTINT_FCLK_DIV32)              ||                              \
+    ((faclk) == EXTINT_FCLK_DIV64))
+
+/*! Parameter validity check for EXTINT filter B function. */
+#define IS_EXTINT_FBE(fbe)                                                      \
+(   ((fbe) == EXTINT_FILTER_B_OFF)              ||                              \
+    ((fbe) == EXTINT_FILTER_B_ON))
+/*! Parameter validity check for EXTINT filter B time. */
+#define IS_EXTINT_FBTIME(fbtime)                                                \
+(   ((fbtime) == EXTINT_FILTER_B_LVL1)          ||                              \
+    ((fbtime) == EXTINT_FILTER_B_LVL2)          ||                              \
+    ((fbtime) == EXTINT_FILTER_B_LVL3)          ||                              \
+    ((fbtime) == EXTINT_FILTER_B_LVL4))
+
+/*! Parameter validity check for EXTINT trigger edge. */
+#define IS_EXTINT_TRIG(trigger)                                                 \
+(   ((trigger) == EXTINT_TRIG_LOW)              ||                              \
+    ((trigger) == EXTINT_TRIG_RISING)           ||                              \
+    ((trigger) == EXTINT_TRIG_FALLING)          ||                              \
+    ((trigger) == EXTINT_TRIG_BOTH))
+
+/*! Parameter validity check for EXTINT channel. */
+#define IS_EXTINT_CH(ch)                                                        \
+(   ((ch) != 0x00UL)                            &&                              \
+    (((ch) | EXTINT_CH_ALL) == EXTINT_CH_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+/**
+ * @defgroup INTC_Local_Variable INTC Local Variable
+ * @{
+ */
+static func_ptr_t m_apfnIrqHandler[IRQ_NUM_MAX] = {NULL};
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup INTC_Global_Functions INTC Global Functions
+ * @{
+ */
+/**
+ * @brief  IRQ sign in function
+ * @param  [in] pstcIrqSignConfig: pointer of IRQ registration structure
+ *   @arg  enIntSrc: can be any value @ref en_int_src_t
+ *   @arg  enIRQn: can be any value from IRQn_MIN ~ IRQn_MAX for different product
+ *   @arg  pfnCallback: Callback function
+ * @retval int32_t:
+ *           - LL_OK: IRQ register successfully
+ *           - LL_ERR_INVD_PARAM: IRQ No. and Peripheral Int source are not match; NULL pointer.
+ *           - LL_ERR_UNINIT: Specified IRQ entry was signed before.
+ */
+int32_t INTC_IrqSignIn(const stc_irq_signin_config_t *pstcIrqSignConfig)
+{
+    __IO uint32_t *INTC_SELx;
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcIrqSignConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(pstcIrqSignConfig->enIntSrc <= INT_SRC_MAX);
+        /* IRQ032~127 whether out of range */
+        if ((((((uint32_t)pstcIrqSignConfig->enIntSrc / IRQ_GRP_MOD) * IRQ_GRP_NUM + IRQ_GRP_LOW) >             \
+              (uint32_t)pstcIrqSignConfig->enIRQn)                                                    ||        \
+             ((((uint32_t)pstcIrqSignConfig->enIntSrc / IRQ_GRP_MOD) * IRQ_GRP_NUM + IRQ_GRP_HIGH) <            \
+              (uint32_t)pstcIrqSignConfig->enIRQn))                                                   &&        \
+            ((uint32_t)pstcIrqSignConfig->enIRQn >= IRQ_GRP_BASE)) {
+            i32Ret = LL_ERR_INVD_PARAM;
+        }
+
+        else {
+            INTC_SELx = (__IO uint32_t *)(INTSEL_REG + (4U * (uint32_t)(pstcIrqSignConfig->enIRQn)));
+            /* for MISRAC2004-12.4 */
+            if (INTSEL_RST_VALUE == ((*INTC_SELx) & INTSEL_RST_VALUE)) {
+                WRITE_REG32(*INTC_SELx, pstcIrqSignConfig->enIntSrc);
+                m_apfnIrqHandler[pstcIrqSignConfig->enIRQn] = pstcIrqSignConfig->pfnCallback;
+            } else if ((uint32_t)(pstcIrqSignConfig->enIntSrc) == ((*INTC_SELx) & INTSEL_RST_VALUE)) {
+                m_apfnIrqHandler[pstcIrqSignConfig->enIRQn] = pstcIrqSignConfig->pfnCallback;
+            } else {
+                i32Ret = LL_ERR_UNINIT;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  IRQ sign out function
+ * @param  [in] enIRQn: can be any value from IRQn_MIN ~ IRQn_MAX for different product
+ * @retval int32_t:
+ *           - LL_OK: IRQ sign out successfully
+ *           - LL_ERR_INVD_PARAM: IRQ No. is out of range
+ */
+int32_t INTC_IrqSignOut(IRQn_Type enIRQn)
+{
+    __IO uint32_t *INTC_SELx;
+    int32_t i32Ret = LL_OK;
+
+    if ((enIRQn < IRQn_MIN) || (enIRQn > IRQn_MAX)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        INTC_SELx = (__IO uint32_t *)(INTSEL_REG + (4UL * (uint32_t)enIRQn));
+        WRITE_REG32(*INTC_SELx, INTSEL_RST_VALUE);
+        m_apfnIrqHandler[(uint8_t)enIRQn - IRQn_OFFSET] = NULL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Stop mode wake-up source configure
+ * @param  [in] u32WakeupSrc: Wake-up source, @ref INTC_Stop_Wakeup_Source_Sel for details
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void INTC_WakeupSrcCmd(uint32_t u32WakeupSrc, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_INTC_WKUP_SRC(u32WakeupSrc));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(INTWKEN_REG, u32WakeupSrc);
+    } else {
+        CLR_REG32_BIT(INTWKEN_REG, u32WakeupSrc);
+    }
+}
+
+/**
+ * @brief  Event or Interrupt output configure
+ * @param  [in] u32Event: Event index, @ref INTC_Event_Channel_Sel for details
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void INTC_EventCmd(uint32_t u32Event, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_INTC_EVT(u32Event));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_INTC->EVTER, u32Event);
+    } else {
+        CLR_REG32_BIT(CM_INTC->EVTER, u32Event);
+    }
+}
+
+/**
+ * @brief  Interrupt function configure
+ * @param  [in] u32Int: Interrupt index, @ref INT_Channel_Sel for details
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void INTC_IntCmd(uint32_t u32Int, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_INTC_INT(u32Int));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_INTC->IER, u32Int);
+    } else {
+        CLR_REG32_BIT(CM_INTC->IER, u32Int);
+    }
+}
+
+/**
+ * @brief  Software Interrupt initialize function
+ * @param  [in] u32Ch: Software Interrupt channel, @ref SWINT_Channel_Sel for details
+ * @param  [in] pfnCallback: Callback function
+ * @param  [in] u32Priority: Software interrupt priority
+ * @retval None
+ */
+void INTC_SWIntInit(uint32_t u32Ch, const func_ptr_t pfnCallback, uint32_t u32Priority)
+{
+    stc_irq_signin_config_t stcIrqSignConfig;
+
+    stcIrqSignConfig.enIRQn = (IRQn_Type)(__CLZ(__RBIT(u32Ch)));
+    stcIrqSignConfig.enIntSrc = (en_int_src_t)(__CLZ(__RBIT(u32Ch)));
+    /* Callback function */
+    stcIrqSignConfig.pfnCallback = pfnCallback;
+    (void)INTC_IrqSignIn(&stcIrqSignConfig);
+
+    NVIC_ClearPendingIRQ(stcIrqSignConfig.enIRQn);
+    NVIC_SetPriority(stcIrqSignConfig.enIRQn, u32Priority);
+    NVIC_EnableIRQ(stcIrqSignConfig.enIRQn);
+}
+
+/**
+ * @brief  Software Interrupt function configure
+ * @param  [in] u32SWInt: Software Interrupt channel, @ref SWINT_Channel_Sel for details
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void INTC_SWIntCmd(uint32_t u32SWInt, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_INTC_SWI(u32SWInt));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_INTC->SWIER, u32SWInt);
+    } else {
+        CLR_REG32_BIT(CM_INTC->SWIER, u32SWInt);
+    }
+}
+
+/**
+ * @brief  Initialize NMI. Fill each pstcNmiInit with default value
+ * @param  [in] pstcNmiInit: Pointer to a stc_nmi_init_t structure that
+ *                             contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: NMI structure initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t NMI_StructInit(stc_nmi_init_t *pstcNmiInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcNmiInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcNmiInit->u32Src        = 0UL;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize NMI.
+ * @param  [in] pstcNmiInit: Pointer to a pstcNmiInit structure that
+ *                             contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: NMI initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t NMI_Init(const stc_nmi_init_t *pstcNmiInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcNmiInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Parameter validity checking */
+        DDL_ASSERT(IS_NMI_SRC(pstcNmiInit->u32Src));
+        /* Clear all NMI trigger source before set */
+        WRITE_REG32(NMICFR_REG, NMI_SRC_ALL);
+
+        /* NMI trigger source configure */
+        WRITE_REG32(NMIENR_REG, pstcNmiInit->u32Src);
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Get NMI trigger source
+ * @param  [in] u32Src: NMI trigger source, @ref NMI_TriggerSrc_Sel for details
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t NMI_GetNmiStatus(uint32_t u32Src)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_NMI_SRC(u32Src));
+
+    return (((READ_REG32(CM_INTC->NMIFR) & u32Src)) != 0UL) ? SET : RESET;
+}
+
+/**
+ * @brief  Set NMI trigger source
+ * @param  [in] u32Src: NMI trigger source, @ref NMI_TriggerSrc_Sel for details
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void NMI_NmiSrcCmd(uint32_t u32Src, en_functional_state_t enNewState)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_NMI_SRC(u32Src));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(NMIENR_REG, u32Src);
+    } else {
+        CLR_REG32_BIT(NMIENR_REG, u32Src);
+    }
+}
+
+/**
+ * @brief  Clear specified NMI trigger source
+ * @param  [in] u32Src: NMI trigger source, @ref NMI_TriggerSrc_Sel for diff. MCU in details
+ * @retval None
+ */
+void NMI_ClearNmiStatus(uint32_t u32Src)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_NMI_SRC(u32Src));
+
+    WRITE_REG32(NMICFR_REG, u32Src);
+}
+
+/**
+ * @brief  Initialize External interrupt.
+ * @param  [in] u32Ch: ExtInt channel.
+ * @param  [in] pstcExtIntInit: Pointer to a stc_extint_init_t structure that
+ *                             contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK:  EXTINT initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EXTINT_Init(uint32_t u32Ch, const stc_extint_init_t *pstcExtIntInit)
+{
+    uint8_t u8ExtIntPos;
+    int32_t i32Ret = LL_OK;
+    uint32_t EIRQCRVal;
+    __IO uint32_t *EIRQCRx;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcExtIntInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Parameter validity checking */
+        DDL_ASSERT(IS_EXTINT_CH(u32Ch));
+        DDL_ASSERT(IS_EXTINT_FAE(pstcExtIntInit->u32Filter));
+        DDL_ASSERT(IS_EXTINT_FACLK(pstcExtIntInit->u32FilterClock));
+        DDL_ASSERT(IS_EXTINT_TRIG(pstcExtIntInit->u32Edge));
+        DDL_ASSERT(IS_EXTINT_FBE(pstcExtIntInit->u32FilterB));
+        DDL_ASSERT(IS_EXTINT_FBTIME(pstcExtIntInit->u32FilterBClock));
+        for (u8ExtIntPos = 0U; u8ExtIntPos < EXTINT_CH_NUM_MAX; u8ExtIntPos++) {
+            if (0UL != (u32Ch & (1UL << u8ExtIntPos))) {
+                EIRQCRx = (__IO uint32_t *)((uint32_t)&CM_INTC->EIRQCR0 + 4UL * u8ExtIntPos);
+                EIRQCRVal = pstcExtIntInit->u32Filter | pstcExtIntInit->u32FilterClock  |   \
+                            pstcExtIntInit->u32Edge;
+                EIRQCRVal |= pstcExtIntInit->u32FilterB;
+                WRITE_REG32(CM_INTC->NOCCR, pstcExtIntInit->u32FilterBClock);
+                CLR_REG32_BIT(*EIRQCRx, INTC_EIRQCR_NOCEN);
+                CLR_REG32_BIT(*EIRQCRx, INTC_EIRQCR_EFEN);
+                WRITE_REG32(*EIRQCRx, EIRQCRVal);
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize ExtInt. Fill each pstcExtIntInit with default value
+ * @param  [in] pstcExtIntInit: Pointer to a stc_extint_init_t structure
+ *                              that contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: EXTINT structure initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t EXTINT_StructInit(stc_extint_init_t *pstcExtIntInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcExtIntInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Configure to default value */
+        pstcExtIntInit->u32Filter      = EXTINT_FILTER_OFF;
+        pstcExtIntInit->u32FilterClock = EXTINT_FCLK_DIV1;
+        pstcExtIntInit->u32Edge        = EXTINT_TRIG_FALLING;
+        pstcExtIntInit->u32FilterB      = EXTINT_FILTER_B_OFF;
+        pstcExtIntInit->u32FilterBClock = EXTINT_FILTER_B_LVL1;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Clear specified External interrupt trigger source
+ * @param  [in] u32ExtIntCh: External interrupt channel, @ref EXTINT_Channel_Sel for details
+ * @retval None
+ */
+void EXTINT_ClearExtIntStatus(uint32_t u32ExtIntCh)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_EXTINT_CH(u32ExtIntCh));
+
+    WRITE_REG32(EIRQCFR_REG, u32ExtIntCh);
+}
+
+/**
+ * @brief  Get specified External interrupt trigger source
+ * @param  [in] u32ExtIntCh: External interrupt channel, @ref EXTINT_Channel_Sel for details
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EXTINT_GetExtIntStatus(uint32_t u32ExtIntCh)
+{
+    /* Parameter validity checking */
+    DDL_ASSERT(IS_EXTINT_CH(u32ExtIntCh));
+
+    return ((READ_REG16(EIRQFR_REG) & u32ExtIntCh) != 0U) ? SET : RESET;
+}
+
+/**
+ * @brief  Interrupt No.000 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ000_Handler(void)
+{
+    m_apfnIrqHandler[INT000_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.001 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ001_Handler(void)
+{
+    m_apfnIrqHandler[INT001_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.002 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ002_Handler(void)
+{
+    m_apfnIrqHandler[INT002_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.003 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ003_Handler(void)
+{
+    m_apfnIrqHandler[INT003_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.004 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ004_Handler(void)
+{
+    m_apfnIrqHandler[INT004_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.005 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ005_Handler(void)
+{
+    m_apfnIrqHandler[INT005_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.006 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ006_Handler(void)
+{
+    m_apfnIrqHandler[INT006_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.007 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ007_Handler(void)
+{
+    m_apfnIrqHandler[INT007_IRQn]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.008 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ008_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT008_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.009 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ009_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT009_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.010 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ010_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT010_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.011 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ011_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT011_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.012 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ012_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT012_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.013 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ013_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT013_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.014 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ014_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT014_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.015 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ015_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT015_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.016 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ016_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT016_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.017 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ017_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT017_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.018 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ018_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT018_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.019 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ019_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT019_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.020 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ020_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT020_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.021 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ021_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT021_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.022 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ022_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT022_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.023 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ023_Handler(void)
+{
+    m_apfnIrqHandler[(uint32_t)INT023_IRQn - IRQn_OFFSET]();
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.024 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ024_Handler(void)
+{
+    m_apfnIrqHandler[INT024_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.025 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ025_Handler(void)
+{
+    m_apfnIrqHandler[INT025_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.026 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ026_Handler(void)
+{
+    m_apfnIrqHandler[INT026_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.027 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ027_Handler(void)
+{
+    m_apfnIrqHandler[INT027_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.028 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ028_Handler(void)
+{
+    m_apfnIrqHandler[INT028_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.029 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ029_Handler(void)
+{
+    m_apfnIrqHandler[INT029_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.030 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ030_Handler(void)
+{
+    m_apfnIrqHandler[INT030_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.031 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ031_Handler(void)
+{
+    m_apfnIrqHandler[INT031_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.032 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ032_Handler(void)
+{
+    m_apfnIrqHandler[INT032_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.033 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ033_Handler(void)
+{
+    m_apfnIrqHandler[INT033_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.034 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ034_Handler(void)
+{
+    m_apfnIrqHandler[INT034_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.035 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ035_Handler(void)
+{
+    m_apfnIrqHandler[INT035_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.036 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ036_Handler(void)
+{
+    m_apfnIrqHandler[INT036_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.037 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ037_Handler(void)
+{
+    m_apfnIrqHandler[INT037_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.038 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ038_Handler(void)
+{
+    m_apfnIrqHandler[INT038_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.039 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ039_Handler(void)
+{
+    m_apfnIrqHandler[INT039_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.040 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ040_Handler(void)
+{
+    m_apfnIrqHandler[INT040_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.041 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ041_Handler(void)
+{
+    m_apfnIrqHandler[INT041_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.042 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ042_Handler(void)
+{
+    m_apfnIrqHandler[INT042_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.043 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ043_Handler(void)
+{
+    m_apfnIrqHandler[INT043_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.044 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ044_Handler(void)
+{
+    m_apfnIrqHandler[INT044_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.045 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ045_Handler(void)
+{
+    m_apfnIrqHandler[INT045_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.046 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ046_Handler(void)
+{
+    m_apfnIrqHandler[INT046_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.047 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ047_Handler(void)
+{
+    m_apfnIrqHandler[INT047_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.048 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ048_Handler(void)
+{
+    m_apfnIrqHandler[INT048_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.049 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ049_Handler(void)
+{
+    m_apfnIrqHandler[INT049_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.050 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ050_Handler(void)
+{
+    m_apfnIrqHandler[INT050_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.051 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ051_Handler(void)
+{
+    m_apfnIrqHandler[INT051_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.052 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ052_Handler(void)
+{
+    m_apfnIrqHandler[INT052_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.053 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ053_Handler(void)
+{
+    m_apfnIrqHandler[INT053_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.054 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ054_Handler(void)
+{
+    m_apfnIrqHandler[INT054_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.055 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ055_Handler(void)
+{
+    m_apfnIrqHandler[INT055_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.056 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ056_Handler(void)
+{
+    m_apfnIrqHandler[INT056_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.057 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ057_Handler(void)
+{
+    m_apfnIrqHandler[INT057_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.058 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ058_Handler(void)
+{
+    m_apfnIrqHandler[INT058_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.059 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ059_Handler(void)
+{
+    m_apfnIrqHandler[INT059_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.060 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ060_Handler(void)
+{
+    m_apfnIrqHandler[INT060_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.061 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ061_Handler(void)
+{
+    m_apfnIrqHandler[INT061_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.062 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ062_Handler(void)
+{
+    m_apfnIrqHandler[INT062_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.063 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ063_Handler(void)
+{
+    m_apfnIrqHandler[INT063_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.064 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ064_Handler(void)
+{
+    m_apfnIrqHandler[INT064_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.065 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ065_Handler(void)
+{
+    m_apfnIrqHandler[INT065_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.066 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ066_Handler(void)
+{
+    m_apfnIrqHandler[INT066_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.067 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ067_Handler(void)
+{
+    m_apfnIrqHandler[INT067_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.068 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ068_Handler(void)
+{
+    m_apfnIrqHandler[INT068_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.069 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ069_Handler(void)
+{
+    m_apfnIrqHandler[INT069_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.070 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ070_Handler(void)
+{
+    m_apfnIrqHandler[INT070_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.071 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ071_Handler(void)
+{
+    m_apfnIrqHandler[INT071_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.072 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ072_Handler(void)
+{
+    m_apfnIrqHandler[INT072_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.073 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ073_Handler(void)
+{
+    m_apfnIrqHandler[INT073_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.074 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ074_Handler(void)
+{
+    m_apfnIrqHandler[INT074_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.075 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ075_Handler(void)
+{
+    m_apfnIrqHandler[INT075_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.076 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ076_Handler(void)
+{
+    m_apfnIrqHandler[INT076_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.077 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ077_Handler(void)
+{
+    m_apfnIrqHandler[INT077_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.078 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ078_Handler(void)
+{
+    m_apfnIrqHandler[INT078_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.079 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ079_Handler(void)
+{
+    m_apfnIrqHandler[INT079_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.080 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ080_Handler(void)
+{
+    m_apfnIrqHandler[INT080_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.081 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ081_Handler(void)
+{
+    m_apfnIrqHandler[INT081_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.082 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ082_Handler(void)
+{
+    m_apfnIrqHandler[INT082_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.083 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ083_Handler(void)
+{
+    m_apfnIrqHandler[INT083_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.084 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ084_Handler(void)
+{
+    m_apfnIrqHandler[INT084_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.085 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ085_Handler(void)
+{
+    m_apfnIrqHandler[INT085_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.086 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ086_Handler(void)
+{
+    m_apfnIrqHandler[INT086_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.087 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ087_Handler(void)
+{
+    m_apfnIrqHandler[INT087_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.088 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ088_Handler(void)
+{
+    m_apfnIrqHandler[INT088_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.089 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ089_Handler(void)
+{
+    m_apfnIrqHandler[INT089_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.090 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ090_Handler(void)
+{
+    m_apfnIrqHandler[INT090_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.091 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ091_Handler(void)
+{
+    m_apfnIrqHandler[INT091_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.092 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ092_Handler(void)
+{
+    m_apfnIrqHandler[INT092_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.093 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ093_Handler(void)
+{
+    m_apfnIrqHandler[INT093_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.094 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ094_Handler(void)
+{
+    m_apfnIrqHandler[INT094_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.095 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ095_Handler(void)
+{
+    m_apfnIrqHandler[INT095_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.096 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ096_Handler(void)
+{
+    m_apfnIrqHandler[INT096_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.097 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ097_Handler(void)
+{
+    m_apfnIrqHandler[INT097_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.098 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ098_Handler(void)
+{
+    m_apfnIrqHandler[INT098_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.099 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ099_Handler(void)
+{
+    m_apfnIrqHandler[INT099_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.100 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ100_Handler(void)
+{
+    m_apfnIrqHandler[INT100_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.101 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ101_Handler(void)
+{
+    m_apfnIrqHandler[INT101_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.102 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ102_Handler(void)
+{
+    m_apfnIrqHandler[INT102_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.103 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ103_Handler(void)
+{
+    m_apfnIrqHandler[INT103_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.104 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ104_Handler(void)
+{
+    m_apfnIrqHandler[INT104_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.105 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ105_Handler(void)
+{
+    m_apfnIrqHandler[INT105_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.106 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ106_Handler(void)
+{
+    m_apfnIrqHandler[INT106_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.107 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ107_Handler(void)
+{
+    m_apfnIrqHandler[INT107_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.108 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ108_Handler(void)
+{
+    m_apfnIrqHandler[INT108_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.109 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ109_Handler(void)
+{
+    m_apfnIrqHandler[INT109_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.110 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ110_Handler(void)
+{
+    m_apfnIrqHandler[INT110_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.111 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ111_Handler(void)
+{
+    m_apfnIrqHandler[INT111_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.112 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ112_Handler(void)
+{
+    m_apfnIrqHandler[INT112_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.113 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ113_Handler(void)
+{
+    m_apfnIrqHandler[INT113_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.114 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ114_Handler(void)
+{
+    m_apfnIrqHandler[INT114_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.115 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ115_Handler(void)
+{
+    m_apfnIrqHandler[INT115_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.116 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ116_Handler(void)
+{
+    m_apfnIrqHandler[INT116_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.117 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ117_Handler(void)
+{
+    m_apfnIrqHandler[INT117_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.118 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ118_Handler(void)
+{
+    m_apfnIrqHandler[INT118_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.119 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ119_Handler(void)
+{
+    m_apfnIrqHandler[INT119_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.120 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ120_Handler(void)
+{
+    m_apfnIrqHandler[INT120_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.121 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ121_Handler(void)
+{
+    m_apfnIrqHandler[INT121_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.122 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ122_Handler(void)
+{
+    m_apfnIrqHandler[INT122_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.123 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ123_Handler(void)
+{
+    m_apfnIrqHandler[INT123_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.124 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ124_Handler(void)
+{
+    m_apfnIrqHandler[INT124_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.125 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ125_Handler(void)
+{
+    m_apfnIrqHandler[INT125_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.126 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ126_Handler(void)
+{
+    m_apfnIrqHandler[INT126_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.127 IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ127_Handler(void)
+{
+    m_apfnIrqHandler[INT127_IRQn]();
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_INTERRUPTS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_keyscan.c
+++ b/hc32f4a2/src/hc32_ll_keyscan.c
@@ -1,0 +1,242 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_keyscan.c
+ * @brief This file provides firmware functions to manage the matrix keyscan
+ * function (KEYSCAN).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add function KEYSCAN_DeInit
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_keyscan.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_KEYSCAN KEYSCAN
+ * @brief Matrix keyscan Driver Library
+ * @{
+ */
+
+#if (LL_KEYSCAN_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup KEYSCAN_Local_Macros KEYSCAN Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup KEYSCAN_Check_Parameters_Validity KEYSCAN Check Parameters Validity
+ * @{
+ */
+/*! Parameter valid check for KEYSCAN HiZ state cycles. */
+#define IS_KEYSCAN_HIZ_CYCLE(clc)                                               \
+(   ((clc) == KEYSCAN_HIZ_CYCLE_4)          ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_8)          ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_16)         ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_32)         ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_64)         ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_256)        ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_512)        ||                                  \
+    ((clc) == KEYSCAN_HIZ_CYCLE_1024))
+
+/*! Parameter valid check for KEYSCAN low level output cycles. */
+#define IS_KEYSCAN_LOW_CYCLE(clc)                                                 \
+(   ((clc) == KEYSCAN_LOW_CYCLE_4)          ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_8)          ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_16)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_32)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_64)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_128)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_256)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_512)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_1K)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_2K)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_4K)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_8K)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_16K)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_32K)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_64K)        ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_128K)       ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_256K)       ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_512K)       ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_1M)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_2M)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_4M)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_8M)         ||                                  \
+    ((clc) == KEYSCAN_LOW_CYCLE_16M))
+
+/*! Parameter valid check for KEYSCAN scan clock. */
+#define IS_KEYSCAN_CLK(clk)                                                     \
+(   ((clk) == KEYSCAN_CLK_HCLK)             ||                                  \
+    ((clk) == KEYSCAN_CLK_LRC)              ||                                  \
+    ((clk) == KEYSCAN_CLK_XTAL32))
+
+/*! Parameter valid check for KEYSCAN keyout pins. */
+#define IS_KEYSCAN_OUT(out)                                                     \
+(   ((out) == KEYSCAN_OUT_0T1)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T2)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T3)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T4)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T5)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T6)              ||                                  \
+    ((out) == KEYSCAN_OUT_0T7))
+
+/*! Parameter valid check for KEYSCAN keyin(EIRQ) pins. */
+#define IS_KEYSCAN_IN(in)                                                       \
+(   ((in) != 0x00U)                         &&                                  \
+    (((in) | KEYSCAN_IN_ALL) == KEYSCAN_IN_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup KEYSCAN_Global_Functions KEYSCAN Global Functions
+ * @{
+ */
+
+/**
+ * @brief  KEYSCAN function config.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void KEYSCAN_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    WRITE_REG32(CM_KEYSCAN->SER, enNewState);
+}
+
+/**
+ * @brief  Initialize KEYSCAN config structure. Fill each pstcKeyscanInit with default value
+ * @param  [in] pstcKeyscanInit Pointer to a stc_keyscan_init_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK: KEYSCAN structure initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t KEYSCAN_StructInit(stc_keyscan_init_t *pstcKeyscanInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcKeyscanInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcKeyscanInit->u32HizCycle = KEYSCAN_HIZ_CYCLE_4;
+        pstcKeyscanInit->u32LowCycle = KEYSCAN_LOW_CYCLE_4;
+        pstcKeyscanInit->u32KeyClock = KEYSCAN_CLK_HCLK;
+        pstcKeyscanInit->u32KeyOut   = KEYSCAN_OUT_0T1;
+        pstcKeyscanInit->u32KeyIn    = KEYSCAN_IN_0;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  KEYSCAN initialize.
+ * @param  [in] pstcKeyscanInit KEYSCAN config structure.
+ *   @arg  u32HizCycle  Hiz state keep cycles during low level output.
+ *   @arg  u32LowCycle  Low level output cycles.
+ *   @arg  u32KeyClock  Scan clock.
+ *   @arg  u32KeyOut    KEYOUT selection.
+ *   @arg  u32KeyIn     KEYIN(EIRQ) selection.
+ * @retval int32_t:
+ *           - LL_OK: KEYSCAN function initialize successful
+ *           - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t KEYSCAN_Init(const stc_keyscan_init_t *pstcKeyscanInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcKeyscanInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_KEYSCAN_HIZ_CYCLE(pstcKeyscanInit->u32HizCycle));
+        DDL_ASSERT(IS_KEYSCAN_LOW_CYCLE(pstcKeyscanInit->u32LowCycle));
+        DDL_ASSERT(IS_KEYSCAN_CLK(pstcKeyscanInit->u32KeyClock));
+        DDL_ASSERT(IS_KEYSCAN_OUT(pstcKeyscanInit->u32KeyOut));
+        DDL_ASSERT(IS_KEYSCAN_IN(pstcKeyscanInit->u32KeyIn));
+
+        WRITE_REG32(CM_KEYSCAN->SCR, \
+                    (pstcKeyscanInit->u32HizCycle | pstcKeyscanInit->u32LowCycle | \
+                     pstcKeyscanInit->u32KeyClock | pstcKeyscanInit->u32KeyOut   | \
+                     pstcKeyscanInit->u32KeyIn));
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize the KEYSCAN.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: De-Initialize success.
+ */
+int32_t KEYSCAN_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+    WRITE_REG32(CM_KEYSCAN->SER, 0UL);
+    WRITE_REG32(CM_KEYSCAN->SCR, 0UL);
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif  /* LL_KEYSCAN_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_mau.c
+++ b/hc32f4a2/src/hc32_ll_mau.c
@@ -1,0 +1,308 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_mau.c
+ * @brief This file provides firmware functions to manage the MAU.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Add API MAU_DeInit()
+   2024-06-30       CDT             All parameter assert add module name
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_mau.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_MAU MAU
+ * @brief MAU Driver Library
+ * @{
+ */
+
+#if (LL_MAU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup MAU_Local_Macros MAU Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup MAU_Check_Parameters_Validity MAU Check Parameters Validity
+ * @{
+ */
+#define IS_MAU_UNIT(x)        ((x) == CM_MAU)
+#define IS_MAU_SQRT_LSHBIT_NUM(x)   ((x) <= MAU_SQRT_OUTPUT_LSHIFT_MAX)
+#define IS_MAU_SIN_ANGLE_IDX(x)     ((x) < MAU_SIN_ANGIDX_TOTAL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup MAU_Global_Functions MAU Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Sqrt result left shift config
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  [in] u8ShiftNum      Number of left shift bits
+ *                              Max value is MAU_SQRT_OUTPUT_LSHIFT_MAX
+ * @retval None
+ */
+void MAU_SqrtResultLShiftConfig(CM_MAU_TypeDef *MAUx, uint8_t u8ShiftNum)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+    DDL_ASSERT(IS_MAU_SQRT_LSHBIT_NUM(u8ShiftNum));
+
+    MODIFY_REG32(MAUx->CSR, MAU_CSR_SHIFT, ((uint32_t)u8ShiftNum << MAU_CSR_SHIFT_POS));
+}
+
+/**
+ * @brief  Sqrt interrupt function command
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MAU_SqrtIntCmd(CM_MAU_TypeDef *MAUx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(MAUx->CSR, MAU_CSR_INTEN, (uint32_t)enNewState << MAU_CSR_INTEN_POS);
+}
+
+/**
+ * @brief  Input radicand for sqrt
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  [in] u32Radicand     Data to be square rooted
+ * @retval None
+ */
+void MAU_SqrtWriteData(CM_MAU_TypeDef *MAUx, uint32_t u32Radicand)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+
+    WRITE_REG32(MAUx->DTR0, u32Radicand);
+}
+
+/**
+ * @brief  Start sqrt calculation
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @retval None
+ */
+void MAU_SqrtStart(CM_MAU_TypeDef *MAUx)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+
+    SET_REG32_BIT(MAUx->CSR, MAU_CSR_START);
+}
+
+/**
+ * @brief  Check whether the sqrt calculation is in progress
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t MAU_SqrtGetStatus(const CM_MAU_TypeDef *MAUx)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+
+    return (0UL != READ_REG32_BIT(MAUx->CSR, MAU_CSR_BUSY)) ? SET : RESET;
+}
+
+/**
+ * @brief  Read result of sqrt
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @retval Result of sqrt,range is [0,0x10000]
+ */
+uint32_t MAU_SqrtReadData(const CM_MAU_TypeDef *MAUx)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+
+    return READ_REG32(MAUx->RTR0);
+}
+
+/**
+ * @brief  Initialize the MAU Sqrt function.
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  [in] u8ShiftNum      Sqrt result left shift bits, max value is @ref MAU_SQRT_OUTPUT_LSHIFT_MAX
+ * @param  [in] enNewState      Enable or Disable sqrt interrupt @ref en_functional_state_t
+ * @retval None
+ */
+void MAU_SqrtInit(CM_MAU_TypeDef *MAUx, uint8_t u8ShiftNum, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+    DDL_ASSERT(IS_MAU_SQRT_LSHBIT_NUM(u8ShiftNum));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(MAUx->CSR, MAU_CSR_SHIFT | MAU_CSR_INTEN,
+                 ((((uint32_t)u8ShiftNum << MAU_CSR_SHIFT_POS)) | ((uint32_t)enNewState << MAU_CSR_INTEN_POS)));
+}
+
+/**
+ * @brief  De-initialize the MAU Sqrt function.
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @retval None
+ */
+void MAU_SqrtDeInit(CM_MAU_TypeDef *MAUx)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+
+    CLR_REG32_BIT(MAUx->CSR, MAU_CSR_SHIFT | MAU_CSR_INTEN);
+}
+
+/**
+ * @brief  Square root
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  [in]  u32Radicand    Data to be square rooted
+ * @param  [out] pu32Result     Result of sqrt,range is [0,0x10000]
+ * @retval int32_t:
+ *               -  LL_OK:      No errors occurred
+ *               -  LL_ERR:     Errors occurred
+ */
+int32_t MAU_Sqrt(CM_MAU_TypeDef *MAUx, uint32_t u32Radicand, uint32_t *pu32Result)
+{
+    __IO uint32_t u32TimeCount = MAU_SQRT_TIMEOUT;
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+    DDL_ASSERT(pu32Result != (void *)0UL);
+
+    WRITE_REG32(MAUx->DTR0, u32Radicand);
+
+    SET_REG32_BIT(MAUx->CSR, MAU_CSR_START);
+    __ASM("NOP");
+    __ASM("NOP");
+    __ASM("NOP");
+
+    while ((MAUx->CSR & MAU_CSR_BUSY) != 0UL) {
+        if (u32TimeCount-- == 0UL) {
+            i32Ret = LL_ERR;
+            break;
+        }
+    }
+
+    if (LL_OK == i32Ret) {
+        *pu32Result = READ_REG32(MAUx->RTR0);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Sine
+ * @param  [in] MAUx            Pointer to MAU instance register base.
+ *         This parameter can only be: @arg CM_MAU
+ * @param  u16AngleIdx:         Angle index,range is [0,0xFFF], calculation method for reference:
+           AngleIdx = (uint16_t)(Angle * 4096.0F / 360.0F + 0.5F) % 4096U
+ * @retval Result of Sine in Q15 format
+ */
+int16_t MAU_Sin(CM_MAU_TypeDef *MAUx, uint16_t u16AngleIdx)
+{
+    DDL_ASSERT(IS_MAU_UNIT(MAUx));
+    DDL_ASSERT(IS_MAU_SIN_ANGLE_IDX(u16AngleIdx));
+
+    WRITE_REG16(MAUx->DTR1, u16AngleIdx);
+    __ASM("NOP");
+
+    return (int16_t)READ_REG16(MAUx->RTR1);
+}
+
+/**
+ * @brief  De-initializes MAU.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ *           - LL_ERR_TIMEOUT:          Timeout.
+ */
+int32_t MAU_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32TimeOut = MAU_SQRT_TIMEOUT;
+    /* Wait generating done */
+    while (0UL != READ_REG32(bCM_MAU->CSR_b.BUSY)) {
+        u32TimeOut--;
+        if (0UL == u32TimeOut) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+    if (LL_OK == i32Ret) {
+        WRITE_REG32(CM_MAU->CSR, 0x00000000UL);
+        WRITE_REG32(CM_MAU->DTR0,  0x00000000UL);
+        WRITE_REG32(CM_MAU->RTR0,  0x00000000UL);
+        WRITE_REG32(CM_MAU->DTR1,  0x00000000UL);
+        WRITE_REG32(CM_MAU->RTR1,  0x00000000UL);
+    }
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_MAU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_mpu.c
+++ b/hc32f4a2/src/hc32_ll_mpu.c
@@ -1,0 +1,1015 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_mpu.c
+ * @brief This file provides firmware functions to manage the Memory Protection
+ *        Unit(MPU).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Update define base on new head file
+                                    Modify IS_MPU_SP_START_ADDR & SP start address
+   2023-09-30       CDT             Modify typo
+                                    Optimize MPU_ClearStatus function
+   2023-12-15       CDT             Add API MPU_UnitInit(), MPU_UnitStructInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_mpu.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_MPU MPU
+ * @brief Memory Protection Unit Driver Library
+ * @{
+ */
+
+#if (LL_MPU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup MPU_Local_Macros MPU Local Macros
+ * @{
+ */
+
+/* Number of MPU region */
+#define MPU_REGION_MAX_NUM              (16UL)
+
+/* Number of MPU unit */
+#define MPU_UNIT_MAX_NUM                (5UL)
+
+/* Number of SP unit */
+
+/* MPU Register Combination Mask */
+#define MPU_UNIT_CONFIG_MASK            (MPU_SCR_SMPUBRP | MPU_SCR_SMPUBWP | MPU_SCR_SMPUACT)
+/* DMA units have 16 regions */
+#define MPU_16REGION_UNIT               (MPU_UNIT_DMA1 | MPU_UNIT_DMA2)
+
+/* Get the specified register address of the MPU Intrusion Control */
+#define MPU_RGD_ADDR(__NUM__)           (__IO uint32_t *)((uint32_t)(&(CM_MPU->RGD0)) + ((uint32_t)(__NUM__) << 2U))
+#define MPU_RGE_ADDR(__UNIT__)          (__IO uint32_t *)((uint32_t)(&(CM_MPU->S1RGE))  + ((uint32_t)(__UNIT__) << 4U))
+#define MPU_RGWP_ADDR(__UNIT__)         (__IO uint32_t *)((uint32_t)(&(CM_MPU->S1RGWP)) + ((uint32_t)(__UNIT__) << 4U))
+#define MPU_RGRP_ADDR(__UNIT__)         (__IO uint32_t *)((uint32_t)(&(CM_MPU->S1RGRP)) + ((uint32_t)(__UNIT__) << 4U))
+#define MPU_CR_ADDR(__UNIT__)           (__IO uint32_t *)((uint32_t)(&(CM_MPU->S1CR))   + ((uint32_t)(__UNIT__) << 4U))
+
+/* Get the SP register address */
+
+/**
+ * @defgroup MPU_Check_Parameters_Validity MPU Check Parameters Validity
+ * @{
+ */
+#define IS_MPU_UNIT(x)                                                         \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | MPU_UNIT_ALL) == MPU_UNIT_ALL))
+
+#define IS_MPU_INIT_UNIT(x)                                                    \
+(   ((x) == MPU_UNIT_DMA1)                      ||                             \
+    ((x) == MPU_UNIT_DMA2)                      ||                             \
+    ((x) == MPU_UNIT_USBFS_DMA)                 ||                             \
+    ((x) == MPU_UNIT_USBHS_DMA)                 ||                             \
+    ((x) == MPU_UNIT_ETH_DMA))
+
+#define IS_MPU_REGION(x)                        ((x) <= MPU_REGION_NUM15)
+
+#define IS_MPU_UNIT_REGION(unit, region)                                       \
+(   (((unit) | MPU_16REGION_UNIT) == MPU_16REGION_UNIT)     ||                 \
+    ((region) <= MPU_REGION_NUM7))
+
+#define IS_MPU_BACKGROUND_WR(x)                                                \
+(   ((x) == MPU_BACKGROUND_WR_DISABLE)          ||                             \
+    ((x) == MPU_BACKGROUND_WR_ENABLE))
+
+#define IS_MPU_BACKGROUND_RD(x)                                                \
+(   ((x) == MPU_BACKGROUND_RD_DISABLE)          ||                             \
+    ((x) == MPU_BACKGROUND_RD_ENABLE))
+
+#define IS_MPU_EXP_TYPE(x)                                                     \
+(   ((x) == MPU_EXP_TYPE_NONE)                  ||                             \
+    ((x) == MPU_EXP_TYPE_BUS_ERR)               ||                             \
+    ((x) == MPU_EXP_TYPE_NMI)                   ||                             \
+    ((x) == MPU_EXP_TYPE_RST))
+
+#define IS_MPU_REGION_WR(x)                                                    \
+(   ((x) == MPU_REGION_WR_DISABLE)              ||                             \
+    ((x) == MPU_REGION_WR_ENABLE))
+
+#define IS_MPU_REGION_RD(x)                                                    \
+(   ((x) == MPU_REGION_RD_DISABLE)              ||                             \
+    ((x) == MPU_REGION_RD_ENABLE))
+
+#define IS_MPU_REGION_SIZE(x)                                                  \
+(   ((x) >= MPU_REGION_SIZE_32BYTE)             &&                             \
+    ((x) <= MPU_REGION_SIZE_4GBYTE))
+
+#define IS_MPU_REGION_BASE_ADDER(addr, size)                                   \
+(   ((addr) & ((uint32_t)(~((uint64_t)0xFFFFFFFFUL << ((size) + 1U))))) == 0UL)
+
+#define IS_MPU_FLAG(x)                                                         \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | MPU_FLAG_ALL) == MPU_FLAG_ALL))
+
+#define IS_MPU_IP_TYPE(x)                                                      \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | MPU_IP_ALL) == MPU_IP_ALL))
+
+#define IS_MPU_IP_EXP_TYPE(x)                                                  \
+(   ((x) == MPU_IP_EXP_TYPE_NONE)               ||                             \
+    ((x) == MPU_IP_EXP_TYPE_BUS_ERR))
+
+#define IS_MPU_UNLOCK()                 ((CM_MPU->WP & MPU_WP_MPUWE) == MPU_WP_MPUWE)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup MPU_Global_Functions MPU Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-Initialize MPU.
+ * @param  None
+ * @retval None
+ */
+void MPU_DeInit(void)
+{
+    uint32_t i;
+    __IO uint32_t *RGD;
+    __IO uint32_t *RGE;
+    __IO uint32_t *RGWP;
+    __IO uint32_t *RGRP;
+    __IO uint32_t *CR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+
+    for (i = 0UL; i < MPU_REGION_MAX_NUM; i++) {
+        RGD = MPU_RGD_ADDR(i);
+        WRITE_REG32(*RGD, 0UL);
+    }
+    WRITE_REG32(CM_MPU->ECLR, MPU_FLAG_ALL);
+    WRITE_REG32(CM_MPU->IPPR, 0UL);
+    for (i = 0UL; i < MPU_UNIT_MAX_NUM; i++) {
+        RGE = MPU_RGE_ADDR(i);
+        WRITE_REG32(*RGE, 0UL);
+        RGWP = MPU_RGWP_ADDR(i);
+        WRITE_REG32(*RGWP, 0UL);
+        RGRP = MPU_RGRP_ADDR(i);
+        WRITE_REG32(*RGRP, 0UL);
+        CR = MPU_CR_ADDR(i);
+        WRITE_REG32(*CR, 0UL);
+    }
+}
+
+/**
+ * @brief  Initialize MPU.
+ * @param  [in] pstcMpuInit             Pointer to a @ref stc_mpu_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_Init(const stc_mpu_init_t *pstcMpuInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcMpuInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_MPU_UNLOCK());
+        DDL_ASSERT(IS_MPU_EXP_TYPE(pstcMpuInit->stcDma1.u32ExceptionType));
+        DDL_ASSERT(IS_MPU_BACKGROUND_WR(pstcMpuInit->stcDma1.u32BackgroundWrite));
+        DDL_ASSERT(IS_MPU_BACKGROUND_RD(pstcMpuInit->stcDma1.u32BackgroundRead));
+        DDL_ASSERT(IS_MPU_EXP_TYPE(pstcMpuInit->stcDma2.u32ExceptionType));
+        DDL_ASSERT(IS_MPU_BACKGROUND_WR(pstcMpuInit->stcDma2.u32BackgroundWrite));
+        DDL_ASSERT(IS_MPU_BACKGROUND_RD(pstcMpuInit->stcDma2.u32BackgroundRead));
+        DDL_ASSERT(IS_MPU_EXP_TYPE(pstcMpuInit->stcUsbFSDma.u32ExceptionType));
+        DDL_ASSERT(IS_MPU_BACKGROUND_WR(pstcMpuInit->stcUsbFSDma.u32BackgroundWrite));
+        DDL_ASSERT(IS_MPU_BACKGROUND_RD(pstcMpuInit->stcUsbFSDma.u32BackgroundRead));
+        DDL_ASSERT(IS_MPU_EXP_TYPE(pstcMpuInit->stcUsbHSDma.u32ExceptionType));
+        DDL_ASSERT(IS_MPU_BACKGROUND_WR(pstcMpuInit->stcUsbHSDma.u32BackgroundWrite));
+        DDL_ASSERT(IS_MPU_BACKGROUND_RD(pstcMpuInit->stcUsbHSDma.u32BackgroundRead));
+        DDL_ASSERT(IS_MPU_EXP_TYPE(pstcMpuInit->stcEthDma.u32ExceptionType));
+        DDL_ASSERT(IS_MPU_BACKGROUND_WR(pstcMpuInit->stcEthDma.u32BackgroundWrite));
+        DDL_ASSERT(IS_MPU_BACKGROUND_RD(pstcMpuInit->stcEthDma.u32BackgroundRead));
+
+        MODIFY_REG32(CM_MPU->S1CR, MPU_UNIT_CONFIG_MASK,
+                     (pstcMpuInit->stcDma1.u32ExceptionType | pstcMpuInit->stcDma1.u32BackgroundWrite |
+                      pstcMpuInit->stcDma1.u32BackgroundRead));
+        MODIFY_REG32(CM_MPU->S2CR, MPU_UNIT_CONFIG_MASK,
+                     (pstcMpuInit->stcDma2.u32ExceptionType | pstcMpuInit->stcDma2.u32BackgroundWrite |
+                      pstcMpuInit->stcDma2.u32BackgroundRead));
+        MODIFY_REG32(CM_MPU->FCR, MPU_UNIT_CONFIG_MASK,
+                     (pstcMpuInit->stcUsbFSDma.u32ExceptionType | pstcMpuInit->stcUsbFSDma.u32BackgroundWrite |
+                      pstcMpuInit->stcUsbFSDma.u32BackgroundRead));
+        MODIFY_REG32(CM_MPU->HCR, MPU_UNIT_CONFIG_MASK,
+                     (pstcMpuInit->stcUsbHSDma.u32ExceptionType | pstcMpuInit->stcUsbHSDma.u32BackgroundWrite |
+                      pstcMpuInit->stcUsbHSDma.u32BackgroundRead));
+        MODIFY_REG32(CM_MPU->ECR, MPU_UNIT_CONFIG_MASK,
+                     (pstcMpuInit->stcEthDma.u32ExceptionType | pstcMpuInit->stcEthDma.u32BackgroundWrite |
+                      pstcMpuInit->stcEthDma.u32BackgroundRead));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_mpu_init_t member with default value.
+ * @param  [out] pstcMpuInit            Pointer to a @ref stc_mpu_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_mpu_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_StructInit(stc_mpu_init_t *pstcMpuInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcMpuInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcMpuInit->stcDma1.u32ExceptionType       = MPU_EXP_TYPE_NONE;
+        pstcMpuInit->stcDma1.u32BackgroundWrite     = MPU_BACKGROUND_WR_DISABLE;
+        pstcMpuInit->stcDma1.u32BackgroundRead      = MPU_BACKGROUND_RD_DISABLE;
+        pstcMpuInit->stcDma2.u32ExceptionType       = MPU_EXP_TYPE_NONE;
+        pstcMpuInit->stcDma2.u32BackgroundWrite     = MPU_BACKGROUND_WR_DISABLE;
+        pstcMpuInit->stcDma2.u32BackgroundRead      = MPU_BACKGROUND_RD_DISABLE;
+        pstcMpuInit->stcUsbFSDma.u32ExceptionType   = MPU_EXP_TYPE_NONE;
+        pstcMpuInit->stcUsbFSDma.u32BackgroundWrite = MPU_BACKGROUND_WR_DISABLE;
+        pstcMpuInit->stcUsbFSDma.u32BackgroundRead  = MPU_BACKGROUND_RD_DISABLE;
+        pstcMpuInit->stcUsbHSDma.u32ExceptionType   = MPU_EXP_TYPE_NONE;
+        pstcMpuInit->stcUsbHSDma.u32BackgroundWrite = MPU_BACKGROUND_WR_DISABLE;
+        pstcMpuInit->stcUsbHSDma.u32BackgroundRead  = MPU_BACKGROUND_RD_DISABLE;
+        pstcMpuInit->stcEthDma.u32ExceptionType     = MPU_EXP_TYPE_NONE;
+        pstcMpuInit->stcEthDma.u32BackgroundWrite   = MPU_BACKGROUND_WR_DISABLE;
+        pstcMpuInit->stcEthDma.u32BackgroundRead    = MPU_BACKGROUND_RD_DISABLE;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize MPU Unit.
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] pstcUnitInit            Pointer to a @ref stc_mpu_unit_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_UnitInit(uint32_t u32Unit, stc_mpu_unit_init_t *pstcUnitInit)
+{
+    __IO uint32_t *CR;
+    uint32_t u32UnitPos;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcUnitInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_MPU_UNLOCK());
+        DDL_ASSERT(IS_MPU_INIT_UNIT(u32Unit));
+
+        u32UnitPos = __CLZ(__RBIT(u32Unit));
+
+        CR = MPU_CR_ADDR(u32UnitPos);
+        WRITE_REG32(*CR, pstcUnitInit->u32MpuState        | pstcUnitInit->u32ExceptionType | \
+                    pstcUnitInit->u32BackgroundWrite | pstcUnitInit->u32BackgroundRead);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_mpu_unit_init_t member with default value.
+ * @param  [out] pstcUnitInit           Pointer to a @ref stc_mpu_unit_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_mpu_unit_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_UnitStructInit(stc_mpu_unit_init_t *pstcUnitInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcUnitInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcUnitInit->u32MpuState        = MPU_UNIT_DISABLE;
+        pstcUnitInit->u32ExceptionType   = MPU_EXP_TYPE_NONE;
+        pstcUnitInit->u32BackgroundWrite = MPU_BACKGROUND_WR_DISABLE;
+        pstcUnitInit->u32BackgroundRead  = MPU_BACKGROUND_RD_DISABLE;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the exception type of the unit.
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] u32Type                 Exception type of MPU unit.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_EXP_TYPE_NONE:    The host unit access protection regions will be ignored
+ *           @arg MPU_EXP_TYPE_BUS_ERR: The host unit access protection regions will be ignored and a bus error will be triggered
+ *           @arg MPU_EXP_TYPE_NMI:     The host unit access protection regions will be ignored and a NMI interrupt will be triggered
+ *           @arg MPU_EXP_TYPE_RST:     The host unit access protection regions will trigger the reset
+ * @retval None
+ */
+void MPU_SetExceptionType(uint32_t u32Unit, uint32_t u32Type)
+{
+    __IO uint32_t *CR;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_MPU_EXP_TYPE(u32Type));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            CR = MPU_CR_ADDR(u32UnitPos);
+            MODIFY_REG32(*CR, MPU_SCR_SMPUACT, u32Type);
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Enable or disable the write of the unit for background space.
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_BackgroundWriteCmd(uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CR;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            CR = MPU_CR_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                CLR_REG32_BIT(*CR, MPU_SCR_SMPUBWP);
+            } else {
+                SET_REG32_BIT(*CR, MPU_SCR_SMPUBWP);
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Enable or disable the read of the unit for background space.
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_BackgroundReadCmd(uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CR;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            CR = MPU_CR_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                CLR_REG32_BIT(*CR, MPU_SCR_SMPUBRP);
+            } else {
+                SET_REG32_BIT(*CR, MPU_SCR_SMPUBRP);
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Enable or disable the access control of the unit.
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_UnitCmd(uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *CR;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            CR = MPU_CR_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                SET_REG32_BIT(*CR, MPU_SCR_SMPUE);
+            } else {
+                CLR_REG32_BIT(*CR, MPU_SCR_SMPUE);
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Gets the status of MPU flag.
+ * @param  [in] u32Flag                 The type of MPU flag.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t MPU_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_FLAG(u32Flag));
+
+    if (0UL != (READ_REG32_BIT(CM_MPU->SR, u32Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear the flag of MPU.
+ * @param  [in] u32Flag                 The type of MPU flag.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Flag
+ * @retval None
+ */
+void MPU_ClearStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_FLAG(u32Flag));
+
+    WRITE_REG32(CM_MPU->ECLR, u32Flag);
+}
+
+/**
+ * @brief  Initialize the region.
+ * @note   'MPU_REGION_NUM8' to 'MPU_REGION_NUM15' are only valid when the MPU unit is 'MPU_UNIT_DMA1' or 'MPU_UNIT_DMA2'.
+ * @note   The effective bits of the 'u32BaseAddr' are related to the 'u32Size' of the region,
+ *         and the low 'u32Size+1' bits are fixed at 0.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] pstcRegionInit          Pointer to a @ref stc_mpu_region_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_RegionInit(uint32_t u32Num, const stc_mpu_region_init_t *pstcRegionInit)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *RGD;
+    __IO uint32_t *RGWP;
+    __IO uint32_t *RGRP;
+    uint32_t i;
+    uint32_t u32UnitNum = MPU_UNIT_MAX_NUM;
+    stc_mpu_region_permission_t RegionBuffer[MPU_UNIT_MAX_NUM];
+
+    if (NULL == pstcRegionInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_MPU_UNLOCK());
+        DDL_ASSERT(IS_MPU_REGION(u32Num));
+        DDL_ASSERT(IS_MPU_REGION_SIZE(pstcRegionInit->u32Size));
+        DDL_ASSERT(IS_MPU_REGION_BASE_ADDER(pstcRegionInit->u32BaseAddr, pstcRegionInit->u32Size));
+        DDL_ASSERT(IS_MPU_REGION_WR(pstcRegionInit->stcDma1.u32RegionWrite));
+        DDL_ASSERT(IS_MPU_REGION_RD(pstcRegionInit->stcDma1.u32RegionRead));
+        DDL_ASSERT(IS_MPU_REGION_WR(pstcRegionInit->stcDma2.u32RegionWrite));
+        DDL_ASSERT(IS_MPU_REGION_RD(pstcRegionInit->stcDma2.u32RegionRead));
+        DDL_ASSERT(IS_MPU_REGION_WR(pstcRegionInit->stcUsbFSDma.u32RegionWrite));
+        DDL_ASSERT(IS_MPU_REGION_RD(pstcRegionInit->stcUsbFSDma.u32RegionRead));
+        DDL_ASSERT(IS_MPU_REGION_WR(pstcRegionInit->stcUsbHSDma.u32RegionWrite));
+        DDL_ASSERT(IS_MPU_REGION_RD(pstcRegionInit->stcUsbHSDma.u32RegionRead));
+        DDL_ASSERT(IS_MPU_REGION_WR(pstcRegionInit->stcEthDma.u32RegionWrite));
+        DDL_ASSERT(IS_MPU_REGION_RD(pstcRegionInit->stcEthDma.u32RegionRead));
+
+        RGD = MPU_RGD_ADDR(u32Num);
+        WRITE_REG32(*RGD, (pstcRegionInit->u32Size | pstcRegionInit->u32BaseAddr));
+        /* Configure the read/write permission for the region */
+        RegionBuffer[0] = pstcRegionInit->stcDma1;
+        RegionBuffer[1] = pstcRegionInit->stcDma2;
+        RegionBuffer[2] = pstcRegionInit->stcUsbFSDma;
+        RegionBuffer[3] = pstcRegionInit->stcUsbHSDma;
+        RegionBuffer[4] = pstcRegionInit->stcEthDma;
+        if ((u32Num >= MPU_REGION_NUM8) && (u32Num <= MPU_REGION_NUM15)) {
+            u32UnitNum = 2UL;
+        }
+        for (i = 0UL; i < u32UnitNum; i++) {
+            /* Configure the write permission for the region */
+            RGWP = MPU_RGWP_ADDR(i);
+            if (MPU_REGION_WR_DISABLE != RegionBuffer[i].u32RegionWrite) {
+                CLR_REG32_BIT(*RGWP, (0x1UL << u32Num));
+            } else {
+                SET_REG32_BIT(*RGWP, (0x1UL << u32Num));
+            }
+            /* Configure the read permission for the region */
+            RGRP = MPU_RGRP_ADDR(i);
+            if (MPU_REGION_WR_DISABLE != RegionBuffer[i].u32RegionRead) {
+                CLR_REG32_BIT(*RGRP, (0x1UL << u32Num));
+            } else {
+                SET_REG32_BIT(*RGRP, (0x1UL << u32Num));
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_mpu_region_init_t member with default value.
+ * @param  [out] pstcRegionInit         Pointer to a @ref stc_mpu_region_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_mpu_region_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t MPU_RegionStructInit(stc_mpu_region_init_t *pstcRegionInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRegionInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcRegionInit->u32BaseAddr                 = 0UL;
+        pstcRegionInit->u32Size                     = MPU_REGION_SIZE_32BYTE;
+        pstcRegionInit->stcDma1.u32RegionWrite      = MPU_REGION_WR_DISABLE;
+        pstcRegionInit->stcDma1.u32RegionRead       = MPU_REGION_RD_DISABLE;
+        pstcRegionInit->stcDma2.u32RegionWrite      = MPU_REGION_WR_DISABLE;
+        pstcRegionInit->stcDma2.u32RegionRead       = MPU_REGION_RD_DISABLE;
+        pstcRegionInit->stcUsbFSDma.u32RegionWrite  = MPU_REGION_WR_DISABLE;
+        pstcRegionInit->stcUsbFSDma.u32RegionRead   = MPU_REGION_RD_DISABLE;
+        pstcRegionInit->stcUsbHSDma.u32RegionWrite  = MPU_REGION_WR_DISABLE;
+        pstcRegionInit->stcUsbHSDma.u32RegionRead   = MPU_REGION_RD_DISABLE;
+        pstcRegionInit->stcEthDma.u32RegionWrite    = MPU_REGION_WR_DISABLE;
+        pstcRegionInit->stcEthDma.u32RegionRead     = MPU_REGION_RD_DISABLE;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the base address of the region.
+ * @note   The effective bits of the 'u32Addr' are related to the 'size' of the region,
+ *         and the low 'size+1' bits are fixed at 0.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] u32Addr                 The base address of the region.
+ * @retval None
+ */
+void MPU_SetRegionBaseAddr(uint32_t u32Num, uint32_t u32Addr)
+{
+    __IO uint32_t *RGD;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_REGION(u32Num));
+
+    RGD = MPU_RGD_ADDR(u32Num);
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_REGION_BASE_ADDER(u32Addr, READ_REG32_BIT(*RGD, MPU_RGD_MPURGSIZE)));
+
+    MODIFY_REG32(*RGD, MPU_RGD_MPURGADDR, u32Addr);
+}
+
+/**
+ * @brief  Set the size of the region.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] u32Size                 The size of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_SIZE_32BYTE:   32 Byte
+ *           @arg MPU_REGION_SIZE_64BYTE:   64 Byte
+ *           @arg MPU_REGION_SIZE_128BYTE:  126 Byte
+ *           @arg MPU_REGION_SIZE_256BYTE:  256 Byte
+ *           @arg MPU_REGION_SIZE_512BYTE:  512 Byte
+ *           @arg MPU_REGION_SIZE_1KBYTE:   1K Byte
+ *           @arg MPU_REGION_SIZE_2KBYTE:   2K Byte
+ *           @arg MPU_REGION_SIZE_4KBYTE:   4K Byte
+ *           @arg MPU_REGION_SIZE_8KBYTE:   8K Byte
+ *           @arg MPU_REGION_SIZE_16KBYTE:  16K Byte
+ *           @arg MPU_REGION_SIZE_32KBYTE:  32K Byte
+ *           @arg MPU_REGION_SIZE_64KBYTE:  64K Byte
+ *           @arg MPU_REGION_SIZE_128KBYTE: 128K Byte
+ *           @arg MPU_REGION_SIZE_256KBYTE: 256K Byte
+ *           @arg MPU_REGION_SIZE_512KBYTE: 512K Byte
+ *           @arg MPU_REGION_SIZE_1MBYTE:   1M Byte
+ *           @arg MPU_REGION_SIZE_2MBYTE:   2M Byte
+ *           @arg MPU_REGION_SIZE_4MBYTE:   4M Byte
+ *           @arg MPU_REGION_SIZE_8MBYTE:   8M Byte
+ *           @arg MPU_REGION_SIZE_16MBYTE:  16M Byte
+ *           @arg MPU_REGION_SIZE_32MBYTE:  32M Byte
+ *           @arg MPU_REGION_SIZE_64MBYTE:  64M Byte
+ *           @arg MPU_REGION_SIZE_128MBYTE: 128M Byte
+ *           @arg MPU_REGION_SIZE_256MBYTE: 256M Byte
+ *           @arg MPU_REGION_SIZE_512MBYTE: 512M Byte
+ *           @arg MPU_REGION_SIZE_1GBYTE:   1G Byte
+ *           @arg MPU_REGION_SIZE_2GBYTE:   2G Byte
+ *           @arg MPU_REGION_SIZE_4GBYTE:   4G Byte
+ * @retval None
+ */
+void MPU_SetRegionSize(uint32_t u32Num, uint32_t u32Size)
+{
+    __IO uint32_t *RGD;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_REGION(u32Num));
+    DDL_ASSERT(IS_MPU_REGION_SIZE(u32Size));
+
+    RGD = MPU_RGD_ADDR(u32Num);
+    MODIFY_REG32(*RGD, MPU_RGD_MPURGSIZE, u32Size);
+}
+
+/**
+ * @brief  Enable or disable the write of the unit for the region.
+ * @note   'MPU_REGION_NUM8' to 'MPU_REGION_NUM15' are only valid when the MPU unit is 'MPU_UNIT_DMA1' or 'MPU_UNIT_DMA2'.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_RegionWriteCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *RGWP;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_REGION(u32Num));
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_MPU_UNIT_REGION(u32Unit, u32Num));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            /* Configure the write permission for the region */
+            RGWP = MPU_RGWP_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                CLR_REG32_BIT(*RGWP, (0x1UL << u32Num));
+            } else {
+                SET_REG32_BIT(*RGWP, (0x1UL << u32Num));
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Enable or disable the read of the unit for the region.
+ * @note   'MPU_REGION_NUM8' to 'MPU_REGION_NUM15' are only valid when the MPU unit is 'MPU_UNIT_DMA1' or 'MPU_UNIT_DMA2'.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_RegionReadCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *RGRP;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_REGION(u32Num));
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_MPU_UNIT_REGION(u32Unit, u32Num));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            /* Configure the read permission for the region */
+            RGRP = MPU_RGRP_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                CLR_REG32_BIT(*RGRP, (0x1UL << u32Num));
+            } else {
+                SET_REG32_BIT(*RGRP, (0x1UL << u32Num));
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Enable or disable the access control of the unit for the region.
+ * @note   'MPU_REGION_NUM8' to 'MPU_REGION_NUM15' are only valid when the MPU unit is 'MPU_UNIT_DMA1' or 'MPU_UNIT_DMA2'.
+ * @param  [in] u32Num                  The number of the region.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_REGION_NUM0:      MPU region number 0
+ *           @arg MPU_REGION_NUM1:      MPU region number 1
+ *           @arg MPU_REGION_NUM2:      MPU region number 2
+ *           @arg MPU_REGION_NUM3:      MPU region number 3
+ *           @arg MPU_REGION_NUM4:      MPU region number 4
+ *           @arg MPU_REGION_NUM5:      MPU region number 5
+ *           @arg MPU_REGION_NUM6:      MPU region number 6
+ *           @arg MPU_REGION_NUM7:      MPU region number 7
+ *           @arg MPU_REGION_NUM8:      MPU region number 8
+ *           @arg MPU_REGION_NUM9:      MPU region number 9
+ *           @arg MPU_REGION_NUM10:     MPU region number 10
+ *           @arg MPU_REGION_NUM11:     MPU region number 11
+ *           @arg MPU_REGION_NUM12:     MPU region number 12
+ *           @arg MPU_REGION_NUM13:     MPU region number 13
+ *           @arg MPU_REGION_NUM14:     MPU region number 14
+ *           @arg MPU_REGION_NUM15:     MPU region number 15
+ * @param  [in] u32Unit                 The type of MPU unit.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref MPU_Unit_Type
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_RegionCmd(uint32_t u32Num, uint32_t u32Unit, en_functional_state_t enNewState)
+{
+    __IO uint32_t *RGE;
+    uint32_t u32UnitPos = 0UL;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_REGION(u32Num));
+    DDL_ASSERT(IS_MPU_UNIT(u32Unit));
+    DDL_ASSERT(IS_MPU_UNIT_REGION(u32Unit, u32Num));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Temp = u32Unit;
+    while (0UL != u32Temp) {
+        if (0UL != (u32Temp & 0x1UL)) {
+            RGE = MPU_RGE_ADDR(u32UnitPos);
+            if (DISABLE != enNewState) {
+                SET_REG32_BIT(*RGE, (0x1UL << u32Num));
+            } else {
+                CLR_REG32_BIT(*RGE, (0x1UL << u32Num));
+            }
+        }
+        u32Temp >>= 1UL;
+        u32UnitPos++;
+    }
+}
+
+/**
+ * @brief  Set the type of exception to access the protected IP.
+ * @param  [in] u32Type                 Exception type of MPU IP.
+ *         This parameter can be one of the following values:
+ *           @arg MPU_IP_EXP_TYPE_NONE:     Access to the protected IP will be ignored
+ *           @arg MPU_IP_EXP_TYPE_BUS_ERR:  Access to the protected IP will trigger a bus error
+ * @retval None
+ */
+void MPU_IP_SetExceptionType(uint32_t u32Type)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_IP_EXP_TYPE(u32Type));
+
+    WRITE_REG32(bCM_MPU->IPPR_b.BUSERRE, (u32Type >> MPU_IPPR_BUSERRE_POS));
+}
+
+/**
+ * @brief  Enable or disable write for the IP.
+ * @param  [in] u32Periph               The peripheral of the chip.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg MPU_IP_AES:           AES module
+ *           @arg MPU_IP_HASH:          HASH module
+ *           @arg MPU_IP_TRNG:          TRNG module
+ *           @arg MPU_IP_CRC:           CRC module
+ *           @arg MPU_IP_EFM:           EFM module
+ *           @arg MPU_IP_WDT:           WDT module
+ *           @arg MPU_IP_SWDT:          SWDT module
+ *           @arg MPU_IP_BKSRAM:        BKSRAM module
+ *           @arg MPU_IP_RTC:           RTC module
+ *           @arg MPU_IP_MPU:           MPU module
+ *           @arg MPU_IP_SRAMC:         SRAMC module
+ *           @arg MPU_IP_INTC:          INTC module
+ *           @arg MPU_IP_RMU_CMU_PWC:   RMU, CMU and PWC modules
+ *           @arg MPU_IP_FCG:           PWR_FCG0/1/2/3 and PWR_FCG0PC registers
+ *           @arg MPU_IP_ALL:           All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_IP_WriteCmd(uint32_t u32Periph, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_IP_TYPE(u32Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        CLR_REG32_BIT(CM_MPU->IPPR, (u32Periph << 1U));
+    } else {
+        SET_REG32_BIT(CM_MPU->IPPR, (u32Periph << 1U));
+    }
+}
+
+/**
+ * @brief  Enable or disable read for the IP.
+ * @param  [in] u32Periph               The peripheral of the chip.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg MPU_IP_AES:           AES module
+ *           @arg MPU_IP_HASH:          HASH module
+ *           @arg MPU_IP_TRNG:          TRNG module
+ *           @arg MPU_IP_CRC:           CRC module
+ *           @arg MPU_IP_EFM:           EFM module
+ *           @arg MPU_IP_WDT:           WDT module
+ *           @arg MPU_IP_SWDT:          SWDT module
+ *           @arg MPU_IP_BKSRAM:        BKSRAM module
+ *           @arg MPU_IP_RTC:           RTC module
+ *           @arg MPU_IP_MPU:           MPU module
+ *           @arg MPU_IP_SRAMC:         SRAMC module
+ *           @arg MPU_IP_INTC:          INTC module
+ *           @arg MPU_IP_RMU_CMU_PWC:   RMU, CMU and PWC modules
+ *           @arg MPU_IP_FCG:           PWR_FCG0/1/2/3 and PWR_FCG0PC registers
+ *           @arg MPU_IP_ALL:           All of the above
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void MPU_IP_ReadCmd(uint32_t u32Periph, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_MPU_UNLOCK());
+    DDL_ASSERT(IS_MPU_IP_TYPE(u32Periph));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        CLR_REG32_BIT(CM_MPU->IPPR, u32Periph);
+    } else {
+        SET_REG32_BIT(CM_MPU->IPPR, u32Periph);
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_MPU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_nfc.c
+++ b/hc32f4a2/src/hc32_ll_nfc.c
@@ -1,0 +1,1816 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_nfc.c
+ * @brief This file provides firmware functions to manage the EXMC NFC
+ *        (External Memory Controller: NAND Flash Controller) driver library.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Typo: featrue -> feature; regsiter, Regster -> register
+                                    Modify macro: EXMC_NFC_4BIT_ECCS -> EXMC_NFC_4BIT_ECC
+                                    Change function attributes from local to global: EXMC_NFC_Read/EXMC_NFC_Write
+   2024-06-30       CDT             Remove C Library function: memcpy
+                                    Optimize EXMC_NFC_Read/EXMC_NFC_Write parameter
+   2024-08-31       CDT             Function EXMC_NFC_DeInit add return value
+   2024-11-08       CDT             Optimize function EXMC_NFC_ReadId
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_nfc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EXMC EXMC
+ * @brief External Memory Controller Driver Library
+ * @{
+ */
+
+/**
+ * @defgroup LL_NFC NFC
+ * @brief NAND Flash Controller Driver Library
+ * @{
+ */
+
+#if (LL_NFC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_NFC_Local_Macros EXMC_NFC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_NFC_Check_Parameters_Validity EXMC_NFC Check Parameters Validity
+ * @{
+ */
+
+#define IS_EXMC_NFC_BANK(x)                 ((x) <= EXMC_NFC_BANK7)
+
+#define IS_EXMC_NFC_MEMORY_WIDTH(x)                                            \
+(   ((x) == EXMC_NFC_MEMORY_WIDTH_8BIT)     ||                                 \
+    ((x) == EXMC_NFC_MEMORY_WIDTH_16BIT))
+
+#define IS_EXMC_NFC_BANK_CAPACITY(x)                                           \
+(   ((x) == EXMC_NFC_BANK_CAPACITY_1GBIT)   ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_2GBIT)   ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_4GBIT)   ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_8GBIT)   ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_16GBIT)  ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_32GBIT)  ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_64GBIT)  ||                                 \
+    ((x) == EXMC_NFC_BANK_CAPACITY_512MBIT))
+
+#define IS_EXMC_NFC_PAGE_SIZE(x)                                               \
+(   ((x) == EXMC_NFC_PAGE_SIZE_2KBYTE)      ||                                 \
+    ((x) == EXMC_NFC_PAGE_SIZE_4KBYTE)      ||                                 \
+    ((x) == EXMC_NFC_PAGE_SIZE_8KBYTE))
+
+#define IS_EXMC_NFC_BANK_NUM(x)                                                \
+(   ((x) == EXMC_NFC_1BANK)                 ||                                 \
+    ((x) == EXMC_NFC_2BANKS)                ||                                 \
+    ((x) == EXMC_NFC_4BANKS)                ||                                 \
+    ((x) == EXMC_NFC_8BANKS))
+
+#define IS_EXMC_NFC_WR_PROTECT(x)                                              \
+(   ((x) == EXMC_NFC_WR_PROTECT_ENABLE)     ||                                 \
+    ((x) == EXMC_NFC_WR_PROTECT_DISABLE))
+
+#define IS_EXMC_NFC_ECC_MD(x)                                                  \
+(   ((x) == EXMC_NFC_1BIT_ECC)              ||                                 \
+    ((x) == EXMC_NFC_4BIT_ECC))
+
+#define IS_EXMC_NFC_ROW_ADDR_CYCLES(x)                                         \
+(   ((x) == EXMC_NFC_2_ROW_ADDR_CYCLE)      ||                                 \
+    ((x) == EXMC_NFC_3_ROW_ADDR_CYCLE))
+
+#define IS_EXMC_NFC_SECTION(x)              ((x) <= EXMC_NFC_ECC_SECTION15)
+
+#define IS_EXMC_NFC_INT(x)                                                     \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EXMC_NFC_INT_MASK) == EXMC_NFC_INT_MASK))
+
+#define IS_EXMC_NFC_FLAG(x)                                                    \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | EXMC_NFC_FLAG_MASK) == EXMC_NFC_FLAG_MASK))
+
+#define IS_EXMC_NFC_TIMING_TS(x)            ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TWP(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TRP(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TH(x)            ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TWH(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TRH(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TRR(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TWB(x)           ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TCCS(x)          ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TWTR(x)          ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TRTW(x)          ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_TIMING_TADL(x)          ((x) <= 0xFFUL)
+
+#define IS_EXMC_NFC_COL(x)                  ((x) <= NFC_COL_MAX)
+
+#define IS_EXMC_NFC_PAGE(page, capacity_index)  ((page) <= NFC_PAGE_MAX((capacity_index)))
+
+#define IS_PARAM_ALIGN_WORD(x)              (IS_ADDR_ALIGN_WORD((x)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Interrupt_Mask EXMC_NFC Interrupt Mask
+ * @{
+ */
+#define EXMC_NFC_INT_MASK                                                      \
+(   EXMC_NFC_INT_RB_BANK0                   |                                  \
+    EXMC_NFC_INT_RB_BANK1                   |                                  \
+    EXMC_NFC_INT_RB_BANK2                   |                                  \
+    EXMC_NFC_INT_RB_BANK3                   |                                  \
+    EXMC_NFC_INT_RB_BANK4                   |                                  \
+    EXMC_NFC_INT_RB_BANK5                   |                                  \
+    EXMC_NFC_INT_RB_BANK6                   |                                  \
+    EXMC_NFC_INT_RB_BANK7                   |                                  \
+    EXMC_NFC_INT_ECC_ERROR                  |                                  \
+    EXMC_NFC_INT_ECC_CALC_COMPLETION        |                                  \
+    EXMC_NFC_INT_ECC_CORRECTABLE_ERR        |                                  \
+    EXMC_NFC_INT_ECC_UNCORRECTABLE_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Flag_Mask EXMC_NFC Flag Mask
+ * @{
+ */
+#define EXMC_NFC_FLAG_MASK                                                     \
+(   EXMC_NFC_FLAG_RB_BANK0                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK1                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK2                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK3                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK4                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK5                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK6                  |                                  \
+    EXMC_NFC_FLAG_RB_BANK7                  |                                  \
+    EXMC_NFC_FLAG_ECC_ERR                   |                                  \
+    EXMC_NFC_FLAG_ECC_CALCULATING           |                                  \
+    EXMC_NFC_FLAG_ECC_CALC_COMPLETION       |                                  \
+    EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR       |                                  \
+    EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Memory_Capacity_Index EXMC_NFC Memory Capacity Index
+ * @{
+ */
+#define NFC_CAPACITY_INDEX_512MBIT          (0UL)
+#define NFC_CAPACITY_INDEX_1GBIT            (1UL)
+#define NFC_CAPACITY_INDEX_2GBIT            (2UL)
+#define NFC_CAPACITY_INDEX_4GBIT            (3UL)
+#define NFC_CAPACITY_INDEX_8GBIT            (4UL)
+#define NFC_CAPACITY_INDEX_16GBIT           (5UL)
+#define NFC_CAPACITY_INDEX_32GBIT           (6UL)
+#define NFC_CAPACITY_INDEX_64GBIT           (7UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Command_Register_Value EXMC_NFC Command Register Value
+ * @{
+ */
+/*!< Command value */
+#define NFC_CMD_VALUE(arg, bank, cmd)       ((arg) | ((bank) << 8U) | (cmd))
+
+/*!< Command: Read status */
+#define NFC_ADDR_VALUE(bank, addr)          (0x40000000UL | ((bank) << 8U) | (addr))
+
+/*!< Command: Read status */
+#define CMD_RESET(bank)                     (NFC_CMD_VALUE(0UL, (bank), EXMC_NFC_CMD_RESET))
+
+/*!< Command: Read status */
+#define CMD_ASYNC_RESET(bank)               (NFC_CMD_VALUE(0x82000000UL, (bank), EXMC_NFC_CMD_ASYNCHRONOUS_RST))
+
+/*!< Command: Read status */
+#define CMD_RESET_LUN(bank)                 (NFC_CMD_VALUE(0x82000000UL, (bank), EXMC_NFC_CMD_RST_LUN))
+
+/*!< Command: Read status */
+#define CMD_READ_STATUS(bank)               (NFC_CMD_VALUE(0x81000000UL, (bank), EXMC_NFC_CMD_RD_STATUS))
+
+/*!< Command: Read status */
+#define CMD_READ_STATUS_ENHANCED(bank)      (NFC_CMD_VALUE(0x80000000UL, (bank), EXMC_NFC_CMD_RD_STATUS_ENHANCED))
+
+/*!< Command: Read ID */
+#define CMD_READ_ID(bank)                   (NFC_CMD_VALUE(0x81000000UL, (bank), EXMC_NFC_CMD_RD_ID))
+#define CMD_READ_ID_ADDR(bank, addr)        (NFC_ADDR_VALUE((bank), (addr)))
+
+/*!< Command: Read unique ID */
+#define CMD_READ_UNIQUEID(bank)             (NFC_CMD_VALUE(0x83000000UL, (bank), EXMC_NFC_CMD_RD_UNIQUE_ID))
+#define CMD_READ_UNIQUEID_ADDR(bank)        (NFC_ADDR_VALUE((bank), 0UL))
+
+/*!< Command: Erase block */
+#define CMD_ERASE_BLOCK_1ST_CYCLE(bank)     (NFC_CMD_VALUE(0x81000000UL, (bank), EXMC_NFC_CMD_BLK_ERASE_1ST))
+#define CMD_ERASE_BLOCK_2ND_CYCLE(bank)     (NFC_CMD_VALUE(0x81000000UL, (bank), EXMC_NFC_CMD_BLK_ERASE_2ND))
+
+/*!< Command: Read parameter page */
+#define CMD_READ_PARAMETER_PAGE(bank)       (NFC_CMD_VALUE(0x83000000UL, (bank), EXMC_NFC_CMD_RD_PARAMETER_PAGE))
+#define CMD_READ_PARAMETER_PAGE_ADDR(bank)  (NFC_ADDR_VALUE((bank), 0UL))
+
+/*!< Command: Set feature */
+#define CMD_SET_FEATURE(bank)               (NFC_CMD_VALUE(0x83000000UL, (bank), EXMC_NFC_CMD_SET_FEATURES))
+#define CMD_SET_FEATURE_ADDR(bank, addr)    (NFC_ADDR_VALUE((bank), (addr)))
+
+/*!< Command: Get feature */
+#define CMD_GET_FEATURE(bank)               (NFC_CMD_VALUE(0x83000000UL, (bank), EXMC_NFC_CMD_GET_FEATURES))
+#define CMD_GET_FEATURE_ADDR(bank, addr)    (NFC_ADDR_VALUE((bank), (addr)))
+
+/*!< Command: Address cycle */
+#define CMD_ADDR_1ST_CYCLE(bank, ras)       (NFC_ADDR_VALUE((bank), ((ras) & 0xFFUL)))
+#define CMD_ADDR_2ND_CYCLE(bank, ras)       (NFC_ADDR_VALUE((bank), (((ras) & 0xFF00UL) >> 8UL)))
+#define CMD_ADDR_3RD_CYCLE(bank, ras)       (NFC_ADDR_VALUE((bank), (((ras) & 0xFF0000UL) >> 16UL)))
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_IDXR_Bit_Position EXMC_NFC IDXR Bit Position
+ * @{
+ */
+#define EXMC_NFC_IDXR_COL_POS               (0U)
+#define EXMC_NFC_IDXR_2KPAGE_POS            (12U)
+#define EXMC_NFC_IDXR_512MBIT_BANK_POS      (27U)
+/**
+ * @}
+ */
+
+/*!< NFC BACR register: page field value */
+#define NFC_BACR_PAGE_VAL                   ((uint8_t)((READ_REG32_BIT(CM_NFC->BACR, NFC_BACR_PAGE) >> NFC_BACR_PAGE_POS) & 0x3UL))
+
+/*!< NFC Page Size */
+#define NFC_PAGE_SIZE                       (1024UL << NFC_BACR_PAGE_VAL)
+
+/*!< NFC page max for the specified capacity */
+#define NFC_PAGE_MAX(capacity_index)        ((1UL << (19U + (uint8_t)(capacity_index) - NFC_BACR_PAGE_VAL)) - 1UL)
+
+/*!< NFC column max */
+#define NFC_COL_MAX                         ((1UL << (EXMC_NFC_IDXR_2KPAGE_POS + NFC_BACR_PAGE_VAL - 1U)) - 1UL)
+
+/*!< NFC Spare Size for user data */
+#define NFC_SPARE_SIZE_FOR_USER_DATA        ((READ_REG32_BIT(CM_NFC->BACR, NFC_BACR_SCS) >> NFC_BACR_SCS_POS) << 2UL)
+
+/*!< NFC_ISTR register RBST bit mask */
+#define NFC_FLAG_RB_BANKx_MASK(bank)        (EXMC_NFC_FLAG_RB_BANK0 << (EXMC_NFC_BANK7 & (bank)))
+
+/*!< IDX register mask for 64bit */
+#define NFC_NFC_ISTR_MASK                   (0xFF53UL)
+
+/*!< NFC_DATR for 32bit */
+#define NFC_DATR_REG32(x)                   (CM_NFC->DATR_BASE)
+
+/**
+ * @defgroup EXMC_NFC_ECC_Reference EXMC_NFC ECC Reference
+ * @{
+ */
+/*!< NFC_SYND_REG for 32bit */
+#define NFC_SYND_REG32(sect, reg)           (*((__IO uint32_t *)((uint32_t)(&(CM_NFC->ECC_SYND0_0)) + (((uint32_t)(sect)) << 4UL) + (((uint32_t)(reg)) << 2UL))))
+
+/*!< NFC_ECCR_REG for 32bit */
+#define NFC_ECCR_REG32(sect)                (*((__IO uint32_t *)((uint32_t)(&(CM_NFC->ECCR0))   + (((uint32_t)(sect)) << 2UL))))
+
+/*!< NFC_SYND_MAX_Length (Unit: half-word) */
+#define NFC_SYND_MAX_LEN                    (8U)
+
+/*!< NFC 1Bit ECC Error Bit Mask */
+#define NFC_1BIT_ECC_ERR_BIT_MASK           (0x7U)
+
+/*!< NFC 1Bit ECC Error Byte Position */
+#define NFC_1BIT_ECC_ERR_BYTE_POS           (3U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_IDXR_Register_Reference EXMC_NFC IDXR Register Reference
+ * @note capacity_index @ref EXMC_NFC_Memory_Capacity_Index
+ * @{
+ */
+/*!< IDX register value for 64bit */
+#define NFC_IDXR_VAL(bank, page, col, capacity_index)                          \
+(   (((uint64_t)(col)) << EXMC_NFC_IDXR_COL_POS) |                             \
+    (((uint64_t)(page)) << (EXMC_NFC_IDXR_2KPAGE_POS + NFC_BACR_PAGE_VAL - 1U)) | \
+    (((uint64_t)(bank)) << (EXMC_NFC_IDXR_512MBIT_BANK_POS + (uint8_t)(capacity_index))))
+
+/*!< IDX register mask for 64bit */
+#define NFC_IDXR_MASK                       (0x1FFFFFFFFFULL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup EXMC_NFC_Local_Functions EXMC_NFC Local Functions
+ * @{
+ */
+
+/**
+ * @brief  Get capacity size.
+ * @param  None
+ * @retval Capacity index @ref EXMC_NFC_Memory_Capacity_Index
+ *           - NFC_CAPACITY_INDEX_512MBIT:  NFC device capacity 512MBit
+ *           - NFC_CAPACITY_INDEX_1GBIT:    NFC device capacity 1GBit
+ *           - NFC_CAPACITY_INDEX_2GBIT:    NFC device capacity 2GBit
+ *           - NFC_CAPACITY_INDEX_4GBIT:    NFC device capacity 4GBit
+ *           - NFC_CAPACITY_INDEX_8GBIT:    NFC device capacity 8GBit
+ *           - NFC_CAPACITY_INDEX_16GBIT:   NFC device capacity 16GBit
+ *           - NFC_CAPACITY_INDEX_32GBIT:   NFC device capacity 32GBit
+ *           - NFC_CAPACITY_INDEX_64GBIT:   NFC device capacity 64GBit
+ */
+static uint32_t EXMC_NFC_GetCapacityIndex(void)
+{
+    uint32_t u32Index;
+    const uint32_t u32BacrSize = READ_REG32_BIT(CM_NFC->BACR, NFC_BACR_SIZE);
+
+    switch (u32BacrSize) {
+        case EXMC_NFC_BANK_CAPACITY_512MBIT:
+            u32Index = NFC_CAPACITY_INDEX_512MBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_1GBIT:
+            u32Index = NFC_CAPACITY_INDEX_1GBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_2GBIT:
+            u32Index = NFC_CAPACITY_INDEX_2GBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_4GBIT:
+            u32Index = NFC_CAPACITY_INDEX_4GBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_8GBIT:
+            u32Index = NFC_CAPACITY_INDEX_8GBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_16GBIT:
+            u32Index = NFC_CAPACITY_INDEX_16GBIT;
+            break;
+        case EXMC_NFC_BANK_CAPACITY_32GBIT:
+            u32Index = NFC_CAPACITY_INDEX_32GBIT;
+            break;
+        default:
+            u32Index = NFC_CAPACITY_INDEX_64GBIT;
+            break;
+    }
+
+    return u32Index;
+}
+
+/**
+ * @brief  Wait the specified flag with timeout.
+ * @param  [in] u32Flag                 The specified flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK0:       NFC device bank 0 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK1:       NFC device bank 1 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK2:       NFC device bank 2 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK3:       NFC device bank 3 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK4:       NFC device bank 4 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK5:       NFC device bank 5 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK6:       NFC device bank 6 busy flag
+ *   @arg EXMC_NFC_FLAG_RB_BANK7:       NFC device bank 7 busy flag
+ *   @arg EXMC_NFC_FLAG_ECC_ERR:        ECC error
+ *   @arg EXMC_NFC_FLAG_ECC_CALC_COMPLETION: Calculating ECC completely
+ *   @arg EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR: ECC correctable error
+ *   @arg EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR: ECC uncorrectable error
+ * @param  enStatus                     The waiting flag status (SET or RESET).
+ * @param  u32Timeout                   Timeout duration(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   Complete wait the expected status of the specified flags.
+ *           - LL_ERR_TIMEOUT:          Wait timeout.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+static int32_t EXMC_NFC_WaitFlagUntilTo(uint32_t u32Flag, en_flag_status_t enStatus, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32To = 0UL;
+
+    DDL_ASSERT(IS_EXMC_NFC_FLAG(u32Flag));
+
+    while (EXMC_NFC_GetStatus(u32Flag) != enStatus) {
+        /* Block checking flag if timeout value is EXMC_NFC_MAX_TIMEOUT */
+        if ((u32To > u32Timeout) && (u32Timeout < EXMC_NFC_MAX_TIMEOUT)) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+
+        u32To++;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_NFC_Global_Functions EXMC_NFC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_exmc_nfc_init_t to default values
+ * @param  [out] pstcNfcInit            Pointer to a @ref stc_exmc_nfc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcNfcInit value is NULL.
+ */
+int32_t EXMC_NFC_StructInit(stc_exmc_nfc_init_t *pstcNfcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcNfcInit) {
+        pstcNfcInit->stcBaseConfig.u32CapacitySize = EXMC_NFC_BANK_CAPACITY_8GBIT;
+        pstcNfcInit->stcBaseConfig.u32MemoryWidth = EXMC_NFC_MEMORY_WIDTH_8BIT;
+        pstcNfcInit->stcBaseConfig.u32BankNum = EXMC_NFC_4BANKS;
+        pstcNfcInit->stcBaseConfig.u32PageSize = EXMC_NFC_PAGE_SIZE_2KBYTE;
+        pstcNfcInit->stcBaseConfig.u32WriteProtect = EXMC_NFC_WR_PROTECT_ENABLE;
+        pstcNfcInit->stcBaseConfig.u32EccMode = EXMC_NFC_1BIT_ECC;
+        pstcNfcInit->stcBaseConfig.u32RowAddrCycle = EXMC_NFC_3_ROW_ADDR_CYCLE;
+        pstcNfcInit->stcBaseConfig.u8SpareSizeForUserData = 0U;
+
+        pstcNfcInit->stcTimingReg0.u32TS = 0x02UL;
+        pstcNfcInit->stcTimingReg0.u32TWP = 0x02UL;
+        pstcNfcInit->stcTimingReg0.u32TRP = 0x03UL;
+        pstcNfcInit->stcTimingReg0.u32TH = 0x03UL;
+
+        pstcNfcInit->stcTimingReg1.u32TWH = 0x03UL;
+        pstcNfcInit->stcTimingReg1.u32TRH = 0x03UL;
+        pstcNfcInit->stcTimingReg1.u32TRR = 0x02UL;
+        pstcNfcInit->stcTimingReg1.u32TWB = 0x28UL;
+
+        pstcNfcInit->stcTimingReg2.u32TCCS = 0x03UL;
+        pstcNfcInit->stcTimingReg2.u32TWTR = 0x0DUL;
+        pstcNfcInit->stcTimingReg2.u32TRTW = 0x05UL;
+        pstcNfcInit->stcTimingReg2.u32TADL = 0x03UL;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize EXMC_NFC function.
+ * @param  [in] pstcNfcInit             Pointer to a @ref stc_exmc_nfc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcNfcInit value is NULL.
+ */
+int32_t EXMC_NFC_Init(const stc_exmc_nfc_init_t *pstcNfcInit)
+{
+    uint32_t u32RegVal;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcNfcInit) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK_CAPACITY(pstcNfcInit->stcBaseConfig.u32CapacitySize));
+        DDL_ASSERT(IS_EXMC_NFC_MEMORY_WIDTH(pstcNfcInit->stcBaseConfig.u32MemoryWidth));
+        DDL_ASSERT(IS_EXMC_NFC_BANK_NUM(pstcNfcInit->stcBaseConfig.u32BankNum));
+        DDL_ASSERT(IS_EXMC_NFC_PAGE_SIZE(pstcNfcInit->stcBaseConfig.u32PageSize));
+        DDL_ASSERT(IS_EXMC_NFC_WR_PROTECT(pstcNfcInit->stcBaseConfig.u32WriteProtect));
+        DDL_ASSERT(IS_EXMC_NFC_ECC_MD(pstcNfcInit->stcBaseConfig.u32EccMode));
+        DDL_ASSERT(IS_EXMC_NFC_ROW_ADDR_CYCLES(pstcNfcInit->stcBaseConfig.u32RowAddrCycle));
+
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TS(pstcNfcInit->stcTimingReg0.u32TS));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TWP(pstcNfcInit->stcTimingReg0.u32TWP));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TRP(pstcNfcInit->stcTimingReg0.u32TRP));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TH(pstcNfcInit->stcTimingReg0.u32TH));
+
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TWH(pstcNfcInit->stcTimingReg1.u32TWH));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TRH(pstcNfcInit->stcTimingReg1.u32TRH));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TRR(pstcNfcInit->stcTimingReg1.u32TRR));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TWB(pstcNfcInit->stcTimingReg1.u32TWB));
+
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TCCS(pstcNfcInit->stcTimingReg2.u32TCCS));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TWTR(pstcNfcInit->stcTimingReg2.u32TWTR));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TRTW(pstcNfcInit->stcTimingReg2.u32TRTW));
+        DDL_ASSERT(IS_EXMC_NFC_TIMING_TADL(pstcNfcInit->stcTimingReg2.u32TADL));
+
+        /* Set NFC open-page.*/
+        WRITE_REG32(CM_PERIC->NFC_STCR, pstcNfcInit->u32OpenPage);
+
+        /* Disable hardware ECC.*/
+        WRITE_REG32(CM_NFC->IENR, 0x00000080UL);
+
+        /* Clear flag.*/
+        WRITE_REG32(CM_NFC->ISTR, 0x00000000UL);
+
+        /* Set NFC base configure.*/
+        u32RegVal = (pstcNfcInit->stcBaseConfig.u32CapacitySize | pstcNfcInit->stcBaseConfig.u32MemoryWidth | \
+                     pstcNfcInit->stcBaseConfig.u32BankNum      | pstcNfcInit->stcBaseConfig.u32PageSize | \
+                     pstcNfcInit->stcBaseConfig.u32WriteProtect | pstcNfcInit->stcBaseConfig.u32EccMode | \
+                     pstcNfcInit->stcBaseConfig.u32RowAddrCycle | \
+                     (((uint32_t)pstcNfcInit->stcBaseConfig.u8SpareSizeForUserData) << NFC_BACR_SCS_POS));
+        WRITE_REG32(CM_NFC->BACR, u32RegVal);
+
+        /* Set NFC timing register 0.*/
+        u32RegVal = ((pstcNfcInit->stcTimingReg0.u32TS << NFC_TMCR0_TS_POS)   | \
+                     (pstcNfcInit->stcTimingReg0.u32TWP << NFC_TMCR0_TWP_POS) | \
+                     (pstcNfcInit->stcTimingReg0.u32TRP << NFC_TMCR0_TRP_POS) | \
+                     (pstcNfcInit->stcTimingReg0.u32TH << NFC_TMCR0_TH_POS));
+        WRITE_REG32(CM_NFC->TMCR0, u32RegVal);
+
+        /* Set NFC timing register 1.*/
+        u32RegVal = ((pstcNfcInit->stcTimingReg1.u32TWH << NFC_TMCR1_TWH_POS) | \
+                     (pstcNfcInit->stcTimingReg1.u32TRH << NFC_TMCR1_TRH_POS) | \
+                     (pstcNfcInit->stcTimingReg1.u32TRR << NFC_TMCR1_TRR_POS) | \
+                     (pstcNfcInit->stcTimingReg1.u32TWB << NFC_TMCR1_TWB_POS));
+        WRITE_REG32(CM_NFC->TMCR1, u32RegVal);
+
+        /* Set NFC timing register 2.*/
+        u32RegVal = ((pstcNfcInit->stcTimingReg2.u32TCCS << NFC_TMCR2_TCCS_POS) | \
+                     (pstcNfcInit->stcTimingReg2.u32TWTR << NFC_TMCR2_TWTR_POS) | \
+                     (pstcNfcInit->stcTimingReg2.u32TRTW << NFC_TMCR2_TRTW_POS) | \
+                     (pstcNfcInit->stcTimingReg2.u32TADL << NFC_TMCR2_TADL_POS));
+        WRITE_REG32(CM_NFC->TMCR2, u32RegVal);
+
+        /* De-select NFC bank */
+        WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_DESELECT_CHIP);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize EXMC_NFC function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t EXMC_NFC_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(CM_NFC->BACR, 0x00002187UL);
+    WRITE_REG32(CM_NFC->IENR, 0x00000080UL);
+    WRITE_REG32(CM_NFC->ISTR, 0x00000000UL);
+    WRITE_REG32(CM_NFC->TMCR0, 0x03030202UL);
+    WRITE_REG32(CM_NFC->TMCR1, 0x28080303UL);
+    WRITE_REG32(CM_NFC->TMCR2, 0x03050D03UL);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable/disable NFC.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_NFC_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_PERIC->NFC_ENAR, PERIC_NFC_ENAR_NFCEN);
+    } else {
+        CLR_REG32_BIT(CM_PERIC->NFC_ENAR, PERIC_NFC_ENAR_NFCEN);
+    }
+}
+
+/**
+ * @brief  Enable/disable NFC ECC function.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_NFC_EccCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_NFC->IENR, NFC_IENR_ECCDIS);
+    } else {
+        SET_REG32_BIT(CM_NFC->IENR, NFC_IENR_ECCDIS);
+    }
+}
+
+/**
+ * @brief  Enable/disable NFC write protection function.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_NFC_WriteProtectCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(CM_NFC->BACR, NFC_BACR_WP);
+    } else {
+        SET_REG32_BIT(CM_NFC->BACR, NFC_BACR_WP);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified NFC interrupt
+ * @param  [in] u16IntType                The specified interrupt
+ *         This parameter can be any composed value of the macros group @ref EXMC_NFC_Interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK0:  NFC bank 0 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK1:  NFC bank 1 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK2:  NFC bank 2 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK3:  NFC bank 3 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK4:  NFC bank 4 device ready flag
+ *           @arg EXMC_NFC_INT_RB_BANK5:  NFC bank 5 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK6:  NFC bank 6 device ready interrupt
+ *           @arg EXMC_NFC_INT_RB_BANK7:  NFC bank 7 device ready interrupt
+ *           @arg EXMC_NFC_INT_ECC_ERROR: ECC error interrupt
+ *           @arg EXMC_NFC_INT_ECC_CALC_COMPLETION: Calculating ECC completely interrupt
+ *           @arg EXMC_NFC_INT_ECC_CORRECTABLE_ERR: ECC correctable error interrupt
+ *           @arg EXMC_NFC_INT_ECC_UNCORRECTABLE_ERR: ECC uncorrectable error interrupt
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_NFC_IntCmd(uint16_t u16IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_EXMC_NFC_INT(u16IntType));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(CM_NFC->IENR, u16IntType);
+    } else {
+        CLR_REG16_BIT(CM_NFC->IENR, u16IntType);
+    }
+}
+
+/**
+ * @brief  Get the specified flag status.
+ * @param  [in] u32Flag                 The specified flag
+ *         This parameter can be any composed value of the macros group @ref EXMC_NFC_Flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK0:  NFC bank 0 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK1:  NFC bank 1 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK2:  NFC bank 2 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK3:  NFC bank 3 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK4:  NFC bank 4 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK5:  NFC bank 5 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK6:  NFC bank 6 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK7:  NFC bank 7 device ready flag
+ *           @arg EXMC_NFC_FLAG_ECC_ERR:   ECC error
+ *           @arg EXMC_NFC_FLAG_ECC_CALC_COMPLETION: Calculate ECC completely
+ *           @arg EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR: ECC correctable error
+ *           @arg EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR: ECC uncorrectable error
+ *           @arg EXMC_NFC_FLAG_ECC_CALCULATING: Calculating ECC
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EXMC_NFC_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enStatus1 = RESET;
+    en_flag_status_t enStatus2 = RESET;
+
+    DDL_ASSERT(IS_EXMC_NFC_FLAG(u32Flag));
+
+    if (0UL != (u32Flag & NFC_NFC_ISTR_MASK)) {
+        if (0UL != READ_REG32_BIT(CM_NFC->ISTR, (u32Flag & NFC_NFC_ISTR_MASK))) {
+            enStatus1 = SET;
+        }
+    }
+
+    if (0UL != (u32Flag & EXMC_NFC_FLAG_ECC_CALCULATING)) {
+        if (0UL != READ_REG32_BIT(CM_PERIC->NFC_STSR, PERIC_NFC_STSR_PECC)) {
+            enStatus2 = SET;
+        }
+    }
+
+    return (((SET == enStatus1) || (SET == enStatus2)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear the specified flag.
+ * @param  [in] u32Flag                 The specified flag
+ *         This parameter can be any composed value of the following values:
+ *           @arg EXMC_NFC_FLAG_RB_BANK0:  NFC bank 0 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK1:  NFC bank 1 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK2:  NFC bank 2 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK3:  NFC bank 3 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK4:  NFC bank 4 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK5:  NFC bank 5 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK6:  NFC bank 6 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK7:  NFC bank 7 device ready flag
+ *           @arg EXMC_NFC_FLAG_ECC_ERR:   ECC error
+ *           @arg EXMC_NFC_FLAG_ECC_CALC_COMPLETION: Calculating ECC completely
+ *           @arg EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR: ECC correctable error
+ *           @arg EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR: ECC uncorrectable error
+ * @retval None
+ */
+void EXMC_NFC_ClearStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EXMC_NFC_FLAG(u32Flag));
+
+    CLR_REG32_BIT(CM_NFC->ISTR, u32Flag);
+}
+
+/**
+ * @brief  Get the interrupt result status.
+ * @param  [in] u32Flag                 The specified flag
+ *         This parameter can be any composed value of the following values:
+ *           @arg EXMC_NFC_FLAG_RB_BANK0:  NFC bank 0 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK1:  NFC bank 1 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK2:  NFC bank 2 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK3:  NFC bank 3 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK4:  NFC bank 4 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK5:  NFC bank 5 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK6:  NFC bank 6 device ready flag
+ *           @arg EXMC_NFC_FLAG_RB_BANK7:  NFC bank 7 device ready flag
+ *           @arg EXMC_NFC_FLAG_ECC_ERR:   ECC error
+ *           @arg EXMC_NFC_FLAG_ECC_CALC_COMPLETION: Calculating ECC completely
+ *           @arg EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR: ECC correctable error
+ *           @arg EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR: ECC uncorrectable error
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t EXMC_NFC_GetIntResultStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_EXMC_NFC_FLAG(u32Flag));
+
+    return ((READ_REG32_BIT(CM_NFC->IRSR, u32Flag) > 0UL) ? SET : RESET);
+}
+
+/**
+ * @brief  Get the 1BIT ECC result of the specified section.
+ * @param  [in] u32Section              The specified section
+ *         This parameter can be one of the macros group @ref EXMC_NFC_ECC_Section
+ *           @arg EXMC_NFC_ECC_SECTION0:  ECC section 0
+ *           @arg EXMC_NFC_ECC_SECTION1:  ECC section 1
+ *           @arg EXMC_NFC_ECC_SECTION2:  ECC section 2
+ *           @arg EXMC_NFC_ECC_SECTION3:  ECC section 3
+ *           @arg EXMC_NFC_ECC_SECTION4:  ECC section 4
+ *           @arg EXMC_NFC_ECC_SECTION5:  ECC section 5
+ *           @arg EXMC_NFC_ECC_SECTION6:  ECC section 6
+ *           @arg EXMC_NFC_ECC_SECTION7:  ECC section 7
+ *           @arg EXMC_NFC_ECC_SECTION8:  ECC section 8
+ *           @arg EXMC_NFC_ECC_SECTION9:  ECC section 9
+ *           @arg EXMC_NFC_ECC_SECTION10: ECC section 10
+ *           @arg EXMC_NFC_ECC_SECTION11: ECC section 11
+ *           @arg EXMC_NFC_ECC_SECTION12: ECC section 12
+ *           @arg EXMC_NFC_ECC_SECTION13: ECC section 13
+ *           @arg EXMC_NFC_ECC_SECTION14: ECC section 14
+ *           @arg EXMC_NFC_ECC_SECTION15: ECC section 15
+ * @retval Return one of the macros group @ref EXMC_NFC_1Bit_ECC_Result
+ *           - EXMC_NFC_1BIT_ECC_NONE_ERR:          None error
+ *           - EXMC_NFC_1BIT_ECC_SINGLE_BIT_ERR:    Single bit error
+ *           - EXMC_NFC_1BIT_ECC_MULTIPLE_BITS_ERR: Multiple bit error
+ */
+uint32_t EXMC_NFC_Get1BitEccResult(uint32_t u32Section)
+{
+    DDL_ASSERT(IS_EXMC_NFC_SECTION(u32Section));
+
+    return READ_REG32_BIT(NFC_ECCR_REG32(u32Section), (NFC_ECCR_SE | NFC_ECCR_ME));
+}
+
+/**
+ * @brief  Get the 1BIT ECC error bit of the specified section.
+ * @param  [in] u32Section              The specified section
+ *         This parameter can be one of the macros group @ref EXMC_NFC_ECC_Section
+ *           @arg EXMC_NFC_ECC_SECTION0:  ECC section 0
+ *           @arg EXMC_NFC_ECC_SECTION1:  ECC section 1
+ *           @arg EXMC_NFC_ECC_SECTION2:  ECC section 2
+ *           @arg EXMC_NFC_ECC_SECTION3:  ECC section 3
+ *           @arg EXMC_NFC_ECC_SECTION4:  ECC section 4
+ *           @arg EXMC_NFC_ECC_SECTION5:  ECC section 5
+ *           @arg EXMC_NFC_ECC_SECTION6:  ECC section 6
+ *           @arg EXMC_NFC_ECC_SECTION7:  ECC section 7
+ *           @arg EXMC_NFC_ECC_SECTION8:  ECC section 8
+ *           @arg EXMC_NFC_ECC_SECTION9:  ECC section 9
+ *           @arg EXMC_NFC_ECC_SECTION10: ECC section 10
+ *           @arg EXMC_NFC_ECC_SECTION11: ECC section 11
+ *           @arg EXMC_NFC_ECC_SECTION12: ECC section 12
+ *           @arg EXMC_NFC_ECC_SECTION13: ECC section 13
+ *           @arg EXMC_NFC_ECC_SECTION14: ECC section 14
+ *           @arg EXMC_NFC_ECC_SECTION15: ECC section 15
+ * @retval Return one of the macros group @ref EXMC_NFC_1Bit_ECC_Error_Bit_Location
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT0: Bit0 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT1: Bit1 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT2: Bit2 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT3: Bit3 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT4: Bit4 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT5: Bit5 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT6: Bit6 error
+ *           - EXMC_NFC_1BIT_ECC_ERR_BIT7: Bit7 error
+ */
+uint32_t EXMC_NFC_Get1BitEccErrBitLocation(uint32_t u32Section)
+{
+    DDL_ASSERT(IS_EXMC_NFC_SECTION(u32Section));
+
+    return READ_REG32_BIT(NFC_ECCR_REG32(u32Section), NFC_1BIT_ECC_ERR_BIT_MASK);
+}
+
+/**
+ * @brief  Get the 1BIT ECC error byte of the specified section.
+ * @param  [in] u32Section              The specified section
+ *         This parameter can be one of the macros group @ref EXMC_NFC_ECC_Section
+ *           @arg EXMC_NFC_ECC_SECTION0:  ECC section 0
+ *           @arg EXMC_NFC_ECC_SECTION1:  ECC section 1
+ *           @arg EXMC_NFC_ECC_SECTION2:  ECC section 2
+ *           @arg EXMC_NFC_ECC_SECTION3:  ECC section 3
+ *           @arg EXMC_NFC_ECC_SECTION4:  ECC section 4
+ *           @arg EXMC_NFC_ECC_SECTION5:  ECC section 5
+ *           @arg EXMC_NFC_ECC_SECTION6:  ECC section 6
+ *           @arg EXMC_NFC_ECC_SECTION7:  ECC section 7
+ *           @arg EXMC_NFC_ECC_SECTION8:  ECC section 8
+ *           @arg EXMC_NFC_ECC_SECTION9:  ECC section 9
+ *           @arg EXMC_NFC_ECC_SECTION10: ECC section 10
+ *           @arg EXMC_NFC_ECC_SECTION11: ECC section 11
+ *           @arg EXMC_NFC_ECC_SECTION12: ECC section 12
+ *           @arg EXMC_NFC_ECC_SECTION13: ECC section 13
+ *           @arg EXMC_NFC_ECC_SECTION14: ECC section 14
+ *           @arg EXMC_NFC_ECC_SECTION15: ECC section 15
+ * @retval Return the 1BIT ECC error byte.
+ */
+uint32_t EXMC_NFC_Get1BitEccErrByteLocation(uint32_t u32Section)
+{
+    DDL_ASSERT(IS_EXMC_NFC_SECTION(u32Section));
+
+    return (READ_REG32_BIT(NFC_ECCR_REG32(u32Section), NFC_ECCR_ERRLOC) >> NFC_1BIT_ECC_ERR_BYTE_POS);
+}
+
+/**
+ * @brief  Set NFC spare area size.
+ * @param  [in] u8SpareSizeForUserData  NFC spare area size for user data
+ * @retval None
+ */
+void EXMC_NFC_SetSpareAreaSize(uint8_t u8SpareSizeForUserData)
+{
+    MODIFY_REG32(CM_NFC->BACR, NFC_BACR_SCS, ((((uint32_t)u8SpareSizeForUserData) << NFC_BACR_SCS_POS) & NFC_BACR_SCS));
+}
+
+/**
+ * @brief  Set NFC ECC mode.
+ * @param  [in] u32EccMode              ECC mode
+ *         This parameter can be one of the macros group @ref EXMC_NFC_ECC_Mode
+ *           @arg EXMC_NFC_1BIT_ECC:    1 bit ECC
+ *           @arg EXMC_NFC_4BIT_ECC:    4 bit ECC
+ * @retval None
+ */
+void EXMC_NFC_SetEccMode(uint32_t u32EccMode)
+{
+    DDL_ASSERT(IS_EXMC_NFC_ECC_MD(u32EccMode));
+
+    MODIFY_REG32(CM_NFC->BACR, NFC_BACR_ECCM, u32EccMode);
+}
+
+/**
+ * @brief  Get the 4 bits ECC syndrome register value.
+ * @param  [in] u32Section              The syndrome section
+ *         This parameter can be one of the macros group @ref EXMC_NFC_ECC_Section
+ *           @arg EXMC_NFC_ECC_SECTION0:  ECC section 0
+ *           @arg EXMC_NFC_ECC_SECTION1:  ECC section 1
+ *           @arg EXMC_NFC_ECC_SECTION2:  ECC section 2
+ *           @arg EXMC_NFC_ECC_SECTION3:  ECC section 3
+ *           @arg EXMC_NFC_ECC_SECTION4:  ECC section 4
+ *           @arg EXMC_NFC_ECC_SECTION5:  ECC section 5
+ *           @arg EXMC_NFC_ECC_SECTION6:  ECC section 6
+ *           @arg EXMC_NFC_ECC_SECTION7:  ECC section 7
+ *           @arg EXMC_NFC_ECC_SECTION8:  ECC section 8
+ *           @arg EXMC_NFC_ECC_SECTION9:  ECC section 9
+ *           @arg EXMC_NFC_ECC_SECTION10: ECC section 10
+ *           @arg EXMC_NFC_ECC_SECTION11: ECC section 11
+ *           @arg EXMC_NFC_ECC_SECTION12: ECC section 12
+ *           @arg EXMC_NFC_ECC_SECTION13: ECC section 13
+ *           @arg EXMC_NFC_ECC_SECTION14: ECC section 14
+ *           @arg EXMC_NFC_ECC_SECTION15: ECC section 15
+ * @param  [out] au16Synd               The syndrome value
+ * @param  [in] u8Len                   The length to be read(unit: half-word)
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer au16Synd value is NULL or u8Len is out of range.
+ * @note  u8Len value don't be greater than 8
+ */
+int32_t EXMC_NFC_GetSyndrome(uint32_t u32Section, uint16_t au16Synd[], uint8_t u8Len)
+{
+    uint8_t i;
+    uint32_t u32SyndVal;
+    uint8_t u8LoopWords;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != au16Synd) && (u8Len <= NFC_SYND_MAX_LEN)) {
+        DDL_ASSERT(IS_EXMC_NFC_SECTION(u32Section));
+
+        u8LoopWords = (u8Len >> 1U);
+        for (i = 0U; i < u8LoopWords; i++) {
+            u32SyndVal = READ_REG32(NFC_SYND_REG32(u32Section, i));
+            RW_MEM16(&au16Synd[i * 2U]) = (uint16_t)(u32SyndVal);
+            RW_MEM16(&au16Synd[i * 2U + 1U ]) = (uint16_t)(u32SyndVal >> 16U);
+        }
+
+        if ((u8Len % 2U) != 0U) {
+            u32SyndVal = READ_REG32(NFC_SYND_REG32(u32Section, i));
+            RW_MEM16(&au16Synd[i * 2U]) = (uint16_t)(u32SyndVal);
+        }
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Read NFC device status
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @retval NFC device status
+ */
+uint32_t EXMC_NFC_ReadStatus(uint32_t u32Bank)
+{
+    uint32_t u32Status;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    /* Write 0x81000M70 to NFC_CMDR, M = bank number */
+    WRITE_REG32(CM_NFC->CMDR, CMD_READ_STATUS(u32Bank));
+
+    u32Status = READ_REG32(CM_NFC->DATR_BASE);
+
+    EXMC_NFC_DeselectChip();
+
+    return u32Status;
+}
+
+/**
+ * @brief  Read status enhanced
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32RowAddr              The row address
+ * @retval NFC device status enhanced
+ */
+uint32_t EXMC_NFC_ReadStatusEnhanced(uint32_t u32Bank, uint32_t u32RowAddr)
+{
+    uint32_t u32Status;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    /* Erase block step:
+        1. Write 0x81000M78 to NFC_CMDR, M = bank number
+        2. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the lowest bytes of Row address
+        3. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the middle bytes of Row address
+        4. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the highest bytes of Row address
+        5. Read Data Register */
+    WRITE_REG32(CM_NFC->CMDR, CMD_READ_STATUS_ENHANCED(u32Bank));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_1ST_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_2ND_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_3RD_CYCLE(u32Bank, u32RowAddr));
+
+    u32Status = READ_REG32(CM_NFC->DATR_BASE);
+
+    EXMC_NFC_DeselectChip();
+
+    return u32Status;
+}
+
+/**
+ * @brief  Reset NFC device
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Reset timeout.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_Reset(uint32_t u32Bank, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+    /* Reset step:
+        1. Write 0x00000MFF to NFC_CMDR, M = bank number
+        2. Wait RB signal until high level */
+    WRITE_REG32(CM_NFC->CMDR, CMD_RESET(u32Bank));
+
+    i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+
+    EXMC_NFC_DeselectChip();
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Asynchronous reset
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Reset timeout.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_AsyncReset(uint32_t u32Bank, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+    /* Reset step:
+        1. Write 0x00000MFC to NFC_CMDR, M = bank number
+        2. Wait RB signal until high level */
+    WRITE_REG32(CM_NFC->CMDR, CMD_ASYNC_RESET(u32Bank));
+
+    i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+    EXMC_NFC_DeselectChip();
+    return i32Ret;
+}
+
+/**
+ * @brief  Reset lun of NFC device
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32RowAddr              The row address
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Reset timeout.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_ResetLun(uint32_t u32Bank, uint32_t u32RowAddr, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+    /* Reset lun step:
+        1. Write 0x82000MFA to NFC_CMDR, M = bank number
+        2. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the lowest bytes of Row address
+        3. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the middle bytes of Row address
+        4. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the highest bytes of Row address
+        5. Wait RB signal until high level */
+    WRITE_REG32(CM_NFC->CMDR, CMD_RESET_LUN(u32Bank));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_1ST_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_2ND_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_3RD_CYCLE(u32Bank, u32RowAddr));
+
+    i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+    return i32Ret;
+}
+
+/**
+ * @brief  Read ID
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the following values:
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32IdAddr               The address
+ * @param  [in] au8DevId                The id buffer
+ * @param  [in] u32NumBytes             The number of bytes to read
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Read timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer au8DevId value is NULL or u32NumBytes value is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_ReadId(uint32_t u32Bank, uint32_t u32IdAddr,
+                        uint8_t au8DevId[], uint32_t u32NumBytes, uint32_t u32Timeout)
+{
+    uint32_t i;
+    uint32_t u32TmpId;
+    __UNUSED __IO uint32_t u32DummyRead;
+    const uint32_t u32LoopWords = u32NumBytes / 4UL;
+    const uint32_t u32RemainBytes = u32NumBytes % 4UL;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != au8DevId) && (u32NumBytes > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+        DDL_ASSERT(u32IdAddr <= 0xFFUL);
+
+        /* Read Id step:
+            1. Read NFC_DATR
+            2. Write 0x81000M90 to NFC_CMDR, M = bank number
+            3. Write 0x40000MAB to NFC_CMDR, M = bank number, AB=ID address
+            4. Read NFC_DATR
+            5. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+        (void)u32Timeout;
+        u32DummyRead = NFC_DATR_REG32(0);
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_ID(u32Bank));
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_ID_ADDR(u32Bank, u32IdAddr));
+
+        for (i = 0UL; i < u32LoopWords; i++) {
+            u32TmpId = NFC_DATR_REG32(i);
+
+            au8DevId[i * 4UL]       = (uint8_t)(u32TmpId  & 0xFFUL);
+            au8DevId[i * 4UL + 1UL] = (uint8_t)((u32TmpId >> 8U)  & 0xFFUL);
+            au8DevId[i * 4UL + 2UL] = (uint8_t)((u32TmpId >> 16U) & 0xFFUL);
+            au8DevId[i * 4UL + 3UL] = (uint8_t)((u32TmpId >> 24U) & 0xFFUL);
+        }
+
+        if (u32RemainBytes > 0UL) {
+            u32TmpId = NFC_DATR_REG32(i);
+
+            for (i = 0UL; i < u32RemainBytes; i++) {
+                au8DevId[u32LoopWords * 4UL + i] = (uint8_t)((u32TmpId >> (8UL * i)) & 0xFFUL);
+            }
+        }
+
+        EXMC_NFC_DeselectChip();
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Read Unique ID
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the following values:
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] au32UniqueId            The id buffer
+ * @param  [in] u8NumWords              The number of words to read
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Read timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer au32UniqueId value is NULL or u8NumWords value is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT
+ */
+int32_t EXMC_NFC_ReadUniqueId(uint32_t u32Bank, uint32_t au32UniqueId[], uint8_t u8NumWords, uint32_t u32Timeout)
+{
+    uint8_t i;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != au32UniqueId) && (u8NumWords > 0U)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+        /* Read Id step:
+            1. Write 0x81000M90 to NFC_CMDR, M = bank number
+            2. Write 0x40000M00 to NFC_CMDR, M = bank number, AB=ID address
+            3. Read NFC_DATR
+            4. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_UNIQUEID(u32Bank));
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_UNIQUEID_ADDR(u32Bank));
+
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+        if (LL_OK == i32Ret) {
+            for (i = 0U; i < u8NumWords; i++) {
+                au32UniqueId[i] = NFC_DATR_REG32(i);
+            }
+        }
+
+        EXMC_NFC_DeselectChip();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Read parameter page
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] au32Data                The data buffer
+ * @param  [in] u16NumWords             The number of words to read
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Read timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer au32Data value is NULL or u16NumWords value is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_ReadParameterPage(uint32_t u32Bank,
+                                   uint32_t au32Data[], uint16_t u16NumWords, uint32_t u32Timeout)
+{
+    uint16_t i;
+    int32_t i32Ret = LL_ERR;
+
+    if ((NULL != au32Data) && (u16NumWords > 0U)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+        /* Read parameter page step:
+            1. Write 0x81000MEC to NFC_CMDR, M = bank number
+            2. Write 0x40000M00 to NFC_CMDR, M = bank number
+            3. Read NFC_DATR
+            4. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_PARAMETER_PAGE(u32Bank));
+        WRITE_REG32(CM_NFC->CMDR, CMD_READ_PARAMETER_PAGE_ADDR(u32Bank));
+
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+        if (LL_OK == i32Ret) {
+            for (i = 0U; i < u16NumWords; i++) {
+                au32Data[i] = NFC_DATR_REG32(i);
+            }
+        }
+
+        EXMC_NFC_DeselectChip();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set feature
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u8FeatureAddr           The feature address
+ * @param  [in] au32Data                The data buffer
+ * @param  [in] u8NumWords              The number of words to set
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Set timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer au32Data value is NULL or u8NumWords value is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_SetFeature(uint32_t u32Bank, uint8_t u8FeatureAddr,
+                            const uint32_t au32Data[], uint8_t u8NumWords, uint32_t u32Timeout)
+{
+    uint8_t i;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != au32Data) && (u8NumWords > 0U)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+        WRITE_REG32(CM_NFC->CMDR, CMD_SET_FEATURE(u32Bank));
+        WRITE_REG32(CM_NFC->CMDR, CMD_SET_FEATURE_ADDR(u32Bank, u8FeatureAddr));
+
+        for (i = 0U; i < u8NumWords; i++) {
+            NFC_DATR_REG32(i) = au32Data[i];
+        }
+
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+
+        EXMC_NFC_DeselectChip();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get feature
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u8FeatureAddr           The feature address
+ * @param  [out] au32Data               The data buffer
+ * @param  [in] u8NumWords              The number of words to get
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Get timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer au32Data value is NULL or u8NumWords value is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_GetFeature(uint32_t u32Bank, uint8_t u8FeatureAddr,
+                            uint32_t au32Data[], uint8_t u8NumWords, uint32_t u32Timeout)
+{
+    uint8_t i;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != au32Data) && (u8NumWords > 0U)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+        WRITE_REG32(CM_NFC->CMDR, CMD_GET_FEATURE(u32Bank));
+        WRITE_REG32(CM_NFC->CMDR, CMD_GET_FEATURE_ADDR(u32Bank, u8FeatureAddr));
+
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+        if (LL_OK == i32Ret) {
+            for (i = 0U; i < u8NumWords; i++) {
+                au32Data[i] = NFC_DATR_REG32(i);
+            }
+        }
+
+        EXMC_NFC_DeselectChip();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Erase NFC device block
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32RowAddr              The row address
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Erase timeout.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_EraseBlock(uint32_t u32Bank, uint32_t u32RowAddr, uint32_t u32Timeout)
+{
+    int32_t i32Ret;
+
+    DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+
+    EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(u32Bank));
+
+    /* Erase block step:
+        1. Write 0x81000M60 to NFC_CMDR, M = bank number
+        2. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the lowest bytes of Row address
+        3. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the middle bytes of Row address
+        4. Write 0x40000MAB to NFC_CMDR, M = bank number, AB= the highest bytes of Row address
+        5. Write 0x00000MD0 to NFC_CMDR, M = bank number
+        6. Wait RB signal until high level */
+    WRITE_REG32(CM_NFC->CMDR, CMD_ERASE_BLOCK_1ST_CYCLE(u32Bank));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_1ST_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_2ND_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ADDR_3RD_CYCLE(u32Bank, u32RowAddr));
+    WRITE_REG32(CM_NFC->CMDR, CMD_ERASE_BLOCK_2ND_CYCLE(u32Bank));
+
+    i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(u32Bank), SET, u32Timeout);
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC read operation
+ * @param  [in] pstcColumn              Pointer to a @ref stc_exmc_nfc_column_t structure.
+ * @param  [out] au32Data               The buffer for reading
+ * @param  [in] u32NumWords             The buffer size for words
+ * @param  [in] enEccState              Disable/enable ECC function
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcColumn/au32Data value is NULL or u32NumWords is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_Read(stc_exmc_nfc_column_t *pstcColumn,
+                      uint32_t au32Data[], uint32_t u32NumWords,
+                      en_functional_state_t enEccState, uint32_t u32Timeout)
+{
+    uint32_t i;
+    uint64_t u64Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    const uint32_t u32CapacityIndex = EXMC_NFC_GetCapacityIndex();
+
+    if ((NULL != pstcColumn) && (NULL != au32Data) && (u32NumWords > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(pstcColumn->u32Bank));
+        DDL_ASSERT(IS_EXMC_NFC_PAGE(pstcColumn->u32Page, u32CapacityIndex));
+        DDL_ASSERT(IS_EXMC_NFC_COL(pstcColumn->u32Column));
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enEccState));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(pstcColumn->u32Bank) | EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR | \
+                             EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR | EXMC_NFC_FLAG_ECC_CALC_COMPLETION | EXMC_NFC_FLAG_ECC_ERR);
+
+        EXMC_NFC_EccCmd(enEccState);
+
+        /* Read page step:
+            1. Write 0x00000000 to NFC_CMDR
+            2. Write NAND Flash address to NFC_IDXR0/1
+            3. Write 0x000000E0 to NFC_CMDR
+            4. Wait RB signal until high level
+            5. Read NFC_DATR
+            6. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+
+        /* 1. Write 0x00000000 to NFC_CMDR */
+        WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_RD_1ST);
+
+        /* 2. Write NAND Flash address to NFC_IDXR0/1 */
+        u64Value = (NFC_IDXR_VAL(pstcColumn->u32Bank, pstcColumn->u32Page, pstcColumn->u32Column, \
+                                 u32CapacityIndex) & NFC_IDXR_MASK);
+        WRITE_REG32(CM_NFC->IDXR0, (uint32_t)(u64Value & 0xFFFFFFFFUL));
+        WRITE_REG32(CM_NFC->IDXR1, (uint32_t)(u64Value >> 32UL));
+
+        /* 3. Write 0x000000E0 to NFC_CMDR */
+        WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_RD_2ND);
+
+        /* 4. Wait RB signal until high level */
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(pstcColumn->u32Bank), SET, u32Timeout);
+        if (LL_OK == i32Ret) {
+            /* 5. Read NFC_DATR */
+            for (i = 0UL; i < u32NumWords; i++) {
+                au32Data[i] = NFC_DATR_REG32(i);
+            }
+
+            /* Clear Flag */
+            EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(pstcColumn->u32Bank));
+
+            if (ENABLE == enEccState) {
+                /* Write 0x00000023 to NFC_CMDR */
+                WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_CALCULATE_ECC);
+
+                /* 4. Wait RB signal until high level */
+                i32Ret = EXMC_NFC_WaitFlagUntilTo(EXMC_NFC_FLAG_ECC_CALCULATING, RESET, u32Timeout);
+                EXMC_NFC_EccCmd(DISABLE);
+            }
+        }
+
+        /* 6. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+        EXMC_NFC_DeselectChip();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC write operation
+ * @param  [in] pstcColumn              Pointer to a @ref stc_exmc_nfc_column_t structure.
+ * @param  [in] au32Data                The buffer for writing
+ * @param  [in] u32NumWords             The buffer size for words
+ * @param  [in] enEccState              Disable/enable ECC function
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcColumn/au32Data value is NULL or u32NumWords is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT.
+ */
+int32_t EXMC_NFC_Write(stc_exmc_nfc_column_t *pstcColumn,
+                       const uint32_t au32Data[], uint32_t u32NumWords,
+                       en_functional_state_t enEccState, uint32_t u32Timeout)
+{
+    uint32_t i;
+    uint64_t u64Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    const uint32_t u32CapacityIndex = EXMC_NFC_GetCapacityIndex();
+
+    if ((NULL != pstcColumn) && (NULL != au32Data) && (u32NumWords > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(pstcColumn->u32Bank));
+        DDL_ASSERT(IS_EXMC_NFC_PAGE(pstcColumn->u32Page, u32CapacityIndex));
+        DDL_ASSERT(IS_EXMC_NFC_COL(pstcColumn->u32Column));
+        DDL_ASSERT(IS_FUNCTIONAL_STATE(enEccState));
+
+        EXMC_NFC_ClearStatus(NFC_FLAG_RB_BANKx_MASK(pstcColumn->u32Bank) | EXMC_NFC_FLAG_ECC_UNCORRECTABLE_ERR | \
+                             EXMC_NFC_FLAG_ECC_CORRECTABLE_ERR | EXMC_NFC_FLAG_ECC_CALC_COMPLETION | EXMC_NFC_FLAG_ECC_ERR);
+
+        EXMC_NFC_EccCmd(enEccState);
+
+        /* Write page step:
+            1. Write 0x00000080 to NFC_CMDR
+            2. Write NAND Flash address to NFC_IDXR0/1
+            3. Write NFC_DATR
+            4. Write 0x00000010 to NFC_CMDR
+            5. Wait RB signal until high level
+            6. Write 0x000000FE to NFC_CMDR, and invalidate CE */
+
+        /* 1. Write 0x00000080 to NFC_CMDR */
+        WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_PAGE_PROGRAM_1ST);
+
+        /* 2. Write NAND Flash address to NFC_IDXR0/1 */
+        u64Value = (NFC_IDXR_VAL(pstcColumn->u32Bank, pstcColumn->u32Page, pstcColumn->u32Column, \
+                                 u32CapacityIndex) & NFC_IDXR_MASK);
+        WRITE_REG32(CM_NFC->IDXR0, (uint32_t)(u64Value & 0xFFFFFFFFUL));
+        WRITE_REG32(CM_NFC->IDXR1, (uint32_t)(u64Value >> 32UL));
+
+        /* 3. Write NFC_DATR */
+        for (i = 0UL; i < u32NumWords; i++) {
+            NFC_DATR_REG32(i) = au32Data[i];
+        }
+
+        /* 4. Write 0x00000010 to NFC_CMDR */
+        WRITE_REG32(CM_NFC->CMDR, EXMC_NFC_CMD_PAGE_PROGRAM_2ND);
+
+        /* 5. Wait RB signal until high level */
+        i32Ret = EXMC_NFC_WaitFlagUntilTo(NFC_FLAG_RB_BANKx_MASK(pstcColumn->u32Bank), SET, u32Timeout);
+
+        /* Write 0x000000FE to NFC_CMDR, and invalidate CE */
+        EXMC_NFC_DeselectChip();
+
+        if (ENABLE == enEccState) {
+            EXMC_NFC_EccCmd(DISABLE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC page read
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Page                 The specified page
+ * @param  [out] pu8Data                The buffer for reading
+ * @param  [in] u32NumBytes             The buffer size for bytes
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pu8Data value value is NULL or u32NumBytes is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT
+ */
+int32_t EXMC_NFC_ReadPageMeta(uint32_t u32Bank, uint32_t u32Page, uint8_t *pu8Data,
+                              uint32_t u32NumBytes, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    stc_exmc_nfc_column_t stcColumn;
+
+    if ((NULL != pu8Data) && (u32NumBytes > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+        DDL_ASSERT(IS_PARAM_ALIGN_WORD(u32NumBytes));
+        DDL_ASSERT(IS_ADDR_ALIGN_WORD(pu8Data));
+
+        stcColumn.u32Bank = u32Bank;
+        stcColumn.u32Page = u32Page;
+        stcColumn.u32Column = 0UL;
+        i32Ret = EXMC_NFC_Read(&stcColumn, (uint32_t *)((uint32_t)pu8Data), \
+                               (u32NumBytes / 4UL), DISABLE, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC page write
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Page                 The specified page
+ * @param  [in] pu8Data                 The buffer for writing
+ * @param  [in] u32NumBytes             The buffer size for bytes
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pu8Data value is NULL or u32NumBytes is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT
+ */
+int32_t EXMC_NFC_WritePageMeta(uint32_t u32Bank, uint32_t u32Page,
+                               const uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    stc_exmc_nfc_column_t stcColumn;
+
+    if ((NULL != pu8Data) && (u32NumBytes > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+        DDL_ASSERT(IS_PARAM_ALIGN_WORD(u32NumBytes));
+        DDL_ASSERT(IS_ADDR_ALIGN_WORD(pu8Data));
+
+        stcColumn.u32Bank = u32Bank;
+        stcColumn.u32Page = u32Page;
+        stcColumn.u32Column = 0UL;
+        i32Ret = EXMC_NFC_Write(&stcColumn, (uint32_t *)((uint32_t)pu8Data), \
+                                (u32NumBytes / 4UL), DISABLE, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC page read by hardware ECC
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Page                 The specified page
+ * @param  [out] pu8Data                The buffer for reading
+ * @param  [in] u32NumBytes             The buffer size for bytes
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pu8Data value is NULL or u32NumBytes is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT
+ */
+int32_t EXMC_NFC_ReadPageHwEcc(uint32_t u32Bank, uint32_t u32Page,
+                               uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    stc_exmc_nfc_column_t stcColumn;
+#ifdef __DEBUG
+    const uint32_t u32PageSize = NFC_PAGE_SIZE;
+    const uint32_t u32SpareSizeUserData = NFC_SPARE_SIZE_FOR_USER_DATA;
+#endif
+
+    if ((NULL != pu8Data) && (u32NumBytes > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+        DDL_ASSERT(IS_PARAM_ALIGN_WORD(u32NumBytes));
+        DDL_ASSERT(IS_ADDR_ALIGN_WORD(pu8Data));
+        DDL_ASSERT(u32NumBytes <= (u32PageSize + u32SpareSizeUserData));
+
+        stcColumn.u32Bank = u32Bank;
+        stcColumn.u32Page = u32Page;
+        stcColumn.u32Column = 0UL;
+        i32Ret = EXMC_NFC_Read(&stcColumn, (uint32_t *)((uint32_t)pu8Data), \
+                               (u32NumBytes / 4UL), ENABLE, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  NFC page  write by hardware ECC
+ * @param  [in] u32Bank                 The specified bank
+ *         This parameter can be one of the macros group @ref EXMC_NFC_Bank
+ *           @arg EXMC_NFC_BANK0:       NFC device bank 0
+ *           @arg EXMC_NFC_BANK1:       NFC device bank 1
+ *           @arg EXMC_NFC_BANK2:       NFC device bank 2
+ *           @arg EXMC_NFC_BANK3:       NFC device bank 3
+ *           @arg EXMC_NFC_BANK4:       NFC device bank 4
+ *           @arg EXMC_NFC_BANK5:       NFC device bank 5
+ *           @arg EXMC_NFC_BANK6:       NFC device bank 6
+ *           @arg EXMC_NFC_BANK7:       NFC device bank 7
+ * @param  [in] u32Page                 The specified page
+ * @param  [in] pu8Data                 The buffer for writing
+ * @param  [in] u32NumBytes             The buffer size for bytes
+ * @param  [in] u32Timeout              The operation timeout value(Max value @ref EXMC_NFC_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Write timeout.
+ *           - LL_ERR_INVD_PARAM:       The pointer pu8Data value is NULL or u32NumBytes is 0.
+ * @note Block waiting until operation complete if u32Timeout value is EXMC_NFC_MAX_TIMEOUT
+ */
+int32_t EXMC_NFC_WritePageHwEcc(uint32_t u32Bank, uint32_t u32Page,
+                                const uint8_t *pu8Data, uint32_t u32NumBytes, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    stc_exmc_nfc_column_t stcColumn;
+#ifdef __DEBUG
+    const uint32_t u32PageSize = NFC_PAGE_SIZE;
+    const uint32_t u32SpareSizeUserData = NFC_SPARE_SIZE_FOR_USER_DATA;
+#endif
+
+    if ((NULL != pu8Data) && (u32NumBytes > 0UL)) {
+        DDL_ASSERT(IS_EXMC_NFC_BANK(u32Bank));
+        DDL_ASSERT(IS_PARAM_ALIGN_WORD(u32NumBytes));
+        DDL_ASSERT(IS_ADDR_ALIGN_WORD((uint32_t)pu8Data));
+        DDL_ASSERT(u32NumBytes <= (u32PageSize + u32SpareSizeUserData));
+
+        stcColumn.u32Bank = u32Bank;
+        stcColumn.u32Page = u32Page;
+        stcColumn.u32Column = 0UL;
+        i32Ret = EXMC_NFC_Write(&stcColumn, (uint32_t *)((uint32_t)pu8Data), \
+                                (u32NumBytes / 4UL), ENABLE, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_NFC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_ots.c
+++ b/hc32f4a2/src/hc32_ll_ots.c
@@ -1,0 +1,410 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_ots.c
+ * @brief This file provides firmware functions to manage the OTS.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             API fixed: OTS_CalculateTemp()
+   2023-06-30       CDT             Modify typo
+                                    Modify API OTS_DeInit()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_ots.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_OTS OTS
+ * @brief OTS Driver Library
+ * @{
+ */
+
+#if (LL_OTS_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup OTS_Local_Macros OTS Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup OTS_Configuration_Bit_Mask OTS Configuration Bit Mask
+ * @{
+ */
+#define OTS_CTL_INIT_MSK            (OTS_CTL_OTSCK | OTS_CTL_TSSTP)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Ext_Reg_Address OTS Extension Register Address
+ * @{
+ */
+#define OTS_PDR1_ADDR               ((uint32_t)(&CM_OTS->PDR1))
+#define OTS_PDR2_ADDR               ((uint32_t)(&CM_OTS->PDR2))
+#define OTS_PDR3_ADDR               ((uint32_t)(&CM_OTS->PDR3))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Factor OTS Factor
+ * @{
+ */
+#define OTS_DR1_FACTOR              (1.7F)
+
+#define OTS_DR2_FACTOR              (1.0F)
+#define OTS_ECR_XTAL_FACTOR         (1.0F)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Check_Parameters_Validity OTS check parameters validity
+ * @{
+ */
+#define IS_OTS_CLK(x)               (((x) == OTS_CLK_HRC) || ((x) == OTS_CLK_XTAL))
+
+#define IS_OTS_AUTO_OFF_EN(x)       (((x) == OTS_AUTO_OFF_DISABLE) || ((x) == OTS_AUTO_OFF_ENABLE))
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/**
+ * @defgroup OTS_Local_Variables OTS Local Variables
+ * @{
+ */
+static float32_t m_f32SlopeK  = 0.0F;
+static float32_t m_f32OffsetM = 0.0F;
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @addtogroup OTS_Local_Functions OTS Local Functions
+ * @{
+ */
+/**
+ * @brief  Get built-in slope K and offset M.
+ * @param  [in]  pstcOTSInit            Pointer to a stc_ots_init_t structure value that
+ *                                      contains the configuration information for OTS.
+ * @retval None
+ */
+static void OTS_GetDfltPara(const stc_ots_init_t *pstcOTSInit)
+{
+#define OTS_SCAL_T1         (ai8Temp[pstcOTSInit->stcParaCond.u8T1])
+#define OTS_SCAL_T2         (ai8Temp[pstcOTSInit->stcParaCond.u8T2])
+#define OTS_SCAL_A1         (af32A[0U])
+#define OTS_SCAL_A2         (af32A[1U])
+
+    uint8_t i;
+    int8_t ai8Temp[] = {-40, 25, 125};
+    uint32_t au32PDRAddr[3U];
+    uint32_t au32PDR[2U];
+    uint16_t u16D1;
+    uint16_t u16D2;
+    uint32_t u32PDRAddrT1;
+    uint32_t u32PDRAddrT2;
+    float32_t f32D1;
+    float32_t f32D2;
+    float32_t af32A[2U];
+    float32_t f32Ehrc = OTS_ECR_XTAL_FACTOR;
+    float32_t f32ClkFactor = (float32_t)pstcOTSInit->stcParaCond.u16ClockFreq / 8.0F;
+
+    /* Intermediate variables: avoid misrac2012-13.2_c, 13.1 */
+    au32PDRAddr[0U] = OTS_PDR3_ADDR;
+    au32PDRAddr[1U] = OTS_PDR1_ADDR;
+    au32PDRAddr[2U] = OTS_PDR2_ADDR;
+    u32PDRAddrT1 = au32PDRAddr[pstcOTSInit->stcParaCond.u8T1];
+    u32PDRAddrT2 = au32PDRAddr[pstcOTSInit->stcParaCond.u8T2];
+
+    au32PDR[0U] = RW_MEM32(u32PDRAddrT1);
+    au32PDR[1U] = RW_MEM32(u32PDRAddrT2);
+
+    if (pstcOTSInit->u16ClockSrc == OTS_CLK_HRC) {
+        f32Ehrc = (float32_t)pstcOTSInit->stcParaCond.u16ClockFreq / 0.032768F;
+    }
+
+    for (i = 0U; i < 2U; i++) {
+        u16D1 = (uint16_t)au32PDR[i];
+        u16D2 = (uint16_t)(au32PDR[i] >> 16U);
+        f32D1 = ((float32_t)u16D1) * f32ClkFactor;
+        f32D2 = ((float32_t)u16D2) * f32ClkFactor;
+        af32A[i] = ((OTS_DR1_FACTOR / f32D1) - (OTS_DR2_FACTOR / f32D2)) * f32Ehrc;
+    }
+    m_f32SlopeK  = ((float32_t)OTS_SCAL_T2 - (float32_t)OTS_SCAL_T1) / (OTS_SCAL_A2 - OTS_SCAL_A1);
+    m_f32OffsetM = (float32_t)OTS_SCAL_T2 - (m_f32SlopeK * OTS_SCAL_A2);
+}
+/**
+ * @}
+ */
+
+/**
+ * @defgroup OTS_Global_Functions OTS Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes OTS according to the specified parameters in the structure stc_ots_init_t.
+ * @param  [in]  pstcOTSInit            Pointer to a stc_ots_init_t structure value that
+ *                                      contains the configuration information for OTS.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcOTSInit == NULL.
+ */
+int32_t OTS_Init(const stc_ots_init_t *pstcOTSInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcOTSInit != NULL) {
+        DDL_ASSERT(IS_OTS_CLK(pstcOTSInit->u16ClockSrc));
+        DDL_ASSERT(IS_OTS_AUTO_OFF_EN(pstcOTSInit->u16AutoOffEn));
+
+        /* Stop OTS sampling. */
+        OTS_Stop();
+        WRITE_REG16(CM_OTS->CTL, (pstcOTSInit->u16ClockSrc | pstcOTSInit->u16AutoOffEn));
+        if ((pstcOTSInit->f32SlopeK == 0.0F) && (pstcOTSInit->f32OffsetM == 0.0F)) {
+            OTS_GetDfltPara(pstcOTSInit);
+        } else {
+            m_f32SlopeK  = pstcOTSInit->f32SlopeK;
+            m_f32OffsetM = pstcOTSInit->f32OffsetM;
+        }
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set a default value for OTS initialization structure.
+ * @param  [in]  pstcOTSInit            Pointer to a stc_ots_init_t structure that
+ *                                      contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcOTSInit == NULL.
+ */
+int32_t OTS_StructInit(stc_ots_init_t *pstcOTSInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcOTSInit != NULL) {
+        pstcOTSInit->u16ClockSrc  = OTS_CLK_HRC;
+        pstcOTSInit->f32SlopeK    = 0.0F;
+        pstcOTSInit->f32OffsetM   = 0.0F;
+        pstcOTSInit->u16AutoOffEn = OTS_AUTO_OFF_ENABLE;
+        pstcOTSInit->stcParaCond.u16ClockFreq = 8U;
+        pstcOTSInit->stcParaCond.u8T1 = OTS_PARAM_TEMP_COND_T25;
+        pstcOTSInit->stcParaCond.u8T2 = OTS_PARAM_TEMP_COND_T125;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initializes OTS peripheral. Reset the registers of OTS.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t OTS_DeInit(void)
+{
+    /* Stop OTS. */
+    OTS_Stop();
+    /* Set the value of all registers to the reset value. */
+    WRITE_REG16(CM_OTS->CTL, 0U);
+    WRITE_REG16(CM_OTS->DR1, 0U);
+    WRITE_REG16(CM_OTS->DR2, 0U);
+    WRITE_REG16(CM_OTS->ECR, 0U);
+    return LL_OK;
+}
+
+/**
+ * @brief  Get temperature via normal mode.
+ * @param  [out] pf32Temp               Pointer to a float32_t type address that the temperature value to be stored.
+ * @param  [in]  u32Timeout             Timeout value.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ *           - LL_ERR_INVD_PARAM:       pf32Temp == NULL.
+ */
+int32_t OTS_Polling(float32_t *pf32Temp, uint32_t u32Timeout)
+{
+    __IO uint32_t u32TimeCount = u32Timeout;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pf32Temp != NULL) {
+        i32Ret = LL_ERR_TIMEOUT;
+        OTS_Start();
+        while (u32TimeCount-- != 0U) {
+            if (READ_REG32(bCM_OTS->CTL_b.OTSST) == 0UL) {
+                *pf32Temp = OTS_CalculateTemp();
+                i32Ret = LL_OK;
+                break;
+            }
+        }
+        OTS_Stop();
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the OTS interrupt.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void OTS_IntCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    WRITE_REG32(bCM_OTS->CTL_b.OTSIE, enNewState);
+}
+
+/**
+ * @brief  OTS scaling experiment. Get the value of the data register at the specified temperature to calculate K and M.
+ * @param  [out] pu16Dr1:               Pointer to an address to store the value of data register 1.
+ * @param  [out] pu16Dr2:               Pointer to an address to store the value of data register 2.
+ * @param  [out] pu16Ecr:               Pointer to an address to store the value of register ECR.
+ * @param  [out] pf32A:                 Pointer to an address to store the parameter A.
+ * @param  [in]  u32Timeout:            Timeout value.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ *           - LL_ERR_INVD_PARAM:       If one the following cases matches:
+ *                                      - pu16Dr1 == NULL.
+ *                                      - pu16Dr2 == NULL.
+ *                                      - pu16Ecr == NULL.
+ *                                      - pf32A == NULL.
+ */
+int32_t OTS_ScalingExperiment(uint16_t *pu16Dr1, uint16_t *pu16Dr2,
+                              uint16_t *pu16Ecr, float32_t *pf32A,
+                              uint32_t u32Timeout)
+{
+    float32_t f32Dr1;
+    float32_t f32Dr2;
+    float32_t f32Ecr;
+    __IO uint32_t u32TimeCount = u32Timeout;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((NULL != pu16Dr1) && (NULL != pu16Dr2) && \
+        (NULL != pu16Ecr) && (NULL != pf32A)) {
+        i32Ret = LL_ERR_TIMEOUT;
+        OTS_Start();
+        while (u32TimeCount-- != 0U) {
+            if (READ_REG32(bCM_OTS->CTL_b.OTSST) == 0UL) {
+                i32Ret = LL_OK;
+                break;
+            }
+        }
+        OTS_Stop();
+
+        if (i32Ret == LL_OK) {
+            *pu16Dr1 = READ_REG16(CM_OTS->DR1);
+            *pu16Dr2 = READ_REG16(CM_OTS->DR2);
+
+            f32Dr1 = (float32_t)(*pu16Dr1);
+            f32Dr2 = (float32_t)(*pu16Dr2);
+
+            if (READ_REG8_BIT(CM_OTS->CTL, OTS_CTL_OTSCK) == OTS_CLK_HRC) {
+                *pu16Ecr = READ_REG16(CM_OTS->ECR);
+                f32Ecr   = (float32_t)(*pu16Ecr);
+            } else {
+                *pu16Ecr = 1U;
+                f32Ecr   = OTS_ECR_XTAL_FACTOR;
+            }
+
+            if ((f32Dr1 != 0.0F) && (f32Dr2 != 0.0F) && (f32Ecr != 0.0F)) {
+                *pf32A = ((OTS_DR1_FACTOR / f32Dr1) - (OTS_DR2_FACTOR / f32Dr2)) * f32Ecr;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate the temperature value.
+ * @param  None
+ * @retval A float32_t type value of temperature.
+ */
+float32_t OTS_CalculateTemp(void)
+{
+    float32_t f32Ret = -300.0F;
+    uint16_t u16Dr1  = READ_REG16(CM_OTS->DR1);
+    uint16_t u16Dr2  = READ_REG16(CM_OTS->DR2);
+    uint16_t u16Ecr  = READ_REG16(CM_OTS->ECR);
+    float32_t f32Dr1 = (float32_t)u16Dr1;
+    float32_t f32Dr2 = (float32_t)u16Dr2;
+    float32_t f32Ecr = (float32_t)u16Ecr;
+
+    if (READ_REG8_BIT(CM_OTS->CTL, OTS_CTL_OTSCK) == OTS_CLK_XTAL) {
+        f32Ecr = OTS_ECR_XTAL_FACTOR;
+    }
+
+    if ((f32Dr1 != 0.0F) && (f32Dr2 != 0.0F) && (f32Ecr != 0.0F)) {
+        f32Ret = m_f32SlopeK * ((OTS_DR1_FACTOR / f32Dr1) - (OTS_DR2_FACTOR / f32Dr2)) * f32Ecr + m_f32OffsetM;
+    }
+
+    return f32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_OTS_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_pwc.c
+++ b/hc32f4a2/src/hc32_ll_pwc.c
@@ -1,0 +1,1424 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_pwc.c
+ * @brief This file provides firmware functions to manage the Power Control(PWC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Refine API PWC_STOP_Enter()
+   2022-10-31       CDT             Modify API PWC_HighSpeedToLowSpeed() base umRev1.13
+   2023-01-15       CDT             Optimize API PWC_STOP_ClockSelect() & comment
+   2023-06-30       CDT             Modify typo
+                                    Add api PWC_LVD_DeInit()
+                                    Modify API PWC_STOP_Enter() & add assert IS_PWC_STOP_TYPE()
+   2023-12-15       CDT             Remove redundant assert
+                                    Modify API PWC_PD_Enter() #use assert to replace the unlock, and add return value
+                                    Modify API PWC_STOP_Enter() #delete redundancies code
+                                    Unified the operation mode for register
+                                    Refine PWC_SLEEP_Enter()
+                                    Add API PWC_PD_SetIoState() & PWC_PD_SetMode()
+                                    Add assert in PWC_PD_Config()
+   2024-06-30       CDT             Modify LVD initialize process
+                                    Remove macro PWC_LVD_EXT_INPUT_EN_REG & PWC_LVD_EXT_INPUT_EN_BIT & PWC_LVD_CMP_OUTPUT_EN_REG & PWC_LVD_CMP_OUTPUT_EN_BIT
+                                    Modify PWC_LVD_ClearStatus & PWC_PD_ClearWakeupStatus for couping risk
+                                    Couping Risks caused by modifying the status bits of the WKTM
+   2024-08-31       CDT             Modify macro name IS_PWC_WKT_COMPARISION_VALUE as IS_PWC_WKT_COMPARISON_VALUE
+                                    Accessed CM_PWC->WKTC2 in 8-bit
+   2024-11-08       CDT             Add assert for PWC_STOP_Enter()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_pwc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_PWC PWC
+ * @brief Power Control Driver Library
+ * @{
+ */
+
+#if (LL_PWC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup PWC_Local_Macros PWC Local Macros
+ * @{
+ */
+
+/* Get the backup register address of PWC */
+#define PWC_BKRx(x)                     ((uint32_t)(&(CM_PWC->BKR0)) + ((uint32_t)(x) << 2U))
+
+#define PWC_MD_SWITCH_TIMEOUT           (30UL)
+#define PWC_MD_SWITCH_TIMEOUT2          (0x1000UL)
+
+#define PWC_PD_PDWKF0_MSK               (0x3FU)
+#define PWC_PD_PDWKF1_MSK               (0xB0U)
+
+#define PWC_LVD_EN_REG                  (CM_PWC->PVDCR0)
+#define PWC_LVD_EN_BIT                  (PWC_PVDCR0_PVD1EN)
+#define PWC_LVD_FILTER_EN_REG           (CM_PWC->PVDFCR)
+#define PWC_LVD_FILTER_EN_BIT           (PWC_PVDFCR_PVD1NFDIS)
+#define PWC_LVD_STATUS_REG              (CM_PWC->PVDDSR)
+
+#define PWC_LVD2_POS                    (4U)
+#define PWC_LVD_BIT_OFFSET(x)           ((uint8_t)((x) * PWC_LVD2_POS))
+#define PWC_LVD_EN_BIT_OFFSET(x)        (x)
+
+#define PWC_RAM_MASK                    (PWC_RAMPC0_RAMPDC0 | PWC_RAMPC0_RAMPDC1 |  \
+                                         PWC_RAMPC0_RAMPDC2 | PWC_RAMPC0_RAMPDC3 |  \
+                                         PWC_RAMPC0_RAMPDC4 | PWC_RAMPC0_RAMPDC5 |  \
+                                         PWC_RAMPC0_RAMPDC6 | PWC_RAMPC0_RAMPDC7 |  \
+                                         PWC_RAMPC0_RAMPDC8 | PWC_RAMPC0_RAMPDC9 |  \
+                                         PWC_RAMPC0_RAMPDC10)
+
+#define PWC_PRAM_MASK                   (PWC_RAM_PD_CAN1    | PWC_RAM_PD_CAN2  |    \
+                                         PWC_RAM_PD_ETHERRX | PWC_RAM_PD_CACHE |    \
+                                         PWC_RAM_PD_SDIO1   | PWC_RAM_PD_USBFS |    \
+                                         PWC_RAM_PD_SDIO2   | PWC_RAM_PD_USBHS |    \
+                                         PWC_RAM_PD_NFC     | PWC_RAM_PD_ETHERTX)
+
+#define PWC_LVD_FLAG_MASK               (PWC_LVD1_FLAG_MON | PWC_LVD1_FLAG_DETECT | \
+                                         PWC_LVD2_FLAG_MON | PWC_LVD2_FLAG_DETECT)
+
+#define PWC_LVD_EXP_NMI_POS             (8U)
+
+/**
+ * @defgroup PWC_Check_Parameters_Validity PWC Check Parameters Validity
+ * @{
+ */
+
+/* Check PWC register lock status. */
+#define IS_PWC_UNLOCKED()               ((CM_PWC->FPRC & PWC_FPRC_FPRCB1) == PWC_FPRC_FPRCB1)
+/* Check PWC LVD register lock status. */
+#define IS_PWC_LVD_UNLOCKED()           ((CM_PWC->FPRC & PWC_FPRC_FPRCB3) == PWC_FPRC_FPRCB3)
+/* Parameter validity check for EFM lock status. */
+#define IS_PWC_EFM_UNLOCKED()           (CM_EFM->FAPRT == 0x00000001UL)
+
+/* Parameter validity check for stop type */
+#define IS_PWC_STOP_TYPE(x)                                                     \
+(   ((x) == PWC_STOP_WFI)                           ||                          \
+    ((x) == PWC_STOP_WFE_INT)                       ||                          \
+    ((x) == PWC_STOP_WFE_EVT))
+
+/* Parameter validity check for sleep type */
+#define IS_PWC_SLEEP_TYPE(x)                                                    \
+(   ((x) == PWC_SLEEP_WFI)                          ||                          \
+    ((x) == PWC_SLEEP_WFE_INT)                      ||                          \
+    ((x) == PWC_SLEEP_WFE_EVT))
+
+/* Parameter validity check for internal RAM setting of power mode control */
+#define IS_PWC_RAM_CONTROL(x)                                                   \
+(   ((x) != 0x00UL)                                 &&                          \
+    (((x) | PWC_RAM_MASK) == PWC_RAM_MASK))
+
+/* Parameter validity check for peripheral RAM setting of power mode control */
+#define IS_PWC_PRAM_CONTROL(x)                                                  \
+(   ((x) != 0x00UL)                                 &&                          \
+    (((x) | PWC_PRAM_MASK) == PWC_PRAM_MASK))
+
+/* Parameter validity check for RAM setting of MCU operating mode */
+#define IS_PWC_RAM_MD(x)                                                        \
+(   ((x) == PWC_RAM_HIGH_SPEED)                     ||                          \
+    ((x) == PWC_RAM_ULOW_SPEED))
+
+/* Parameter validity check for LVD channel. */
+#define IS_PWC_LVD_CH(x)                                                        \
+(   ((x) == PWC_LVD_CH1)                            ||                          \
+    ((x) == PWC_LVD_CH2))
+
+/* Parameter validity check for LVD function setting. */
+#define IS_PWC_LVD_EN(x)                                                        \
+(   ((x) == PWC_LVD_ON)                             ||                          \
+    ((x) == PWC_LVD_OFF))
+
+/* Parameter validity check for LVD compare output setting. */
+#define IS_PWC_LVD_CMP_EN(x)                                                    \
+(   ((x) == PWC_LVD_CMP_ON)                         ||                          \
+    ((x) == PWC_LVD_CMP_OFF))
+
+/*  Parameter validity check for PWC LVD exception type. */
+#define IS_PWC_LVD_EXP_TYPE(x)                                                  \
+(   ((x) == PWC_LVD_EXP_TYPE_NONE)                  ||                          \
+    ((x) == PWC_LVD_EXP_TYPE_INT)                   ||                          \
+    ((x) == PWC_LVD_EXP_TYPE_NMI)                   ||                          \
+    ((x) == PWC_LVD_EXP_TYPE_RST))
+
+/* Parameter validity check for LVD digital noise filter function setting. */
+#define IS_PWC_LVD_FILTER_EN(x)                                                 \
+(   ((x) == PWC_LVD_FILTER_ON)                      ||                          \
+    ((x) == PWC_LVD_FILTER_OFF))
+
+/* Parameter validity check for LVD digital noise filter clock setting. */
+#define IS_PWC_LVD_FILTER_CLK(x)                                                \
+(   ((x) == PWC_LVD_FILTER_LRC_DIV1)                ||                          \
+    ((x) == PWC_LVD_FILTER_LRC_DIV2)                ||                          \
+    ((x) == PWC_LVD_FILTER_LRC_DIV4)                ||                          \
+    ((x) == PWC_LVD_FILTER_LRC_MUL2))
+
+/* Parameter validity check for LVD detect voltage setting. */
+#define IS_PWC_LVD_THRESHOLD_VOLTAGE(x)                                         \
+(   ((x) == PWC_LVD_THRESHOLD_LVL0)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL1)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL2)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL3)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL4)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL5)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL6)                 ||                          \
+    ((x) == PWC_LVD_THRESHOLD_LVL7))
+
+/* Parameter validity check for LVD trigger setting. */
+#define IS_PWC_LVD_TRIG_EDGE(x)                                                 \
+(   ((x) == PWC_LVD_TRIG_FALLING)                   ||                          \
+    ((x) == PWC_LVD_TRIG_RISING)                    ||                          \
+    ((x) == PWC_LVD_TRIG_BOTH))
+
+/* Parameter validity check for LVD trigger setting. */
+#define IS_PWC_LVD_CLR_FLAG(x)                                                  \
+(   ((x) == PWC_LVD1_FLAG_DETECT)                   ||                          \
+    ((x) == PWC_LVD2_FLAG_DETECT))
+
+/* Parameter validity check for LVD flag. */
+#define IS_PWC_LVD_GET_FLAG(x)                                                  \
+(   ((x) != 0x00U)                                  &&                          \
+    (((x) | PWC_LVD_FLAG_MASK) == PWC_LVD_FLAG_MASK))
+
+/* Parameter validity check for power down mode. */
+#define IS_PWC_PD_MD(x)                                                         \
+(   ((x) == PWC_PD_MD1)                             ||                          \
+    ((x) == PWC_PD_MD2)                             ||                          \
+    ((x) == PWC_PD_MD3)                             ||                          \
+    ((x) == PWC_PD_MD4))
+
+/* Parameter validity check for IO state while power down mode. */
+#define IS_PWC_PD_IO_STATE(x)                                                   \
+(   ((x) == PWC_PD_IO_KEEP1)                        ||                          \
+    ((x) == PWC_PD_IO_KEEP2)                        ||                          \
+    ((x) == PWC_PD_IO_HIZ))
+
+/* Parameter validity check for power down mode wake up event with trigger. */
+#define IS_PWC_WAKEUP_TRIG_EVT(x)                                               \
+(   ((x) != 0x00U)                                  &&                          \
+    (((x) | PWC_PD_WKUP_TRIG_ALL) == PWC_PD_WKUP_TRIG_ALL))
+
+/* Parameter validity check for power down mode wake up trigger edge. */
+#define IS_PWC_WAKEUP_TRIG(x)                                                   \
+(   ((x) == PWC_PD_WKUP_TRIG_FALLING)               ||                          \
+    ((x) == PWC_PD_WKUP_TRIG_RISING))
+
+/* Parameter validity check for wake up flag. */
+#define IS_PWC_WKUP_FLAG(x)                                                     \
+(   ((x) != 0x00U)                                  &&                          \
+    (((x) | PWC_PD_WKUP_FLAG_ALL) == PWC_PD_WKUP_FLAG_ALL))
+
+/* Parameter validity check for stop mode drive capacity. */
+#define IS_PWC_STOP_DRV(drv)                                                    \
+(   ((drv) == PWC_STOP_DRV_HIGH)                    ||                          \
+    ((drv) == PWC_STOP_DRV_LOW))
+
+/* Parameter validity check for vcap selection while power down mode. */
+#define IS_PWC_PD_VCAP_SEL(x)                                                   \
+(   ((x) == PWC_PD_VCAP_0P1UF)                      ||                          \
+    ((x) == PWC_PD_VCAP_0P047UF))
+
+/* Parameter validity check for clock setting after wake-up from stop mode. */
+#define IS_PWC_STOP_CLK(x)                                                      \
+(   ((x) == PWC_STOP_CLK_KEEP)                      ||                          \
+    ((x) == PWC_STOP_CLK_MRC))
+
+/* Parameter validity check for flash wait setting after wake-up from stop mode. */
+#define IS_PWC_STOP_FLASH_WAIT(x)                                               \
+(   ((x)== PWC_STOP_FLASH_WAIT_ON)                  ||                          \
+    ((x)== PWC_STOP_FLASH_WAIT_OFF))
+
+/* Parameter validity check for ex-bus setting in stop mode. */
+#define IS_PWC_STOP_EXBUS(x)                                                    \
+(   ((x)== PWC_STOP_EXBUS_HIZ)                      ||                          \
+    ((x)== PWC_STOP_EXBUS_HOLD))
+
+/*  Parameter validity check for power monitor sel. */
+#define IS_PWC_PWR_MON_SEL(x)                                                   \
+(   ((x) == PWC_PWR_MON_IREF)                       ||                          \
+    ((x) == PWC_PWR_MON_VBAT_DIV2))
+
+/* Parameter validity check for VBAT Reference Voltage. */
+#define IS_PWC_VBAT_REF_VOL(x)                                                  \
+(   ((x) == PWC_VBAT_REF_VOL_2P1V)                  ||                          \
+    ((x) == PWC_VBAT_REF_VOL_1P8V))
+
+/* Parameter validity check for BACKUP RAM Flag. */
+#define IS_PWC_BACKUP_RAM_FLAG(x)                                               \
+(   0U != ((x) & (PWC_BACKUP_RAM_FLAG_RAMPDF | PWC_BACKUP_RAM_FLAG_RAMVALID)))
+
+/* Parameter validity check for Backup Register Number. */
+#define IS_PWC_BACKUP_REGISTER_NUMBER(x)            ((x) <= 127U)
+
+#define IS_PWC_LDO_SEL(x)                                                       \
+(   ((x) != 0x00U)                                  &&                          \
+    (((x) | PWC_LDO_MASK) == PWC_LDO_MASK))
+
+/* Parameter validity check for WKT Clock Source. */
+#define IS_PWC_WKT_CLK_SRC(x)                                                   \
+(   ((x)== PWC_WKT_CLK_SRC_64HZ)                    ||                          \
+    ((x)== PWC_WKT_CLK_SRC_XTAL32)                  ||                          \
+    ((x)== PWC_WKT_CLK_SRC_RTCLRC))
+
+/* Parameter validity check for WKT Comparison Value. */
+#define IS_PWC_WKT_COMPARISON_VALUE(x)             ((x) <= 0x0FFFU)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup PWC_Global_Functions PWC Global Functions
+ * @{
+ */
+/**
+ * @brief  Enter power down mode.
+ * @param  None
+ * @retval int32_t:
+ *          - LL_ERR_TIMEOUT:   Enter PD mode timeout
+ * @note   Not return LL_OK because if enter PD mode OK, the MCU will shut down, and reset after woken-up.
+ */
+int32_t PWC_PD_Enter(void)
+{
+    int32_t i32Ret;
+    uint32_t u32Timeout = 0UL;
+
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    /* Ensure pvd not reset exception */
+    CLR_REG8_BIT(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1IRS | PWC_PVDCR1_PVD2IRS);
+    for (; ;) {
+        SET_REG16_BIT(CM_PWC->STPMCR, PWC_STPMCR_STOP);
+        SET_REG8_BIT(CM_PWC->PWRC0, PWC_PWRC0_PWDN);
+        __WFI();
+        u32Timeout++;
+        if (u32Timeout > 1000UL) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enter stop mode.
+ * @param  [in] u8StopType specifies the type of enter stop's command.
+ *   @arg  PWC_STOP_WFI             Enter stop mode by WFI, and wake-up by interrupt handle.
+ *   @arg  PWC_STOP_WFE_INT         Enter stop mode by WFE, and wake-up by interrupt request.
+ *   @arg  PWC_STOP_WFE_EVT         Enter stop mode by WFE, and wake-up by event.
+ * @retval None
+ */
+void PWC_STOP_Enter(uint8_t u8StopType)
+{
+
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_STOP_TYPE(u8StopType));
+    DDL_ASSERT(0U == (CM_PWC->PWRC0 & PWC_PWRC0_PDMDS));
+
+    SET_REG16_BIT(CM_PWC->STPMCR, PWC_STPMCR_STOP);
+    CLR_REG8_BIT(CM_PWC->PWRC0, PWC_PWRC0_PWDN);
+    if (PWC_STOP_WFI == u8StopType) {
+        __WFI();
+    } else {
+        if (PWC_STOP_WFE_INT == u8StopType) {
+            SET_REG32_BIT(SCB->SCR, SCB_SCR_SEVONPEND_Msk);
+        }
+        __SEV();
+        __WFE();
+        __WFE();
+    }
+
+}
+
+/**
+ * @brief  Enter sleep mode.
+ * @param  [in] u8SleepType specifies the type of enter sleep's command.
+ *   @arg  PWC_SLEEP_WFI            Enter sleep mode by WFI, and wake-up by interrupt handle.
+ *   @arg  PWC_SLEEP_WFE_INT        Enter sleep mode by WFE, and wake-up by interrupt request.
+ *   @arg  PWC_SLEEP_WFE_EVT        Enter sleep mode by WFE, and wake-up by event.
+
+ * @retval None
+ */
+void PWC_SLEEP_Enter(uint8_t u8SleepType)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_SLEEP_TYPE(u8SleepType));
+
+    CLR_REG16_BIT(CM_PWC->STPMCR, PWC_STPMCR_STOP);
+    CLR_REG8_BIT(CM_PWC->PWRC0, PWC_PWRC0_PWDN);
+
+    if (PWC_SLEEP_WFI == u8SleepType) {
+        __WFI();
+    } else {
+        if (PWC_SLEEP_WFE_INT == u8SleepType) {
+            SET_REG32_BIT(SCB->SCR, SCB_SCR_SEVONPEND_Msk);
+        }
+        __SEV();
+        __WFE();
+        __WFE();
+    }
+}
+
+/**
+ * @brief  Configure ram run mode.
+ * @param  [in] u16Mode  Specifies the mode to run.
+ *  @arg    PWC_RAM_HIGH_SPEED
+ *  @arg    PWC_RAM_ULOW_SPEED
+ * @retval None
+ */
+void PWC_RamModeConfig(uint16_t u16Mode)
+{
+    DDL_ASSERT(IS_PWC_RAM_MD(u16Mode));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG16(CM_PWC->RAMOPM, u16Mode);
+}
+
+/**
+ * @brief  Initialize LVD config structure. Fill each pstcLvdInit with default value
+ * @param  [in] pstcLvdInit Pointer to a stc_pwc_lvd_init_t structure that contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: LVD structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_LVD_StructInit(stc_pwc_lvd_init_t *pstcLvdInit)
+{
+    int32_t i32Ret = LL_OK;
+    /* Check if pointer is NULL */
+    if (NULL == pstcLvdInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* RESET LVD init structure parameters values */
+        pstcLvdInit->u32State              = PWC_LVD_OFF;
+        pstcLvdInit->u32CompareOutputState = PWC_LVD_CMP_OFF;
+        pstcLvdInit->u32ExceptionType      = PWC_LVD_EXP_TYPE_NONE;
+        pstcLvdInit->u32Filter             = PWC_LVD_FILTER_OFF;
+        pstcLvdInit->u32FilterClock        = PWC_LVD_FILTER_LRC_MUL2;
+        pstcLvdInit->u32ThresholdVoltage   = PWC_LVD_THRESHOLD_LVL0;
+        pstcLvdInit->u32TriggerEdge        = PWC_LVD_TRIG_FALLING;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief LVD configuration.
+ * @param [in] u8Ch LVD channel @ref PWC_LVD_Channel.
+ * @param [in] pstcLvdInit Pointer to a stc_pwc_lvd_init_t structure that contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: LVD initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_LVD_Init(uint8_t u8Ch, const stc_pwc_lvd_init_t *pstcLvdInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcLvdInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+        DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+        DDL_ASSERT(IS_PWC_LVD_EN(pstcLvdInit->u32State));
+        DDL_ASSERT(IS_PWC_LVD_EXP_TYPE(pstcLvdInit->u32ExceptionType));
+        DDL_ASSERT(IS_PWC_LVD_CMP_EN(pstcLvdInit->u32CompareOutputState));
+        DDL_ASSERT(IS_PWC_LVD_FILTER_EN(pstcLvdInit->u32Filter));
+        DDL_ASSERT(IS_PWC_LVD_FILTER_CLK(pstcLvdInit->u32FilterClock));
+        DDL_ASSERT(IS_PWC_LVD_THRESHOLD_VOLTAGE(pstcLvdInit->u32ThresholdVoltage));
+        DDL_ASSERT(IS_PWC_LVD_TRIG_EDGE(pstcLvdInit->u32TriggerEdge));
+
+        /* disable filter function in advance */
+        SET_REG8_BIT(CM_PWC->PVDFCR, (PWC_PVDFCR_PVD1NFDIS << PWC_LVD_BIT_OFFSET(u8Ch)));
+        /* Enable LVD */
+        MODIFY_REG8(CM_PWC->PVDCR0, PWC_PVDCR0_PVD1EN << u8Ch, pstcLvdInit->u32State << u8Ch);
+        /* Delay 10us */
+        DDL_DelayUS(10U);
+        /* Configure the filter */
+        MODIFY_REG8(CM_PWC->PVDFCR, (PWC_PVDFCR_PVD1NFDIS | PWC_PVDFCR_PVD1NFCKS) << PWC_LVD_BIT_OFFSET(u8Ch), \
+                    (pstcLvdInit->u32Filter | pstcLvdInit->u32FilterClock) << PWC_LVD_BIT_OFFSET(u8Ch));
+        /* Config LVD threshold voltage */
+        MODIFY_REG8(CM_PWC->PVDLCR, PWC_PVDLCR_PVD1LVL << PWC_LVD_BIT_OFFSET(u8Ch), \
+                    pstcLvdInit->u32ThresholdVoltage << PWC_LVD_BIT_OFFSET(u8Ch));
+        /* Config the trigger edge */
+        MODIFY_REG8(CM_PWC->PVDICR, PWC_PVDICR_PVD1EDGS <<  PWC_LVD_BIT_OFFSET(u8Ch), \
+                    pstcLvdInit->u32TriggerEdge << PWC_LVD_BIT_OFFSET(u8Ch));
+        /* Enable compare output */
+        MODIFY_REG8(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1CMPOE << PWC_LVD_BIT_OFFSET(u8Ch), \
+                    pstcLvdInit->u32CompareOutputState << PWC_LVD_BIT_OFFSET(u8Ch));
+        /* config exception type while PVDEN & PVDCMPOE enable */
+        MODIFY_REG8(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1IRS << PWC_LVD_BIT_OFFSET(u8Ch), \
+                    (pstcLvdInit->u32ExceptionType & 0xFFU) << PWC_LVD_BIT_OFFSET(u8Ch));
+        MODIFY_REG8(CM_PWC->PVDICR, PWC_PVDICR_PVD1NMIS <<  PWC_LVD_BIT_OFFSET(u8Ch), \
+                    ((pstcLvdInit->u32ExceptionType >> PWC_LVD_EXP_NMI_POS) & 0xFFU) << PWC_LVD_BIT_OFFSET(u8Ch));
+        /* Clear the flag */
+        CLR_REG8_BIT(CM_PWC->PVDDSR, PWC_PVDDSR_PVD1DETFLG);
+        /* Enable exception */
+        MODIFY_REG8(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1IRE << PWC_LVD_BIT_OFFSET(u8Ch), \
+                    (pstcLvdInit->u32ExceptionType & 0xFFU) << PWC_LVD_BIT_OFFSET(u8Ch));
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief De-initialize PWC LVD.
+ * @param [in] u8Ch LVD channel @ref PWC_LVD_Channel.
+ * @retval None
+ */
+void PWC_LVD_DeInit(uint8_t u8Ch)
+{
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    /* Disable LVD */
+    CLR_REG_BIT(CM_PWC->PVDCR0, PWC_PVDCR0_PVD1EN << u8Ch);
+    /* Disable Ext-Vcc */
+    if (PWC_LVD_CH2 == u8Ch) {
+        CLR_REG8_BIT(CM_PWC->PVDCR0, PWC_PVDCR0_EXVCCINEN);
+    } else {
+        /* rsvd */
+    }
+    /* Reset filter */
+    CLR_REG8_BIT(CM_PWC->PVDFCR, (PWC_PVDFCR_PVD1NFDIS | PWC_PVDFCR_PVD1NFCKS)  << PWC_LVD_BIT_OFFSET(u8Ch));
+    /* Reset configure */
+    CLR_REG8_BIT(CM_PWC->PVDCR1, (PWC_PVDCR1_PVD1IRE | PWC_PVDCR1_PVD1IRS | PWC_PVDCR1_PVD1CMPOE) << \
+                 PWC_LVD_BIT_OFFSET(u8Ch));
+    CLR_REG8_BIT(CM_PWC->PVDICR, (PWC_PVDICR_PVD1NMIS | PWC_PVDICR_PVD1EDGS) << PWC_LVD_BIT_OFFSET(u8Ch));
+    /* Reset threshold voltage */
+    CLR_REG8_BIT(CM_PWC->PVDLCR, PWC_PVDLCR_PVD1LVL << PWC_LVD_BIT_OFFSET(u8Ch));
+}
+
+/**
+ * @brief  Enable or disable LVD.
+ * @param  [in] u8Ch Specifies which channel to operate. @ref PWC_LVD_Channel.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_LVD_Cmd(uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        SET_REG_BIT(PWC_LVD_EN_REG, PWC_LVD_EN_BIT << PWC_LVD_EN_BIT_OFFSET(u8Ch));
+    } else {
+        CLR_REG_BIT(PWC_LVD_EN_REG, PWC_LVD_EN_BIT << PWC_LVD_EN_BIT_OFFSET(u8Ch));
+    }
+}
+
+/**
+ * @brief  Enable or disable LVD external input.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   While enable external input, should choose PWC_LVD_CH2 to initialize and threshold voltage must set PWC_LVD_EXTVCC
+ */
+void PWC_LVD_ExtInputCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->PVDCR0, PWC_PVDCR0_EXVCCINEN);
+    } else {
+        CLR_REG8_BIT(CM_PWC->PVDCR0, PWC_PVDCR0_EXVCCINEN);
+    }
+}
+
+/**
+ * @brief  Enable or disable LVD compare output.
+ * @param  [in] u8Ch Specifies which channel to operate. @ref PWC_LVD_Channel.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_LVD_CompareOutputCmd(uint8_t u8Ch, en_functional_state_t enNewState)
+{
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1CMPOE << PWC_LVD_BIT_OFFSET(u8Ch));
+    } else {
+        CLR_REG8_BIT(CM_PWC->PVDCR1, PWC_PVDCR1_PVD1CMPOE << PWC_LVD_BIT_OFFSET(u8Ch));
+    }
+}
+
+/**
+ * @brief  Enable or disable LVD digital filter.
+ * @param  [in] u8Ch Specifies which channel to operate. @ref PWC_LVD_Channel.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_LVD_DigitalFilterCmd(uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        CLR_REG_BIT(PWC_LVD_FILTER_EN_REG, PWC_LVD_FILTER_EN_BIT << PWC_LVD_BIT_OFFSET(u8Ch));
+    } else {
+        SET_REG_BIT(PWC_LVD_FILTER_EN_REG, PWC_LVD_FILTER_EN_BIT << PWC_LVD_BIT_OFFSET(u8Ch));
+    }
+}
+
+/**
+ * @brief  Enable or disable LVD compare output.
+ * @param  [in] u8Ch Specifies which channel to operate. @ref PWC_LVD_Channel.
+ * @param  [in] u32Clock Specifies filter clock. @ref PWC_LVD_DFS_Clk_Sel
+ * @retval None
+ */
+void PWC_LVD_SetFilterClock(uint8_t u8Ch, uint32_t u32Clock)
+{
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_FILTER_CLK(u32Clock));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+    MODIFY_REG8(CM_PWC->PVDFCR, PWC_PVDFCR_PVD1NFCKS << PWC_LVD_BIT_OFFSET(u8Ch), \
+                u32Clock << PWC_LVD_BIT_OFFSET(u8Ch));
+}
+
+/**
+ * @brief Set LVD threshold voltage.
+ * @param  [in] u8Ch        Specifies which channel to operate. @ref PWC_LVD_Channel.
+ * @param  [in] u32Voltage  Specifies threshold voltage. @ref PWC_LVD_Detection_Voltage_Sel
+ * @retval None
+ * @note    While PWC_LVD_CH2, PWC_LVD_EXTVCC only valid while EXTINPUT enable.
+ */
+void PWC_LVD_SetThresholdVoltage(uint8_t u8Ch, uint32_t u32Voltage)
+{
+    DDL_ASSERT(IS_PWC_LVD_CH(u8Ch));
+    DDL_ASSERT(IS_PWC_LVD_THRESHOLD_VOLTAGE(u32Voltage));
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+
+    MODIFY_REG8(CM_PWC->PVDLCR, (PWC_PVDLCR_PVD1LVL << PWC_LVD_BIT_OFFSET(u8Ch)), \
+                u32Voltage << PWC_LVD_BIT_OFFSET(u8Ch));
+}
+
+/**
+ * @brief  Get LVD flag.
+ * @param  [in] u8Flag LVD flag to be get @ref PWC_LVD_Flag
+ * @retval An @ref en_flag_status_t enumeration value
+ * @note   PVDxDETFLG is available when PVDCR0.PVDxEN and PVDCR1.PVDxCMPOE are set to '1'
+ */
+en_flag_status_t PWC_LVD_GetStatus(uint8_t u8Flag)
+{
+    DDL_ASSERT(IS_PWC_LVD_GET_FLAG(u8Flag));
+    return ((0x00U != READ_REG8_BIT(PWC_LVD_STATUS_REG, u8Flag)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear LVD flag.
+ * @param  [in] u8Flag LVD flag to be get @ref PWC_LVD_Flag
+ *  @arg      PWC_LVD1_FLAG_DETECT
+ *  @arg      PWC_LVD2_FLAG_DETECT
+ * @retval None
+ * @note   PWC_LVD1_FLAG_DETECT could clear both LVD1 & LVD2 flag
+ */
+void PWC_LVD_ClearStatus(uint8_t u8Flag)
+{
+    (void)u8Flag;
+
+    DDL_ASSERT(IS_PWC_LVD_UNLOCKED());
+    DDL_ASSERT(IS_PWC_LVD_CLR_FLAG(u8Flag));
+
+    CLR_REG8_BIT(PWC_LVD_STATUS_REG, PWC_PVDDSR_PVD1DETFLG);
+}
+
+/**
+ * @brief  LDO(HRC & PLL) command.
+ * @param  [in] u16Ldo  Specifies the LDO to command.
+ *  @arg    PWC_LDO_PLL
+ *  @arg    PWC_LDO_HRC
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_LDO_Cmd(uint16_t u16Ldo, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_LDO_SEL(u16Ldo));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        CLR_REG8_BIT(CM_PWC->PWRC1, u16Ldo);
+    } else {
+        SET_REG8_BIT(CM_PWC->PWRC1, u16Ldo);
+    }
+}
+
+/**
+ * @brief  Switch high speed to ultra low speed, set the drive ability.
+ * @param  None
+ * @retval int32_t:
+ *          - LL_OK: Mode switch successful.
+ *          - LL_ERR: Mode switch failure, check whether EFM was unlocked please.
+ * @note   Before calling this API, please switch system clock to the required
+ *         low speed frequency in advance, and make sure NO any flash program
+ *         or erase operation background.
+ */
+int32_t PWC_HighSpeedToLowSpeed(void)
+{
+    uint32_t u32To = PWC_MD_SWITCH_TIMEOUT2;
+
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_EFM_UNLOCKED());
+
+    WRITE_REG32(bCM_EFM->FRMC_b.LVM, ENABLE);
+    WRITE_REG16(CM_PWC->RAMOPM, PWC_RAM_ULOW_SPEED);
+
+    while (PWC_RAM_ULOW_SPEED != READ_REG16(CM_PWC->RAMOPM)) {
+        WRITE_REG16(CM_PWC->RAMOPM, PWC_RAM_ULOW_SPEED);
+        if (0UL == u32To--) {
+            return LL_ERR;
+        }
+    }
+
+    u32To = PWC_MD_SWITCH_TIMEOUT2;
+    while (0UL == READ_REG32(bCM_EFM->FRMC_b.LVM)) {
+        WRITE_REG32(bCM_EFM->FRMC_b.LVM, ENABLE);
+        if (0UL == u32To--) {
+            return LL_ERR;
+        }
+    }
+
+    CLR_REG8_BIT(CM_PWC->PWRC2, PWC_PWRC2_DDAS);
+    WRITE_REG8(CM_PWC->PWRC3, 0x00UL);
+    MODIFY_REG8(CM_PWC->PWRC2, PWC_PWRC2_DVS, PWC_PWRC2_DVS_1);
+
+    /* Delay 30uS*/
+    DDL_DelayUS(PWC_MD_SWITCH_TIMEOUT);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Switch ultra low speed to high speed, set the drive ability.
+ * @param  None
+ * @retval int32_t:
+ *          - LL_OK: Mode switch successful.
+ *          - LL_ERR: Mode switch failure, check whether EFM was unlocked please.
+ * @note   After calling this API, the system clock is able to switch high frequency.
+ */
+/**
+ * @brief  Switch ultra low speed to high speed, set the drive ability.
+ * @param  None
+ * @retval int32_t:
+ *          - LL_OK: Mode switch successful.
+ *          - LL_ERR: Mode switch failure, check whether EFM was unlocked please.
+ * @note   After calling this API, the system clock is able to switch high frequency.
+ */
+int32_t PWC_LowSpeedToHighSpeed(void)
+{
+    uint32_t u32To = PWC_MD_SWITCH_TIMEOUT2;
+
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_EFM_UNLOCKED());
+    SET_REG8_BIT(CM_PWC->PWRC2, PWC_PWRC2_DDAS);
+    WRITE_REG8(CM_PWC->PWRC3, 0xFFUL);
+    SET_REG8_BIT(CM_PWC->PWRC2, PWC_PWRC2_DVS);
+
+    /* Delay 30uS*/
+    DDL_DelayUS(PWC_MD_SWITCH_TIMEOUT);
+
+    WRITE_REG32(bCM_EFM->FRMC_b.LVM, DISABLE);
+    WRITE_REG16(CM_PWC->RAMOPM, PWC_RAM_HIGH_SPEED);
+
+    while (PWC_RAM_HIGH_SPEED != READ_REG16(CM_PWC->RAMOPM)) {
+        WRITE_REG16(CM_PWC->RAMOPM, PWC_RAM_HIGH_SPEED);
+        if (0UL == u32To--) {
+            return LL_ERR;
+        }
+    }
+
+    u32To = PWC_MD_SWITCH_TIMEOUT2;
+    while (0UL != READ_REG32(bCM_EFM->FRMC_b.LVM)) {
+        WRITE_REG32(bCM_EFM->FRMC_b.LVM, DISABLE);
+        if (0UL == u32To--) {
+            return LL_ERR;
+        }
+    }
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Ram area power down command.
+ * @param  [in] u32Ram Specifies which ram to operate. @ref PWC_PD_Ram
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ *  @arg    ENABLE:      Power down mode
+ *  @arg    DISABLE:     Run mode
+ * @retval None
+ */
+void PWC_PD_RamCmd(uint32_t u32Ram, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_RAM_CONTROL(u32Ram));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->RAMPC0, u32Ram);
+    } else {
+        CLR_REG8_BIT(CM_PWC->RAMPC0, u32Ram);
+    }
+}
+
+/**
+ * @brief  Ram area power down command.
+ * @param  [in] u32PeriphRam Specifies which ram to operate. @ref PWC_PD_Periph_Ram
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ *  @arg    ENABLE:      Power down mode
+ *  @arg    DISABLE:     Run mode
+ * @retval None
+ */
+void PWC_PD_PeriphRamCmd(uint32_t u32PeriphRam, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_PRAM_CONTROL(u32PeriphRam));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->PRAMLPC, u32PeriphRam);
+    } else {
+        CLR_REG8_BIT(CM_PWC->PRAMLPC, u32PeriphRam);
+    }
+}
+
+/**
+ * @brief  Initialize Power down mode config structure. Fill each pstcPDModeConfig with default value
+ * @param  [in] pstcPDModeConfig Pointer to a stc_pwc_pd_mode_config_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: Power down mode structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_PD_StructInit(stc_pwc_pd_mode_config_t *pstcPDModeConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcPDModeConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcPDModeConfig->u8IOState = PWC_PD_IO_KEEP1;
+        pstcPDModeConfig->u8Mode = PWC_PD_MD1;
+        pstcPDModeConfig->u8VcapCtrl = PWC_PD_VCAP_0P1UF;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Power down mode config structure.
+ * @param  [in] pstcPDModeConfig Pointer to a stc_pwc_pd_mode_config_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: Power down mode config successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_PD_Config(const stc_pwc_pd_mode_config_t *pstcPDModeConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcPDModeConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        DDL_ASSERT(IS_PWC_UNLOCKED());
+        DDL_ASSERT(IS_PWC_PD_IO_STATE(pstcPDModeConfig->u8IOState));
+        DDL_ASSERT(IS_PWC_PD_MD(pstcPDModeConfig->u8Mode));
+        DDL_ASSERT(IS_PWC_PD_VCAP_SEL(pstcPDModeConfig->u8VcapCtrl));
+
+        MODIFY_REG8(CM_PWC->PWRC0, (PWC_PWRC0_IORTN | PWC_PWRC0_PDMDS),         \
+                    (pstcPDModeConfig->u8IOState | pstcPDModeConfig->u8Mode));
+        MODIFY_REG8(CM_PWC->PWRC1, PWC_PWRC1_PDTS, pstcPDModeConfig->u8VcapCtrl << PWC_PWRC1_PDTS_POS);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set IO state while PD mode.
+ * @param  [in] u8IoState IO state while power down mode
+ *   @arg  PWC_PD_IO_KEEP1
+ *   @arg  PWC_PD_IO_KEEP2
+ *   @arg  PWC_PD_IO_HIZ
+ * @retval None
+ */
+void PWC_PD_SetIoState(uint8_t u8IoState)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_PD_IO_STATE(u8IoState));
+
+    MODIFY_REG8(CM_PWC->PWRC0, PWC_PWRC0_IORTN, u8IoState);
+}
+
+/**
+ * @brief  Set power down mode.
+ * @param  [in] u8PdMode Power down mode
+ *   @arg  PWC_PD_MD1       Power down mode 1
+ *   @arg  PWC_PD_MD2       Power down mode 2
+ *   @arg  PWC_PD_MD3       Power down mode 3
+ *   @arg  PWC_PD_MD4       Power down mode 4
+ * @retval None
+ */
+void PWC_PD_SetMode(uint8_t u8PdMode)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    DDL_ASSERT(IS_PWC_PD_MD(u8PdMode));
+
+    MODIFY_REG8(CM_PWC->PWRC0, PWC_PWRC0_PDMDS, u8PdMode);
+}
+
+/**
+ * @brief  Power down mode wake up event config.
+ * @param  [in] u32Event Wakeup Event. @ref PWC_WKUP_Event_Sel
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_PD_WakeupCmd(uint32_t u32Event, en_functional_state_t enNewState)
+{
+    uint8_t u8Event0 = (uint8_t)u32Event;
+    uint8_t u8Event1 = (uint8_t)(u32Event >> PWC_PD_WKUP1_POS);
+    uint8_t u8Event2 = (uint8_t)(u32Event >> PWC_PD_WKUP2_POS);
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->PDWKE0, u8Event0);
+        SET_REG8_BIT(CM_PWC->PDWKE1, u8Event1);
+        SET_REG8_BIT(CM_PWC->PDWKE2, u8Event2);
+    } else {
+        CLR_REG8_BIT(CM_PWC->PDWKE0, u8Event0);
+        CLR_REG8_BIT(CM_PWC->PDWKE1, u8Event1);
+        CLR_REG8_BIT(CM_PWC->PDWKE2, u8Event2);
+    }
+}
+
+/**
+ * @brief  Power down mode wake up event trigger config.
+ * @param  [in] u8Event PVD and wake up pin. @ref PWC_WKUP_Trigger_Event_Sel
+ * @param  [in] u8TrigEdge The trigger edge.
+ *  @arg PWC_PD_WKUP_TRIG_FALLING
+ *  @arg PWC_PD_WKUP_TRIG_RISING
+ * @retval None
+ */
+void PWC_PD_SetWakeupTriggerEdge(uint8_t u8Event, uint8_t u8TrigEdge)
+{
+    DDL_ASSERT(IS_PWC_WAKEUP_TRIG_EVT(u8Event));
+    DDL_ASSERT(IS_PWC_WAKEUP_TRIG(u8TrigEdge));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (PWC_PD_WKUP_TRIG_RISING == u8TrigEdge) {
+        SET_REG8_BIT(CM_PWC->PDWKES, u8Event);
+    } else {
+        CLR_REG8_BIT(CM_PWC->PDWKES, u8Event);
+    }
+}
+
+/**
+ * @brief  Get wake up event flag.
+ * @param  [in] u16Flag Wake up event. @ref PWC_WKUP_Event_Flag_Sel
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t PWC_PD_GetWakeupStatus(uint16_t u16Flag)
+{
+    uint8_t u8Flag0;
+    uint8_t u8Flag1;
+
+    DDL_ASSERT(IS_PWC_WKUP_FLAG(u16Flag));
+
+    u8Flag0 = READ_REG8_BIT(CM_PWC->PDWKF0, u16Flag);
+    u8Flag1 = READ_REG8_BIT(CM_PWC->PDWKF1, (u16Flag >> PWC_PD_WKUP_FLAG1_POS));
+
+    return (((0U != u8Flag0) || (0U != u8Flag1)) ? SET : RESET);
+}
+
+/**
+ * @brief  Clear wake up event flag.
+ * @param  [in] u16Flag Wake up event. @ref PWC_WKUP_Event_Flag_Sel
+ * @retval None
+ */
+void PWC_PD_ClearWakeupStatus(uint16_t u16Flag)
+{
+    uint8_t u8Flag0;
+    uint8_t u8Flag1;
+
+    DDL_ASSERT(IS_PWC_WKUP_FLAG(u16Flag));
+
+    u8Flag0 = (uint8_t)u16Flag;
+    u8Flag1 = (uint8_t)(u16Flag >> PWC_PD_WKUP_FLAG1_POS);
+
+    WRITE_REG8(CM_PWC->PDWKF0, (~u8Flag0) & PWC_PD_PDWKF0_MSK);
+    WRITE_REG8(CM_PWC->PDWKF1, (~u8Flag1) & PWC_PD_PDWKF1_MSK);
+}
+
+/**
+ * @brief Stop mode config.
+ * @param [in] pstcStopConfig Chip config before entry stop mode.
+ *  @arg    u8StopDrv, MCU from which speed mode entry stop mode.
+ *  @arg    u16Clock, System clock setting after wake-up from stop mode.
+ *  @arg    u16FlashWait, Whether wait flash stable after wake-up from stop mode.
+ *  @arg    u16ExBusHold, ExBus status in stop mode.
+ * @retval int32_t:
+ *          - LL_OK: Stop mode config successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_STOP_Config(const stc_pwc_stop_mode_config_t *pstcStopConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcStopConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+
+        DDL_ASSERT(IS_PWC_UNLOCKED());
+
+        DDL_ASSERT(IS_PWC_STOP_CLK(pstcStopConfig->u16Clock));
+        DDL_ASSERT(IS_PWC_STOP_FLASH_WAIT(pstcStopConfig->u16FlashWait));
+        DDL_ASSERT(IS_PWC_STOP_EXBUS(pstcStopConfig->u16ExBusHold));
+        DDL_ASSERT(IS_PWC_STOP_DRV(pstcStopConfig->u8StopDrv));
+        MODIFY_REG8(CM_PWC->PWRC1, PWC_PWRC1_STPDAS, pstcStopConfig->u8StopDrv);
+        MODIFY_REG16(CM_PWC->STPMCR, (PWC_STPMCR_EXBUSOE | PWC_STPMCR_CKSMRC | PWC_STPMCR_FLNWT), \
+                     (pstcStopConfig->u16ExBusHold | pstcStopConfig->u16Clock | pstcStopConfig->u16FlashWait));
+
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize stop mode config structure. Fill each pstcStopConfig with default value
+ * @param  [in] pstcStopConfig Pointer to a stc_pwc_stop_mode_config_t structure that
+ *                            contains configuration information.
+ * @retval int32_t:
+ *          - LL_OK: Stop down mode structure initialize successful
+ *          - LL_ERR_INVD_PARAM: NULL pointer
+ */
+int32_t PWC_STOP_StructInit(stc_pwc_stop_mode_config_t *pstcStopConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Check if pointer is NULL */
+    if (NULL == pstcStopConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcStopConfig->u16Clock = PWC_STOP_CLK_KEEP;
+        pstcStopConfig->u16FlashWait = PWC_STOP_FLASH_WAIT_ON;
+        pstcStopConfig->u16ExBusHold = PWC_STOP_EXBUS_HIZ;
+        pstcStopConfig->u8StopDrv = PWC_STOP_DRV_HIGH;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief Stop mode wake up clock config.
+ * @param [in] u8Clock System clock setting after wake-up from stop mode. @ref PWC_STOP_CLK_Sel
+ * @retval None
+ */
+void PWC_STOP_ClockSelect(uint8_t u8Clock)
+{
+    DDL_ASSERT(IS_PWC_STOP_CLK(u8Clock));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG16(CM_PWC->STPMCR, PWC_STPMCR_CKSMRC, (uint16_t)u8Clock);
+
+}
+
+/**
+ * @brief  Stop mode wake up flash wait config.
+ * @param  [in] enNewState An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_STOP_FlashWaitCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        CLR_REG16_BIT(CM_PWC->STPMCR, PWC_STPMCR_FLNWT);
+    } else {
+        SET_REG16_BIT(CM_PWC->STPMCR, PWC_STPMCR_FLNWT);
+    }
+}
+
+/**
+ * @brief Stop mode ex-bus status config.
+ * @param [in] u16ExBusHold ExBus status in stop mode.
+ *  @arg   PWC_STOP_EXBUS_HIZ
+ *  @arg   PWC_STOP_EXBUS_HOLD
+ * @retval None
+ */
+void PWC_STOP_ExBusHoldConfig(uint16_t u16ExBusHold)
+{
+    DDL_ASSERT(IS_PWC_STOP_EXBUS(u16ExBusHold));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG16(CM_PWC->STPMCR, PWC_STPMCR_EXBUSOE, u16ExBusHold);
+}
+
+/**
+ * @brief Stop mode driver capacity config.
+ * @param [in] u8StopDrv Drive capacity while enter stop mode.
+ *  @arg    PWC_STOP_DRV_HIGH
+ *  @arg    PWC_STOP_DRV_LOW
+ * @retval None
+ */
+void PWC_STOP_SetDrv(uint8_t u8StopDrv)
+{
+    DDL_ASSERT(IS_PWC_STOP_DRV(u8StopDrv));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG8(CM_PWC->PWRC1, PWC_PWRC1_STPDAS, u8StopDrv);
+}
+
+/**
+ * @brief  PWC power monitor command.
+ * @param  [in] enNewState      An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   This monitor power is used for ADC and output to REGC pin.
+ */
+void PWC_PowerMonitorCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    if (ENABLE == enNewState) {
+        SET_REG8_BIT(CM_PWC->PWRC4, PWC_PWRC4_ADBUFE);
+    } else {
+        CLR_REG8_BIT(CM_PWC->PWRC4, PWC_PWRC4_ADBUFE);
+    }
+
+}
+
+/**
+ * @brief  PWC power monitor voltage config.
+ * @param  [in] u8VoltageSrc   PWC power monitor voltage config @ref PWC_Monitor_Power.
+ *         This parameter can be one of the following values
+ *  @arg    PWC_PWR_MON_IREF
+ *  @arg    PWC_PWR_MON_VBAT_DIV2
+ * @retval None
+ * @note   This monitor power is used for ADC and output to REGC pin.
+ */
+void PWC_SetPowerMonitorVoltageSrc(uint8_t u8VoltageSrc)
+{
+    DDL_ASSERT(IS_PWC_PWR_MON_SEL(u8VoltageSrc));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG8(CM_PWC->PWRC4, PWC_PWRC4_ADBUFS, u8VoltageSrc);
+}
+
+/**
+ * @brief  VBAT monitor reference voltage selection.
+ * @param  [in] u8RefVoltage                VBAT monitor reference voltage.
+ *         This parameter can be one of the following values:
+ *  @arg    PWC_VBAT_REF_VOL_1P8V:  Vbat reference voltage is 1.8V
+ *  @arg    PWC_VBAT_REF_VOL_2P1V:  Vbat reference voltage is 2.1V
+ * @retval None
+ */
+void PWC_VBAT_SetMonitorVoltage(uint8_t u8RefVoltage)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_VBAT_REF_VOL(u8RefVoltage));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG32(bCM_PWC->PWRC4_b.VBATREFSEL, u8RefVoltage);
+}
+
+/**
+ * @brief  ENABLE or DISABLE VBAT monitor.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_VBAT_MonitorCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG32(bCM_PWC->PWRC4_b.VBATME, enNewState);
+}
+
+/**
+ * @brief  Get VBAT voltage status.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value.
+ *         - SET: Flag is set, VBAT < VBATREF
+ *         - RESET: Flag is reset, VBAT > VBATREF
+ */
+en_flag_status_t PWC_VBAT_GetVoltageStatus(void)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    return ((0UL != READ_REG32(bCM_PWC->PWRC4_b.VBATMON)) ? SET : RESET);
+}
+
+/**
+ * @brief  ENABLE or DISABLE VBAT voltage divide monitor.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_VBAT_VoltageDivMonitorCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG32(bCM_PWC->VBATCR_b.VBATDIVMONE, enNewState);
+}
+
+/**
+ * @brief  RESET the VBAT area.
+ * @param  None
+ * @retval None
+ */
+void PWC_VBAT_Reset(void)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    WRITE_REG8(CM_PWC->VBATRSTR, 0xA5U);
+}
+
+/**
+ * @brief  ENABLE or DISABLE VBAT power.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_VBAT_PowerCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    WRITE_REG32(bCM_PWC->VBATCR_b.CSDIS, enNewState);
+}
+
+/**
+ * @brief  ENABLE or DISABLE Backup RAM power.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_BKR_PowerCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        WRITE_REG32(bCM_PWC->VBATCR_b.VBTRSD, 0UL);
+    } else {
+        WRITE_REG32(bCM_PWC->VBATCR_b.VBTRSD, 1UL);
+    }
+}
+
+/**
+ * @brief  Get Backup RAM flag.
+ * @param  [in] u8Flag                  Backup RAM flag.
+ *         This parameter can be one or any combination of the following values:
+ *  @arg    PWC_BACKUP_RAM_FLAG_RAMPDF:   Backup RAM power down flag
+ *  @arg    PWC_BACKUP_RAM_FLAG_RAMVALID: Backup RAM read/write flag
+ * @retval  An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t PWC_BKR_GetStatus(uint8_t u8Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_BACKUP_RAM_FLAG(u8Flag));
+
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    if (0U != (READ_REG8_BIT(CM_PWC->VBATCR, u8Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Write Backup register.
+ * @param  [in] u8RegNum                Backup register number.
+ *  @arg    This parameter can be a number between Min_Data = 0 and Max_Data = 127.
+ * @param  [in] u8RegVal                Value written to register
+ * @retval None
+ */
+void PWC_BKR_Write(uint8_t u8RegNum, uint8_t u8RegVal)
+{
+    __IO uint8_t *BKR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_BACKUP_REGISTER_NUMBER(u8RegNum));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    BKR = (__IO uint8_t *)PWC_BKRx(u8RegNum);
+    WRITE_REG8(*BKR, u8RegVal);
+}
+
+/**
+ * @brief  Read Backup register.
+ * @param  [in] u8RegNum                Backup register number.
+ *  @arg    This parameter can be a number between Min_Data = 0 and Max_Data = 127.
+ * @retval uint8_t                      Register value
+ */
+uint8_t PWC_BKR_Read(uint8_t u8RegNum)
+{
+    uint8_t u8RegVal;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_BACKUP_REGISTER_NUMBER(u8RegNum));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    u8RegVal = READ_REG8(*((__IO uint8_t *)PWC_BKRx(u8RegNum)));
+
+    return u8RegVal;
+}
+
+/**
+ * @brief  WKT Timer Initialize.
+ * @param  [in] u16ClkSrc               Clock source.
+ *         This parameter can be one of the values @ref PWC_WKT_Clock_Source.
+ * @param  [in] u16CmpVal               Comparison value of the Counter.
+ *  @arg    This parameter can be a number between Min_Data = 0 and Max_Data = 0xFFF.
+ * @retval None
+ */
+void PWC_WKT_Config(uint16_t u16ClkSrc, uint16_t u16CmpVal)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_WKT_CLK_SRC(u16ClkSrc));
+    DDL_ASSERT(IS_PWC_WKT_COMPARISON_VALUE(u16CmpVal));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    MODIFY_REG8(CM_PWC->WKTC2, PWC_WKTC2_WKCKS | PWC_WKTC2_WKOVF, u16ClkSrc | PWC_WKTC2_WKOVF);
+    WRITE_REG8(CM_PWC->WKTC0, (u16CmpVal & PWC_WKTC0_WKTMCMP));
+    WRITE_REG8(CM_PWC->WKTC1, ((u16CmpVal >> 8U) & PWC_WKTC1_WKTMCMP));
+}
+
+/**
+ * @brief  SET WKT Timer compare value.
+ * @param  [in] u16CmpVal               Comparison value of the Counter.
+ *  @arg    This parameter can be a number between Min_Data = 0 and Max_Data = 0xFFF.
+ * @retval None
+ */
+void PWC_WKT_SetCompareValue(uint16_t u16CmpVal)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_PWC_WKT_COMPARISON_VALUE(u16CmpVal));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    WRITE_REG8(CM_PWC->WKTC0, (u16CmpVal & PWC_WKTC0_WKTMCMP));
+    WRITE_REG8(CM_PWC->WKTC1, ((u16CmpVal >> 8U) & PWC_WKTC1_WKTMCMP));
+}
+
+/**
+ * @brief  Get WKT Timer compare value.
+ * @param  None
+ * @retval uint16_t                     WKT Compare value
+ */
+uint16_t PWC_WKT_GetCompareValue(void)
+{
+    uint16_t u16CmpVal;
+
+    u16CmpVal  = (uint16_t)(READ_REG16_BIT(CM_PWC->WKTC1, PWC_WKTC1_WKTMCMP) << 8U);
+    u16CmpVal |= READ_REG8(CM_PWC->WKTC0);
+
+    return u16CmpVal;
+}
+
+/**
+ * @brief  ENABLE or DISABLE WKT Timer.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void PWC_WKT_Cmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+
+    if (ENABLE == enNewState) {
+        MODIFY_REG8(CM_PWC->WKTC2, PWC_WKTC2_WKTCE | PWC_WKTC2_WKOVF, PWC_WKT_ON | PWC_WKTC2_WKOVF);
+    } else {
+        MODIFY_REG8(CM_PWC->WKTC2, PWC_WKTC2_WKTCE, PWC_WKT_OFF);
+    }
+}
+
+/**
+ * @brief  Get WKT Timer count match flag.
+ * @param  None
+ * @retval An @ref en_flag_status_t enumeration type value. enumeration value:
+ */
+en_flag_status_t PWC_WKT_GetStatus(void)
+{
+    en_flag_status_t enFlagState;
+
+    enFlagState = (0U != READ_REG8_BIT(CM_PWC->WKTC2, PWC_WKTC2_WKOVF)) ? SET : RESET;
+
+    return enFlagState;
+}
+
+/**
+ * @brief  Clear WKT Timer count match flag.
+ * @param  None
+ * @retval None
+ */
+void PWC_WKT_ClearStatus(void)
+{
+    DDL_ASSERT(IS_PWC_UNLOCKED());
+    CLR_REG8_BIT(CM_PWC->WKTC2, PWC_WKTC2_WKOVF);
+}
+
+/**
+ * @}
+ */
+
+#endif  /* LL_PWC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_qspi.c
+++ b/hc32f4a2/src/hc32_ll_qspi.c
@@ -1,0 +1,478 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_qspi.c
+ * @brief This file provides firmware functions to manage the QSPI.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Modify the conditions for entering direct communication mode
+   2023-09-30       CDT             Optimize QSPI_ClearStatus function
+                                    Modify return value type of QSPI_DeInit function
+   2024-06-30       CDT             Delete judgement condition when switching to direct communication mode
+   2024-11-08       CDT             Modify QSPI->SR2 to QSPI->CLR
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_qspi.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_QSPI QSPI
+ * @brief QSPI Driver Library
+ * @{
+ */
+
+#if (LL_QSPI_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup QSPI_Local_Macros QSPI Local Macros
+ * @{
+ */
+
+/* QSPI registers Mask */
+#define QSPI_CR_CLR_MASK                (QSPI_CR_DIV    | QSPI_CR_SPIMD3    | QSPI_CR_PFSAE  | \
+                                         QSPI_CR_PFE    | QSPI_CR_MDSEL)
+#define QSPI_FCR_CLR_MASK               (QSPI_FCR_DUTY  | QSPI_FCR_DMCYCN   | QSPI_FCR_SSNLD | \
+                                         QSPI_FCR_SSNHD | QSPI_FCR_FOUR_BIC | QSPI_FCR_AWSL)
+#define QSPI_CUSTOM_MD_CLR_MASK         (QSPI_CR_IPRSL  | QSPI_CR_APRSL     | QSPI_CR_DPRSL)
+
+/**
+ * @defgroup QSPI_Check_Parameters_Validity QSPI check parameters validity
+ * @{
+ */
+
+#define IS_QSPI_CLK_DIV(x)                                                     \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | QSPI_CLK_DIV64) == QSPI_CLK_DIV64))
+
+#define IS_QSPI_SPI_MD(x)                                                      \
+(   ((x) == QSPI_SPI_MD0)                                   ||                 \
+    ((x) == QSPI_SPI_MD3))
+
+#define IS_QSPI_PREFETCH_MD(x)                                                 \
+(   ((x) == QSPI_PREFETCH_MD_INVD)                          ||                 \
+    ((x) == QSPI_PREFETCH_MD_EDGE_STOP)                     ||                 \
+    ((x) == QSPI_PREFETCH_MD_IMMED_STOP))
+
+#define IS_QSPI_READ_MD(x)                                                     \
+(   ((x) == QSPI_RD_MD_STD_RD)                              ||                 \
+    ((x) == QSPI_RD_MD_FAST_RD)                             ||                 \
+    ((x) == QSPI_RD_MD_DUAL_OUTPUT_FAST_RD)                 ||                 \
+    ((x) == QSPI_RD_MD_DUAL_IO_FAST_RD)                     ||                 \
+    ((x) == QSPI_RD_MD_QUAD_OUTPUT_FAST_RD)                 ||                 \
+    ((x) == QSPI_RD_MD_QUAD_IO_FAST_RD)                     ||                 \
+    ((x) == QSPI_RD_MD_CUSTOM_STANDARD_RD)                  ||                 \
+    ((x) == QSPI_RD_MD_CUSTOM_FAST_RD))
+
+#define IS_QSPI_DUMMY_CYCLE(x)                              (((x) | QSPI_DUMMY_CYCLE18) == QSPI_DUMMY_CYCLE18)
+
+#define IS_QSPI_ADDR_WIDTH(x)                                                  \
+(   ((x) == QSPI_ADDR_WIDTH_8BIT)                           ||                 \
+    ((x) == QSPI_ADDR_WIDTH_16BIT)                          ||                 \
+    ((x) == QSPI_ADDR_WIDTH_24BIT)                          ||                 \
+    ((x) == QSPI_ADDR_WIDTH_32BIT_INSTR_24BIT)              ||                 \
+    ((x) == QSPI_ADDR_WIDTH_32BIT_INSTR_32BIT))
+
+#define IS_QSPI_QSSN_SETUP_TIME(x)                                             \
+(   ((x) == QSPI_QSSN_SETUP_ADVANCE_QSCK0P5)                ||                 \
+    ((x) == QSPI_QSSN_SETUP_ADVANCE_QSCK1P5))
+
+#define IS_QSPI_QSSN_RELEASE_TIME(x)                                           \
+(   ((x) == QSPI_QSSN_RELEASE_DELAY_QSCK0P5)                ||                 \
+    ((x) == QSPI_QSSN_RELEASE_DELAY_QSCK1P5)                ||                 \
+    ((x) == QSPI_QSSN_RELEASE_DELAY_QSCK32)                 ||                 \
+    ((x) == QSPI_QSSN_RELEASE_DELAY_QSCK128)                ||                 \
+    ((x) == QSPI_QSSN_RELEASE_DELAY_INFINITE))
+
+#define IS_QSPI_QSSN_INTERVAL_TIME(x)                       ((x) <= QSPI_QSSN_INTERVAL_QSCK16)
+
+#define IS_QSPI_INSTR_PROTOCOL(x)                                              \
+(   ((x) == QSPI_INSTR_PROTOCOL_1LINE)                      ||                 \
+    ((x) == QSPI_INSTR_PROTOCOL_2LINE)                      ||                 \
+    ((x) == QSPI_INSTR_PROTOCOL_4LINE))
+
+#define IS_QSPI_ADDR_PROTOCOL(x)                                               \
+(   ((x) == QSPI_ADDR_PROTOCOL_1LINE)                       ||                 \
+    ((x) == QSPI_ADDR_PROTOCOL_2LINE)                       ||                 \
+    ((x) == QSPI_ADDR_PROTOCOL_4LINE))
+
+#define IS_QSPI_DATA_PROTOCOL(x)                                               \
+(   ((x) == QSPI_DATA_PROTOCOL_1LINE)                       ||                 \
+    ((x) == QSPI_DATA_PROTOCOL_2LINE)                       ||                 \
+    ((x) == QSPI_DATA_PROTOCOL_4LINE))
+
+#define IS_QSPI_WP_PIN_LVL(x)                                                  \
+(   ((x) == QSPI_WP_PIN_LOW)                                ||                 \
+    ((x) == QSPI_WP_PIN_HIGH))
+
+#define IS_QSPI_FLAG(x)                                                        \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | QSPI_FLAG_ALL) == QSPI_FLAG_ALL))
+
+#define IS_QSPI_CLR_FLAG(x)                                                    \
+(   ((x) != 0U)                                             &&                 \
+    (((x) | QSPI_FLAG_CLR_ALL) == QSPI_FLAG_CLR_ALL))
+
+#define IS_QSPI_BLOCK_SIZE(x)                               ((x) <= (QSPI_EXAR_EXADR >> QSPI_EXAR_EXADR_POS))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/**
+ * @defgroup QSPI_Local_Variable QSPI Local Variable
+ * @{
+ */
+
+/* Current read mode */
+static uint32_t m_u32ReadMode = 0U;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup QSPI_Global_Functions QSPI Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-initializes QSPI.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ */
+int32_t QSPI_DeInit(void)
+{
+    WRITE_REG32(CM_QSPI->CR,    0x003F0000UL);
+    WRITE_REG32(CM_QSPI->CSCR,  0x0FUL);
+    WRITE_REG32(CM_QSPI->FCR,   0x8033UL);
+    WRITE_REG32(CM_QSPI->CCMD,  0x0UL);
+    WRITE_REG32(CM_QSPI->XCMD,  0xFFUL);
+    WRITE_REG32(CM_QSPI->CLR,   QSPI_FLAG_ROM_ACCESS_ERR);
+    WRITE_REG32(CM_QSPI->EXAR,  0UL);
+    return LL_OK;
+}
+
+/**
+ * @brief  Initialize QSPI.
+ * @param  [in] pstcQspiInit            Pointer to a @ref stc_qspi_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t QSPI_Init(const stc_qspi_init_t *pstcQspiInit)
+{
+    int32_t i32Ret  = LL_OK;
+    uint32_t u32Duty = 0UL;
+
+    if (NULL == pstcQspiInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_QSPI_CLK_DIV(pstcQspiInit->u32ClockDiv));
+        DDL_ASSERT(IS_QSPI_SPI_MD(pstcQspiInit->u32SpiMode));
+        DDL_ASSERT(IS_QSPI_PREFETCH_MD(pstcQspiInit->u32PrefetchMode));
+        DDL_ASSERT(IS_QSPI_READ_MD(pstcQspiInit->u32ReadMode));
+        DDL_ASSERT(IS_QSPI_DUMMY_CYCLE(pstcQspiInit->u32DummyCycle));
+        DDL_ASSERT(IS_QSPI_ADDR_WIDTH(pstcQspiInit->u32AddrWidth));
+        DDL_ASSERT(IS_QSPI_QSSN_SETUP_TIME(pstcQspiInit->u32SetupTime));
+        DDL_ASSERT(IS_QSPI_QSSN_RELEASE_TIME(pstcQspiInit->u32ReleaseTime));
+        DDL_ASSERT(IS_QSPI_QSSN_INTERVAL_TIME(pstcQspiInit->u32IntervalTime));
+
+        /* Duty cycle compensation */
+        if (0UL == (pstcQspiInit->u32ClockDiv & QSPI_CLK_DIV2)) {
+            u32Duty = QSPI_FCR_DUTY;
+        }
+        MODIFY_REG32(CM_QSPI->CR, QSPI_CR_CLR_MASK, (pstcQspiInit->u32ClockDiv | pstcQspiInit->u32SpiMode |
+                                                     pstcQspiInit->u32PrefetchMode | pstcQspiInit->u32ReadMode));
+        WRITE_REG32(CM_QSPI->CSCR, ((pstcQspiInit->u32ReleaseTime >> 8U) | pstcQspiInit->u32IntervalTime));
+        MODIFY_REG32(CM_QSPI->FCR, QSPI_FCR_CLR_MASK, (pstcQspiInit->u32DummyCycle | pstcQspiInit->u32AddrWidth |
+                                                       pstcQspiInit->u32SetupTime | (pstcQspiInit->u32ReleaseTime & 0xFFU) | u32Duty));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_qspi_init_t member with default value.
+ * @param  [out] pstcQspiInit           Pointer to a @ref stc_qspi_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_qspi_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t QSPI_StructInit(stc_qspi_init_t *pstcQspiInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcQspiInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcQspiInit->u32ClockDiv       = QSPI_CLK_DIV2;
+        pstcQspiInit->u32SpiMode        = QSPI_SPI_MD0;
+        pstcQspiInit->u32PrefetchMode   = QSPI_PREFETCH_MD_INVD;
+        pstcQspiInit->u32ReadMode       = QSPI_RD_MD_STD_RD;
+        pstcQspiInit->u32DummyCycle     = QSPI_DUMMY_CYCLE3;
+        pstcQspiInit->u32AddrWidth      = QSPI_ADDR_WIDTH_24BIT;
+        pstcQspiInit->u32SetupTime      = QSPI_QSSN_SETUP_ADVANCE_QSCK0P5;
+        pstcQspiInit->u32ReleaseTime    = QSPI_QSSN_RELEASE_DELAY_QSCK0P5;
+        pstcQspiInit->u32IntervalTime   = QSPI_QSSN_INTERVAL_QSCK1;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the level of WP pin.
+ * @param  [in] u32Level                The level value.
+ *         This parameter can be one of the following values:
+ *           @arg QSPI_WP_PIN_LOW:      WP(QSIO2) pin output low
+ *           @arg QSPI_WP_PIN_HIGH:     WP(QSIO2) pin output high
+ * @retval None
+ */
+void QSPI_SetWpPinLevel(uint32_t u32Level)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_WP_PIN_LVL(u32Level));
+
+    MODIFY_REG32(CM_QSPI->FCR, QSPI_FCR_WPOL, u32Level);
+}
+
+/**
+ * @brief  Set the prefetch mode.
+ * @param  [in] u32Mode                 The prefetch mode.
+ *         This parameter can be one of the following values:
+ *           @arg QSPI_PREFETCH_MD_INVD:        Disable prefetch
+ *           @arg QSPI_PREFETCH_MD_EDGE_STOP:   Stop prefetch at the edge of byte
+ *           @arg QSPI_PREFETCH_MD_IMMED_STOP:  Stop prefetch at current position immediately
+ * @retval None
+ */
+void QSPI_SetPrefetchMode(uint32_t u32Mode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_PREFETCH_MD(u32Mode));
+
+    MODIFY_REG32(CM_QSPI->CR, (QSPI_CR_PFE | QSPI_CR_PFSAE), u32Mode);
+}
+
+/**
+ * @brief  Selects the block to access.
+ * @param  [in] u8Block                 Memory block number (range is 0 to 63)
+ * @retval None
+ */
+void QSPI_SelectMemoryBlock(uint8_t u8Block)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_BLOCK_SIZE(u8Block));
+
+    WRITE_REG32(CM_QSPI->EXAR, ((uint32_t)u8Block << QSPI_EXAR_EXADR_POS));
+}
+
+/**
+ * @brief  Set the read mode.
+ * @param  [in] u32Mode                 Read mode.
+ *         This parameter can be one of the following values:
+ *           @arg QSPI_RD_MD_STD_RD:                Standard read mode (no dummy cycles)
+ *           @arg QSPI_RD_MD_FAST_RD:               Fast read mode (dummy cycles between address and data)
+ *           @arg QSPI_RD_MD_DUAL_OUTPUT_FAST_RD:   Fast read dual output mode (data on 2 lines)
+ *           @arg QSPI_RD_MD_DUAL_IO_FAST_RD:       Fast read dual I/O mode (address and data on 2 lines)
+ *           @arg QSPI_RD_MD_QUAD_OUTPUT_FAST_RD:   Fast read quad output mode (data on 4 lines)
+ *           @arg QSPI_RD_MD_QUAD_IO_FAST_RD:       Fast read quad I/O mode (address and data on 4 lines)
+ *           @arg QSPI_RD_MD_CUSTOM_STANDARD_RD:    Custom standard read mode
+ *           @arg QSPI_RD_MD_CUSTOM_FAST_RD:        Custom fast read mode
+ * @retval None
+ */
+void QSPI_SetReadMode(uint32_t u32Mode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_READ_MD(u32Mode));
+
+    MODIFY_REG32(CM_QSPI->CR, QSPI_CR_MDSEL, u32Mode);
+}
+
+/**
+ * @brief  Configure the custom read.
+ * @param  [in] pstcCustomMode          Pointer to a @ref stc_qspi_custom_mode_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t QSPI_CustomReadConfig(const stc_qspi_custom_mode_t *pstcCustomMode)
+{
+    int32_t i32Ret  = LL_OK;
+
+    if (NULL == pstcCustomMode) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_QSPI_INSTR_PROTOCOL(pstcCustomMode->u32InstrProtocol));
+        DDL_ASSERT(IS_QSPI_ADDR_PROTOCOL(pstcCustomMode->u32AddrProtocol));
+        DDL_ASSERT(IS_QSPI_DATA_PROTOCOL(pstcCustomMode->u32DataProtocol));
+
+        MODIFY_REG32(CM_QSPI->CR, QSPI_CUSTOM_MD_CLR_MASK, (pstcCustomMode->u32InstrProtocol |
+                                                            pstcCustomMode->u32AddrProtocol | pstcCustomMode->u32DataProtocol));
+        WRITE_REG32(CM_QSPI->CCMD, pstcCustomMode->u8InstrCode);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable XIP mode.
+ * @param  [in] u8ModeCode              Enter or exit XIP mode code
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void QSPI_XipModeCmd(uint8_t u8ModeCode, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(CM_QSPI->XCMD, u8ModeCode);
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_QSPI->CR, QSPI_CR_XIPE);
+    } else {
+        CLR_REG32_BIT(CM_QSPI->CR, QSPI_CR_XIPE);
+    }
+}
+
+/**
+ * @brief  Enter direct communication mode.
+ * @param  None
+ * @retval None
+ */
+void QSPI_EnterDirectCommMode(void)
+{
+    /* Backup the read mode */
+    m_u32ReadMode = READ_REG32_BIT(CM_QSPI->CR, QSPI_CR_MDSEL);
+    /* Set standard read mode */
+    CLR_REG32_BIT(CM_QSPI->CR, QSPI_CR_MDSEL);
+    /* Enter direct communication mode */
+    SET_REG32_BIT(CM_QSPI->CR, QSPI_CR_DCOME);
+}
+
+/**
+ * @brief  Exit direct communication mode.
+ * @param  None
+ * @retval None
+ */
+void QSPI_ExitDirectCommMode(void)
+{
+    /* Exit direct communication mode */
+    CLR_REG32_BIT(CM_QSPI->CR, QSPI_CR_DCOME);
+    /* Recovery the read mode */
+    SET_REG32_BIT(CM_QSPI->CR, m_u32ReadMode);
+}
+
+/**
+ * @brief  Get the size of prefetched buffer.
+ * @param  None
+ * @retval uint8_t                      Prefetched buffer size.
+ */
+uint8_t QSPI_GetPrefetchBufSize(void)
+{
+    return (uint8_t)(READ_REG32_BIT(CM_QSPI->SR, QSPI_SR_PFNUM) >> QSPI_SR_PFNUM_POS);
+}
+
+/**
+ * @brief  Get QSPI flag.
+ * @param  [in] u32Flag                 QSPI flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg QSPI_FLAG_DIRECT_COMM_BUSY:   Serial transfer being processed
+ *           @arg QSPI_FLAG_XIP_MD:             XIP mode
+ *           @arg QSPI_FLAG_ROM_ACCESS_ERR:     ROM access detection status in direct communication mode
+ *           @arg QSPI_FLAG_PREFETCH_BUF_FULL:  Prefetch buffer is full
+ *           @arg QSPI_FLAG_PREFETCH_STOP:      Prefetch function operating
+ *           @arg QSPI_FLAG_ALL:                All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t QSPI_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_FLAG(u32Flag));
+
+    if (0UL != READ_REG32_BIT(CM_QSPI->SR, u32Flag)) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear QSPI flag.
+ * @param  [in] u32Flag                 QSPI flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg QSPI_FLAG_ROM_ACCESS_ERR: ROM access detection status in direct communication mode
+ *           @arg QSPI_FLAG_CLR_ALL:        All of the above
+ * @retval None
+ */
+void QSPI_ClearStatus(uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_QSPI_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(CM_QSPI->CLR, u32Flag);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_QSPI_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_rmu.c
+++ b/hc32f4a2/src/hc32_ll_rmu.c
@@ -1,0 +1,155 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_rmu.c
+ * @brief This file provides firmware functions to manage the Reset Manage Unit
+ *        (RMU).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-06-30       CDT             Use IS_RMU_UNLOCKED() to assert
+   2024-06-30       CDT             Modify IS_VALID_RMU_RST_FLAG -> IS_RMU_RST_FLAG
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_rmu.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_RMU RMU
+ * @brief RMU Driver Library
+ * @{
+ */
+
+#if (LL_RMU_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup RMU_Local_Macros RMU Local Macros
+ * @{
+ */
+#define IS_RMU_UNLOCKED()       ((CM_PWC->FPRC & PWC_FPRC_FPRCB1) == PWC_FPRC_FPRCB1)
+
+/**
+ * @defgroup RMU_Check_Parameters_Validity RMU Check Parameters Validity
+ * @{
+ */
+
+/*! Parameter validity check for RMU reset cause. */
+#define IS_RMU_RST_FLAG(x)                                                      \
+(   ((x) != 0UL)                            &&                                  \
+    (((x) | RMU_FLAG_ALL) == RMU_FLAG_ALL))
+
+/**
+ * @}
+ */
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup RMU_Global_Functions RMU Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Get the reset cause.
+ * @param  [in] u32RmuResetCause    Reset flags that need to be queried, @ref RMU_ResetCause in details
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t RMU_GetStatus(uint32_t u32RmuResetCause)
+{
+    en_flag_status_t enStatus;
+    DDL_ASSERT(IS_RMU_RST_FLAG(u32RmuResetCause));
+
+    enStatus = ((0UL == READ_REG32_BIT(CM_RMU->RSTF0, u32RmuResetCause)) ? RESET : SET);
+    return enStatus;
+}
+
+/**
+ * @brief  Clear reset Status.
+ * @param  None
+ * @retval None
+ * @note   Clear reset flag should be done after read RMU_RSTF0 register.
+ *         Call PWC_Unlock(PWC_UNLOCK_CODE_1) unlock RMU_RSTF0 register first.
+ */
+void RMU_ClearStatus(void)
+{
+    DDL_ASSERT(IS_RMU_UNLOCKED());
+    SET_REG_BIT(CM_RMU->RSTF0, RMU_RSTF0_CLRF);
+    __NOP();
+    __NOP();
+    __NOP();
+    __NOP();
+    __NOP();
+    __NOP();
+}
+
+/**
+ * @brief  Enable or disable LOCKUP reset.
+ * @param  [in] enNewState    An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   Call LL_PERIPH_WE(LL_PERIPH_PWC_CLK_RMU) unlock RMU_PRSTCR0 register first.
+ */
+void RMU_CPULockUpCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_RMU_UNLOCKED());
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    WRITE_REG32(bCM_RMU->PRSTCR0_b.LKUPREN, enNewState);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_RMU_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/src/hc32_ll_rtc.c
+++ b/hc32f4a2/src/hc32_ll_rtc.c
@@ -1,0 +1,1148 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_rtc.c
+ * @brief This file provides firmware functions to manage the Real-Time
+ *        Clock(RTC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-06-30       CDT             Modify RTC_EnterRwMode,RTC_ExitRwMode,RTC_ConfirmLPMCond,RTC_SetIntPeriod,RTC_AlarmCmd,RTC_IntCmd,RTC_ClearStatus for couping risk
+   2024-08-31       CDT             Optimized access code for some registers to improve readability
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_rtc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_RTC RTC
+ * @brief Real-Time Clock Driver Library
+ * @{
+ */
+
+#if (LL_RTC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup RTC_Local_Macros RTC Local Macros
+ * @{
+ */
+
+/* RTC TPCR register Mask */
+#define RTC_TPCR_CLR_MASK                   (RTC_TPCR0_TPCT0 | RTC_TPCR0_TPNF0 | RTC_TPCR0_TPRSTE0 | RTC_TPCR0_TSTPE0)
+/* Get the specified register address of the RTC Intrusion Control */
+#define RTC_TPCRx(__CH__)                   ((uint32_t)(&(CM_RTC->TPCR0)) + (uint32_t)(__CH__))
+
+/* RTC CR2 & TPSR flag mask */
+#define RTC_CR2_FLAG_MASK                       (RTC_CR2_ALMF | RTC_CR2_PRDF)
+#define RTC_TPSR_FLAG_MASK                      (RTC_TPSR_TPOVF | RTC_TPSR_TPF0 | RTC_TPSR_TPF1)
+
+/* RTC software reset timeout(ms) */
+#define RTC_SW_RST_TIMEOUT                  (100UL)
+/* RTC mode switch timeout(ms) */
+#define RTC_MD_SWITCH_TIMEOUT               (100UL)
+
+/**
+ * @defgroup RTC_Check_Parameters_Validity RTC Check Parameters Validity
+ * @{
+ */
+#define IS_RTC_DATA_FMT(x)                                                     \
+(   ((x) == RTC_DATA_FMT_DEC)                       ||                         \
+    ((x) == RTC_DATA_FMT_BCD))
+
+#define IS_RTC_CLK_SRC(x)                                                      \
+(   ((x) == RTC_CLK_SRC_XTAL32)                     ||                         \
+    ((x) == RTC_CLK_SRC_LRC))
+
+#define IS_RTC_HOUR_FMT(x)                                                     \
+(   ((x) == RTC_HOUR_FMT_12H)                       ||                         \
+    ((x) == RTC_HOUR_FMT_24H))
+
+#define IS_RTC_INT_PERIOD(x)                                                   \
+(   ((x) == RTC_INT_PERIOD_INVD)                    ||                         \
+    ((x) == RTC_INT_PERIOD_PER_HALF_SEC)            ||                         \
+    ((x) == RTC_INT_PERIOD_PER_SEC)                 ||                         \
+    ((x) == RTC_INT_PERIOD_PER_MINUTE)              ||                         \
+    ((x) == RTC_INT_PERIOD_PER_HOUR)                ||                         \
+    ((x) == RTC_INT_PERIOD_PER_DAY)                 ||                         \
+    ((x) == RTC_INT_PERIOD_PER_MONTH))
+
+#define IS_RTC_CLK_COMPEN(x)                                                   \
+(   ((x) == RTC_CLK_COMPEN_DISABLE)                 ||                         \
+    ((x) == RTC_CLK_COMPEN_ENABLE))
+
+#define IS_RTC_CLK_COMPEN_MD(x)                                                \
+(   ((x) == RTC_CLK_COMPEN_MD_DISTRIBUTED)          ||                         \
+    ((x) == RTC_CLK_COMPEN_MD_UNIFORM))
+
+#define IS_RTC_HOUR_12H_AM_PM(x)                                               \
+(   ((x) == RTC_HOUR_12H_AM)                        ||                         \
+    ((x) == RTC_HOUR_12H_PM))
+
+#define IS_RTC_INTRU_CH(x)                                                     \
+(   ((x) == RTC_INTRU_CH0)                          ||                         \
+    ((x) == RTC_INTRU_CH1))
+
+#define IS_RTC_INTRU_TIMESTAMP(x)                                              \
+(   ((x) == RTC_INTRU_TS_DISABLE)                   ||                         \
+    ((x) == RTC_INTRU_TS_ENABLE))
+
+#define IS_RTC_INTRU_RST_BACKUP_REG(x)                                         \
+(   ((x) == RTC_INTRU_RST_BACKUP_REG_DISABLE)       ||                         \
+    ((x) == RTC_INTRU_RST_BACKUP_REG_ENABLE))
+
+#define IS_RTC_INTRU_FILTER(x)                                                 \
+(   ((x) == RTC_INTRU_FILTER_INVD)                  ||                         \
+    ((x) == RTC_INTRU_FILTER_THREE_TIME)            ||                         \
+    ((x) == RTC_INTRU_FILTER_THREE_TIME_CLK_DIV32))
+
+#define IS_RTC_INTRU_TRIG_EDGE(x)                                              \
+(   ((x) == RTC_INTRU_TRIG_EDGE_NONE)               ||                         \
+    ((x) == RTC_INTRU_TRIG_EDGE_RISING)             ||                         \
+    ((x) == RTC_INTRU_TRIG_EDGE_FALLING)            ||                         \
+    ((x) == RTC_INTRU_TRIG_EDGE_RISING_FALLING))
+
+#define IS_RTC_GET_FLAG(x)                                                     \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | RTC_FLAG_ALL) == RTC_FLAG_ALL))
+
+#define IS_RTC_CLR_FLAG(x)                                                     \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | RTC_FLAG_CLR_ALL) == RTC_FLAG_CLR_ALL))
+
+#define IS_RTC_INT(x)                                                          \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | RTC_INT_ALL) == RTC_INT_ALL))
+
+#define IS_RTC_YEAR(x)                              ((x) <= 99U)
+
+#define IS_RTC_MONTH(x)                             (((x) >= 1U) && ((x) <= 12U))
+
+#define IS_RTC_DAY(x)                               (((x) >= 1U) && ((x) <= 31U))
+
+#define IS_RTC_HOUR_12H(x)                          (((x) >= 1U) && ((x) <= 12U))
+
+#define IS_RTC_HOUR_24H(x)                          ((x) <= 23U)
+
+#define IS_RTC_MINUTE(x)                            ((x) <= 59U)
+
+#define IS_RTC_SEC(x)                               ((x) <= 59U)
+
+#define IS_RTC_WEEKDAY(x)                           ((x) <= 6U)
+
+#define IS_RTC_ALARM_WEEKDAY(x)                     (((x) >= 0x01U) && ((x) <= 0x7FU))
+
+#define IS_RTC_COMPEN_VALUE(x)                      ((x) <= 0x1FFU)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup RTC_Global_Functions RTC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-Initialize RTC.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: De-Initialize success
+ *           - LL_ERR_TIMEOUT: De-Initialize timeout
+ */
+int32_t RTC_DeInit(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    WRITE_REG32(bCM_RTC->CR0_b.RESET, RESET);
+    /* Waiting for normal count status or end of RTC software reset */
+    u32Count = RTC_SW_RST_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0UL != READ_REG32(bCM_RTC->CR0_b.RESET)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    if (LL_OK == i32Ret) {
+        /* Reset all RTC registers */
+        WRITE_REG32(bCM_RTC->CR0_b.RESET, SET);
+        /* Waiting for RTC software reset to complete */
+        u32Count = RTC_SW_RST_TIMEOUT * (HCLK_VALUE / 20000UL);
+        while (0UL != READ_REG32(bCM_RTC->CR0_b.RESET)) {
+            if (0UL == u32Count) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+            u32Count--;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize RTC.
+ * @param  [in] pstcRtcInit             Pointer to a @ref stc_rtc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_Init(const stc_rtc_init_t *pstcRtcInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_CLK_SRC(pstcRtcInit->u8ClockSrc));
+        DDL_ASSERT(IS_RTC_HOUR_FMT(pstcRtcInit->u8HourFormat));
+        DDL_ASSERT(IS_RTC_INT_PERIOD(pstcRtcInit->u8IntPeriod));
+        DDL_ASSERT(IS_RTC_CLK_COMPEN(pstcRtcInit->u8ClockCompen));
+        DDL_ASSERT(IS_RTC_COMPEN_VALUE(pstcRtcInit->u16CompenValue));
+        DDL_ASSERT(IS_RTC_CLK_COMPEN_MD(pstcRtcInit->u8CompenMode));
+
+        /* RTC CR3 Configuration */
+        MODIFY_REG8(CM_RTC->CR3, (RTC_CR3_LRCEN | RTC_CR3_RCKSEL), pstcRtcInit->u8ClockSrc);
+        /* RTC CR1 Configuration */
+        MODIFY_REG8(CM_RTC->CR1, (RTC_CR1_PRDS | RTC_CR1_AMPM | RTC_CR1_ONEHZSEL),
+                    (pstcRtcInit->u8IntPeriod | pstcRtcInit->u8HourFormat | pstcRtcInit->u8CompenMode));
+        /* RTC Compensation Configuration */
+        MODIFY_REG8(CM_RTC->ERRCRH, (RTC_ERRCRH_COMPEN | RTC_ERRCRH_COMP8),
+                    (pstcRtcInit->u8ClockCompen | (uint8_t)((pstcRtcInit->u16CompenValue >> 8U) & 0x01U)));
+        WRITE_REG8(CM_RTC->ERRCRL, (uint8_t)(pstcRtcInit->u16CompenValue & 0xFFU));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_rtc_init_t member with default value.
+ * @param  [out] pstcRtcInit            Pointer to a @ref stc_rtc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_rtc_init_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_StructInit(stc_rtc_init_t *pstcRtcInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcRtcInit->u8ClockSrc     = RTC_CLK_SRC_LRC;
+        pstcRtcInit->u8HourFormat   = RTC_HOUR_FMT_24H;
+        pstcRtcInit->u8IntPeriod    = RTC_INT_PERIOD_INVD;
+        pstcRtcInit->u8ClockCompen  = RTC_CLK_COMPEN_DISABLE;
+        pstcRtcInit->u8CompenMode   = RTC_CLK_COMPEN_MD_DISTRIBUTED;
+        pstcRtcInit->u16CompenValue = 0U;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enter RTC read/write mode.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Enter mode success
+ *           - LL_ERR_TIMEOUT: Enter mode timeout
+ */
+int32_t RTC_EnterRwMode(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Mode switch when RTC is running */
+    if (0UL != READ_REG32(bCM_RTC->CR1_b.START)) {
+        if (1UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+            SET_REG8_BIT(CM_RTC->CR2, RTC_CR2_RWREQ | RTC_CR2_FLAG_MASK);
+            /* Waiting for RWEN bit set */
+            u32Count = RTC_MD_SWITCH_TIMEOUT * (HCLK_VALUE / 20000UL);
+            while (1UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+                if (0UL == u32Count) {
+                    i32Ret = LL_ERR_TIMEOUT;
+                    break;
+                }
+                u32Count--;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Exit RTC read/write mode.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Exit mode success
+ *           - LL_ERR_TIMEOUT: Exit mode timeout
+ */
+int32_t RTC_ExitRwMode(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Mode switch when RTC is running */
+    if (0UL != READ_REG32(bCM_RTC->CR1_b.START)) {
+        if (0UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+            MODIFY_REG8(CM_RTC->CR2, (RTC_CR2_RWREQ | RTC_CR2_FLAG_MASK), ~RTC_CR2_RWREQ);
+            /* Waiting for RWEN bit reset */
+            u32Count = RTC_MD_SWITCH_TIMEOUT * (HCLK_VALUE / 20000UL);
+            while (0UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+                if (0UL == u32Count) {
+                    i32Ret = LL_ERR_TIMEOUT;
+                    break;
+                }
+                u32Count--;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Confirm the condition for RTC to enter low power mode.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK: Can enter low power mode
+ *           - LL_ERR_TIMEOUT: Can't enter low power mode
+ */
+int32_t RTC_ConfirmLPMCond(void)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Check RTC work status */
+    if (0UL != READ_REG32(bCM_RTC->CR1_b.START)) {
+        SET_REG8_BIT(CM_RTC->CR2, RTC_CR2_RWREQ | RTC_CR2_FLAG_MASK);
+        /* Waiting for RTC RWEN bit set */
+        u32Count = RTC_MD_SWITCH_TIMEOUT * (HCLK_VALUE / 20000UL);
+        while (1UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+            if (0UL == u32Count) {
+                i32Ret = LL_ERR_TIMEOUT;
+                break;
+            }
+            u32Count--;
+        }
+
+        if (LL_OK == i32Ret) {
+            MODIFY_REG8(CM_RTC->CR2, (RTC_CR2_RWREQ | RTC_CR2_FLAG_MASK), ~RTC_CR2_RWREQ);
+            /* Waiting for RTC RWEN bit reset */
+            u32Count = RTC_MD_SWITCH_TIMEOUT * (HCLK_VALUE / 20000UL);
+            while (0UL != READ_REG32(bCM_RTC->CR2_b.RWEN)) {
+                if (0UL == u32Count) {
+                    i32Ret = LL_ERR_TIMEOUT;
+                    break;
+                }
+                u32Count--;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the RTC interrupt period.
+ * @param  [in] u8Period                Specifies the interrupt period.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_INT_PERIOD_INVD:          Period interrupt invalid
+ *           @arg RTC_INT_PERIOD_PER_HALF_SEC:  Interrupt per half second
+ *           @arg RTC_INT_PERIOD_PER_SEC:       Interrupt per second
+ *           @arg RTC_INT_PERIOD_PER_MINUTE:    Interrupt per minute
+ *           @arg RTC_INT_PERIOD_PER_HOUR:      Interrupt per hour
+ *           @arg RTC_INT_PERIOD_PER_DAY:       Interrupt per day
+ *           @arg RTC_INT_PERIOD_PER_MONTH:     Interrupt per month
+ * @retval None
+ */
+void RTC_SetIntPeriod(uint8_t u8Period)
+{
+    uint32_t u32RtcSta;
+    uint32_t u32IntSta;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_INT_PERIOD(u8Period));
+
+    u32RtcSta = READ_REG32(bCM_RTC->CR1_b.START);
+    u32IntSta = READ_REG32(bCM_RTC->CR2_b.PRDIE);
+    /* Disable period interrupt when START=1 and clear period flag after write */
+    if ((0UL != u32IntSta) && (0UL != u32RtcSta)) {
+        MODIFY_REG8(CM_RTC->CR2, (RTC_CR2_PRDIE | RTC_CR2_FLAG_MASK), ~RTC_CR2_PRDIE);
+    }
+
+    /* RTC CR1 Configuration */
+    MODIFY_REG8(CM_RTC->CR1, RTC_CR1_PRDS, u8Period);
+    MODIFY_REG8(CM_RTC->CR2, RTC_CR2_FLAG_MASK, ~RTC_CR2_PRDF);
+
+    if ((0UL != u32IntSta) && (0UL != u32RtcSta)) {
+        SET_REG8_BIT(CM_RTC->CR2, RTC_CR2_PRDIE | RTC_CR2_FLAG_MASK);
+    }
+}
+
+/**
+ * @brief  Set the RTC clock source.
+ * @param  [in] u8Src                   Specifies the clock source.
+ *         This parameter can be one of the following values:
+ *           @arg @ref RTC_Clock_Source
+ * @retval None
+ */
+void RTC_SetClockSrc(uint8_t u8Src)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_CLK_SRC(u8Src));
+
+    MODIFY_REG8(CM_RTC->CR3, (RTC_CR3_LRCEN | RTC_CR3_RCKSEL), u8Src);
+}
+
+/**
+ * @brief  Set RTC clock compensation value.
+ * @param  [in] u16Value                Specifies the clock compensation value of RTC.
+ *           @arg This parameter can be a number between Min_Data = 0 and Max_Data = 0x1FF.
+ * @retval None
+ */
+void RTC_SetClockCompenValue(uint16_t u16Value)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_COMPEN_VALUE(u16Value));
+
+    WRITE_REG32(bCM_RTC->ERRCRH_b.COMP8, ((uint32_t)u16Value >> 8U) & 0x01U);
+    WRITE_REG8(CM_RTC->ERRCRL, (uint8_t)(u16Value & 0x00FFU));
+}
+
+/**
+ * @brief  Get RTC counter status.
+ * @param  None
+ * @retval An @ref en_functional_state_t enumeration value.
+ *           - ENABLE: RTC counter started
+ *           - DISABLE: RTC counter stopped
+ */
+en_functional_state_t RTC_GetCounterState(void)
+{
+    en_functional_state_t enState = DISABLE;
+
+    if (0UL != READ_REG32(bCM_RTC->CR1_b.START)) {
+        enState = ENABLE;
+    }
+
+    return enState;
+}
+
+/**
+ * @brief  Enable or disable RTC count.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_Cmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_RTC->CR1_b.START, enNewState);
+}
+
+/**
+ * @brief  Enable or disable RTC LRC function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_LrcCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_RTC->CR3_b.LRCEN, enNewState);
+}
+
+/**
+ * @brief  Enable or disable RTC 1HZ output.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_OneHzOutputCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_RTC->CR1_b.ONEHZOE, enNewState);
+}
+
+/**
+ * @brief  Enable or disable clock compensation.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_ClockCompenCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    WRITE_REG32(bCM_RTC->ERRCRH_b.COMPEN, enNewState);
+}
+
+/**
+ * @brief  Set RTC current date.
+ * @param  [in] u8Format                Specifies the format of the entered parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [in] pstcRtcDate             Pointer to a @ref stc_rtc_date_t structure
+ * @retval int32_t:
+ *           - LL_OK: Set date success
+ *           - LL_ERR: Set date failed
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_SetDate(uint8_t u8Format, stc_rtc_date_t *pstcRtcDate)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcDate) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+        if (RTC_DATA_FMT_DEC != u8Format) {
+            DDL_ASSERT(IS_RTC_YEAR(RTC_BCD2DEC(pstcRtcDate->u8Year)));
+            DDL_ASSERT(IS_RTC_MONTH(RTC_BCD2DEC(pstcRtcDate->u8Month)));
+            DDL_ASSERT(IS_RTC_DAY(RTC_BCD2DEC(pstcRtcDate->u8Day)));
+        } else {
+            DDL_ASSERT(IS_RTC_YEAR(pstcRtcDate->u8Year));
+            DDL_ASSERT(IS_RTC_MONTH(pstcRtcDate->u8Month));
+            DDL_ASSERT(IS_RTC_DAY(pstcRtcDate->u8Day));
+        }
+        DDL_ASSERT(IS_RTC_WEEKDAY(pstcRtcDate->u8Weekday));
+
+        /* Enter read/write mode */
+        if (LL_OK != RTC_EnterRwMode()) {
+            i32Ret = LL_ERR;
+        } else {
+            if (RTC_DATA_FMT_DEC == u8Format) {
+                pstcRtcDate->u8Year  = RTC_DEC2BCD(pstcRtcDate->u8Year);
+                pstcRtcDate->u8Month = RTC_DEC2BCD(pstcRtcDate->u8Month);
+                pstcRtcDate->u8Day   = RTC_DEC2BCD(pstcRtcDate->u8Day);
+            }
+
+            WRITE_REG8(CM_RTC->YEAR, pstcRtcDate->u8Year);
+            WRITE_REG8(CM_RTC->MON,  pstcRtcDate->u8Month);
+            WRITE_REG8(CM_RTC->DAY,  pstcRtcDate->u8Day);
+            WRITE_REG8(CM_RTC->WEEK, pstcRtcDate->u8Weekday);
+
+            /* Exit read/write mode */
+            if (LL_OK != RTC_ExitRwMode()) {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get RTC current date.
+ * @param  [in] u8Format                Specifies the format of the returned parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [out] pstcRtcDate            Pointer to a @ref stc_rtc_date_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get date success
+ *           - LL_ERR: Get date failed
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_GetDate(uint8_t u8Format, stc_rtc_date_t *pstcRtcDate)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcDate) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+        /* Enter read/write mode */
+        if (LL_OK != RTC_EnterRwMode()) {
+            i32Ret = LL_ERR;
+        } else {
+            /* Get RTC date registers */
+            pstcRtcDate->u8Year    = READ_REG8(CM_RTC->YEAR);
+            pstcRtcDate->u8Month   = READ_REG8(CM_RTC->MON);
+            pstcRtcDate->u8Day     = READ_REG8(CM_RTC->DAY);
+            pstcRtcDate->u8Weekday = READ_REG8(CM_RTC->WEEK);
+
+            /* Check decimal format*/
+            if (RTC_DATA_FMT_DEC == u8Format) {
+                pstcRtcDate->u8Year  = RTC_BCD2DEC(pstcRtcDate->u8Year);
+                pstcRtcDate->u8Month = RTC_BCD2DEC(pstcRtcDate->u8Month);
+                pstcRtcDate->u8Day   = RTC_BCD2DEC(pstcRtcDate->u8Day);
+            }
+
+            /* exit read/write mode */
+            if (LL_OK != RTC_ExitRwMode()) {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set RTC current time.
+ * @param  [in] u8Format                Specifies the format of the entered parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [in] pstcRtcTime             Pointer to a @ref stc_rtc_time_t structure
+ * @retval int32_t:
+ *           - LL_OK: Set time success
+ *           - LL_ERR: Set time failed
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_SetTime(uint8_t u8Format, stc_rtc_time_t *pstcRtcTime)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcTime) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+        if (RTC_DATA_FMT_DEC != u8Format) {
+            if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+                DDL_ASSERT(IS_RTC_HOUR_12H(RTC_BCD2DEC(pstcRtcTime->u8Hour)));
+                DDL_ASSERT(IS_RTC_HOUR_12H_AM_PM(pstcRtcTime->u8AmPm));
+            } else {
+                DDL_ASSERT(IS_RTC_HOUR_24H(RTC_BCD2DEC(pstcRtcTime->u8Hour)));
+            }
+            DDL_ASSERT(IS_RTC_MINUTE(RTC_BCD2DEC(pstcRtcTime->u8Minute)));
+            DDL_ASSERT(IS_RTC_SEC(RTC_BCD2DEC(pstcRtcTime->u8Second)));
+        } else {
+            if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+                DDL_ASSERT(IS_RTC_HOUR_12H(pstcRtcTime->u8Hour));
+                DDL_ASSERT(IS_RTC_HOUR_12H_AM_PM(pstcRtcTime->u8AmPm));
+            } else {
+                DDL_ASSERT(IS_RTC_HOUR_24H(pstcRtcTime->u8Hour));
+            }
+            DDL_ASSERT(IS_RTC_MINUTE(pstcRtcTime->u8Minute));
+            DDL_ASSERT(IS_RTC_SEC(pstcRtcTime->u8Second));
+        }
+
+        /* Enter read/write mode */
+        if (LL_OK != RTC_EnterRwMode()) {
+            i32Ret = LL_ERR;
+        } else {
+            if (RTC_DATA_FMT_DEC == u8Format) {
+                pstcRtcTime->u8Hour   = RTC_DEC2BCD(pstcRtcTime->u8Hour);
+                pstcRtcTime->u8Minute = RTC_DEC2BCD(pstcRtcTime->u8Minute);
+                pstcRtcTime->u8Second = RTC_DEC2BCD(pstcRtcTime->u8Second);
+            }
+            if ((RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) &&
+                (RTC_HOUR_12H_PM == pstcRtcTime->u8AmPm)) {
+                SET_REG8_BIT(pstcRtcTime->u8Hour, RTC_HOUR_12H_PM);
+            }
+
+            WRITE_REG8(CM_RTC->HOUR, pstcRtcTime->u8Hour);
+            WRITE_REG8(CM_RTC->MIN,  pstcRtcTime->u8Minute);
+            WRITE_REG8(CM_RTC->SEC,  pstcRtcTime->u8Second);
+
+            /* Exit read/write mode */
+            if (LL_OK != RTC_ExitRwMode()) {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get RTC current time.
+ * @param  [in] u8Format                Specifies the format of the returned parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [out] pstcRtcTime            Pointer to a @ref stc_rtc_time_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get time success
+ *           - LL_ERR: Get time failed
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_GetTime(uint8_t u8Format, stc_rtc_time_t *pstcRtcTime)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcTime) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+        /* Enter read/write mode */
+        if (LL_OK != RTC_EnterRwMode()) {
+            i32Ret = LL_ERR;
+        } else {
+            /* Get RTC time registers */
+            pstcRtcTime->u8Hour   = READ_REG8(CM_RTC->HOUR);
+            pstcRtcTime->u8Minute = READ_REG8(CM_RTC->MIN);
+            pstcRtcTime->u8Second = READ_REG8(CM_RTC->SEC);
+
+            if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+                if (RTC_HOUR_12H_PM == (pstcRtcTime->u8Hour & RTC_HOUR_12H_PM)) {
+                    CLR_REG8_BIT(pstcRtcTime->u8Hour, RTC_HOUR_12H_PM);
+                    pstcRtcTime->u8AmPm  = RTC_HOUR_12H_PM;
+                } else {
+                    pstcRtcTime->u8AmPm = RTC_HOUR_12H_AM;
+                }
+            } else {
+                pstcRtcTime->u8AmPm = RTC_HOUR_24H;
+            }
+
+            /* Check decimal format*/
+            if (RTC_DATA_FMT_DEC == u8Format) {
+                pstcRtcTime->u8Hour   = RTC_BCD2DEC(pstcRtcTime->u8Hour);
+                pstcRtcTime->u8Minute = RTC_BCD2DEC(pstcRtcTime->u8Minute);
+                pstcRtcTime->u8Second = RTC_BCD2DEC(pstcRtcTime->u8Second);
+            }
+
+            /* exit read/write mode */
+            if (LL_OK != RTC_ExitRwMode()) {
+                i32Ret = LL_ERR;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set RTC alarm time.
+ * @param  [in] u8Format                Specifies the format of the entered parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [in] pstcRtcAlarm            Pointer to a @ref stc_rtc_alarm_t structure
+ * @retval int32_t:
+ *           - LL_OK: Set RTC alarm time success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_SetAlarm(uint8_t u8Format, stc_rtc_alarm_t *pstcRtcAlarm)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcAlarm) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+        if (RTC_DATA_FMT_DEC != u8Format) {
+            if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+                DDL_ASSERT(IS_RTC_HOUR_12H(RTC_BCD2DEC(pstcRtcAlarm->u8AlarmHour)));
+                DDL_ASSERT(IS_RTC_HOUR_12H_AM_PM(pstcRtcAlarm->u8AlarmAmPm));
+            } else {
+                DDL_ASSERT(IS_RTC_HOUR_24H(RTC_BCD2DEC(pstcRtcAlarm->u8AlarmHour)));
+            }
+            DDL_ASSERT(IS_RTC_MINUTE(RTC_BCD2DEC(pstcRtcAlarm->u8AlarmMinute)));
+        } else {
+            if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+                DDL_ASSERT(IS_RTC_HOUR_12H(pstcRtcAlarm->u8AlarmHour));
+                DDL_ASSERT(IS_RTC_HOUR_12H_AM_PM(pstcRtcAlarm->u8AlarmAmPm));
+            } else {
+                DDL_ASSERT(IS_RTC_HOUR_24H(pstcRtcAlarm->u8AlarmHour));
+            }
+            DDL_ASSERT(IS_RTC_MINUTE(pstcRtcAlarm->u8AlarmMinute));
+        }
+        DDL_ASSERT(IS_RTC_ALARM_WEEKDAY(pstcRtcAlarm->u8AlarmWeekday));
+
+        /* Configure alarm registers */
+        if (RTC_DATA_FMT_DEC == u8Format) {
+            pstcRtcAlarm->u8AlarmHour   = RTC_DEC2BCD(pstcRtcAlarm->u8AlarmHour);
+            pstcRtcAlarm->u8AlarmMinute = RTC_DEC2BCD(pstcRtcAlarm->u8AlarmMinute);
+        }
+        if ((RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) &&
+            (RTC_HOUR_12H_PM == pstcRtcAlarm->u8AlarmAmPm)) {
+            SET_REG8_BIT(pstcRtcAlarm->u8AlarmHour, RTC_HOUR_12H_PM);
+        }
+
+        WRITE_REG8(CM_RTC->ALMHOUR, pstcRtcAlarm->u8AlarmHour);
+        WRITE_REG8(CM_RTC->ALMMIN,  pstcRtcAlarm->u8AlarmMinute);
+        WRITE_REG8(CM_RTC->ALMWEEK, pstcRtcAlarm->u8AlarmWeekday);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get RTC alarm time.
+ * @param  [in] u8Format                Specifies the format of the returned parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [out] pstcRtcAlarm           Pointer to a @ref stc_rtc_alarm_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get RTC alarm time success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_GetAlarm(uint8_t u8Format, stc_rtc_alarm_t *pstcRtcAlarm)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcRtcAlarm) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+
+        /* Get RTC date and time register */
+        pstcRtcAlarm->u8AlarmWeekday = READ_REG8(CM_RTC->ALMWEEK);
+        pstcRtcAlarm->u8AlarmMinute  = READ_REG8(CM_RTC->ALMMIN);
+        pstcRtcAlarm->u8AlarmHour    = READ_REG8(CM_RTC->ALMHOUR);
+
+        if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+            if (RTC_HOUR_12H_PM == (pstcRtcAlarm->u8AlarmHour & RTC_HOUR_12H_PM)) {
+                CLR_REG8_BIT(pstcRtcAlarm->u8AlarmHour, RTC_HOUR_12H_PM);
+                pstcRtcAlarm->u8AlarmAmPm = RTC_HOUR_12H_PM;
+            } else {
+                pstcRtcAlarm->u8AlarmAmPm = RTC_HOUR_12H_AM;
+            }
+        } else {
+            pstcRtcAlarm->u8AlarmAmPm = RTC_HOUR_24H;
+        }
+
+        /* Check decimal format*/
+        if (RTC_DATA_FMT_DEC == u8Format) {
+            pstcRtcAlarm->u8AlarmHour   = RTC_BCD2DEC(pstcRtcAlarm->u8AlarmHour);
+            pstcRtcAlarm->u8AlarmMinute = RTC_BCD2DEC(pstcRtcAlarm->u8AlarmMinute);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable RTC alarm.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_AlarmCmd(en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG8_BIT(CM_RTC->CR2, RTC_CR2_ALME | RTC_CR2_FLAG_MASK);
+    } else {
+        MODIFY_REG8(CM_RTC->CR2, (RTC_CR2_ALME | RTC_CR2_FLAG_MASK), ~RTC_CR2_ALME);
+    }
+}
+
+/**
+ * @brief  De-Initialize RTC intrusion function..
+ * @param  [in] u8Ch                    Specifies the RTC intrusion channel.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_INTRU_CH0:    Intrusion channel 0
+ *           @arg RTC_INTRU_CH1:    Intrusion channel 1
+ * @retval None
+ */
+void RTC_INTRU_DeInit(uint8_t u8Ch)
+{
+    __IO uint8_t *TPCR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_INTRU_CH(u8Ch));
+
+    TPCR = (__IO uint8_t *)RTC_TPCRx(u8Ch);
+    WRITE_REG8(*TPCR, 0U);
+    WRITE_REG8(CM_RTC->TPSR, 0U);
+}
+
+/**
+ * @brief  Initialize RTC intrusion function.
+ * @param  [in] u8Ch                    Specifies the RTC intrusion channel.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_INTRU_CH0:    Intrusion channel 0
+ *           @arg RTC_INTRU_CH1:    Intrusion channel 1
+ * @param  [in] pstcIntru               Pointer to a @ref stc_rtc_intrusion_t structure
+ * @retval int32_t:
+ *           - LL_OK: Configure RTC intrusion function success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_INTRU_Init(uint8_t u8Ch, const stc_rtc_intrusion_t *pstcIntru)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint8_t *TPCR;
+
+    if (NULL == pstcIntru) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_INTRU_CH(u8Ch));
+        DDL_ASSERT(IS_RTC_INTRU_TIMESTAMP(pstcIntru->u8Timestamp));
+        DDL_ASSERT(IS_RTC_INTRU_RST_BACKUP_REG(pstcIntru->u8ResetBackupReg));
+        DDL_ASSERT(IS_RTC_INTRU_FILTER(pstcIntru->u8Filter));
+        DDL_ASSERT(IS_RTC_INTRU_TRIG_EDGE(pstcIntru->u8TriggerEdge));
+
+        TPCR = (__IO uint8_t *)RTC_TPCRx(u8Ch);
+        /* RTC Intrusion control Configuration */
+        MODIFY_REG8(*TPCR, RTC_TPCR_CLR_MASK,
+                    (pstcIntru->u8Timestamp | pstcIntru->u8ResetBackupReg |
+                     pstcIntru->u8Filter    | pstcIntru->u8TriggerEdge));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Fills each stc_rtc_intrusion_t member with default value.
+ * @param  [out] pstcIntru              Pointer to a @ref stc_rtc_intrusion_t structure
+ * @retval int32_t:
+ *           - LL_OK: stc_rtc_intrusion_t member initialize success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_INTRU_StructInit(stc_rtc_intrusion_t *pstcIntru)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcIntru) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcIntru->u8Timestamp       = RTC_INTRU_TS_DISABLE;
+        pstcIntru->u8ResetBackupReg  = RTC_INTRU_RST_BACKUP_REG_DISABLE;
+        pstcIntru->u8Filter          = RTC_INTRU_FILTER_INVD;
+        pstcIntru->u8TriggerEdge     = RTC_INTRU_TRIG_EDGE_NONE;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get RTC intrusion timestamp.
+ * @param  [in] u8Format                Specifies the format of the returned parameters.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_DATA_FMT_DEC:     Decimal data format
+ *           @arg RTC_DATA_FMT_BCD:     BCD data format
+ * @param  [out] pstcTimestamp          Pointer to a @ref stc_rtc_timestamp_t structure
+ * @retval int32_t:
+ *           - LL_OK: Get RTC intrusion timestamp success
+ *           - LL_ERR_INVD_PARAM: Invalid parameter
+ */
+int32_t RTC_INTRU_GetTimestamp(uint8_t u8Format, stc_rtc_timestamp_t *pstcTimestamp)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTimestamp) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_RTC_DATA_FMT(u8Format));
+
+        /* Get RTC Timestamp registers */
+        pstcTimestamp->stcTime.u8Hour   = READ_REG8(CM_RTC->HOURTP);
+        pstcTimestamp->stcTime.u8Minute = READ_REG8(CM_RTC->MINTP);
+        pstcTimestamp->stcTime.u8Second = READ_REG8(CM_RTC->SECTP);
+        pstcTimestamp->u8Month          = READ_REG8(CM_RTC->MONTP);
+        pstcTimestamp->u8Day            = READ_REG8(CM_RTC->DAYTP);
+
+        if (RTC_HOUR_FMT_12H == READ_REG32(bCM_RTC->CR1_b.AMPM)) {
+            if (RTC_HOUR_12H_PM == (pstcTimestamp->stcTime.u8Hour & RTC_HOUR_12H_PM)) {
+                CLR_REG8_BIT(pstcTimestamp->stcTime.u8Hour, RTC_HOUR_12H_PM);
+                pstcTimestamp->stcTime.u8AmPm  = RTC_HOUR_12H_PM;
+            } else {
+                pstcTimestamp->stcTime.u8AmPm = RTC_HOUR_12H_AM;
+            }
+        } else {
+            pstcTimestamp->stcTime.u8AmPm = RTC_HOUR_24H;
+        }
+
+        /* Check decimal format*/
+        if (RTC_DATA_FMT_DEC == u8Format) {
+            pstcTimestamp->stcTime.u8Hour   = RTC_BCD2DEC(pstcTimestamp->stcTime.u8Hour);
+            pstcTimestamp->stcTime.u8Minute = RTC_BCD2DEC(pstcTimestamp->stcTime.u8Minute);
+            pstcTimestamp->stcTime.u8Second = RTC_BCD2DEC(pstcTimestamp->stcTime.u8Second);
+            pstcTimestamp->u8Month          = RTC_BCD2DEC(pstcTimestamp->u8Month);
+            pstcTimestamp->u8Day            = RTC_BCD2DEC(pstcTimestamp->u8Day);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable RTC intrusion.
+ * @param  [in] u8Ch                    Specifies the RTC intrusion channel.
+ *         This parameter can be one of the following values:
+ *           @arg RTC_INTRU_CH0:        Intrusion channel 0
+ *           @arg RTC_INTRU_CH1:        Intrusion channel 1
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_INTRU_Cmd(uint8_t u8Ch, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_INTRU_CH(u8Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (RTC_INTRU_CH0 != u8Ch) {
+        WRITE_REG32(bCM_RTC->TPCR1_b.TPEN1, enNewState);
+    } else {
+        WRITE_REG32(bCM_RTC->TPCR0_b.TPEN0, enNewState);
+    }
+}
+
+/**
+ * @brief  Enable or disable specified RTC interrupt.
+ * @param  [in] u32IntType              Specifies the RTC interrupt source.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref RTC_Interrupt
+ * @param  [in] enNewState                An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void RTC_IntCmd(uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint32_t u32IntTemp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32IntTemp = u32IntType & 0x0000FFUL;
+    if (0UL != u32IntTemp) {
+        if (DISABLE != enNewState) {
+            SET_REG8_BIT(CM_RTC->CR2, u32IntTemp | RTC_CR2_FLAG_MASK);
+        } else {
+            MODIFY_REG8(CM_RTC->CR2, (u32IntTemp | RTC_CR2_FLAG_MASK), ~u32IntTemp);
+        }
+    }
+
+    /* Intrusion interrupt */
+    if (0UL != (u32IntType & 0x00FF00UL)) {
+        WRITE_REG32(bCM_RTC->TPCR0_b.TPIE0, enNewState);
+    }
+    if (0UL != (u32IntType & 0xFF0000UL)) {
+        WRITE_REG32(bCM_RTC->TPCR1_b.TPIE1, enNewState);
+    }
+}
+
+/**
+ * @brief  Get RTC flag status.
+ * @param  [in] u32Flag                 Specifies the RTC flag type.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref RTC_Flag
+ *           @arg RTC_FLAG_ALL:         All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t RTC_GetStatus(uint32_t u32Flag)
+{
+    uint8_t u8FlagTemp;
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_GET_FLAG(u32Flag));
+
+    u8FlagTemp = (uint8_t)(u32Flag & 0xFFU);
+    if (0U != u8FlagTemp) {
+        if (0U != (READ_REG8_BIT(CM_RTC->CR2, u8FlagTemp))) {
+            enFlagSta = SET;
+        }
+    }
+
+    /* Intrusion interrupt flag */
+    u8FlagTemp = (uint8_t)((u32Flag >> 16U) & 0xFFU);
+    if ((0U != u8FlagTemp) && (SET != enFlagSta)) {
+        if (0U != (READ_REG8_BIT(CM_RTC->TPSR, u8FlagTemp))) {
+            enFlagSta = SET;
+        }
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear RTC flag.
+ * @param  [in] u32Flag                 Specifies the RTC flag type.
+ *         This parameter can be one or any combination of the following values:
+ *           @arg @ref RTC_Flag
+ *           @arg RTC_FLAG_CLR_ALL:     All of the above
+ * @retval None
+ */
+void RTC_ClearStatus(uint32_t u32Flag)
+{
+    uint8_t u8FlagTemp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_RTC_CLR_FLAG(u32Flag));
+
+    u8FlagTemp = (uint8_t)(u32Flag & 0xFFU);
+    if (0U != u8FlagTemp) {
+        MODIFY_REG8(CM_RTC->CR2, RTC_CR2_FLAG_MASK, ~u8FlagTemp);
+    }
+
+    u8FlagTemp  = (uint8_t)((u32Flag >> 16U) & 0xFFU);
+    /* Intrusion interrupt flag */
+    if (0U != u8FlagTemp) {
+        WRITE_REG8(CM_RTC->TPSR, ((uint8_t)(~u8FlagTemp)) & RTC_TPSR_FLAG_MASK);
+    }
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_RTC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_sdioc.c
+++ b/hc32f4a2/src/hc32_ll_sdioc.c
@@ -1,0 +1,2876 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_sdioc.c
+ * @brief This file provides firmware functions to manage the Secure Digital
+ *        Input and Output Controller(SDIOC).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Modify response type of MMC CMD3
+                                    Rename function SDMMC_ACMD41_SendOperatCond to SDMMC_ACMD41_SendOperateCond
+                                    Rename function SDMMC_CMD1_SendOperatCond to SDMMC_CMD1_SendOperateCond
+                                    Optimize SDIOC_GetMode function
+                                    Support CMD5/CMD52/CMD53
+   2024-08-31       CDT             Add parameter for SDMMC_CMD38_Erase
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_sdioc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_SDIOC SDIOC
+ * @brief SDIOC Driver Library
+ * @{
+ */
+
+#if (LL_SDIOC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SDIOC_Local_Macros SDIOC Local Macros
+ * @{
+ */
+
+/* CMD52 arguments field shift */
+#define SDIO_CMD52_ARG_REG_ADDR_SHIFT           (9U)
+#define SDIO_CMD52_ARG_FUNC_SHIFT               (28U)
+
+/* CMD53 arguments field shift */
+#define SDIO_CMD53_ARG_REG_ADDR_SHIFT           (9U)
+#define SDIO_CMD53_ARG_FUNC_SHIFT               (28U)
+
+/* Masks for R6 Response */
+#define SDMMC_R6_GEN_UNKNOWN_ERR                (0x00002000UL)
+#define SDMMC_R6_ILLEGAL_CMD                    (0x00004000UL)
+#define SDMMC_R6_COM_CRC_FAIL                   (0x00008000UL)
+
+/* SDMMC command parameters */
+#define SDMMC_CMD8_CHECK_PATTERN                (0x000001AAUL)
+/* 3.2V-3.3V */
+#define SDMMC_ACMD41_VOLT_WIN                   (0x80100000UL)
+
+/* Command send and response timeout(ms) */
+#define SDMMC_CMD_TIMEOUT                       (5000UL)
+/* Max erase Timeout 60s */
+#define SDMMC_MAX_ERASE_TIMEOUT                 (60000UL)
+/* SDIOC software reset timeout(ms) */
+#define SDIOC_SW_RST_TIMEOUT                    (50UL)
+
+/* SDIOC NORINTSGEN register Mask */
+#define SDIOC_NORINTSGEN_CLR_MASK               (0x01F7U)
+/* SDIOC ERRINTSGEN register Mask */
+#define SDIOC_ERRINTSGEN_CLR_MASK               (0x017FU)
+
+/*!< Get the specified register address of the specified SDIOC unit */
+#define SDIOC_ARG_ADDR(__UNIT__)                (__IO uint32_t*)((uint32_t)(&((__UNIT__)->ARG0)))
+#define SDIOC_BUF_ADDR(__UNIT__)                (__IO uint32_t*)((uint32_t)(&((__UNIT__)->BUF0)))
+#define SDIOC_RESP_ADDR(__UNIT__, __RESP__)     (__IO uint32_t*)((uint32_t)(&((__UNIT__)->RESP0)) + (__RESP__))
+
+/**
+ * @defgroup SDIOC_Check_Parameters_Validity SDIOC Check Parameters Validity
+ * @{
+ */
+#define IS_SDIOC_UNIT(x)                                                       \
+(   ((x) == CM_SDIOC1)                          ||                             \
+    ((x) == CM_SDIOC2))
+
+#define IS_SDIOC_MD(x)                                                         \
+(   ((x) == SDIOC_MD_SD)                        ||                             \
+    ((x) == SDIOC_MD_MMC))
+
+#define IS_SDIOC_CARD_DETECT_WAY(x)                                            \
+(   ((x) == SDIOC_CARD_DETECT_CD_PIN_LVL)       ||                             \
+    ((x) == SDIOC_CARD_DETECT_TEST_SIGNAL))
+
+#define IS_SDIOC_CARD_DETECT_TEST_LEVEL(x)                                     \
+(   ((x) == SDIOC_CARD_DETECT_TEST_LVL_LOW)     ||                             \
+    ((x) == SDIOC_CARD_DETECT_TEST_LVL_HIGH))
+
+#define IS_SDIOC_SPEED_MD(x)                                                   \
+(   ((x) == SDIOC_SPEED_MD_NORMAL)              ||                             \
+    ((x) == SDIOC_SPEED_MD_HIGH))
+
+#define IS_SDIOC_BUS_WIDTH(x)                                                  \
+(   ((x) == SDIOC_BUS_WIDTH_1BIT)               ||                             \
+    ((x) == SDIOC_BUS_WIDTH_4BIT)               ||                             \
+    ((x) == SDIOC_BUS_WIDTH_8BIT))
+
+#define IS_SDIOC_CLK_DIV(x)                                                    \
+(   ((x) == SDIOC_CLK_DIV1)                     ||                             \
+    ((x) == SDIOC_CLK_DIV2)                     ||                             \
+    ((x) == SDIOC_CLK_DIV4)                     ||                             \
+    ((x) == SDIOC_CLK_DIV8)                     ||                             \
+    ((x) == SDIOC_CLK_DIV16)                    ||                             \
+    ((x) == SDIOC_CLK_DIV32)                    ||                             \
+    ((x) == SDIOC_CLK_DIV64)                    ||                             \
+    ((x) == SDIOC_CLK_DIV128)                   ||                             \
+    ((x) == SDIOC_CLK_DIV256))
+
+#define IS_SDIOC_CMD_TYPE(x)                                                   \
+(   ((x) == SDIOC_CMD_TYPE_NORMAL)              ||                             \
+    ((x) == SDIOC_CMD_TYPE_SUSPEND)             ||                             \
+    ((x) == SDIOC_CMD_TYPE_RESUME)              ||                             \
+    ((x) == SDIOC_CMD_TYPE_ABORT))
+
+#define IS_SDIOC_DATA_LINE(x)                                                  \
+(   ((x) == SDIOC_DATA_LINE_DISABLE)            ||                             \
+    ((x) == SDIOC_DATA_LINE_ENABLE))
+
+#define IS_SDIOC_TRANS_DIR(x)                                                  \
+(   ((x) == SDIOC_TRANS_DIR_TO_CARD)            ||                             \
+    ((x) == SDIOC_TRANS_DIR_TO_HOST))
+
+#define IS_SDIOC_AUTO_SEND_CMD12(x)                                            \
+(   ((x) == SDIOC_AUTO_SEND_CMD12_DISABLE)      ||                             \
+    ((x) == SDIOC_AUTO_SEND_CMD12_ENABLE))
+
+#define IS_SDIOC_TRANS_MD(x)                                                   \
+(   ((x) == SDIOC_TRANS_MD_SINGLE)              ||                             \
+    ((x) == SDIOC_TRANS_MD_INFINITE)            ||                             \
+    ((x) == SDIOC_TRANS_MD_MULTI)               ||                             \
+    ((x) == SDIOC_TRANS_MD_STOP_MULTI))
+
+#define IS_SDIOC_DATA_TIMEOUT_TIME(x)           ((x) <= SDIOC_DATA_TIMEOUT_CLK_2E27)
+
+#define IS_SDIOC_RESP_REG(x)                                                   \
+(   ((x) == SDIOC_RESP_REG_BIT0_31)             ||                             \
+    ((x) == SDIOC_RESP_REG_BIT32_63)            ||                             \
+    ((x) == SDIOC_RESP_REG_BIT64_95)            ||                             \
+    ((x) == SDIOC_RESP_REG_BIT96_127))
+
+#define IS_SDIOC_SW_RST_TYPE(x)                                                \
+(   ((x) == SDIOC_SW_RST_DATA_LINE)             ||                             \
+    ((x) == SDIOC_SW_RST_CMD_LINE)              ||                             \
+    ((x) == SDIOC_SW_RST_ALL))
+
+#define IS_SDIOC_OUTPUT_CLK_FREQ(x)                                            \
+(   ((x) == SDIOC_OUTPUT_CLK_FREQ_400K)         ||                             \
+    ((x) == SDIOC_OUTPUT_CLK_FREQ_25M)          ||                             \
+    ((x) == SDIOC_OUTPUT_CLK_FREQ_26M)          ||                             \
+    ((x) == SDIOC_OUTPUT_CLK_FREQ_50M)          ||                             \
+    ((x) == SDIOC_OUTPUT_CLK_FREQ_52M))
+
+#define IS_SDIOC_GET_HOST_FLAG(x)                                              \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_HOST_FLAG_ALL) == SDIOC_HOST_FLAG_ALL))
+
+#define IS_SDIOC_GET_INT_FLAG(x)                                               \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_INT_FLAG_ALL) == SDIOC_INT_FLAG_ALL))
+
+#define IS_SDIOC_CLR_INT_FLAG(x)                                               \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_INT_FLAG_CLR_ALL) == SDIOC_INT_FLAG_CLR_ALL))
+
+#define IS_SDIOC_INT(x)                                                        \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_INT_ALL) == SDIOC_INT_ALL))
+
+#define IS_SDIOC_AUTO_CMD_ERR_FLAG(x)                                          \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_AUTO_CMD_ERR_FLAG_ALL) == SDIOC_AUTO_CMD_ERR_FLAG_ALL))
+
+#define IS_SDIOC_FORCE_AUTO_CMD_ERR(x)                                         \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_FORCE_AUTO_CMD_ERR_ALL) == SDIOC_FORCE_AUTO_CMD_ERR_ALL))
+
+#define IS_SDIOC_FORCE_ERR_INT(x)                                              \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SDIOC_FORCE_ERR_INT_ALL) == SDIOC_FORCE_ERR_INT_ALL))
+
+#define IS_SDIOC_RESP_TYPE(x)                                                  \
+(   ((x) == SDIOC_RESP_TYPE_NO)                 ||                             \
+    ((x) == SDIOC_RESP_TYPE_R2)                 ||                             \
+    ((x) == SDIOC_RESP_TYPE_R3_R4)              ||                             \
+    ((x) == SDIOC_RESP_TYPE_R1_R5_R6_R7)        ||                             \
+    ((x) == SDIOC_RESP_TYPE_R1B_R5B))
+
+#define IS_SDIOC_CMD_INDEX(x)                   ((x) < 0x40U)
+
+#define IS_SDIOC_BLOCK_SIZE(x)                  (((x) >= 1U) && ((x) <= 512U))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup SDIOC_Global_Functions SDIOC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Wait for command response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32CheckFlag            Check flags
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_INT_FLAG_CC:    Command Complete status
+ *           @arg SDIOC_INT_FLAG_CIE:   Command Index error status
+ *           @arg SDIOC_INT_FLAG_CEBE:  Command End Bit error status
+ *           @arg SDIOC_INT_FLAG_CCE:   Command CRC error status
+ *           @arg SDIOC_INT_FLAG_CTOE:  Command Timeout error status
+ * @param  [in] u32Timeout              Timeout time(ms) for waiting SDIOC
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_WaitResponse(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32CheckFlag,
+                                  uint32_t u32Timeout, uint32_t *pu32ErrStatus)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Temp;
+
+    *pu32ErrStatus = 0UL;
+    /* The u32Timeout is expressed in ms */
+    u32Count = u32Timeout * (HCLK_VALUE / 20000UL);
+    while (RESET == SDIOC_GetIntStatus(SDIOCx, u32CheckFlag)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    if (LL_OK == i32Ret) {
+        i32Ret = LL_ERR;
+        u32Temp = CLR_REG32_BIT(u32CheckFlag, SDIOC_INT_FLAG_CC);
+        if (RESET == SDIOC_GetIntStatus(SDIOCx, u32Temp)) {
+            /* No error flag set */
+            *pu32ErrStatus = SDMMC_ERR_NONE;
+            SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_STATIC_FLAGS);
+            i32Ret = LL_OK;
+        } else if ((RESET != SDIOC_GetIntStatus(SDIOCx, SDIOC_INT_FLAG_CIE)) &&
+                   (SDIOC_INT_FLAG_CIE == (u32CheckFlag & SDIOC_INT_FLAG_CIE))) {
+            *pu32ErrStatus = SDMMC_ERR_CMD_INDEX;
+            SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_FLAG_CIE);
+        } else if ((RESET != SDIOC_GetIntStatus(SDIOCx, SDIOC_INT_FLAG_CEBE)) &&
+                   (SDIOC_INT_FLAG_CEBE == (u32CheckFlag & SDIOC_INT_FLAG_CEBE))) {
+            *pu32ErrStatus = SDMMC_ERR_CMD_STOP_BIT;
+            SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_FLAG_CEBE);
+        } else if ((RESET != SDIOC_GetIntStatus(SDIOCx, SDIOC_INT_FLAG_CCE)) &&
+                   (SDIOC_INT_FLAG_CCE == (u32CheckFlag & SDIOC_INT_FLAG_CCE))) {
+            *pu32ErrStatus = SDMMC_ERR_CMD_CRC_FAIL;
+            SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_FLAG_CCE);
+        } else {
+            *pu32ErrStatus = SDMMC_ERR_CMD_TIMEOUT;
+            SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_FLAG_CTOE);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks for error conditions for no response command.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdError(CM_SDIOC_TypeDef *SDIOCx)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* The SDMMC_CMD_TIMEOUT is expressed in ms */
+    u32Count = SDMMC_CMD_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (RESET == SDIOC_GetIntStatus(SDIOCx, SDIOC_INT_FLAG_CC)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+    if (LL_OK == i32Ret) {
+        SDIOC_ClearIntStatus(SDIOCx, SDIOC_INT_STATIC_FLAGS);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks for error conditions for R1 response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Timeout              Timeout time(ms) for waiting SDIOC
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp1(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Timeout, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    uint32_t u32RespVal;
+
+    i32Ret = SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC  | SDIOC_INT_FLAG_CIE | SDIOC_INT_FLAG_CEBE |
+                                         SDIOC_INT_FLAG_CCE | SDIOC_INT_FLAG_CTOE), u32Timeout, pu32ErrStatus);
+    if (LL_OK == i32Ret) {
+        /* Fetch has received a response. */
+        (void)SDIOC_GetResponse(SDIOCx, SDIOC_RESP_REG_BIT0_31, &u32RespVal);
+        if (0UL != (u32RespVal & SDMMC_ERR_BITS_MASK)) {
+            *pu32ErrStatus = u32RespVal & SDMMC_ERR_BITS_MASK;
+            i32Ret = LL_ERR;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks for error conditions for R1 response with busy.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Timeout              Timeout time(ms) for waiting SDIOC
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp1Busy(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Timeout, uint32_t *pu32ErrStatus)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret;
+    uint32_t u32RespVal;
+
+    i32Ret = SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC  | SDIOC_INT_FLAG_CIE | SDIOC_INT_FLAG_CEBE |
+                                         SDIOC_INT_FLAG_CCE | SDIOC_INT_FLAG_CTOE), u32Timeout, pu32ErrStatus);
+    if (LL_OK == i32Ret) {
+        /* Fetch has received a response. */
+        (void)SDIOC_GetResponse(SDIOCx, SDIOC_RESP_REG_BIT0_31, &u32RespVal);
+        if (0UL != (u32RespVal & SDMMC_ERR_BITS_MASK)) {
+            *pu32ErrStatus = u32RespVal & SDMMC_ERR_BITS_MASK;
+            i32Ret = LL_ERR;
+        } else {
+            /* Wait for busy status to release */
+            u32Count = u32Timeout * (HCLK_VALUE / 20000UL);
+            while (RESET == SDIOC_GetHostStatus(SDIOCx, SDIOC_HOST_FLAG_DATL_D0)) {
+                if (0UL == u32Count) {
+                    i32Ret = LL_ERR_TIMEOUT;
+                    break;
+                }
+                u32Count--;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks for error conditions for R2(CID or CSD) response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp2(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    return SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC | SDIOC_INT_FLAG_CEBE | SDIOC_INT_FLAG_CCE |
+                                       SDIOC_INT_FLAG_CTOE), SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+}
+
+/**
+ * @brief  Checks for error conditions for R3(OCR) response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp3(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    return SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC | SDIOC_INT_FLAG_CEBE | SDIOC_INT_FLAG_CTOE),
+                              SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+}
+
+/**
+ * @brief  Checks for error conditions for R4 response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp4(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    return SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC | SDIOC_INT_FLAG_CEBE | SDIOC_INT_FLAG_CCE |
+                                       SDIOC_INT_FLAG_CTOE), SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+}
+
+/**
+ * @brief  Checks for error conditions for R5 response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp5(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    return SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC | SDIOC_INT_FLAG_CEBE | SDIOC_INT_FLAG_CCE |
+                                       SDIOC_INT_FLAG_CTOE), SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+}
+
+/**
+ * @brief  Checks for error conditions for R6(RCA) response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu16RCA                Pointer to a value of device RCA
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp6(CM_SDIOC_TypeDef *SDIOCx, uint16_t *pu16RCA, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    uint32_t u32RespVal;
+
+    i32Ret = SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC  | SDIOC_INT_FLAG_CIE | SDIOC_INT_FLAG_CEBE |
+                                         SDIOC_INT_FLAG_CCE | SDIOC_INT_FLAG_CTOE), SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+    if (LL_OK == i32Ret) {
+        i32Ret = LL_ERR;
+        /* Fetch has received a response. */
+        (void)SDIOC_GetResponse(SDIOCx, SDIOC_RESP_REG_BIT0_31, &u32RespVal);
+        if (0UL == (u32RespVal & (SDMMC_R6_GEN_UNKNOWN_ERR | SDMMC_R6_ILLEGAL_CMD | SDMMC_R6_COM_CRC_FAIL))) {
+            i32Ret = LL_OK;
+            *pu16RCA = (uint16_t)(u32RespVal >> 16U);
+        } else if (SDMMC_R6_GEN_UNKNOWN_ERR == (u32RespVal & SDMMC_R6_GEN_UNKNOWN_ERR)) {
+            *pu32ErrStatus = SDMMC_ERR_GENERAL_UNKNOWN_ERR;
+        } else if (SDMMC_R6_ILLEGAL_CMD == (u32RespVal & SDMMC_R6_ILLEGAL_CMD)) {
+            *pu32ErrStatus = SDMMC_ERR_ILLEGAL_CMD;
+        } else {
+            *pu32ErrStatus = SDMMC_ERR_COM_CRC_FAILED;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks for error conditions for R7 response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: The response is normal received
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+static int32_t SDMMC_GetCmdResp7(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    return SDMMC_WaitResponse(SDIOCx, (SDIOC_INT_FLAG_CC  | SDIOC_INT_FLAG_CIE | SDIOC_INT_FLAG_CEBE |
+                                       SDIOC_INT_FLAG_CCE | SDIOC_INT_FLAG_CTOE), SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+}
+
+/**
+ * @brief  De-Initialize SDIOC.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval int32_t:
+ *           - LL_OK: SDIOC De-Initialize success
+ *           - LL_ERR_TIMEOUT: Software reset timeout
+ */
+int32_t SDIOC_DeInit(CM_SDIOC_TypeDef *SDIOCx)
+{
+    return SDIOC_SWReset(SDIOCx, SDIOC_SW_RST_ALL);
+}
+
+/**
+ * @brief  Initialize SDIOC.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] pstcSdiocInit           Pointer to a @ref stc_sdioc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: SDIOC Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcSdiocInit == NULL
+ */
+int32_t SDIOC_Init(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_init_t *pstcSdiocInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcSdiocInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+        DDL_ASSERT(IS_SDIOC_MD(pstcSdiocInit->u32Mode));
+        DDL_ASSERT(IS_SDIOC_CARD_DETECT_WAY(pstcSdiocInit->u8CardDetect));
+        DDL_ASSERT(IS_SDIOC_SPEED_MD(pstcSdiocInit->u8SpeedMode));
+        DDL_ASSERT(IS_SDIOC_BUS_WIDTH(pstcSdiocInit->u8BusWidth));
+        DDL_ASSERT(IS_SDIOC_CLK_DIV(pstcSdiocInit->u16ClockDiv));
+
+        /* Set the SDIOC mode */
+        if (CM_SDIOC1 == SDIOCx) {
+            WRITE_REG32(bCM_PERIC->SDIOC_SYCTLREG_b.SELMMC1, pstcSdiocInit->u32Mode);
+        } else {
+            WRITE_REG32(bCM_PERIC->SDIOC_SYCTLREG_b.SELMMC2, pstcSdiocInit->u32Mode);
+        }
+        /* Set the SDIOC clock control value */
+        WRITE_REG16(SDIOCx->CLKCON, (pstcSdiocInit->u16ClockDiv | SDIOC_CLKCON_ICE | SDIOC_CLKCON_CE));
+        /* Set the SDIOC host control value */
+        WRITE_REG8(SDIOCx->HOSTCON, (pstcSdiocInit->u8CardDetect | pstcSdiocInit->u8BusWidth |
+                                     pstcSdiocInit->u8SpeedMode));
+        /* Enable normal interrupt status */
+        WRITE_REG16(SDIOCx->NORINTSTEN, SDIOC_NORINTSGEN_CLR_MASK);
+        /* Enable error interrupt status */
+        WRITE_REG16(SDIOCx->ERRINTSTEN, SDIOC_ERRINTSGEN_CLR_MASK);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_sdioc_init_t to default values.
+ * @param  [out] pstcSdiocInit          Pointer to a @ref stc_sdioc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcSdiocInit == NULL
+ */
+int32_t SDIOC_StructInit(stc_sdioc_init_t *pstcSdiocInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcSdiocInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcSdiocInit->u32Mode      = SDIOC_MD_SD;
+        pstcSdiocInit->u8CardDetect = SDIOC_CARD_DETECT_CD_PIN_LVL;
+        pstcSdiocInit->u8SpeedMode  = SDIOC_SPEED_MD_NORMAL;
+        pstcSdiocInit->u8BusWidth   = SDIOC_BUS_WIDTH_1BIT;
+        pstcSdiocInit->u16ClockDiv  = SDIOC_CLK_DIV1;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set software reset.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8Type                  Software reset type
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_SW_RST_DATA_LINE:   Only part of data circuit is reset
+ *           @arg SDIOC_SW_RST_CMD_LINE:    Only part of command circuit is reset
+ *           @arg SDIOC_SW_RST_ALL:         Reset the entire Host Controller except for the card detection circuit
+ * @retval int32_t:
+ *           - LL_OK: Software reset success
+ *           - LL_ERR_TIMEOUT: Software reset timeout
+ */
+int32_t SDIOC_SWReset(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Type)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32Count;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_SW_RST_TYPE(u8Type));
+
+    WRITE_REG8(SDIOCx->SFTRST, u8Type);
+    /* Wait for reset finish */
+    u32Count = SDIOC_SW_RST_TIMEOUT * (HCLK_VALUE / 20000UL);
+    while (0U != READ_REG8_BIT(SDIOCx->SFTRST, u8Type)) {
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable power.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_PowerCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG8_BIT(SDIOCx->PWRCON, SDIOC_PWRCON_PWON);
+    } else {
+        CLR_REG8_BIT(SDIOCx->PWRCON, SDIOC_PWRCON_PWON);
+    }
+}
+
+/**
+ * @brief  Get power state.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval An @ref en_functional_state_t enumeration value.
+ *           - DISABLE: Power off or SDIOCx == NULL
+ *           - ENABLE: Power on
+ */
+en_functional_state_t SDIOC_GetPowerState(const CM_SDIOC_TypeDef *SDIOCx)
+{
+    en_functional_state_t enPowerSta = DISABLE;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+    if (0U != (READ_REG8_BIT(SDIOCx->PWRCON, SDIOC_PWRCON_PWON))) {
+        enPowerSta = ENABLE;
+    }
+
+    return enPowerSta;
+}
+
+/**
+ * @brief  Get SDIOC work mode.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval uint32_t value:
+ *           - SDIOC_MD_SD:   SDIOCx selects SD mode
+ *           - SDIOC_MD_MMC:  SDIOCx selects MMC mode
+ */
+uint32_t SDIOC_GetMode(const CM_SDIOC_TypeDef *SDIOCx)
+{
+    uint32_t u32SdMode;
+    uint32_t u32Temp;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+    if (CM_SDIOC1 == SDIOCx) {
+        u32Temp = PERIC_SDIOC_SYCTLREG_SELMMC1;
+    } else {
+        u32Temp = PERIC_SDIOC_SYCTLREG_SELMMC2;
+    }
+    u32SdMode = READ_REG32_BIT(CM_PERIC->SDIOC_SYCTLREG, u32Temp);
+    if (0UL != u32SdMode) { /* MMC mode */
+        u32SdMode = SDIOC_MD_MMC;
+    } else {
+        u32SdMode = SDIOC_MD_SD;
+    }
+
+    return u32SdMode;
+}
+
+/**
+ * @brief  Enable or disable clock output.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_ClockCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG8_BIT(SDIOCx->CLKCON, SDIOC_CLKCON_CE);
+    } else {
+        CLR_REG8_BIT(SDIOCx->CLKCON, SDIOC_CLKCON_CE);
+    }
+}
+
+/**
+ * @brief  Set clock division.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u16Div                  Clock division
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_CLK_DIV1:       CLK1/1
+ *           @arg SDIOC_CLK_DIV2:       CLK1/2
+ *           @arg SDIOC_CLK_DIV4:       CLK1/4
+ *           @arg SDIOC_CLK_DIV8:       CLK1/8
+ *           @arg SDIOC_CLK_DIV16:      CLK1/16
+ *           @arg SDIOC_CLK_DIV32:      CLK1/32
+ *           @arg SDIOC_CLK_DIV64:      CLK1/64
+ *           @arg SDIOC_CLK_DIV128:     CLK1/128
+ *           @arg SDIOC_CLK_DIV256:     CLK1/256
+ * @retval None
+ */
+void SDIOC_SetClockDiv(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Div)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_CLK_DIV(u16Div));
+
+    MODIFY_REG16(SDIOCx->CLKCON, SDIOC_CLKCON_FS, u16Div);
+}
+
+/**
+ * @brief  Find the most suitable clock division for the set clock frequency.
+ * @note   More clock values can be set as needed, but the maximum cannot exceed 50MHz.
+ * @param  [in] u32ClockFreq            SDIOCx_CK clock frequency
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_OUTPUT_CLK_FREQ_400K:   SDIOC clock: 400KHz
+ *           @arg SDIOC_OUTPUT_CLK_FREQ_25M:    SDIOC clock: 25MHz
+ *           @arg SDIOC_OUTPUT_CLK_FREQ_26M:    SDIOC clock: 26MHz
+ *           @arg SDIOC_OUTPUT_CLK_FREQ_50M:    SDIOC clock: 50MHz
+ *           @arg SDIOC_OUTPUT_CLK_FREQ_52M:    SDIOC clock: 52MHz
+ *           @arg Any other value
+ * @param  [out] pu16Div                Pointer to a value of clock division
+ * @retval int32_t:
+ *           - LL_OK: SDIOC Initialize success
+ *           - LL_ERR: The Bus clock frequency is too high
+ *           - LL_ERR_INVD_PARAM: pu16Div == NULL or 0UL == u32ClockFreq
+ */
+int32_t SDIOC_GetOptimumClockDiv(uint32_t u32ClockFreq, uint16_t *pu16Div)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32BusClock;
+    uint32_t u32ClockDiv;
+    uint32_t u32Temp;
+
+    if ((NULL == pu16Div) || (0UL == u32ClockFreq)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Get BUS frequency */
+        u32BusClock = SystemCoreClock / (0x01UL << (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK1S) >> CMU_SCFGR_PCLK1S_POS));
+        u32ClockDiv = u32BusClock / u32ClockFreq;
+        if (0UL != (u32BusClock % u32ClockFreq)) {
+            u32ClockDiv++;
+        }
+        /* Check the effectiveness of clock division */
+        if (u32ClockDiv > 256U) { /* Maximum division is 256 */
+            i32Ret = LL_ERR;
+        } else {
+            if (1U == u32ClockDiv) {
+                *pu16Div = SDIOC_CLK_DIV1;
+            } else {
+                for (u32Temp = SDIOC_CLK_DIV2; u32Temp <= SDIOC_CLK_DIV256; u32Temp <<= 1U) {
+                    if (u32ClockDiv <= (u32Temp >> (SDIOC_CLKCON_FS_POS - 1U))) {
+                        break;
+                    }
+                }
+                *pu16Div = (uint16_t)u32Temp;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Verify the validity of the clock division.
+ * @param  [in] u32Mode                 SDIOC work mode
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_MD_SD:          SDIOCx selects SD mode
+ *           @arg SDIOC_MD_MMC:         SDIOCx selects MMC mode
+ * @param  [in] u8SpeedMode             Speed mode
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_SPEED_MD_NORMAL:    Normal speed mode
+ *           @arg SDIOC_SPEED_MD_HIGH:      High speed mode
+ * @param  [in] u16ClockDiv             Clock division
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_CLK_DIV1:       CLK1/1
+ *           @arg SDIOC_CLK_DIV2:       CLK1/2
+ *           @arg SDIOC_CLK_DIV4:       CLK1/4
+ *           @arg SDIOC_CLK_DIV8:       CLK1/8
+ *           @arg SDIOC_CLK_DIV16:      CLK1/16
+ *           @arg SDIOC_CLK_DIV32:      CLK1/32
+ *           @arg SDIOC_CLK_DIV64:      CLK1/64
+ *           @arg SDIOC_CLK_DIV128:     CLK1/128
+ *           @arg SDIOC_CLK_DIV256:     CLK1/256
+ * @retval int32_t:
+ *           - LL_OK: The clock division is valid
+ *           - LL_ERR: The Bus clock frequency is too high
+ */
+int32_t SDIOC_VerifyClockDiv(uint32_t u32Mode, uint8_t u8SpeedMode, uint16_t u16ClockDiv)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32BusClock;
+    uint32_t u32ClockFreq;
+    uint32_t u32MaxFreq;
+    uint32_t u32DivValue;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_MD(u32Mode));
+    DDL_ASSERT(IS_SDIOC_SPEED_MD(u8SpeedMode));
+    DDL_ASSERT(IS_SDIOC_CLK_DIV(u16ClockDiv));
+
+    /* Get Bus frequency */
+    u32BusClock = SystemCoreClock / (0x01UL << (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK1S) >> CMU_SCFGR_PCLK1S_POS));
+    u32DivValue = ((uint32_t)u16ClockDiv >> (SDIOC_CLKCON_FS_POS - 1U));
+    if (0UL == u32DivValue) {
+        u32ClockFreq = u32BusClock;
+    } else {
+        u32ClockFreq = u32BusClock / u32DivValue;
+    }
+
+    if (SDIOC_SPEED_MD_NORMAL == u8SpeedMode) {
+        if (SDIOC_MD_SD != u32Mode) { /* MMC mode */
+            u32MaxFreq = SDIOC_OUTPUT_CLK_FREQ_26M;
+        } else {
+            u32MaxFreq = SDIOC_OUTPUT_CLK_FREQ_25M;
+        }
+    } else {
+        if (SDIOC_MD_SD != u32Mode) { /* MMC mode */
+            u32MaxFreq = SDIOC_OUTPUT_CLK_FREQ_52M;
+        } else {
+            u32MaxFreq = SDIOC_OUTPUT_CLK_FREQ_50M;
+        }
+    }
+    if (u32ClockFreq > u32MaxFreq) {
+        i32Ret = LL_ERR;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get device insert status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SDIOC_GetInsertStatus(const CM_SDIOC_TypeDef *SDIOCx)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+    if (0UL != (READ_REG32_BIT(SDIOCx->PSTAT, SDIOC_PSTAT_CSS))) {
+        if (0UL != (READ_REG32_BIT(SDIOCx->PSTAT, SDIOC_PSTAT_CIN))) {
+            enFlagSta = SET;
+        }
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Set speed mode.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8SpeedMode             Speed mode
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_SPEED_MD_NORMAL:    Normal speed mode
+ *           @arg SDIOC_SPEED_MD_HIGH:      High speed mode
+ * @retval None
+ */
+void SDIOC_SetSpeedMode(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8SpeedMode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_SPEED_MD(u8SpeedMode));
+
+    if (SDIOC_SPEED_MD_NORMAL != u8SpeedMode) {
+        SET_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_HSEN);
+    } else {
+        CLR_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_HSEN);
+    }
+}
+
+/**
+ * @brief  Set bus width.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8BusWidth              Bus width
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_BUS_WIDTH_1BIT: The Bus width is 1 bit
+ *           @arg SDIOC_BUS_WIDTH_4BIT: The Bus width is 4 bit
+ *           @arg SDIOC_BUS_WIDTH_8BIT: The Bus width is 8 bit
+ * @retval None
+ */
+void SDIOC_SetBusWidth(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8BusWidth)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_BUS_WIDTH(u8BusWidth));
+
+    MODIFY_REG8(SDIOCx->HOSTCON, (SDIOC_HOSTCON_DW | SDIOC_HOSTCON_EXDW), u8BusWidth);
+}
+
+/**
+ * @brief  Set card detect line select.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8Src                   Card detect source
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_CARD_DETECT_CD_PIN_LVL:     SDIOCx_CD(x=1~2) line is selected (for normal use)
+ *           @arg SDIOC_CARD_DETECT_TEST_SIGNAL:    The Card Detect Test Level is selected(for test purpose)
+ * @retval None
+ */
+void SDIOC_SetCardDetectSrc(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Src)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_CARD_DETECT_WAY(u8Src));
+
+    if (SDIOC_CARD_DETECT_CD_PIN_LVL != u8Src) {
+        SET_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_CDSS);
+    } else {
+        CLR_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_CDSS);
+    }
+}
+
+/**
+ * @brief  Set card detect test level.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8Level                 Card test level
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_CARD_DETECT_TEST_LVL_LOW:   Card identification test signal is low level (with device insertion)
+ *           @arg SDIOC_CARD_DETECT_TEST_LVL_HIGH:  Card identification test signal is high level (no device insertion)
+ * @retval None
+ */
+void SDIOC_SetCardDetectTestLevel(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Level)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_CARD_DETECT_TEST_LEVEL(u8Level));
+
+    if (SDIOC_CARD_DETECT_TEST_LVL_LOW != u8Level) {
+        SET_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_CDTL);
+    } else {
+        CLR_REG8_BIT(SDIOCx->HOSTCON, SDIOC_HOSTCON_CDTL);
+    }
+}
+
+/**
+ * @brief  Configure the SDIOCx command parameters.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] pstcCmdConfig           Pointer to a @ref stc_sdioc_cmd_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Configure SDIOCx command parameters success
+ *           - LL_ERR_INVD_PARAM: pstcCmdConfig == NULL
+ */
+int32_t SDIOC_SendCommand(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_cmd_config_t *pstcCmdConfig)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t *pu32Temp;
+
+    if (NULL == pstcCmdConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+        DDL_ASSERT(IS_SDIOC_CMD_INDEX(pstcCmdConfig->u16CmdIndex));
+        DDL_ASSERT(IS_SDIOC_CMD_TYPE(pstcCmdConfig->u16CmdType));
+        DDL_ASSERT(IS_SDIOC_DATA_LINE(pstcCmdConfig->u16DataLine));
+        DDL_ASSERT(IS_SDIOC_RESP_TYPE(pstcCmdConfig->u16ResponseType));
+
+        /* Set the SDIOC Command parameters value */
+        pu32Temp = SDIOC_ARG_ADDR(SDIOCx);
+        WRITE_REG32(*pu32Temp, pstcCmdConfig->u32Argument);
+        /* Set the SDIOC Command controller value */
+        WRITE_REG16(SDIOCx->CMD, ((uint16_t)(pstcCmdConfig->u16CmdIndex << SDIOC_CMD_IDX_POS) |
+                                  pstcCmdConfig->u16CmdType | pstcCmdConfig->u16DataLine |
+                                  pstcCmdConfig->u16ResponseType));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_sdioc_cmd_config_t to default values.
+ * @param  [out] pstcCmdConfig          Pointer to a @ref stc_sdioc_cmd_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcDataConfig == NULL
+ */
+int32_t SDIOC_CommandStructInit(stc_sdioc_cmd_config_t *pstcCmdConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcCmdConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcCmdConfig->u32Argument      = 0U;
+        pstcCmdConfig->u16CmdIndex      = 0U;
+        pstcCmdConfig->u16CmdType       = SDIOC_CMD_TYPE_NORMAL;
+        pstcCmdConfig->u16DataLine      = SDIOC_DATA_LINE_DISABLE;
+        pstcCmdConfig->u16ResponseType  = SDIOC_RESP_TYPE_NO;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get the response received from the card for the last command
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u8Reg                   SDIOC response register
+ *         This parameter can be one of the following values:
+ *           @arg SDIOC_RESP_REG_BIT0_31:   Command Response Register 0-31bit
+ *           @arg SDIOC_RESP_REG_BIT32_63:  Command Response Register 32-63bit
+ *           @arg SDIOC_RESP_REG_BIT64_95:  Command Response Register 64-95bit
+ *           @arg SDIOC_RESP_REG_BIT96_127: Command Response Register 96-127bit
+ * @param  [out] pu32Value              Pointer to a Response value
+ * @retval int32_t:
+ *           - LL_OK: Get response success
+ *           - LL_ERR_INVD_PARAM: pu32Value == NULL
+ */
+int32_t SDIOC_GetResponse(CM_SDIOC_TypeDef *SDIOCx, uint8_t u8Reg, uint32_t *pu32Value)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pu32Value) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+        DDL_ASSERT(IS_SDIOC_RESP_REG(u8Reg));
+
+        *pu32Value = READ_REG32(*SDIOC_RESP_ADDR(SDIOCx, u8Reg));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configure the SDIOCx data parameters.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] pstcDataConfig          Pointer to a @ref stc_sdioc_data_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Configure SDIOCx data parameters success
+ *           - LL_ERR_INVD_PARAM: pstcDataConfig == NULL
+ */
+int32_t SDIOC_ConfigData(CM_SDIOC_TypeDef *SDIOCx, const stc_sdioc_data_config_t *pstcDataConfig)
+{
+    int32_t i32Ret = LL_OK;
+    uint16_t u16BlkCnt;
+
+    if (NULL == pstcDataConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+        DDL_ASSERT(IS_SDIOC_BLOCK_SIZE(pstcDataConfig->u16BlockSize));
+        DDL_ASSERT(IS_SDIOC_TRANS_DIR(pstcDataConfig->u16TransDir));
+        DDL_ASSERT(IS_SDIOC_AUTO_SEND_CMD12(pstcDataConfig->u16AutoCmd12));
+        DDL_ASSERT(IS_SDIOC_TRANS_MD(pstcDataConfig->u16TransMode));
+        DDL_ASSERT(IS_SDIOC_DATA_TIMEOUT_TIME(pstcDataConfig->u16DataTimeout));
+
+        if (SDIOC_TRANS_MD_STOP_MULTI == pstcDataConfig->u16TransMode) {
+            u16BlkCnt = 0U;
+        } else {
+            u16BlkCnt = pstcDataConfig->u16BlockCount;
+        }
+        /* Set the SDIOC Data Transfer Timeout value */
+        WRITE_REG8(SDIOCx->TOUTCON, pstcDataConfig->u16DataTimeout);
+        /* Set the SDIOC Block Count value */
+        WRITE_REG16(SDIOCx->BLKSIZE, pstcDataConfig->u16BlockSize);
+        /* Set the SDIOC Block Size value */
+        WRITE_REG16(SDIOCx->BLKCNT, u16BlkCnt);
+        /* Set the SDIOC Data Transfer Mode */
+        WRITE_REG16(SDIOCx->TRANSMODE, ((pstcDataConfig->u16TransDir | pstcDataConfig->u16AutoCmd12 |
+                                         pstcDataConfig->u16TransMode) & 0xFFU));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_sdioc_data_config_t to default values.
+ * @param  [out] pstcDataConfig         Pointer to a @ref stc_sdioc_data_config_t structure
+ * @retval int32_t:
+ *           - LL_OK: Structure Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcDataConfig == NULL
+ */
+int32_t SDIOC_DataStructInit(stc_sdioc_data_config_t *pstcDataConfig)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcDataConfig) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcDataConfig->u16BlockSize    = 512U;
+        pstcDataConfig->u16BlockCount   = 0U;
+        pstcDataConfig->u16TransDir     = SDIOC_TRANS_DIR_TO_CARD;
+        pstcDataConfig->u16AutoCmd12    = SDIOC_AUTO_SEND_CMD12_DISABLE;
+        pstcDataConfig->u16TransMode    = SDIOC_TRANS_MD_SINGLE;
+        pstcDataConfig->u16DataTimeout  = SDIOC_DATA_TIMEOUT_CLK_2E13;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Read data from SDIOC FIFO.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] au8Data                Pointer to the buffer
+ * @param  [in] u32Len                  Data length
+ * @retval int32_t:
+ *           - LL_OK: Read data success
+ *           - LL_ERR_INVD_PARAM: NULL == au8Data or (u32Len % 4U) != 0
+ */
+int32_t SDIOC_ReadBuffer(CM_SDIOC_TypeDef *SDIOCx, uint8_t au8Data[], uint32_t u32Len)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+    uint32_t u32Temp;
+    __IO uint32_t *BUF_REG;
+
+    if ((NULL == au8Data) || (0U != (u32Len % 4U))) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+        BUF_REG = SDIOC_BUF_ADDR(SDIOCx);
+        for (i = 0U; i < u32Len; i += 4U) {
+            u32Temp = READ_REG32(*BUF_REG);
+            au8Data[i]      = (uint8_t)(u32Temp & 0xFFUL);
+            au8Data[i + 1U] = (uint8_t)((u32Temp >> 8U) & 0xFFUL);
+            au8Data[i + 2U] = (uint8_t)((u32Temp >> 16U) & 0xFFUL);
+            au8Data[i + 3U] = (uint8_t)((u32Temp >> 24U) & 0xFFUL);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Write data to SDIOC FIFO.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] au8Data                 Pointer to the buffer
+ * @param  [in] u32Len                  Data length
+ * @retval int32_t:
+ *           - LL_OK: Write data success
+ *           - LL_ERR_INVD_PARAM: NULL == au8Data or (u32Len % 4U) != 0
+ */
+int32_t SDIOC_WriteBuffer(CM_SDIOC_TypeDef *SDIOCx, const uint8_t au8Data[], uint32_t u32Len)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t i;
+    uint32_t u32Temp;
+    __IO uint32_t *BUF_REG;
+
+    if ((NULL == au8Data) || (0U != (u32Len % 4U))) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+        BUF_REG = SDIOC_BUF_ADDR(SDIOCx);
+        for (i = 0U; i < u32Len; i += 4U) {
+            u32Temp = ((uint32_t)au8Data[i + 3U] << 24U) | ((uint32_t)au8Data[i + 2U] << 16U) |
+                      ((uint32_t)au8Data[i + 1U] << 8U)  | au8Data[i];
+            WRITE_REG32(*BUF_REG, u32Temp);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable block gap stop.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_BlockGapStopCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_SABGR);
+    } else {
+        CLR_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_SABGR);
+    }
+}
+
+/**
+ * @brief  Restart data transfer.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @retval None
+ */
+void SDIOC_RestartTrans(CM_SDIOC_TypeDef *SDIOCx)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+
+    SET_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_CR);
+}
+
+/**
+ * @brief  Enable or disable read wait.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_ReadWaitCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_RWC);
+    } else {
+        CLR_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_RWC);
+    }
+}
+
+/**
+ * @brief  Enable or disable data block gap interrupt.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_BlockGapIntCmd(CM_SDIOC_TypeDef *SDIOCx, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (DISABLE != enNewState) {
+        SET_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_IABG);
+    } else {
+        CLR_REG8_BIT(SDIOCx->BLKGPCON, SDIOC_BLKGPCON_IABG);
+    }
+}
+
+/**
+ * @brief  Enable or disable interrupt.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32IntType              Normal and error interrupts source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SDIOC_INT_CINTSEN:    Card interrupt
+ *           @arg SDIOC_INT_CRMSEN:     Card Removal interrupt
+ *           @arg SDIOC_INT_CISTSEN:    Card Insertion interrupt
+ *           @arg SDIOC_INT_BRRSEN:     Buffer Read Ready interrupt
+ *           @arg SDIOC_INT_BWRSEN:     Buffer Write Ready interrupt
+ *           @arg SDIOC_INT_BGESEN:     Block Gap Event interrupt
+ *           @arg SDIOC_INT_TCSEN:      Transfer Complete interrupt
+ *           @arg SDIOC_INT_CCSEN:      Command Complete interrupt
+ *           @arg SDIOC_INT_ACESEN:     Auto CMD12 error interrupt
+ *           @arg SDIOC_INT_DEBESEN:    Data End Bit error interrupt
+ *           @arg SDIOC_INT_DCESEN:     Data CRC error interrupt
+ *           @arg SDIOC_INT_DTOESEN:    Data Timeout error interrupt
+ *           @arg SDIOC_INT_CIESEN:     Command Index error interrupt
+ *           @arg SDIOC_INT_CEBESEN:    Command End Bit error interrupt
+ *           @arg SDIOC_INT_CCESEN:     Command CRC error interrupt
+ *           @arg SDIOC_INT_CTOESEN:    Command Timeout error interrupt
+ *           @arg SDIOC_INT_ALL:        All of the above
+ *           @arg SDIOC_NORMAL_INT_ALL: All of the normal interrupt
+ *           @arg SDIOC_ERR_INT_ALL:    All of the error interrupt
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_IntCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint16_t u16NormalInt;
+    uint16_t u16ErrorInt;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u16NormalInt = (uint16_t)(u32IntType & 0xFFFFU);
+    u16ErrorInt  = (uint16_t)(u32IntType >> 16U);
+    if (DISABLE != enNewState) {
+        if (0U != u16NormalInt) {
+            SET_REG16_BIT(SDIOCx->NORINTSGEN, u16NormalInt);
+        }
+        if (0U != u16ErrorInt) {
+            SET_REG16_BIT(SDIOCx->ERRINTSGEN, u16ErrorInt);
+        }
+    } else {
+        if (0U != u16NormalInt) {
+            CLR_REG16_BIT(SDIOCx->NORINTSGEN, u16NormalInt);
+        }
+        if (0U != u16ErrorInt) {
+            CLR_REG16_BIT(SDIOCx->ERRINTSGEN, u16ErrorInt);
+        }
+    }
+}
+
+/**
+ * @brief  Get interrupt enable state.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32IntType              Normal and error interrupts source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SDIOC_INT_CINTSEN:    Card interrupt
+ *           @arg SDIOC_INT_CRMSEN:     Card Removal interrupt
+ *           @arg SDIOC_INT_CISTSEN:    Card Insertion interrupt
+ *           @arg SDIOC_INT_BRRSEN:     Buffer Read Ready interrupt
+ *           @arg SDIOC_INT_BWRSEN:     Buffer Write Ready interrupt
+ *           @arg SDIOC_INT_BGESEN:     Block Gap Event interrupt
+ *           @arg SDIOC_INT_TCSEN:      Transfer Complete interrupt
+ *           @arg SDIOC_INT_CCSEN:      Command Complete interrupt
+ *           @arg SDIOC_INT_ACESEN:     Auto CMD12 error interrupt
+ *           @arg SDIOC_INT_DEBESEN:    Data End Bit error interrupt
+ *           @arg SDIOC_INT_DCESEN:     Data CRC error interrupt
+ *           @arg SDIOC_INT_DTOESEN:    Data Timeout error interrupt
+ *           @arg SDIOC_INT_CIESEN:     Command Index error interrupt
+ *           @arg SDIOC_INT_CEBESEN:    Command End Bit error interrupt
+ *           @arg SDIOC_INT_CCESEN:     Command CRC error interrupt
+ *           @arg SDIOC_INT_CTOESEN:    Command Timeout error interrupt
+ *           @arg SDIOC_INT_ALL:        All of the above
+ *           @arg SDIOC_NORMAL_INT_ALL: All of the normal interrupt
+ *           @arg SDIOC_ERR_INT_ALL:    All of the error interrupt
+ * @retval An @ref en_functional_state_t enumeration value.
+ *           - ENABLE: The interrupt is enable
+ *           - DISABLE: The interrupt is disable
+ */
+en_functional_state_t SDIOC_GetIntEnableState(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType)
+{
+    uint16_t u16NormalInt;
+    uint16_t u16ErrorInt;
+    en_functional_state_t enIntSta = DISABLE;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_INT(u32IntType));
+
+    u16NormalInt = (uint16_t)(u32IntType & 0xFFFFU);
+    u16ErrorInt  = (uint16_t)(u32IntType >> 16U);
+    if (0U != u16NormalInt) {
+        if (0U != (READ_REG16_BIT(SDIOCx->NORINTSGEN, u16NormalInt))) {
+            enIntSta = ENABLE;
+        }
+    }
+    if ((0U != u16ErrorInt) && (enIntSta != ENABLE)) {
+        if (0U != (READ_REG16_BIT(SDIOCx->ERRINTSGEN, u16ErrorInt))) {
+            enIntSta = ENABLE;
+        }
+    }
+
+    return enIntSta;
+}
+
+/**
+ * @brief  Get interrupt flag status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Flag                 Normal and error interrupts flag
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_INT_FLAG_EI:    Error interrupt flag
+ *           @arg SDIOC_INT_FLAG_CINT:  Card interrupt flag
+ *           @arg SDIOC_INT_FLAG_CRM:   Card Removal flag
+ *           @arg SDIOC_INT_FLAG_CIST:  Card Insertion flag
+ *           @arg SDIOC_INT_FLAG_BRR:   Buffer Read Ready flag
+ *           @arg SDIOC_INT_FLAG_BWR:   Buffer Write Ready flag
+ *           @arg SDIOC_INT_FLAG_BGE:   Block Gap Event flag
+ *           @arg SDIOC_INT_FLAG_TC:    Transfer Complete flag
+ *           @arg SDIOC_INT_FLAG_CC:    Command Complete flag
+ *           @arg SDIOC_INT_FLAG_ACE:   Auto CMD12 error flag
+ *           @arg SDIOC_INT_FLAG_DEBE:  Data End Bit error flag
+ *           @arg SDIOC_INT_FLAG_DCE:   Data CRC error flag
+ *           @arg SDIOC_INT_FLAG_DTOE:  Data Timeout error flag
+ *           @arg SDIOC_INT_FLAG_CIE:   Command Index error flag
+ *           @arg SDIOC_INT_FLAG_CEBE:  Command End Bit error flag
+ *           @arg SDIOC_INT_FLAG_CCE:   Command CRC error flag
+ *           @arg SDIOC_INT_FLAG_CTOE:  Command Timeout error flag
+ *           @arg SDIOC_INT_FLAG_ALL:           All of the above
+ *           @arg SDIOC_NORMAL_INT_FLAG_ALL:    All of the normal interrupt flag
+ *           @arg SDIOC_ERR_INT_FLAG_ALL:       All of the error interrupt flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SDIOC_GetIntStatus(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+    uint16_t u16NormalFlag;
+    uint16_t u16ErrorFlag;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_GET_INT_FLAG(u32Flag));
+
+    u16NormalFlag = (uint16_t)(u32Flag & 0xFFFFU);
+    u16ErrorFlag  = (uint16_t)(u32Flag >> 16U);
+    if (0U != u16NormalFlag) {
+        if (0U != (READ_REG16_BIT(SDIOCx->NORINTST, u16NormalFlag))) {
+            enFlagSta = SET;
+        }
+    }
+    if ((0U != u16ErrorFlag) && (enFlagSta != SET)) {
+        if (0U != (READ_REG16_BIT(SDIOCx->ERRINTST, u16ErrorFlag))) {
+            enFlagSta = SET;
+        }
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear interrupt flag status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Flag                 Normal and error interrupts flag
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SDIOC_INT_FLAG_CRM:   Card Removal flag
+ *           @arg SDIOC_INT_FLAG_CIST:  Card Insertion flag
+ *           @arg SDIOC_INT_FLAG_BRR:   Buffer Read Ready flag
+ *           @arg SDIOC_INT_FLAG_BWR:   Buffer Write Ready flag
+ *           @arg SDIOC_INT_FLAG_BGE:   Block Gap Event flag
+ *           @arg SDIOC_INT_FLAG_TC:    Transfer Complete flag
+ *           @arg SDIOC_INT_FLAG_CC:    Command Complete flag
+ *           @arg SDIOC_INT_FLAG_ACE:   Auto CMD12 error flag
+ *           @arg SDIOC_INT_FLAG_DEBE:  Data End Bit error flag
+ *           @arg SDIOC_INT_FLAG_DCE:   Data CRC error flag
+ *           @arg SDIOC_INT_FLAG_DTOE:  Data Timeout error flag
+ *           @arg SDIOC_INT_FLAG_CIE:   Command Index error flag
+ *           @arg SDIOC_INT_FLAG_CEBE:  Command End Bit error flag
+ *           @arg SDIOC_INT_FLAG_CCE:   Command CRC error flag
+ *           @arg SDIOC_INT_FLAG_CTOE:  Command Timeout error flag
+ *           @arg SDIOC_INT_FLAG_CLR_ALL:   All of the above
+ * @retval None
+ */
+void SDIOC_ClearIntStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag)
+{
+    uint16_t u16NormalFlag;
+    uint16_t u16ErrorFlag;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_CLR_INT_FLAG(u32Flag));
+
+    u16NormalFlag = (uint16_t)(u32Flag & 0xFFFFU);
+    u16ErrorFlag  = (uint16_t)(u32Flag >> 16U);
+    if (0U != u16NormalFlag) {
+        WRITE_REG16(SDIOCx->NORINTST, u16NormalFlag);
+    }
+    if (0U != u16ErrorFlag) {
+        WRITE_REG16(SDIOCx->ERRINTST, u16ErrorFlag);
+    }
+}
+
+/**
+ * @brief  Enable or disable interrupt status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32IntType              Normal and error interrupts source
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SDIOC_INT_CINTSEN:    Card interrupt
+ *           @arg SDIOC_INT_CRMSEN:     Card Removal interrupt
+ *           @arg SDIOC_INT_CISTSEN:    Card Insertion interrupt
+ *           @arg SDIOC_INT_BRRSEN:     Buffer Read Ready interrupt
+ *           @arg SDIOC_INT_BWRSEN:     Buffer Write Ready interrupt
+ *           @arg SDIOC_INT_BGESEN:     Block Gap Event interrupt
+ *           @arg SDIOC_INT_TCSEN:      Transfer Complete interrupt
+ *           @arg SDIOC_INT_CCSEN:      Command Complete interrupt
+ *           @arg SDIOC_INT_ACESEN:     Auto CMD12 error interrupt
+ *           @arg SDIOC_INT_DEBESEN:    Data End Bit error interrupt
+ *           @arg SDIOC_INT_DCESEN:     Data CRC error interrupt
+ *           @arg SDIOC_INT_DTOESEN:    Data Timeout error interrupt
+ *           @arg SDIOC_INT_CIESEN:     Command Index error interrupt
+ *           @arg SDIOC_INT_CEBESEN:    Command End Bit error interrupt
+ *           @arg SDIOC_INT_CCESEN:     Command CRC error interrupt
+ *           @arg SDIOC_INT_CTOESEN:    Command Timeout error interrupt
+ *           @arg SDIOC_INT_ALL:        All of the above
+ *           @arg SDIOC_NORMAL_INT_ALL: All of the normal interrupt
+ *           @arg SDIOC_ERR_INT_ALL:    All of the error interrupt
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SDIOC_IntStatusCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint16_t u16NormalInt;
+    uint16_t u16ErrorInt;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u16NormalInt = (uint16_t)(u32IntType & 0xFFFFU);
+    u16ErrorInt  = (uint16_t)(u32IntType >> 16U);
+    if (DISABLE != enNewState) {
+        if (0U != u16NormalInt) {
+            SET_REG16_BIT(SDIOCx->NORINTSTEN, u16NormalInt);
+        }
+        if (0U != u16ErrorInt) {
+            SET_REG16_BIT(SDIOCx->ERRINTSTEN, u16ErrorInt);
+        }
+    } else {
+        if (0U != u16NormalInt) {
+            CLR_REG16_BIT(SDIOCx->NORINTSTEN, u16NormalInt);
+        }
+        if (0U != u16ErrorInt) {
+            CLR_REG16_BIT(SDIOCx->ERRINTSTEN, u16ErrorInt);
+        }
+    }
+}
+
+/**
+ * @brief  Get Host status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Flag                 Host flag
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_HOST_FLAG_CMDL:     CMD Line Level flag
+ *           @arg SDIOC_HOST_FLAG_DATL:     DAT[3:0] Line Level flag
+ *           @arg SDIOC_HOST_FLAG_DATL_D0:  DAT[0] Line Level flag
+ *           @arg SDIOC_HOST_FLAG_DATL_D1:  DAT[1] Line Level flag
+ *           @arg SDIOC_HOST_FLAG_DATL_D2:  DAT[2] Line Level flag
+ *           @arg SDIOC_HOST_FLAG_DATL_D3:  DAT[3] Line Level flag
+ *           @arg SDIOC_HOST_FLAG_WPL:      Write Protect Line Level flag
+ *           @arg SDIOC_HOST_FLAG_CDL:      Card Detect Line Level flag
+ *           @arg SDIOC_HOST_FLAG_CSS:      Device Stable flag
+ *           @arg SDIOC_HOST_FLAG_CIN:      Device Inserted flag
+ *           @arg SDIOC_HOST_FLAG_BRE:      Data buffer full flag
+ *           @arg SDIOC_HOST_FLAG_BWE:      Data buffer empty flag
+ *           @arg SDIOC_HOST_FLAG_RTA:      Read operation flag
+ *           @arg SDIOC_HOST_FLAG_WTA:      Write operation flag
+ *           @arg SDIOC_HOST_FLAG_DA:       DAT Line transfer flag
+ *           @arg SDIOC_HOST_FLAG_CID:      Command Inhibit with data flag
+ *           @arg SDIOC_HOST_FLAG_CIC:      Command Inhibit flag
+ *           @arg SDIOC_HOST_FLAG_ALL:      All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SDIOC_GetHostStatus(const CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_GET_HOST_FLAG(u32Flag));
+
+    if (0UL != (READ_REG32_BIT(SDIOCx->PSTAT, u32Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Get auto CMD12 error status.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u16Flag                 Auto CMD12 error flag
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_CMDE: Command Not Issued By Auto CMD12 error flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_IE:   Auto CMD12 Index error flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_EBE:  Auto CMD12 End Bit error flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_CE:   Auto CMD12 CRC error flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_TOE:  Auto CMD12 Timeout error flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_NE:   Auto CMD12 Not Executed flag
+ *           @arg SDIOC_AUTO_CMD_ERR_FLAG_ALL:  All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SDIOC_GetAutoCmdErrorStatus(const CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_AUTO_CMD_ERR_FLAG(u16Flag));
+
+    if (0U != (READ_REG16_BIT(SDIOCx->ATCERRST, u16Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Force the specified auto CMD12 error event.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u16Event                Auto CMD12 error event
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FCMDE:   Force Event for Command Not Issued By Auto CMD12 error
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FIE:     Force Event for Auto CMD12 Index error
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FEBE:    Force Event for Auto CMD12 End Bit error
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FCE:     Force Event for Auto CMD12 CRC error
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FTOE:    Force Event for Auto CMD12 Timeout error
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_FNE:     Force Event for Auto CMD12 Not Executed
+ *           @arg SDIOC_FORCE_AUTO_CMD_ERR_ALL:     All of the above
+ * @retval None
+ */
+void SDIOC_ForceAutoCmdErrorEvent(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Event)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_FORCE_AUTO_CMD_ERR(u16Event));
+
+    WRITE_REG16(SDIOCx->FEA, u16Event);
+}
+
+/**
+ * @brief  Force the specified error interrupt event.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u16Event                Error interrupt event
+ *         This parameter can be one or any combination the following values:
+ *           @arg SDIOC_FORCE_ERR_INT_FACE:     Force Event for Auto CMD12 error
+ *           @arg SDIOC_FORCE_ERR_INT_FDEBE:    Force Event for Data End Bit error
+ *           @arg SDIOC_FORCE_ERR_INT_FDCE:     Force Event for Data CRC error
+ *           @arg SDIOC_FORCE_ERR_INT_FDTOE:    Force Event for Data Timeout error
+ *           @arg SDIOC_FORCE_ERR_INT_FCIE:     Force Event for Command Index error
+ *           @arg SDIOC_FORCE_ERR_INT_FCEBE:    Force Event for Command End Bit error
+ *           @arg SDIOC_FORCE_ERR_INT_FCCE:     Force Event for Command CRC error
+ *           @arg SDIOC_FORCE_ERR_INT_FCTOE:    Force Event for Command Timeout error
+ *           @arg SDIOC_FORCE_ERR_INT_ALL:      All of the above
+ * @retval None
+ */
+void SDIOC_ForceErrorIntEvent(CM_SDIOC_TypeDef *SDIOCx, uint16_t u16Event)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_SDIOC_UNIT(SDIOCx));
+    DDL_ASSERT(IS_SDIOC_FORCE_ERR_INT(u16Event));
+
+    WRITE_REG16(SDIOCx->FEE, u16Event);
+}
+
+/**
+ * @brief  Send the Go Idle State command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD0_GoIdleState(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        *pu32ErrStatus                  = SDMMC_ERR_NONE;
+        stcCmdConfig.u32Argument        = 0UL;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD0_GO_IDLE_STATE;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_NO;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdError(SDIOCx);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Send CID command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD2_AllSendCID(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = 0UL;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD2_ALL_SEND_CID;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R2;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp2(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the command for asking the card to publish a new relative address(RCA).
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu16RCA                Pointer to the new RCA value
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu16RCA == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD3_SendRelativeAddr(CM_SDIOC_TypeDef *SDIOCx, uint16_t *pu16RCA, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+    uint32_t u32SdMode;
+
+    if ((NULL == pu16RCA) || (NULL == pu32ErrStatus)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = (uint32_t)(*pu16RCA) << 16U;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD3_SEND_RELATIVE_ADDR;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            u32SdMode = SDIOC_GetMode(SDIOCx);
+            if (SDIOC_MD_SD != u32SdMode) { /* MMC mode */
+                i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+            } else {
+                i32Ret = SDMMC_GetCmdResp6(SDIOCx, pu16RCA, pu32ErrStatus);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Checks switchable function and switch card function.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD6_SwitchFunc(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+    uint32_t u32SdMode;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument    = u32Argument;
+        stcCmdConfig.u16CmdIndex    = SDIOC_CMD6_SWITCH_FUNC;
+        stcCmdConfig.u16CmdType     = SDIOC_CMD_TYPE_NORMAL;
+        u32SdMode                   = SDIOC_GetMode(SDIOCx);
+        if (SDIOC_MD_SD != u32SdMode) { /* MMC mode */
+            stcCmdConfig.u16DataLine      = SDIOC_DATA_LINE_DISABLE;
+            stcCmdConfig.u16ResponseType  = SDIOC_RESP_TYPE_R1B_R5B;
+        } else {
+            stcCmdConfig.u16DataLine      = SDIOC_DATA_LINE_ENABLE;
+            stcCmdConfig.u16ResponseType  = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        }
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            if (SDIOC_MD_SD != u32SdMode) { /* MMC mode */
+                i32Ret = SDMMC_GetCmdResp1Busy(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+            } else {
+                i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Select Deselect command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32RCA                  Relative Card Address(RCA)
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD7_SelectDeselectCard(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32RCA;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD7_SELECT_DESELECT_CARD;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1B_R5B;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1Busy(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Interface Condition command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD8_SendInterfaceCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+    uint32_t u32SdMode;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Argument: - [31:12]: Reserved (shall be set to '0')
+        - [11:8]: Supply Voltage (VHS) 0x1 (Range: 2.7-3.6 V)
+        - [7:0]: Check Pattern (recommended 0xAA) */
+        stcCmdConfig.u32Argument        = SDMMC_CMD8_CHECK_PATTERN;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD8_SEND_IF_COND;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        u32SdMode                       = SDIOC_GetMode(SDIOCx);
+        if (SDIOC_MD_SD != u32SdMode) { /* MMC mode */
+            stcCmdConfig.u16DataLine    = SDIOC_DATA_LINE_ENABLE;
+        } else {
+            stcCmdConfig.u16DataLine    = SDIOC_DATA_LINE_DISABLE;
+        }
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            if (SDIOC_MD_SD != u32SdMode) { /* MMC mode */
+                i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+            } else {
+                i32Ret = SDMMC_GetCmdResp7(SDIOCx, pu32ErrStatus);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Send CSD command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32RCA                  Relative Card Address(RCA)
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD9_SendCSD(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32RCA;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD9_SEND_CSD;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R2;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp2(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Stop Transfer command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD12_StopTrans(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = 0UL;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD12_STOP_TRANSMISSION;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1B_R5B;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1Busy(SDIOCx, SDMMC_CMD_TIMEOUT * 1000UL, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Status command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32RCA                  Relative Card Address(RCA)
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD13_SendStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32RCA, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32RCA;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD13_SEND_STATUS;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Data Block Length command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32BlockLen             Block length
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD16_SetBlockLength(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32BlockLen, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32BlockLen;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD16_SET_BLOCKLEN;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Read Single Block command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32ReadAddr             Data address
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD17_ReadSingleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32ReadAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32ReadAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD17_READ_SINGLE_BLOCK;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Read Multi Block command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32ReadAddr             Data address
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD18_ReadMultipleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32ReadAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32ReadAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD18_READ_MULTI_BLOCK;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Write Single Block command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32WriteAddr            Data address
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD24_WriteSingleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32WriteAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32WriteAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD24_WRITE_SINGLE_BLOCK;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Write Multi Block command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32WriteAddr            Data address
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD25_WriteMultipleBlock(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32WriteAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32WriteAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD25_WRITE_MULTI_BLOCK;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Start Address Erase command for SD and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32StartAddr            The start address will be erased
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD32_EraseBlockStartAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32StartAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32StartAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD32_ERASE_WR_BLK_START;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the End Address Erase command for SD and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32EndAddr              The end address will be erased
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD33_EraseBlockEndAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32EndAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32EndAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD33_ERASE_WR_BLK_END;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Erase command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD38_Erase(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32Argument;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD38_ERASE;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1B_R5B;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1Busy(SDIOCx, SDMMC_MAX_ERASE_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Application command to verify that that the next command
+ *         is an application specific command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD55_AppCmd(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32Argument;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD55_APP_CMD;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Bus Width command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32BusWidth             The data bus width
+ *         This parameter can be one of the following values:
+ *           @arg SDMMC_SCR_BUS_WIDTH_1BIT: 1 bit bus
+ *           @arg SDMMC_SCR_BUS_WIDTH_4BIT: 4 bits bus
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_ACMD6_SetBusWidth(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32BusWidth, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32BusWidth;
+        stcCmdConfig.u16CmdIndex        = SDIOC_ACMD6_SET_BUS_WIDTH;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Status register command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_ACMD13_SendStatus(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = 0UL;
+        stcCmdConfig.u16CmdIndex        = SDIOC_ACMD13_SD_STATUS;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the command asking the accessed card to send its operating condition register(OCR).
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_ACMD41_SendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32Argument | SDMMC_ACMD41_VOLT_WIN;
+        stcCmdConfig.u16CmdIndex        = SDIOC_ACMD41_SD_APP_OP_COND;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R3_R4;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp3(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Send SCR command and check the response.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_ACMD51_SendSCR(CM_SDIOC_TypeDef *SDIOCx, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = 0UL;
+        stcCmdConfig.u16CmdIndex        = SDIOC_ACMD51_SEND_SCR;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Sends host capacity support information command.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD1_SendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32Argument;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD1_SEND_OP_COND;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R3_R4;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp3(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the Start Address Erase command and check the response
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32StartAddr            The start address will be erased
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD35_EraseGroupStartAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32StartAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32StartAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD35_ERASE_GROUP_START;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the End Address Erase command and check the response
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32EndAddr              The end address will be erased
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD36_EraseGroupEndAddr(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32EndAddr, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32EndAddr;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD36_ERASE_GROUP_END;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp1(SDIOCx, SDMMC_CMD_TIMEOUT, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the IO_SEND_OP_COND command for inquiring about the voltage range needed by the I/O card.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] u32Argument             Argument used for the command.
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD5_IOSendOperateCond(CM_SDIOC_TypeDef *SDIOCx, uint32_t u32Argument, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if (NULL == pu32ErrStatus) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        stcCmdConfig.u32Argument        = u32Argument;
+        stcCmdConfig.u16CmdIndex        = SDIOC_CMD5_IO_SEND_OP_COND;
+        stcCmdConfig.u16CmdType         = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine        = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType    = SDIOC_RESP_TYPE_R3_R4;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        /* Check for error conditions */
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp4(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the IO_RW_DIRECT command to access a single I/O register.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] pstcCmdArg              Pointer to a @ref stc_sdio_cmd52_arg_t structure
+ * @param  [in] u8In                    Data to write
+ * @param  [out] pu8Out                 Pointer to buffer to store command response
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error or response(R5) indicate error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pstcCmdArg == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD52_IORwDirect(CM_SDIOC_TypeDef *SDIOCx, const stc_sdio_cmd52_arg_t *pstcCmdArg,
+                               uint8_t u8In, uint8_t *pu8Out, uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    uint32_t u32Arg;
+    uint32_t u32R5;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if ((NULL == pstcCmdArg) || (NULL == pu32ErrStatus)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Command arguments */
+        u32Arg = 0UL;
+        u32Arg |= pstcCmdArg->u32RwFlag;
+        u32Arg |= ((uint32_t)pstcCmdArg->u8FuncNum << SDIO_CMD52_ARG_FUNC_SHIFT);
+        u32Arg |= (pstcCmdArg->u32RegAddr << SDIO_CMD52_ARG_REG_ADDR_SHIFT);
+        u32Arg |= pstcCmdArg->u32RawFlag;
+        u32Arg |= u8In;
+
+        stcCmdConfig.u32Argument     = u32Arg;
+        stcCmdConfig.u16CmdIndex     = SDIOC_CMD52_IO_RW_DIRECT;
+        stcCmdConfig.u16CmdType      = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine     = SDIOC_DATA_LINE_DISABLE;
+        stcCmdConfig.u16ResponseType = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp5(SDIOCx, pu32ErrStatus);
+            if (LL_OK == i32Ret) {
+                (void)SDIOC_GetResponse(SDIOCx, SDIOC_RESP_REG_BIT0_31, &u32R5);
+                if (NULL != pu8Out) {
+                    *pu8Out = (uint8_t)(u32R5 & 0x000000FFUL);
+                }
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Send the IO_RW_EXTENDED command to access a large number of I/O registers.
+ * @param  [in] SDIOCx                  Pointer to SDIOC unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_SDIOC1:            SDIOC unit 1 instance
+ *           @arg CM_SDIOC2:            SDIOC unit 2 instance
+ * @param  [in] pstcCmdArg              Pointer to a @ref stc_sdio_cmd53_arg_t structure
+ * @param  [out] pu32ErrStatus          Pointer to the error state value
+ * @retval int32_t:
+ *           - LL_OK: Command send completed
+ *           - LL_ERR: Refer to pu32ErrStatus for the reason of error or response(R5) indicate error
+ *           - LL_ERR_INVD_PARAM: SDIOCx == NULL or pstcCmdArg == NULL or pu32ErrStatus == NULL
+ *           - LL_ERR_TIMEOUT: Wait timeout
+ */
+int32_t SDMMC_CMD53_IORwExtended(CM_SDIOC_TypeDef *SDIOCx, const stc_sdio_cmd53_arg_t *pstcCmdArg,
+                                 uint32_t *pu32ErrStatus)
+{
+    int32_t i32Ret;
+    uint32_t u32Arg;
+    stc_sdioc_cmd_config_t stcCmdConfig;
+
+    if ((NULL == pstcCmdArg) || (NULL == pu32ErrStatus)) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Command arguments */
+        u32Arg = 0UL;
+        u32Arg |= pstcCmdArg->u32RwFlag;
+        u32Arg |= ((uint32_t)pstcCmdArg->u8FuncNum << SDIO_CMD53_ARG_FUNC_SHIFT);
+        u32Arg |= pstcCmdArg->u32BlockMode;
+        u32Arg |= pstcCmdArg->u32OperateCode;
+        u32Arg |= (pstcCmdArg->u32RegAddr << SDIO_CMD53_ARG_REG_ADDR_SHIFT);
+
+        stcCmdConfig.u32Argument     = u32Arg;
+        stcCmdConfig.u16CmdIndex     = SDIOC_CMD53_IO_RW_EXTENDED;
+        stcCmdConfig.u16CmdType      = SDIOC_CMD_TYPE_NORMAL;
+        stcCmdConfig.u16DataLine     = SDIOC_DATA_LINE_ENABLE;
+        stcCmdConfig.u16ResponseType = SDIOC_RESP_TYPE_R1_R5_R6_R7;
+        i32Ret = SDIOC_SendCommand(SDIOCx, &stcCmdConfig);
+        if (LL_OK == i32Ret) {
+            i32Ret = SDMMC_GetCmdResp5(SDIOCx, pu32ErrStatus);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_SDIOC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_smc.c
+++ b/hc32f4a2/src/hc32_ll_smc.c
@@ -1,0 +1,545 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_smc.c
+ * @brief This file provides firmware functions to manage the EXMC_SMC
+ *        (External Memory Controller: Static Memory Controller).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Modify EXMC_SMC_StructInit, EXMC_SMC_Init, EXMC_SMC_GetChipConfig
+                                    Delete function comments: EXMC_SMC_Chipx
+   2023-06-30       CDT             Function EXMC_SMC_DeInit add return value
+   2024-06-30       CDT             Update macro: EXMC_SMC_READ_BURST_CONTINUOUS -> EXMC_SMC_READ_BURST_INFINITE
+                                    Update macro: EXMC_SMC_WRITE_BURST_CONTINUOUS -> EXMC_SMC_WRITE_BURST_INFINITE
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_smc.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_EXMC EXMC
+ * @brief External Memory Controller Driver Library
+ * @{
+ */
+
+/**
+ * @defgroup LL_SMC SMC
+ * @brief Static Memory Controller Driver Library
+ * @{
+ */
+
+#if (LL_SMC_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_SMC_Local_Macros EXMC_SMC Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup EXMC_SMC_Check_Parameters_Validity EXMC_SMC Check Parameters Validity
+ * @{
+ */
+
+#define IS_EXMC_SMC_MEMORY_WIDTH(x)                                            \
+(   ((x) == EXMC_SMC_MEMORY_WIDTH_16BIT)        ||                             \
+    ((x) == EXMC_SMC_MEMORY_WIDTH_32BIT))
+
+#define IS_EXMC_SMC_READ_MD(x)                                                 \
+(   ((x) == EXMC_SMC_READ_SYNC)                 ||                             \
+    ((x) == EXMC_SMC_READ_ASYNC))
+
+#define IS_EXMC_SMC_WRITE_MD(x)                                                \
+(   ((x) == EXMC_SMC_WRITE_SYNC)                ||                             \
+    ((x) == EXMC_SMC_WRITE_ASYNC))
+
+#define IS_EXMC_SMC_CHIP(x)                                                    \
+(   ((x) == EXMC_SMC_CHIP0)                     ||                             \
+    ((x) == EXMC_SMC_CHIP1)                     ||                             \
+    ((x) == EXMC_SMC_CHIP2)                     ||                             \
+    ((x) == EXMC_SMC_CHIP3))
+
+#define IS_EXMC_SMC_READ_BURST(x)                                              \
+(   ((x) == EXMC_SMC_READ_BURST_1BEAT)          ||                             \
+    ((x) == EXMC_SMC_READ_BURST_4BEAT)          ||                             \
+    ((x) == EXMC_SMC_READ_BURST_8BEAT)          ||                             \
+    ((x) == EXMC_SMC_READ_BURST_16BEAT)         ||                             \
+    ((x) == EXMC_SMC_READ_BURST_32BEAT)         ||                             \
+    ((x) == EXMC_SMC_READ_BURST_INFINITE))
+
+#define IS_EXMC_SMC_WRITE_BURST(x)                                             \
+(   ((x) == EXMC_SMC_WRITE_BURST_1BEAT)         ||                             \
+    ((x) == EXMC_SMC_WRITE_BURST_4BEAT)         ||                             \
+    ((x) == EXMC_SMC_WRITE_BURST_8BEAT)         ||                             \
+    ((x) == EXMC_SMC_WRITE_BURST_16BEAT)        ||                             \
+    ((x) == EXMC_SMC_WRITE_BURST_32BEAT)        ||                             \
+    ((x) == EXMC_SMC_WRITE_BURST_INFINITE))
+
+#define IS_EXMC_SMC_BLS_SYNC(x)                                                \
+(   ((x) == EXMC_SMC_BLS_SYNC_CS)               ||                             \
+    ((x) == EXMC_SMC_BLS_SYNC_WE))
+
+#define IS_EXMC_SMC_BAA_PORT(x)                                                \
+(   ((x) == EXMC_SMC_BAA_PORT_DISABLE)          ||                             \
+    ((x) == EXMC_SMC_BAA_PORT_ENABLE))
+
+#define IS_EXMC_SMC_ADV_PORT(x)                                                \
+(   ((x) == EXMC_SMC_ADV_PORT_DISABLE)          ||                             \
+    ((x) == EXMC_SMC_ADV_PORT_ENABLE))
+
+#define IS_EXMC_SMC_CMD(x)                                                     \
+(   ((x) == EXMC_SMC_CMD_MDREGCONFIG)           ||                             \
+    ((x) == EXMC_SMC_CMD_UPDATEREGS)            ||                             \
+    ((x) == EXMC_SMC_CMD_MDREGCONFIG_AND_UPDATEREGS))
+
+#define IS_EXMC_SMC_CRE_POLARITY(x)                                            \
+(   ((x) == EXMC_SMC_CRE_POLARITY_LOW)          ||                             \
+    ((x) == EXMC_SMC_CRE_POLARITY_HIGH))
+
+#define IS_EXMC_SMC_SAMPLE_CLK(x)                                              \
+(   ((x) == EXMC_SMC_SAMPLE_CLK_INTERNCLK)      ||                             \
+    ((x) == EXMC_SMC_SAMPLE_CLK_INTERNCLK_INVT) ||                             \
+    ((x) == EXMC_SMC_SAMPLE_CLK_EXTCLK))
+
+#define IS_EXMC_SMC_MAP_ADDR(match, msk)                                       \
+(   (EXMC_SMC_MAP_ADDR((match), (msk)) >= EXMC_SMC_ADDR_MIN) &&                \
+    (EXMC_SMC_MAP_ADDR((match), (msk)) <= EXMC_SMC_ADDR_MAX))
+
+#define IS_EXMC_SMC_REFRESH_PERIOD(x)           ((x) <= (uint8_t)SMC_RFTR_REFPRD)
+
+#define IS_EXMC_SMC_CMD_ADDR(x)                 ((x) <= 0xFFFFFUL)
+
+#define IS_EXMC_SMC_TIMING_RC_CYCLE(x)          ((x) <= 0x0FUL)
+
+#define IS_EXMC_SMC_TIMING_WC_CYCLE(x)          ((x) <= 0x0FUL)
+
+#define IS_EXMC_SMC_TIMING_CEOE_CYCLE(x)        ((x) <= 7UL)
+
+#define IS_EXMC_SMC_TIMING_WP_CYCLE(x)          ((x) <= 7UL)
+
+#define IS_EXMC_SMC_TIMING_PC_CYCLE(x)          ((x) <= 7UL)
+
+#define IS_EXMC_SMC_TIMING_TR_CYCLE(x)          ((x) <= 7UL)
+
+/**
+ * @}
+ */
+
+/* EXMC_SMC map address */
+#define EXMC_SMC_MAP_ADDR(MATCH, MSK)   ((~((MATCH) ^ (MSK))) << 24U)
+
+/**
+ * @defgroup EXMC_SMC_Register EXMC_SMC Register
+ * @{
+ */
+#define EXMC_SMC_CPSRx(__CHIPx__)       ((__IO uint32_t *)(((uint32_t)(&CM_SMC->CPSR0))  + (0x20UL * (__CHIPx__))))
+#define EXMC_SMC_TMSRx(__CHIPx__)       ((__IO uint32_t *)(((uint32_t)(&CM_SMC->TMSR0))  + (0x20UL * (__CHIPx__))))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Register_Bit_Mask EXMC_SMC Register Bit Mask
+ * @{
+ */
+#define SMC_CSCR0_ADDMSKx_POS(__CHIPx__)    (((__CHIPx__) & 0x03UL) << 3U)
+#define SMC_CSCR0_ADDMSKx(__CHIPx__)        (SMC_CSCR0_ADDMSK0 << SMC_CSCR0_ADDMSKx_POS((__CHIPx__)))
+
+#define SMC_CSCR1_ADDMATx_POS(__CHIPx__)    (((__CHIPx__) & 0x03UL) << 3U)
+#define SMC_CSCR1_ADDMATx(__CHIPx__)        (SMC_CSCR1_ADDMAT0 << SMC_CSCR1_ADDMATx_POS((__CHIPx__)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup EXMC_SMC_Register_Reset_Value EXMC_SMC Register Reset Value
+ * @{
+ */
+#define EXMC_SMC_BACR_RST_VALUE             (0x00000300UL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup EXMC_SMC_Global_Functions EXMC_SMC Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure @ref stc_exmc_smc_init_t to default values
+ * @param  [out] pstcSmcInit            Pointer to a @ref stc_exmc_smc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcSmcInit value is NULL.
+ */
+int32_t EXMC_SMC_StructInit(stc_exmc_smc_init_t *pstcSmcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSmcInit) {
+        pstcSmcInit->stcChipConfig.u32ReadMode = EXMC_SMC_READ_ASYNC;
+        pstcSmcInit->stcChipConfig.u32WriteMode = EXMC_SMC_WRITE_ASYNC;
+        pstcSmcInit->stcChipConfig.u32ReadBurstLen = EXMC_SMC_READ_BURST_1BEAT;
+        pstcSmcInit->stcChipConfig.u32WriteBurstLen = EXMC_SMC_WRITE_BURST_1BEAT;
+        pstcSmcInit->stcChipConfig.u32MemoryWidth = EXMC_SMC_MEMORY_WIDTH_16BIT;
+        pstcSmcInit->stcChipConfig.u32BAA = EXMC_SMC_BAA_PORT_DISABLE;
+        pstcSmcInit->stcChipConfig.u32ADV = EXMC_SMC_ADV_PORT_DISABLE;
+        pstcSmcInit->stcChipConfig.u32BLS = EXMC_SMC_BLS_SYNC_CS;
+        pstcSmcInit->stcChipConfig.u32AddrMask = 0xF8UL;        /* Address space 128M: 0x60000000 ~ 0x67FFFFFF */
+        pstcSmcInit->stcChipConfig.u32AddrMatch = 0x60UL;
+
+        pstcSmcInit->stcTimingConfig.u8RC = 7U;
+        pstcSmcInit->stcTimingConfig.u8WC = 7U;
+        pstcSmcInit->stcTimingConfig.u8CEOE = 1U;
+        pstcSmcInit->stcTimingConfig.u8WP = 5U;
+        pstcSmcInit->stcTimingConfig.u8PC = 0U;
+        pstcSmcInit->stcTimingConfig.u8TR = 0U;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize EXMC_SMC function.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @param  [in] pstcSmcInit             Pointer to a @ref stc_exmc_smc_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcSmcInit value is NULL.
+ */
+int32_t EXMC_SMC_Init(uint32_t u32Chip, const stc_exmc_smc_init_t *pstcSmcInit)
+{
+    uint32_t u32TMCR;
+    uint32_t u32CPCR;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSmcInit) {
+        DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+        DDL_ASSERT(IS_EXMC_SMC_READ_MD(pstcSmcInit->stcChipConfig.u32ReadMode));
+        DDL_ASSERT(IS_EXMC_SMC_WRITE_MD(pstcSmcInit->stcChipConfig.u32WriteMode));
+        DDL_ASSERT(IS_EXMC_SMC_READ_BURST(pstcSmcInit->stcChipConfig.u32ReadBurstLen));
+        DDL_ASSERT(IS_EXMC_SMC_WRITE_BURST(pstcSmcInit->stcChipConfig.u32WriteBurstLen));
+        DDL_ASSERT(IS_EXMC_SMC_MEMORY_WIDTH(pstcSmcInit->stcChipConfig.u32MemoryWidth));
+        DDL_ASSERT(IS_EXMC_SMC_BAA_PORT(pstcSmcInit->stcChipConfig.u32BAA));
+        DDL_ASSERT(IS_EXMC_SMC_ADV_PORT(pstcSmcInit->stcChipConfig.u32ADV));
+        DDL_ASSERT(IS_EXMC_SMC_BLS_SYNC(pstcSmcInit->stcChipConfig.u32BLS));
+        DDL_ASSERT(IS_EXMC_SMC_MAP_ADDR(pstcSmcInit->stcChipConfig.u32AddrMatch, pstcSmcInit->stcChipConfig.u32AddrMask));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_RC_CYCLE(pstcSmcInit->stcTimingConfig.u8RC));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_WC_CYCLE(pstcSmcInit->stcTimingConfig.u8WC));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_CEOE_CYCLE(pstcSmcInit->stcTimingConfig.u8CEOE));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_WP_CYCLE(pstcSmcInit->stcTimingConfig.u8WP));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_PC_CYCLE(pstcSmcInit->stcTimingConfig.u8PC));
+        DDL_ASSERT(IS_EXMC_SMC_TIMING_TR_CYCLE(pstcSmcInit->stcTimingConfig.u8TR));
+
+        u32TMCR = (((uint32_t)pstcSmcInit->stcTimingConfig.u8RC << SMC_TMCR_T_RC_POS) | \
+                   ((uint32_t)pstcSmcInit->stcTimingConfig.u8WC << SMC_TMCR_T_WC_POS) | \
+                   ((uint32_t)pstcSmcInit->stcTimingConfig.u8CEOE << SMC_TMCR_T_CEOE_POS) | \
+                   ((uint32_t)pstcSmcInit->stcTimingConfig.u8WP << SMC_TMCR_T_WP_POS) | \
+                   ((uint32_t)pstcSmcInit->stcTimingConfig.u8PC << SMC_TMCR_T_PC_POS) | \
+                   ((uint32_t)pstcSmcInit->stcTimingConfig.u8TR << SMC_TMCR_T_TR_POS));
+        u32CPCR = (pstcSmcInit->stcChipConfig.u32ReadMode | \
+                   pstcSmcInit->stcChipConfig.u32ReadBurstLen | \
+                   pstcSmcInit->stcChipConfig.u32WriteMode | \
+                   pstcSmcInit->stcChipConfig.u32WriteBurstLen | \
+                   pstcSmcInit->stcChipConfig.u32MemoryWidth | \
+                   pstcSmcInit->stcChipConfig.u32BAA | \
+                   pstcSmcInit->stcChipConfig.u32ADV | \
+                   pstcSmcInit->stcChipConfig.u32BLS);
+        WRITE_REG32(CM_SMC->TMCR, u32TMCR); /* Set SMC timing.*/
+        WRITE_REG32(CM_SMC->CPCR, u32CPCR); /* Set SMC chip configuration.*/
+
+        /* Set chip selection address match/mask space for SMC.*/
+        MODIFY_REG32(CM_SMC->CSCR0, SMC_CSCR0_ADDMSKx(u32Chip), \
+                     (pstcSmcInit->stcChipConfig.u32AddrMask << SMC_CSCR0_ADDMSKx_POS(u32Chip)));
+        MODIFY_REG32(CM_SMC->CSCR1,  SMC_CSCR1_ADDMATx(u32Chip), \
+                     (pstcSmcInit->stcChipConfig.u32AddrMatch << SMC_CSCR1_ADDMATx_POS(u32Chip)));
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize EXMC_SMC function.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t EXMC_SMC_DeInit(void)
+{
+    int32_t i32Ret = LL_OK;
+
+    /* Disable SMC */
+    CLR_REG32_BIT(CM_PERIC->SMC_ENAR, PERIC_SMC_ENAR_SMCEN);
+
+    /* Set register CSCR0/CSCR1 to reset value.*/
+    WRITE_REG32(CM_SMC->CSCR0, 0xFFFFFFFFUL);
+    WRITE_REG32(CM_SMC->CSCR1, 0x00000000UL);
+
+    /* Set register RFTR to reset value.*/
+    WRITE_REG32(CM_SMC->RFTR, 0x00000000UL);
+
+    /* Set register BACR to reset value.*/
+    WRITE_REG32(CM_SMC->BACR, EXMC_SMC_BACR_RST_VALUE);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable/Disable SMC.
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_SMC_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_PERIC->SMC_ENAR, PERIC_SMC_ENAR_SMCEN);
+    } else {
+        CLR_REG32_BIT(CM_PERIC->SMC_ENAR, PERIC_SMC_ENAR_SMCEN);
+    }
+}
+
+/**
+ * @brief  Enable or disable SMC pin mux.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void EXMC_SMC_PinMuxCmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_SMC->BACR, SMC_BACR_MUXMD);
+    } else {
+        CLR_REG32_BIT(CM_SMC->BACR, SMC_BACR_MUXMD);
+    }
+}
+
+/**
+ * @brief  Set SMC sample clock.
+ * @param  [in] u32SampleClock          Sample clock
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Command
+ *           @arg EXMC_SMC_SAMPLE_CLK_INTERNCLK:      Internal EXCLK
+ *           @arg EXMC_SMC_SAMPLE_CLK_INTERNCLK_INVT: Invert internal EXCLK
+ *           @arg EXMC_SMC_SAMPLE_CLK_EXTCLK:         External clock from EXMC_CLK port
+ * @retval None
+ */
+void EXMC_SMC_SetSampleClock(uint32_t u32SampleClock)
+{
+    DDL_ASSERT(IS_EXMC_SMC_SAMPLE_CLK(u32SampleClock));
+
+    MODIFY_REG32(CM_SMC->BACR, SMC_BACR_CKSEL, u32SampleClock);
+}
+
+/**
+ * @brief  Set SMC refresh period value
+ * @param  [in] u8PeriodVal             The SMC refresh period value
+ *           @arg This parameter can be a value between Min_Data = 0 and Max_Data = 0x0F
+ * @retval None
+ */
+void EXMC_SMC_SetRefreshPeriod(uint8_t u8PeriodVal)
+{
+    DDL_ASSERT(IS_EXMC_SMC_REFRESH_PERIOD(u8PeriodVal));
+
+    WRITE_REG32(CM_SMC->RFTR, u8PeriodVal);
+}
+
+/**
+ * @brief  Set EXMC_SMC command.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @param  [in] u32Cmd                  The command.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Command
+ *           @arg EXMC_SMC_CMD_MDREGCONFIG: Configure mode register
+ *           @arg EXMC_SMC_CMD_UPDATEREGS:  Update mode register
+ *           @arg EXMC_SMC_CMD_MDREGCONFIG_AND_UPDATEREGS: Configure mode register and update
+ * @param  [in] u32CrePolarity          The command.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_CRE_Polarity
+ *           @arg EXMC_SMC_CRE_POLARITY_LOW:  CRE is LOW
+ *           @arg EXMC_SMC_CRE_POLARITY_HIGH: CRE is HIGH when ModeReg write occurs
+ * @param  [in] u32Addr                 The address parameter is valid when CMD type is MdRegConfig or MdRegConfig
+ *                                      and UpdateRegs only.
+ * @retval None
+ */
+void EXMC_SMC_SetCommand(uint32_t u32Chip, uint32_t u32Cmd, uint32_t u32CrePolarity, uint32_t u32Addr)
+{
+    uint32_t u32SmcCmdr;
+
+    DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+    DDL_ASSERT(IS_EXMC_SMC_CMD(u32Cmd));
+    DDL_ASSERT(IS_EXMC_SMC_CRE_POLARITY(u32CrePolarity));
+    DDL_ASSERT(IS_EXMC_SMC_CMD_ADDR(u32Addr));
+
+    /* Set SMC_CMDR register for SMC.*/
+    u32SmcCmdr = (u32Addr | u32CrePolarity | u32Cmd | (u32Chip << SMC_CMDR_CMDCHIP_POS));
+    WRITE_REG32(CM_SMC->CMDR, u32SmcCmdr);
+}
+
+/**
+ * @brief  Get the start address of the specified SMC chip.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @retval The start address of the specified SMC chip.
+ */
+uint32_t EXMC_SMC_GetChipStartAddr(uint32_t u32Chip)
+{
+    uint32_t u32Match;
+
+    DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+
+    u32Match = READ_REG32_BIT(CM_SMC->CSCR1, SMC_CSCR1_ADDMATx(u32Chip)) >> SMC_CSCR1_ADDMATx_POS(u32Chip);
+    return (u32Match << 24U);
+}
+
+/**
+ * @brief  Get the end address of the specified SMC chip.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @retval The end address of the specified SMC chip
+ */
+uint32_t EXMC_SMC_GetChipEndAddr(uint32_t u32Chip)
+{
+    uint32_t u32Mask;
+    uint32_t u32Match;
+
+    DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+
+    u32Mask = (READ_REG32_BIT(CM_SMC->CSCR0, SMC_CSCR0_ADDMSKx(u32Chip)) >> SMC_CSCR0_ADDMSKx_POS(u32Chip));
+    u32Match = (READ_REG32_BIT(CM_SMC->CSCR1, SMC_CSCR1_ADDMATx(u32Chip)) >> SMC_CSCR1_ADDMATx_POS(u32Chip));
+
+    return (~((u32Match ^ u32Mask) << 24U));
+}
+
+/**
+ * @brief  Get SMC chip configure.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @param  [in] pstcChipConfig          Pointer to a @ref stc_exmc_smc_chip_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Get successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcChipConfig value is NULL.
+ */
+int32_t EXMC_SMC_GetChipConfig(uint32_t u32Chip, stc_exmc_smc_chip_config_t *pstcChipConfig)
+{
+    __IO uint32_t *SMC_CPSRx;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcChipConfig) {
+        DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+
+        SMC_CPSRx = EXMC_SMC_CPSRx(u32Chip);
+        pstcChipConfig->u32ReadMode = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_RSYN);
+        pstcChipConfig->u32WriteMode = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_WSYN);
+        pstcChipConfig->u32ReadBurstLen = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_RBL);
+        pstcChipConfig->u32WriteBurstLen = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_WBL);
+        pstcChipConfig->u32MemoryWidth = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_MW);
+        pstcChipConfig->u32BAA = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_BAAS);
+        pstcChipConfig->u32ADV = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_ADVS);
+        pstcChipConfig->u32BLS = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_BLSS);
+        pstcChipConfig->u32AddrMask = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_ADDMSK) >> SMC_CPSR_ADDMSK_POS;
+        pstcChipConfig->u32AddrMatch = READ_REG32_BIT(*SMC_CPSRx, SMC_CPSR_ADDMAT) >> SMC_CPSR_ADDMAT_POS;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Get SMC timing configure.
+ * @param  [in] u32Chip                 The chip number.
+ *         This parameter can be one of the macros group @ref EXMC_SMC_Chip
+ * @param  [in] pstcTimingConfig        Pointer to a @ref stc_exmc_smc_timing_config_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Get successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTimingConfig value is NULL.
+ */
+int32_t EXMC_SMC_GetTimingConfig(uint32_t u32Chip, stc_exmc_smc_timing_config_t *pstcTimingConfig)
+{
+    __IO uint32_t *SMC_TMSRx;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTimingConfig) {
+        DDL_ASSERT(IS_EXMC_SMC_CHIP(u32Chip));
+
+        SMC_TMSRx = EXMC_SMC_TMSRx(u32Chip);
+        pstcTimingConfig->u8RC = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_RC) >> SMC_TMCR_T_RC_POS);
+        pstcTimingConfig->u8WC = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_WC) >> SMC_TMCR_T_WC_POS);
+        pstcTimingConfig->u8CEOE = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_CEOE) >> SMC_TMCR_T_CEOE_POS);
+        pstcTimingConfig->u8WP = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_WP) >> SMC_TMCR_T_WP_POS);
+        pstcTimingConfig->u8PC = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_PC) >> SMC_TMCR_T_PC_POS);
+        pstcTimingConfig->u8TR = (uint8_t)(READ_REG32_BIT(*SMC_TMSRx, SMC_TMCR_T_TR) >> SMC_TMCR_T_TR_POS);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_SMC_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_spi.c
+++ b/hc32f4a2/src/hc32_ll_spi.c
@@ -1,0 +1,1016 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_spi.c
+ * @brief This file provides firmware functions to manage the Serial Peripheral
+ *        Interface(SPI).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-01-15       CDT             Add frame level processing for API SPI_TxRx(),SPI_Tx()
+   2023-06-30       CDT             Modify SPI_GetStatus,SPI_TxRx,SPI_Tx function
+                                    Add SPI_SetSckPolarity,SPI_SetSckPhase functions
+                                    Modify return type of function SPI_DeInit
+   2023-12-15       CDT             Modify some assert
+                                    Rename some API SPI_xxxConfig as SPI_Setxxx
+                                    Refine API SPI_Init()
+                                    Add Send restriction in SPI_TxRx function
+   2024-06-30       CDT             Modify SPI_DeInit,SPI_ClearStatus for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_spi.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_SPI SPI
+ * @brief Serial Peripheral Interface Driver Library
+ * @{
+ */
+
+#if (LL_SPI_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SPI_Local_Macros SPI Local Macros
+ * @{
+ */
+#define SPI_CFG1_DEFAULT        (0x00000010UL)
+#define SPI_CFG2_DEFAULT        (0x00000F1DUL)
+
+#define SPI_SS0_VALID_CFG       (0UL)
+#define SPI_SS1_VALID_CFG       (SPI_CFG2_SSA_0)
+#define SPI_SS2_VALID_CFG       (SPI_CFG2_SSA_1)
+#define SPI_SS3_VALID_CFG       (SPI_CFG2_SSA_0 | SPI_CFG2_SSA_1)
+
+/**
+ * @defgroup SPI_Check_Parameters_Validity SPI Check Parameters Validity
+ * @{
+ */
+
+/*! Parameter valid check for SPI peripheral */
+#define IS_SPI_UNIT(x)                                                         \
+(   ((x) == CM_SPI1)                        ||                                 \
+    ((x) == CM_SPI2)                        ||                                 \
+    ((x) == CM_SPI3)                        ||                                 \
+    ((x) == CM_SPI4)                        ||                                 \
+    ((x) == CM_SPI5)                        ||                                 \
+    ((x) == CM_SPI6))
+
+/*! Parameter valid check for SPI wire mode */
+#define IS_SPI_WIRE_MD(x)                                                      \
+(   ((x) == SPI_4_WIRE)                     ||                                 \
+    ((x) == SPI_3_WIRE))
+
+/*! Parameter valid check for SPI transfer mode */
+#define IS_SPI_TRANS_MD(x)                                                     \
+(   ((x) == SPI_FULL_DUPLEX)                ||                                 \
+    ((x) == SPI_SEND_ONLY))
+
+/*! Parameter valid check for SPI master slave mode */
+#define IS_SPI_MASTER_SLAVE(x)                                                 \
+(   ((x) == SPI_SLAVE)                      ||                                 \
+    ((x) == SPI_MASTER))
+
+/*! Parameter valid check for SPI loopback mode */
+#define IS_SPI_SPLPBK(x)                                                       \
+(   ((x) == SPI_LOOPBACK_INVD)              ||                                 \
+    ((x) == SPI_LOOPBACK_MOSI_INVT)         ||                                 \
+    ((x) == SPI_LOOPBACK_MOSI))
+
+/*! Parameter valid check for SPI communication suspend function status */
+#define IS_SPI_SUSPD_MD_STAT(x)                                                \
+(   ((x) == SPI_COM_SUSP_FUNC_OFF)          ||                                 \
+    ((x) == SPI_COM_SUSP_FUNC_ON))
+
+/*! Parameter valid check for SPI data frame level */
+#define IS_SPI_DATA_FRAME(x)                                                   \
+(   ((x) == SPI_1_FRAME)                     ||                                \
+    ((x) == SPI_2_FRAME)                     ||                                \
+    ((x) == SPI_3_FRAME)                     ||                                \
+    ((x) == SPI_4_FRAME))
+
+/*! Parameter valid check for SPI fault detect function status */
+#define IS_SPI_MD_FAULT_DETECT_CMD(x)                                          \
+(   ((x) == SPI_MD_FAULT_DETECT_DISABLE)    ||                                 \
+    ((x) == SPI_MD_FAULT_DETECT_ENABLE))
+
+/*! Parameter valid check for SPI parity check mode */
+#define IS_SPI_PARITY_CHECK(x)                                                 \
+(   ((x) == SPI_PARITY_INVD)                ||                                 \
+    ((x) == SPI_PARITY_EVEN)                ||                                 \
+    ((x) == SPI_PARITY_ODD))
+
+/*! Parameter valid check for SPI interval time delay */
+#define IS_SPI_INTERVAL_DELAY(x)                                               \
+(   ((x) == SPI_INTERVAL_TIME_1SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_2SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_3SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_4SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_5SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_6SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_7SCK)         ||                                 \
+    ((x) == SPI_INTERVAL_TIME_8SCK))
+
+/*! Parameter valid check for SPI release time delay */
+#define IS_SPI_RELEASE_DELAY(x)                                                \
+(   ((x) == SPI_RELEASE_TIME_1SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_2SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_3SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_4SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_5SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_6SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_7SCK)          ||                                 \
+    ((x) == SPI_RELEASE_TIME_8SCK))
+
+/*! Parameter valid check for SPI Setup time delay delay */
+#define IS_SPI_SETUP_DELAY(x)                                                  \
+(   ((x) == SPI_SETUP_TIME_1SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_2SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_3SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_4SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_5SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_6SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_7SCK)            ||                                 \
+    ((x) == SPI_SETUP_TIME_8SCK))
+
+/*! Parameter valid check for SPI read data register target buffer */
+#define IS_SPI_RD_TARGET_BUFF(x)                                               \
+(   ((x) == SPI_RD_TARGET_RD_BUF)           ||                                 \
+    ((x) == SPI_RD_TARGET_WR_BUF))
+
+/*! Parameter valid check for SPI mode */
+#define IS_SPI_SPI_MD(x)                                                       \
+(   ((x) == SPI_MD_0)                       ||                                 \
+    ((x) == SPI_MD_1)                       ||                                 \
+    ((x) == SPI_MD_2)                       ||                                 \
+    ((x) == SPI_MD_3))
+
+/*! Parameter valid check for SPI SCK Polarity */
+#define IS_SPI_SCK_POLARITY(x)                                                 \
+(   ((x) == SPI_SCK_POLARITY_LOW)           ||                                 \
+    ((x) == SPI_SCK_POLARITY_HIGH))
+
+/*! Parameter valid check for SPI SCK Phase */
+#define IS_SPI_SCK_PHASE(x)                                                    \
+(   ((x) == SPI_SCK_PHASE_ODD_EDGE_SAMPLE)  ||                                 \
+    ((x) == SPI_SCK_PHASE_EVEN_EDGE_SAMPLE))
+
+/*! Parameter valid check for SPI SS signal */
+#define IS_SPI_SS_PIN(x)                                                       \
+(   ((x) == SPI_PIN_SS0)                    ||                                 \
+    ((x) == SPI_PIN_SS1)                    ||                                 \
+    ((x) == SPI_PIN_SS2)                    ||                                 \
+    ((x) == SPI_PIN_SS3))
+
+/*! Parameter valid check for SPI SS valid level */
+#define IS_SPI_SS_VALID_LVL(x)                                                 \
+(   ((x) == SPI_SS_VALID_LVL_HIGH)          ||                                 \
+    ((x) == SPI_SS_VALID_LVL_LOW))
+
+/*! Parameter valid check for SPI baudrate prescaler */
+#define IS_SPI_CLK_DIV(x)                                                      \
+(   ((x) == SPI_BR_CLK_DIV2)                ||                                 \
+    ((x) == SPI_BR_CLK_DIV4)                ||                                 \
+    ((x) == SPI_BR_CLK_DIV8)                ||                                 \
+    ((x) == SPI_BR_CLK_DIV16)               ||                                 \
+    ((x) == SPI_BR_CLK_DIV32)               ||                                 \
+    ((x) == SPI_BR_CLK_DIV64)               ||                                 \
+    ((x) == SPI_BR_CLK_DIV128)              ||                                 \
+    ((x) == SPI_BR_CLK_DIV256))
+
+/*! Parameter valid check for SPI data bits */
+#define IS_SPI_DATA_SIZE(x)                                                    \
+(   ((x) == SPI_DATA_SIZE_4BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_5BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_6BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_7BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_8BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_9BIT)             ||                                 \
+    ((x) == SPI_DATA_SIZE_10BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_11BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_12BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_13BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_14BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_15BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_16BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_20BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_24BIT)            ||                                 \
+    ((x) == SPI_DATA_SIZE_32BIT))
+
+/*! Parameter valid check for SPI LSB MSB mode */
+#define IS_SPI_FIRST_BIT(x)                                                    \
+(   ((x) == SPI_FIRST_MSB)                  ||                                 \
+    ((x) == SPI_FIRST_LSB))
+
+/*! Parameter valid check for SPI Communication mode */
+#define IS_SPI_COMM_MD(x)                                                      \
+(   ((x) == SPI_COMM_MD_NORMAL)             ||                                 \
+    ((x) == SPI_COMM_MD_CONT))
+
+/*! Parameter valid check for interrupt flag */
+#define IS_SPI_INT(x)                                                          \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | SPI_INT_ALL) == SPI_INT_ALL))
+
+/*! Parameter valid check for SPI status flag */
+#define IS_SPI_FLAG(x)                                                         \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | SPI_FLAG_ALL) == SPI_FLAG_ALL))
+
+/*! Parameter valid check for SPI status flag for clear */
+#define IS_SPI_CLR_FLAG(x)                                                     \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | SPI_FLAG_CLR_ALL) == SPI_FLAG_CLR_ALL))
+
+/*! Parameter valid check for SPI command*/
+#define IS_SPI_CMD_ALLOWED(x)                                                  \
+(   (READ_REG32_BIT(SPIx->SR, SPI_FLAG_MD_FAULT) == 0UL)    ||                 \
+    ((x) == DISABLE))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup SPI_Local_Func SPI Local Functions
+ * @{
+ */
+
+/**
+ * @brief  SPI check status.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32FlagMask        Bit mask of status flag.
+ * @param  [in]  u32Value           Valid value of the status.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred.
+ *         - LL_ERR_TIMEOUT:        SPI transmit timeout.
+ */
+static int32_t SPI_WaitStatus(const CM_SPI_TypeDef *SPIx, uint32_t u32FlagMask, uint32_t u32Value, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+
+    while (READ_REG32_BIT(SPIx->SR, u32FlagMask) != u32Value) {
+        if (u32Timeout == 0UL) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Timeout--;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  SPI transmit and receive data in full duplex mode.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pvTxBuf            The pointer to the buffer which contains the data to be sent.
+ * @param  [out] pvRxBuf            The pointer to the buffer which the received data will be stored.
+ * @param  [in]  u32Len             The length of the data in byte or half word.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_TIMEOUT:        SPI transmit and receive timeout.
+ */
+static int32_t SPI_TxRx(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t u32BitSize;
+    __IO uint32_t u32TxCnt = 0U, u32RxCnt = 0U;
+    __IO uint32_t u32Count = 0U;
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Tmp;
+    __UNUSED __IO uint32_t u32Read;
+    __IO uint32_t u32TxAllow = 1U;
+    uint32_t u32MSMode;
+    __IO uint32_t u32FrameCnt;
+    uint32_t u32FrameNum = READ_REG32_BIT(SPIx->CFG1, SPI_CFG1_FTHLV) + 1UL;
+    DDL_ASSERT(0UL == (u32Len % u32FrameNum));
+
+    u32MSMode = READ_REG32_BIT(SPIx->CR1, SPI_CR1_MSTR);
+    /* Get data bit size, SPI_DATA_SIZE_4BIT ~ SPI_DATA_SIZE_32BIT */
+    u32BitSize = READ_REG32_BIT(SPIx->CFG2, SPI_CFG2_DSIZE);
+    while (u32RxCnt < u32Len) {
+        /* Tx data */
+        if (u32TxCnt < u32Len) {
+            /* Wait TX buffer empty. */
+            i32Ret = SPI_WaitStatus(SPIx, SPI_FLAG_TX_BUF_EMPTY, SPI_FLAG_TX_BUF_EMPTY, 0U);
+            if ((u32TxAllow == 1U) && (i32Ret == LL_OK) && (((u32MSMode == SPI_MASTER)) || (u32MSMode == SPI_SLAVE))) {
+                if (pvTxBuf != NULL) {
+                    u32FrameCnt = 0UL;
+                    while (u32FrameCnt < u32FrameNum) {
+                        if (u32BitSize <= SPI_DATA_SIZE_8BIT) {
+                            /* SPI_DATA_SIZE_4BIT ~ SPI_DATA_SIZE_8BIT */
+                            WRITE_REG32(SPIx->DR, ((const uint8_t *)pvTxBuf)[u32TxCnt]);
+                        } else if (u32BitSize <= SPI_DATA_SIZE_16BIT) {
+                            /* SPI_DATA_SIZE_9BIT ~ SPI_DATA_SIZE_16BIT */
+                            WRITE_REG32(SPIx->DR, ((const uint16_t *)pvTxBuf)[u32TxCnt]);
+                        } else {
+                            /* SPI_DATA_SIZE_20BIT ~ SPI_DATA_SIZE_32BIT */
+                            WRITE_REG32(SPIx->DR, ((const uint32_t *)pvTxBuf)[u32TxCnt]);
+                        }
+                        u32FrameCnt++;
+                        u32TxCnt++;
+                    }
+                } else {
+                    u32FrameCnt = 0UL;
+                    while (u32FrameCnt < u32FrameNum) {
+                        WRITE_REG32(SPIx->DR, 0xFFFFFFFFUL);
+                        u32FrameCnt++;
+                        u32TxCnt++;
+                    }
+                }
+                u32TxAllow = 0U;
+            }
+        }
+
+        /* RX data */
+        i32Ret = SPI_WaitStatus(SPIx, SPI_FLAG_RX_BUF_FULL, SPI_FLAG_RX_BUF_FULL, 0U);
+        if (i32Ret == LL_OK) {
+            if (pvRxBuf != NULL) {
+                u32FrameCnt = 0UL;
+                while (u32FrameCnt < u32FrameNum) {
+                    u32Tmp = READ_REG32(SPIx->DR);
+                    if (u32BitSize <= SPI_DATA_SIZE_8BIT) {
+                        /* SPI_DATA_SIZE_4BIT ~ SPI_DATA_SIZE_8BIT */
+                        ((uint8_t *)pvRxBuf)[u32RxCnt] = (uint8_t)u32Tmp;
+                    } else if (u32BitSize <= SPI_DATA_SIZE_16BIT) {
+                        /* SPI_DATA_SIZE_9BIT ~ SPI_DATA_SIZE_16BIT */
+                        ((uint16_t *)pvRxBuf)[u32RxCnt] = (uint16_t)u32Tmp;
+                    } else {
+                        /* SPI_DATA_SIZE_20BIT ~ SPI_DATA_SIZE_32BIT */
+                        ((uint32_t *)pvRxBuf)[u32RxCnt] = (uint32_t)u32Tmp;
+                    }
+                    u32FrameCnt++;
+                    u32RxCnt++;
+                }
+            } else {
+                /* Dummy read */
+                u32FrameCnt = 0UL;
+                while (u32FrameCnt < u32FrameNum) {
+                    u32Read = READ_REG32(SPIx->DR);
+                    u32FrameCnt++;
+                    u32RxCnt++;
+                }
+            }
+            u32TxAllow = 1U;
+            u32Count = 0U;
+        }
+
+        /* check timeout */
+        if (u32Count > u32Timeout) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count++;
+    }
+
+    if ((SPI_MASTER == READ_REG32_BIT(SPIx->CR1, SPI_CR1_MSTR)) && (i32Ret == LL_OK)) {
+        i32Ret = SPI_WaitStatus(SPIx, SPI_FLAG_IDLE, 0UL, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  SPI send data only.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pvTxBuf            The pointer to the buffer which contains the data to be sent.
+ * @param  [in]  u32Len             The length of the data in byte or half word or word.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred.
+ *         - LL_ERR_TIMEOUT:        SPI transmit timeout.
+ */
+static int32_t SPI_Tx(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    __IO uint32_t u32TxCnt = 0U;
+    uint32_t u32BitSize;
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32FrameCnt;
+    uint32_t u32FrameNum = READ_REG32_BIT(SPIx->CFG1, SPI_CFG1_FTHLV) + 1UL;
+    DDL_ASSERT(0UL == (u32Len % u32FrameNum));
+
+    /* Get data bit size, SPI_DATA_SIZE_4BIT ~ SPI_DATA_SIZE_32BIT */
+    u32BitSize = READ_REG32_BIT(SPIx->CFG2, SPI_CFG2_DSIZE);
+    while (u32TxCnt < u32Len) {
+        u32FrameCnt = 0UL;
+        while (u32FrameCnt < u32FrameNum) {
+            if (u32BitSize <= SPI_DATA_SIZE_8BIT) {
+                /* SPI_DATA_SIZE_4BIT ~ SPI_DATA_SIZE_8BIT */
+                WRITE_REG32(SPIx->DR, ((const uint8_t *)pvTxBuf)[u32TxCnt]);
+            } else if (u32BitSize <= SPI_DATA_SIZE_16BIT) {
+                /* SPI_DATA_SIZE_9BIT ~ SPI_DATA_SIZE_16BIT */
+                WRITE_REG32(SPIx->DR, ((const uint16_t *)pvTxBuf)[u32TxCnt]);
+            } else {
+                /* SPI_DATA_SIZE_20BIT ~ SPI_DATA_SIZE_32BIT */
+                WRITE_REG32(SPIx->DR, ((const uint32_t *)pvTxBuf)[u32TxCnt]);
+            }
+            u32FrameCnt++;
+            u32TxCnt++;
+        }
+        /* Wait TX buffer empty. */
+        i32Ret = SPI_WaitStatus(SPIx, SPI_FLAG_TX_BUF_EMPTY, SPI_FLAG_TX_BUF_EMPTY, u32Timeout);
+        if (i32Ret != LL_OK) {
+            break;
+        }
+    }
+
+    if ((SPI_MASTER == READ_REG32_BIT(SPIx->CR1, SPI_CR1_MSTR)) && (i32Ret == LL_OK)) {
+        i32Ret = SPI_WaitStatus(SPIx, SPI_FLAG_IDLE, 0UL, u32Timeout);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SPI_Global_Functions SPI Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes the SPI peripheral according to the specified parameters
+ *         in the structure stc_spi_init.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pstcSpiInit        Pointer to a stc_spi_init_t structure that contains
+ *                                  the configuration information for the SPI.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_INVD_PARAM:     pstcSpiInit == NULL or configuration parameter error.
+ * @note   -The parameter u32BaudRatePrescaler is invalid while slave mode
+ */
+int32_t SPI_Init(CM_SPI_TypeDef *SPIx, const stc_spi_init_t *pstcSpiInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+
+    if (NULL != pstcSpiInit) {
+        DDL_ASSERT(IS_SPI_WIRE_MD(pstcSpiInit->u32WireMode));
+        DDL_ASSERT(IS_SPI_TRANS_MD(pstcSpiInit->u32TransMode));
+        DDL_ASSERT(IS_SPI_MASTER_SLAVE(pstcSpiInit->u32MasterSlave));
+        DDL_ASSERT(IS_SPI_MD_FAULT_DETECT_CMD(pstcSpiInit->u32ModeFaultDetect));
+        DDL_ASSERT(IS_SPI_PARITY_CHECK(pstcSpiInit->u32Parity));
+        DDL_ASSERT(IS_SPI_SPI_MD(pstcSpiInit->u32SpiMode));
+        DDL_ASSERT(IS_SPI_CLK_DIV(pstcSpiInit->u32BaudRatePrescaler));
+        DDL_ASSERT(IS_SPI_DATA_SIZE(pstcSpiInit->u32DataBits));
+        DDL_ASSERT(IS_SPI_FIRST_BIT(pstcSpiInit->u32FirstBit));
+        DDL_ASSERT(IS_SPI_SUSPD_MD_STAT(pstcSpiInit->u32SuspendMode));
+        DDL_ASSERT(IS_SPI_DATA_FRAME(pstcSpiInit->u32FrameLevel));
+
+        /* Configuration parameter check */
+        if ((SPI_MASTER == pstcSpiInit->u32MasterSlave) && (SPI_MD_FAULT_DETECT_ENABLE == pstcSpiInit->u32ModeFaultDetect)) {
+            /* pstcSpiInit->u32ModeFaultDetect can not be SPI_MD_FAULT_DETECT_ENABLE in master mode */
+        } else if ((SPI_3_WIRE == pstcSpiInit->u32WireMode) && (SPI_SLAVE == pstcSpiInit->u32MasterSlave)
+                   && ((SPI_MD_0 == pstcSpiInit->u32SpiMode) || (SPI_MD_2 == pstcSpiInit->u32SpiMode))) {
+            /* SPI_3_WIRE can not support SPI_MD_0 and SPI_MD_2 */
+        } else {
+            WRITE_REG32(SPIx->CR1, pstcSpiInit->u32WireMode | pstcSpiInit->u32TransMode | pstcSpiInit->u32MasterSlave | \
+                        pstcSpiInit->u32SuspendMode | pstcSpiInit->u32ModeFaultDetect | pstcSpiInit->u32Parity);
+            MODIFY_REG32(SPIx->CFG1, SPI_CFG1_FTHLV, pstcSpiInit->u32FrameLevel);
+            if (SPI_MASTER == pstcSpiInit->u32MasterSlave) {
+                WRITE_REG32(SPIx->CFG2, pstcSpiInit->u32SpiMode | pstcSpiInit->u32BaudRatePrescaler | pstcSpiInit->u32DataBits | \
+                            pstcSpiInit->u32FirstBit);
+            } else {
+                WRITE_REG32(SPIx->CFG2, pstcSpiInit->u32SpiMode | pstcSpiInit->u32DataBits | pstcSpiInit->u32FirstBit);
+            }
+
+            i32Ret = LL_OK;
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initializes the SPI peripheral.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ */
+int32_t SPI_DeInit(CM_SPI_TypeDef *SPIx)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+
+    WRITE_REG32(SPIx->CR1, 0UL);
+    WRITE_REG32(SPIx->CFG1, SPI_CFG1_DEFAULT);
+    WRITE_REG32(SPIx->CFG2, SPI_CFG2_DEFAULT);
+    WRITE_REG32(SPIx->SR, (~SPI_FLAG_CLR_ALL) & SPI_FLAG_ALL);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Set a default value for the SPI initialization structure.
+ * @param  [in]  pstcSpiInit        Pointer to a stc_spi_init_t structure that
+ *                                  contains configuration information.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred.
+ *         - LL_ERR_INVD_PARAM:     pstcSpiInit == NULL.
+ */
+int32_t SPI_StructInit(stc_spi_init_t *pstcSpiInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSpiInit) {
+        pstcSpiInit->u32WireMode          = SPI_4_WIRE;
+        pstcSpiInit->u32TransMode         = SPI_FULL_DUPLEX;
+        pstcSpiInit->u32MasterSlave       = SPI_MASTER;
+        pstcSpiInit->u32ModeFaultDetect   = SPI_MD_FAULT_DETECT_DISABLE;
+        pstcSpiInit->u32Parity            = SPI_PARITY_INVD;
+        pstcSpiInit->u32SpiMode           = SPI_MD_0;
+        pstcSpiInit->u32BaudRatePrescaler = SPI_BR_CLK_DIV8;
+        pstcSpiInit->u32DataBits          = SPI_DATA_SIZE_8BIT;
+        pstcSpiInit->u32FirstBit          = SPI_FIRST_MSB;
+        pstcSpiInit->u32SuspendMode       = SPI_COM_SUSP_FUNC_OFF;
+        pstcSpiInit->u32FrameLevel        = SPI_1_FRAME;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable SPI interrupt.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32IntType         SPI interrupt type. Can be one or any
+ *                                  combination of the parameter @ref SPI_Int_Type_Define
+ * @param  [in]  enNewState         An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SPI_IntCmd(CM_SPI_TypeDef *SPIx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_SPI_INT(u32IntType));
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(SPIx->CR1, u32IntType);
+    } else {
+        CLR_REG32_BIT(SPIx->CR1, u32IntType);
+    }
+}
+
+/**
+ * @brief  SPI function enable or disable.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  enNewState         An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void SPI_Cmd(CM_SPI_TypeDef *SPIx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_SPI_CMD_ALLOWED(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(SPIx->CR1, SPI_CR1_SPE);
+    } else {
+        CLR_REG32_BIT(SPIx->CR1, SPI_CR1_SPE);
+    }
+}
+
+/**
+ * @brief  Write SPI data register.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Data            The data will be written to the data register.
+ * @retval None.
+ */
+void SPI_WriteData(CM_SPI_TypeDef *SPIx, uint32_t u32Data)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    WRITE_REG32(SPIx->DR, u32Data);
+}
+
+/**
+ * @brief  Read SPI data register.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg  CM_SPIx or CM_SPI
+ * @retval uint32_t                 A 32-bit data of SPI data register.
+ */
+uint32_t SPI_ReadData(const CM_SPI_TypeDef *SPIx)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+
+    return READ_REG32(SPIx->DR);
+}
+
+/**
+ * @brief  SPI get status flag.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Flag            SPI state flag. Can be one or any
+ *                                  combination of the parameter of @ref SPI_State_Flag_Define
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SPI_GetStatus(const CM_SPI_TypeDef *SPIx, uint32_t u32Flag)
+{
+    en_flag_status_t enFlag = RESET;
+    uint32_t u32Status;
+
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_FLAG(u32Flag));
+
+    u32Status = READ_REG32(SPIx->SR);
+    if (SPI_FLAG_IDLE == (SPI_FLAG_IDLE & u32Flag)) {
+        CLR_REG32_BIT(u32Flag, SPI_FLAG_IDLE);
+        if (0U == (u32Status & SPI_FLAG_IDLE)) {
+            enFlag = SET;
+        }
+    }
+    if (0U != READ_REG32_BIT(u32Status, u32Flag)) {
+        enFlag = SET;
+    }
+
+    return enFlag;
+}
+
+/**
+ * @brief  SPI clear state flag.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Flag            SPI state flag. Can be one or any combination of the parameter below
+ *   @arg  SPI_FLAG_OVERRUN
+ *   @arg  SPI_FLAG_MD_FAULT
+ *   @arg  SPI_FLAG_PARITY_ERR
+ *   @arg  SPI_FLAG_UNDERRUN
+ * @retval None
+ */
+void SPI_ClearStatus(CM_SPI_TypeDef *SPIx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(SPIx->SR, (~u32Flag) & SPI_FLAG_ALL);
+}
+
+/**
+ * @brief  SPI loopback function configuration.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Mode            Loopback mode. Can be one parameter @ref SPI_Loopback_Selection_Define
+ * @retval None
+ */
+void SPI_SetLoopbackMode(CM_SPI_TypeDef *SPIx, uint32_t u32Mode)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_SPLPBK(u32Mode));
+
+    MODIFY_REG32(SPIx->CR1, SPI_CR1_SPLPBK | SPI_CR1_SPLPBK2, u32Mode);
+}
+
+/**
+ * @brief  SPI parity check error self diagnosis function enable or disable.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  enNewState         An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+
+void SPI_ParityCheckCmd(CM_SPI_TypeDef *SPIx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(SPIx->CR1, SPI_CR1_PATE);
+    } else {
+        CLR_REG32_BIT(SPIx->CR1, SPI_CR1_PATE);
+    }
+}
+
+/**
+ * @brief  SPI signals delay time configuration
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pstcDelayConfig    Pointer to a stc_spi_delay_t structure that contains
+ *                                  the configuration information for the SPI delay time.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_INVD_PARAM:     pstcDelayConfig == NULL
+ */
+int32_t SPI_DelayTimeConfig(CM_SPI_TypeDef *SPIx, const stc_spi_delay_t *pstcDelayConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+
+    if (NULL != pstcDelayConfig) {
+        DDL_ASSERT(IS_SPI_INTERVAL_DELAY(pstcDelayConfig->u32IntervalDelay));
+        DDL_ASSERT(IS_SPI_RELEASE_DELAY(pstcDelayConfig->u32ReleaseDelay));
+        DDL_ASSERT(IS_SPI_SETUP_DELAY(pstcDelayConfig->u32SetupDelay));
+
+        /* Interval delay */
+        if (SPI_INTERVAL_TIME_1SCK == pstcDelayConfig->u32IntervalDelay) {
+            CLR_REG32_BIT(SPIx->CFG2, SPI_CFG2_MIDIE);
+            CLR_REG32_BIT(SPIx->CFG1, SPI_CFG1_MIDI);
+        } else {
+            MODIFY_REG32(SPIx->CFG1, SPI_CFG1_MIDI, pstcDelayConfig->u32IntervalDelay);
+            SET_REG32_BIT(SPIx->CFG2, SPI_CFG2_MIDIE);
+        }
+
+        /* SCK release delay */
+        if (SPI_RELEASE_TIME_1SCK == pstcDelayConfig->u32ReleaseDelay) {
+            CLR_REG32_BIT(SPIx->CFG2, SPI_CFG2_MSSDLE);
+            CLR_REG32_BIT(SPIx->CFG1, SPI_CFG1_MSSDL);
+        } else {
+            SET_REG32_BIT(SPIx->CFG2, SPI_CFG2_MSSDLE);
+            MODIFY_REG32(SPIx->CFG1, SPI_CFG1_MSSDL, pstcDelayConfig->u32ReleaseDelay);
+        }
+
+        /* Setup delay */
+        if (SPI_SETUP_TIME_1SCK == pstcDelayConfig->u32SetupDelay) {
+            CLR_REG32_BIT(SPIx->CFG2, SPI_CFG2_MSSIE);
+            CLR_REG32_BIT(SPIx->CFG1, SPI_CFG1_MSSI);
+        } else {
+            SET_REG32_BIT(SPIx->CFG2, SPI_CFG2_MSSIE);
+            MODIFY_REG32(SPIx->CFG1, SPI_CFG1_MSSI, pstcDelayConfig->u32SetupDelay);
+        }
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set a default value for the SPI delay time configuration structure.
+ * @param  [in]  pstcDelayConfig    Pointer to a stc_spi_delay_t structure that
+ *                                  contains configuration information.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred.
+ *         - LL_ERR_INVD_PARAM:     pstcDelayConfig == NULL.
+ */
+int32_t SPI_DelayStructInit(stc_spi_delay_t *pstcDelayConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcDelayConfig) {
+        pstcDelayConfig->u32IntervalDelay = SPI_INTERVAL_TIME_1SCK;
+        pstcDelayConfig->u32ReleaseDelay = SPI_RELEASE_TIME_1SCK;
+        pstcDelayConfig->u32SetupDelay = SPI_SETUP_TIME_1SCK;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  SPI SS signal valid level configuration
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32SSPin           Specify the SS pin @ref SPI_SS_Pin_Define
+ * @param  [in]  u32SSLevel         Specify the SS valid level @ref SPI_SS_Level
+ *   @arg  SPI_SS_VALID_LVL_HIGH:   SS high level valid
+ *   @arg  SPI_SS_VALID_LVL_LOW:    SS low level valid
+ * @retval None
+ */
+void SPI_SetSSValidLevel(CM_SPI_TypeDef *SPIx, uint32_t u32SSPin, uint32_t u32SSLevel)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_SS_PIN(u32SSPin));
+    DDL_ASSERT(IS_SPI_SS_VALID_LVL(u32SSLevel));
+
+    if (SPI_SS_VALID_LVL_HIGH == u32SSLevel) {
+        SET_REG32_BIT(SPIx->CFG1, u32SSPin);
+    } else {
+        CLR_REG32_BIT(SPIx->CFG1, u32SSPin);
+    }
+}
+
+/**
+ * @brief  Set the SPI SCK polarity.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Polarity        Specify the SPI SCK polarity @ref SPI_SCK_Polarity_Define
+ * @retval None
+ */
+void SPI_SetSckPolarity(CM_SPI_TypeDef *SPIx, uint32_t u32Polarity)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_SCK_POLARITY(u32Polarity));
+
+    if (SPI_SCK_POLARITY_LOW == u32Polarity) {
+        CLR_REG32_BIT(SPIx->CFG2, SPI_CFG2_CPOL);
+    } else {
+        SET_REG32_BIT(SPIx->CFG2, SPI_CFG2_CPOL);
+    }
+}
+
+/**
+ * @brief  Set the SPI SCK phase.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32Phase           Specify the SPI SCK phase @ref SPI_SCK_Phase_Define
+ * @retval None
+ */
+void SPI_SetSckPhase(CM_SPI_TypeDef *SPIx, uint32_t u32Phase)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_SCK_PHASE(u32Phase));
+
+    if (SPI_SCK_PHASE_ODD_EDGE_SAMPLE == u32Phase) {
+        CLR_REG32_BIT(SPIx->CFG2, SPI_CFG2_CPHA);
+    } else {
+        SET_REG32_BIT(SPIx->CFG2, SPI_CFG2_CPHA);
+    }
+}
+
+/**
+ * @brief  SPI valid SS signal configuration
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32SSPin           Specify the SS pin @ref SPI_SS_Pin_Define
+ * @retval None
+ */
+void SPI_SSPinSelect(CM_SPI_TypeDef *SPIx, uint32_t u32SSPin)
+{
+    uint32_t    u32RegConfig;
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_SS_PIN(u32SSPin));
+
+    switch (u32SSPin) {
+        case SPI_PIN_SS0:
+            u32RegConfig = SPI_SS0_VALID_CFG;
+            break;
+        case SPI_PIN_SS1:
+            u32RegConfig = SPI_SS1_VALID_CFG;
+            break;
+        case SPI_PIN_SS2:
+            u32RegConfig = SPI_SS2_VALID_CFG;
+            break;
+        case SPI_PIN_SS3:
+            u32RegConfig = SPI_SS3_VALID_CFG;
+            break;
+        default:
+            u32RegConfig = SPI_SS0_VALID_CFG;
+            break;
+    }
+    MODIFY_REG32(SPIx->CFG2, SPI_CFG2_SSA, u32RegConfig);
+}
+
+/**
+ * @brief  SPI read buffer configuration
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  u32ReadBuf         Target buffer for read operation @ref SPI_Read_Target_Buf_Define
+ * @retval None
+ */
+void SPI_SetReadBuf(CM_SPI_TypeDef *SPIx, uint32_t u32ReadBuf)
+{
+    DDL_ASSERT(IS_SPI_UNIT(SPIx));
+    DDL_ASSERT(IS_SPI_RD_TARGET_BUFF(u32ReadBuf));
+
+    MODIFY_REG32(SPIx->CFG1, SPI_CFG1_SPRDTD, u32ReadBuf);
+}
+
+/**
+ * @brief  SPI transmit data.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pvTxBuf            The pointer to the buffer which contains the data to be sent.
+ * @param  [in]  u32TxLen           The length of the data to be sent.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_TIMEOUT:        SPI transmit timeout.
+ *         - LL_ERR_INVD_PARAM:     pvTxBuf == NULL or u32TxLen == 0U
+ * @note   -No SS pin active and inactive operation in 3-wire mode. Add operations of SS pin depending on your application.
+ *         -In the send only slave mode, the function needs to increase an appropriate delay after calling to ensure the
+ *          integrity of data transmission.
+ */
+int32_t SPI_Trans(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, uint32_t u32TxLen, uint32_t u32Timeout)
+{
+    uint32_t u32Flags;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvTxBuf != NULL) && (u32TxLen != 0U)) {
+        u32Flags = READ_REG32_BIT(SPIx->CR1, SPI_CR1_TXMDS);
+        if (u32Flags == SPI_SEND_ONLY) {
+            /* Transmit data in send only mode. */
+            i32Ret = SPI_Tx(SPIx, pvTxBuf, u32TxLen, u32Timeout);
+        } else {
+            /* Transmit data in full duplex mode. */
+            i32Ret = SPI_TxRx(SPIx, pvTxBuf, NULL, u32TxLen, u32Timeout);
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  SPI receive data.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pvRxBuf            The pointer to the buffer which the received data to be stored.
+ * @param  [in]  u32RxLen           The length of the data to be received.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_TIMEOUT:        SPI receive timeout.
+ *         - LL_ERR_INVD_PARAM:     pvRxBuf == NULL or u32RxLen == 0U
+ * @note   -No SS pin active and inactive operation in 3-wire mode. Add operations of SS pin depending on your application.
+ */
+int32_t SPI_Receive(CM_SPI_TypeDef *SPIx, void *pvRxBuf, uint32_t u32RxLen, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvRxBuf != NULL) && (u32RxLen != 0U)) {
+        /* Receives data in full duplex master mode. */
+        i32Ret = SPI_TxRx(SPIx, NULL, pvRxBuf, u32RxLen, u32Timeout);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  SPI transmit and receive data.
+ * @param  [in]  SPIx               SPI unit
+ *   @arg CM_SPIx or CM_SPI
+ * @param  [in]  pvTxBuf            The pointer to the buffer which contains the data to be sent.
+ *                                  If this pointer is NULL and the pvRxBuf is NOT NULL, the MOSI output high
+ *                                  and the received data will be stored in the buffer pointed by pvRxBuf.
+ * @param  [out] pvRxBuf            The pointer to the buffer which the received data will be stored.
+ *                                  This for full duplex transfer.
+ * @param  [in]  u32Len             The length of the data(in byte or half word) to be sent and received.
+ * @param  [in]  u32Timeout         Timeout value.
+ * @retval int32_t:
+ *         - LL_OK:                 No errors occurred
+ *         - LL_ERR_TIMEOUT:        SPI transmit and receive timeout.
+ *         - LL_ERR_INVD_PARAM:     pvRxBuf == NULL or pvRxBuf == NULL or u32Len == 0U
+ * @note   SPI receives data while sending data.
+ */
+int32_t SPI_TransReceive(CM_SPI_TypeDef *SPIx, const void *pvTxBuf, void *pvRxBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pvTxBuf != NULL) && (pvRxBuf != NULL) && (u32Len != 0U)) {
+        /* Transmit and receive data in full duplex master mode. */
+        i32Ret = SPI_TxRx(SPIx, pvTxBuf, pvRxBuf, u32Len, u32Timeout);
+    }
+    return i32Ret;
+}
+/**
+ * @}
+ */
+
+#endif /* LL_SPI_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_sram.c
+++ b/hc32f4a2/src/hc32_ll_sram.c
@@ -1,0 +1,316 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_sram.c
+ * @brief This file provides firmware functions to manage the SRAM.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Deleted redundant comments
+   2023-06-30       CDT             API fixed: SRAM_ClearStatus()
+   2023-09-30       CDT             API fixed: SRAM_SetWaitCycle()
+   2023-12-15       CDT             Refine SRAM_SetEccMode, and refine SRAM_SetErrorMode() as SRAM_SetExceptionType
+   2024-08-31       CDT             Modify assert IS_SRAM_ECC_MD()
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_sram.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_SRAM SRAM
+ * @brief SRAM Driver Library
+ * @{
+ */
+
+#if (LL_SRAM_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SRAM_Local_Macros SRAM Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup SRAM_Configuration_Bits_Mask SRAM Configuration Bits Mask
+ * @{
+ */
+#define SRAM_CYCLE_MASK                 (0x00000007UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Ecc_Mode_Mask SRAM ecc mode mask
+ * @{
+ */
+#define SRAM_ECC_MD_MASK                (SRAMC_CKCR_ECCMOD | SRAMC_CKCR_BECCMOD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Exception_Type_Mask SRAM exception type mask
+ * @{
+ */
+#define SRAM_EXP_TYPE_MASK              (SRAMC_CKCR_ECCOAD | SRAMC_CKCR_BECCOAD | SRAMC_CKCR_PYOAD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup SRAM_Check_Parameters_Validity SRAM check parameters validity
+ * @{
+ */
+#define IS_SRAM_BIT_MASK(x, mask)       (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+/* Parameter valid check for SRAM wait cycle */
+#define IS_SRAM_WAIT_CYCLE(x)           ((x) <= SRAM_WAIT_CYCLE7)
+
+/* Parameter valid check for SRAM selection */
+#define IS_SRAM_SEL(x)                  IS_SRAM_BIT_MASK(x, SRAM_SRAM_ALL)
+
+/* Parameter valid check for SRAM ECC SRAM */
+#define IS_SRAM_ECC_SRAM(x)             IS_SRAM_BIT_MASK(x, SRAM_ECC_SRAM_ALL)
+
+/* Parameter valid check for SRAM ECC SRAM */
+#define IS_SRAM_CHECK_SRAM(x)           IS_SRAM_BIT_MASK(x, SRAM_CHECK_SRAM_ALL)
+
+/* Parameter valid check for SRAM flag */
+#define IS_SRAM_FLAG(x)                 IS_SRAM_BIT_MASK(x, SRAM_FLAG_ALL)
+
+/* Check SRAM  WTPR register lock status. */
+#define IS_SRAM_WTPR_UNLOCK()           (CM_SRAMC->WTPR == SRAM_REG_UNLOCK_KEY)
+
+/* Check SRAM CKPR register lock status. */
+#define IS_SRAM_CKPR_UNLOCK()           (CM_SRAMC->CKPR == SRAM_REG_UNLOCK_KEY)
+
+/* Parameter valid check for SRAM exception type mode */
+#define IS_SRAM_EXP_TYPE(x)                                                    \
+(   ((x) == SRAM_EXP_TYPE_NMI)                  ||                             \
+    ((x) == SRAM_EXP_TYPE_RST))
+
+/* Parameter valid check for SRAM ECC mode */
+#define IS_SRAM_ECC_MD(x)               (((x) | SRAM_ECC_MD_MASK) == SRAM_ECC_MD_MASK)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup SRAM_Global_Functions SRAM Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes SRAM.
+ * @param  None
+ * @retval None
+ */
+void SRAM_Init(void)
+{
+    SET_REG32_BIT(CM_SRAMC->CKSR, SRAM_FLAG_ALL);
+}
+
+/**
+ * @brief  De-initializes SRAM. RESET the registers of SRAM.
+ * @param  None
+ * @retval None
+ * @note   Call SRAM_REG_Unlock to unlock registers WTCR and CKCR first.
+ */
+void SRAM_DeInit(void)
+{
+    /* Call SRAM_REG_Unlock to unlock register WTCR and CKCR. */
+    DDL_ASSERT(IS_SRAM_CKPR_UNLOCK());
+    DDL_ASSERT(IS_SRAM_WTPR_UNLOCK());
+
+    WRITE_REG32(CM_SRAMC->WTCR, 0UL);
+    WRITE_REG32(CM_SRAMC->CKCR, 0UL);
+    SET_REG32_BIT(CM_SRAMC->CKSR, SRAM_FLAG_ALL);
+}
+
+/**
+ * @brief  Specifies access wait cycle for SRAM.
+ * @param  [in]  u32SramSel             The SRAM selection.
+ *                                      This parameter can be values of @ref SRAM_Sel
+ * @param  [in]  u32WriteCycle          The write access wait cycle for the specified SRAM
+ *                                      This parameter can be a value of @ref SRAM_Access_Wait_Cycle
+ * @param  [in]  u32ReadCycle           The read access wait cycle for the specified SRAM.
+ *                                      This parameter can be a value of @ref SRAM_Access_Wait_Cycle
+ *   @arg  SRAM_WAIT_CYCLE0:            Wait 0 CPU cycle.
+ *   @arg  SRAM_WAIT_CYCLE1:            Wait 1 CPU cycle.
+ *   @arg  SRAM_WAIT_CYCLE2:            Wait 2 CPU cycles.
+ *   @arg  SRAM_WAIT_CYCLE3:            Wait 3 CPU cycles.
+ *   @arg  SRAM_WAIT_CYCLE4:            Wait 4 CPU cycles.
+ *   @arg  SRAM_WAIT_CYCLE5:            Wait 5 CPU cycles.
+ *   @arg  SRAM_WAIT_CYCLE6:            Wait 6 CPU cycles.
+ *   @arg  SRAM_WAIT_CYCLE7:            Wait 7 CPU cycles.
+ * @retval None
+ * @note   Call SRAM_REG_Unlock to unlock register WTCR first.
+ */
+void SRAM_SetWaitCycle(uint32_t u32SramSel, uint32_t u32WriteCycle, uint32_t u32ReadCycle)
+{
+    uint8_t i = 0U;
+    uint8_t u8OfsWt;
+    uint8_t u8OfsRd;
+
+    DDL_ASSERT(IS_SRAM_SEL(u32SramSel));
+    DDL_ASSERT(IS_SRAM_WAIT_CYCLE(u32WriteCycle));
+    DDL_ASSERT(IS_SRAM_WAIT_CYCLE(u32ReadCycle));
+    DDL_ASSERT(IS_SRAM_WTPR_UNLOCK());
+
+    while (u32SramSel != 0UL) {
+        if ((u32SramSel & 0x1UL) != 0UL) {
+            u8OfsRd = i * 8U;
+            u8OfsWt = u8OfsRd + 4U;
+            MODIFY_REG32(CM_SRAMC->WTCR,
+                         ((SRAM_CYCLE_MASK << u8OfsWt) | (SRAM_CYCLE_MASK << u8OfsRd)),
+                         ((u32WriteCycle << u8OfsWt) | (u32ReadCycle << u8OfsRd)));
+        }
+        u32SramSel >>= 1U;
+        i++;
+    }
+}
+
+/**
+ * @brief  Specifies ECC mode.
+ * @param  [in]  u32EccSram             The ECC SRAM.
+ *                                      This parameter can be any combination of @ref SRAM_ECC_SRAM
+ * @param  [in]  u32EccMode             The ECC mode.
+ *                                      This parameter can be any combination of @ref SRAM_ECC_Mode, but only choose
+ *                                      one value of SRAM_SRAM4_ECC_xx and SRAM_SRAMB_ECC_xx
+ * @retval None
+ * @note   Call SRAM_REG_Unlock to unlock register CKCR first.
+ *         The sram of u32EccMode should be the same with the sram of u32EccSram.
+ */
+void SRAM_SetEccMode(uint32_t u32EccSram, uint32_t u32EccMode)
+{
+    uint32_t u32Mask = 0UL;
+    uint32_t u32Pos = 0UL;
+
+    DDL_ASSERT(IS_SRAM_ECC_SRAM(u32EccSram));
+    DDL_ASSERT(IS_SRAM_ECC_MD(u32EccMode));
+    DDL_ASSERT(IS_SRAM_CKPR_UNLOCK());
+
+    while (0UL != u32EccSram) {
+        if (1UL == (u32EccSram & 0x01UL)) {
+            u32Mask |= (SRAMC_CKCR_ECCMOD << u32Pos);
+        }
+        u32EccSram >>= 1UL;
+        u32Pos += 2UL;
+    }
+
+    MODIFY_REG32(CM_SRAMC->CKCR, u32Mask, u32EccMode);
+}
+
+/**
+ * @brief  Specifies the exception type while the chosen sram check error occurred.
+ * @param  [in] u32CheckSram            The check SRAM.
+ *                                      This parameter can be any combination of @ref SRAM_Check_SRAM
+ * @param  [in] u32ExceptionType        The operation after check error occurred.
+ *                                      This parameter can be a value of @ref SRAM_Exception_Type
+ * @retval None
+ * @note   Call SRAM_REG_Unlock to unlock register CKCR first.
+ */
+void SRAM_SetExceptionType(uint32_t u32CheckSram, uint32_t u32ExceptionType)
+{
+    DDL_ASSERT(IS_SRAM_CHECK_SRAM(u32CheckSram));
+    DDL_ASSERT(IS_SRAM_EXP_TYPE(u32ExceptionType));
+    DDL_ASSERT(IS_SRAM_CKPR_UNLOCK());
+
+    if (SRAM_EXP_TYPE_RST == u32ExceptionType) {
+        SET_REG32_BIT(CM_SRAMC->CKCR, u32CheckSram);
+    } else {
+        CLR_REG32_BIT(CM_SRAMC->CKCR, u32CheckSram);
+    }
+}
+
+/**
+ * @brief  Get the status of the specified flag of SRAM.
+ * @param  [in]  u32Flag                The flag of SRAM.
+ *                                      This parameter can be a value of @ref SRAM_Err_Status_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SRAM_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_SRAM_FLAG(u32Flag));
+    if (READ_REG32_BIT(CM_SRAMC->CKSR, u32Flag) != 0U) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified flag of SRAM.
+ * @param  [in]  u32Flag                The flag of SRAM.
+ *                                      This parameter can be values of @ref SRAM_Err_Status_Flag
+ * @retval None
+ */
+void SRAM_ClearStatus(uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_SRAM_FLAG(u32Flag));
+    WRITE_REG32(CM_SRAMC->CKSR, u32Flag);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_SRAM_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_swdt.c
+++ b/hc32f4a2/src/hc32_ll_swdt.c
@@ -1,0 +1,258 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_swdt.c
+ * @brief This file provides firmware functions to manage the Specialized Watch
+ *        Dog Timer(SWDT).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Optimize SWDT_ClearStatus function timeout
+   2024-06-30       CDT             Modify API SWDT_ClearStatus() for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_swdt.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_SWDT SWDT
+ * @brief Specialized Watch Dog Timer
+ * @{
+ */
+
+#if (LL_SWDT_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup SWDT_Local_Macros SWDT Local Macros
+ * @{
+ */
+
+/* SWDT Refresh Key */
+#define SWDT_REFRESH_KEY_START          (0x0123UL)
+#define SWDT_REFRESH_KEY_END            (0x3210UL)
+
+/* SWDT clear flag timeout(ms) */
+#define SWDT_CLR_FLAG_TIMEOUT           (400UL)
+
+/* SWDT Registers Clear Mask */
+#define SWDT_CR_CLR_MASK                (SWDT_CR_PERI   | SWDT_CR_CKS | SWDT_CR_WDPT | \
+                                         SWDT_CR_SLPOFF | SWDT_CR_ITS)
+
+/**
+ * @defgroup SWDT_Check_Parameters_Validity SWDT Check Parameters Validity
+ * @{
+ */
+
+#define IS_SWDT_CNT_PERIOD(x)                                                  \
+(   ((x) == SWDT_CNT_PERIOD256)                 ||                             \
+    ((x) == SWDT_CNT_PERIOD4096)                ||                             \
+    ((x) == SWDT_CNT_PERIOD16384)               ||                             \
+    ((x) == SWDT_CNT_PERIOD65536))
+
+#define IS_SWDT_CLK_DIV(x)                                                     \
+(   ((x) == SWDT_CLK_DIV1)                      ||                             \
+    ((x) == SWDT_CLK_DIV16)                     ||                             \
+    ((x) == SWDT_CLK_DIV32)                     ||                             \
+    ((x) == SWDT_CLK_DIV64)                     ||                             \
+    ((x) == SWDT_CLK_DIV128)                    ||                             \
+    ((x) == SWDT_CLK_DIV256)                    ||                             \
+    ((x) == SWDT_CLK_DIV2048))
+
+#define IS_SWDT_REFRESH_RANGE(x)                                               \
+(   ((x) == SWDT_RANGE_0TO100PCT)               ||                             \
+    ((x) == SWDT_RANGE_0TO25PCT)                ||                             \
+    ((x) == SWDT_RANGE_25TO50PCT)               ||                             \
+    ((x) == SWDT_RANGE_0TO50PCT)                ||                             \
+    ((x) == SWDT_RANGE_50TO75PCT)               ||                             \
+    ((x) == SWDT_RANGE_0TO25PCT_50TO75PCT)      ||                             \
+    ((x) == SWDT_RANGE_25TO75PCT)               ||                             \
+    ((x) == SWDT_RANGE_0TO75PCT)                ||                             \
+    ((x) == SWDT_RANGE_75TO100PCT)              ||                             \
+    ((x) == SWDT_RANGE_0TO25PCT_75TO100PCT)     ||                             \
+    ((x) == SWDT_RANGE_25TO50PCT_75TO100PCT)    ||                             \
+    ((x) == SWDT_RANGE_0TO50PCT_75TO100PCT)     ||                             \
+    ((x) == SWDT_RANGE_50TO100PCT)              ||                             \
+    ((x) == SWDT_RANGE_0TO25PCT_50TO100PCT)     ||                             \
+    ((x) == SWDT_RANGE_25TO100PCT))
+
+#define IS_SWDT_LPM_CNT(x)                                                     \
+(   ((x) == SWDT_LPM_CNT_CONT)                  ||                             \
+    ((x) == SWDT_LPM_CNT_STOP))
+
+#define IS_SWDT_EXP_TYPE(x)                                                    \
+(   ((x) == SWDT_EXP_TYPE_INT)                  ||                             \
+    ((x) == SWDT_EXP_TYPE_RST))
+
+#define IS_SWDT_FLAG(x)                                                        \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | SWDT_FLAG_ALL) == SWDT_FLAG_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup SWDT_Global_Functions SWDT Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes SWDT.
+ * @param  [in] pstcSwdtInit            Pointer to a @ref stc_swdt_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initializes success
+ *           - LL_ERR_INVD_PARAM: pstcSwdtInit == NULL
+ */
+int32_t SWDT_Init(const stc_swdt_init_t *pstcSwdtInit)
+{
+    int32_t i32Ret = LL_OK;
+    uint32_t u32Temp;
+
+    if (NULL == pstcSwdtInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_SWDT_CNT_PERIOD(pstcSwdtInit->u32CountPeriod));
+        DDL_ASSERT(IS_SWDT_CLK_DIV(pstcSwdtInit->u32ClockDiv));
+        DDL_ASSERT(IS_SWDT_REFRESH_RANGE(pstcSwdtInit->u32RefreshRange));
+        DDL_ASSERT(IS_SWDT_LPM_CNT(pstcSwdtInit->u32LPMCount));
+        DDL_ASSERT(IS_SWDT_EXP_TYPE(pstcSwdtInit->u32ExceptionType));
+
+        u32Temp = pstcSwdtInit->u32CountPeriod  | pstcSwdtInit->u32ClockDiv |
+                  pstcSwdtInit->u32RefreshRange | pstcSwdtInit->u32LPMCount | pstcSwdtInit->u32ExceptionType;
+        /* SWDT CR Configuration(Software Start Mode) */
+        MODIFY_REG32(CM_SWDT->CR, SWDT_CR_CLR_MASK, u32Temp);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  SWDT feed dog.
+ * @note   In software startup mode, Start counter when refreshing for the first time.
+ * @param  None
+ * @retval None
+ */
+void SWDT_FeedDog(void)
+{
+    WRITE_REG32(CM_SWDT->RR, SWDT_REFRESH_KEY_START);
+    WRITE_REG32(CM_SWDT->RR, SWDT_REFRESH_KEY_END);
+}
+
+/**
+ * @brief  Get SWDT flag status.
+ * @param  [in] u32Flag                 SWDT flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SWDT_FLAG_UDF:        Count underflow flag
+ *           @arg SWDT_FLAG_REFRESH:    Refresh error flag
+ *           @arg SWDT_FLAG_ALL:        All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t SWDT_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SWDT_FLAG(u32Flag));
+
+    if (0UL != (READ_REG32_BIT(CM_SWDT->SR, u32Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear SWDT flag.
+ * @param  [in] u32Flag                 SWDT flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg SWDT_FLAG_UDF:        Count underflow flag
+ *           @arg SWDT_FLAG_REFRESH:    Refresh error flag
+ *           @arg SWDT_FLAG_ALL:        All of the above
+ * @retval int32_t:
+ *           - LL_OK: Clear flag success
+ *           - LL_ERR_TIMEOUT: Clear flag timeout
+ */
+int32_t SWDT_ClearStatus(uint32_t u32Flag)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_SWDT_FLAG(u32Flag));
+
+    /* Waiting for FLAG bit clear */
+    u32Count = SWDT_CLR_FLAG_TIMEOUT * (HCLK_VALUE / 25000UL);
+    while (0UL != READ_REG32_BIT(CM_SWDT->SR, u32Flag)) {
+        MODIFY_REG32(CM_SWDT->SR, SWDT_FLAG_ALL, ~u32Flag);
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_SWDT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_tmr0.c
+++ b/hc32f4a2/src/hc32_ll_tmr0.c
@@ -1,0 +1,630 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr0.c
+ * @brief This file provides firmware functions to manage the TMR0
+ *        (TMR0).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2024-06-30       CDT             Modify API of TMR0_DeInit()
+                                    Modify TMR0_ClearStatus for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_tmr0.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TMR0 TMR0
+ * @brief TMR0 Driver Library
+ * @{
+ */
+
+#if (LL_TMR0_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR0_Local_Macros TMR0 Local Macros
+ * @{
+ */
+/* Max channel number */
+#define TMR0_CH_MAX                     (2UL)
+
+#define TMR0_CLK_SRC_MASK               (TMR0_BCONR_SYNSA | TMR0_BCONR_SYNCLKA | TMR0_BCONR_ASYNCLKA)
+#define TMR0_BCONR_CLR_MASK             (TMR0_BCONR_CAPMDA | TMR0_BCONR_CKDIVA | TMR0_BCONR_HICPA | TMR0_CLK_SRC_MASK)
+
+/**
+ * @defgroup TMR0_Register_Address TMR0 Register Address
+ * @{
+ */
+#define TMR0_CNTR_ADDR(__UNIT__, __CH__)    (__IO uint32_t*)((uint32_t)(&((__UNIT__)->CNTAR)) + ((__CH__) << 2UL))
+#define TMR0_CMPR_ADDR(__UNIT__, __CH__)    (__IO uint32_t*)((uint32_t)(&((__UNIT__)->CMPAR)) + ((__CH__) << 2UL))
+/**
+ * @}
+ */
+#define TMR0_CH_OFFSET(__CH__)          ((__CH__) << 4U)
+
+/**
+ * @defgroup TMR0_Check_Parameters_Validity TMR0 Check Parameters Validity
+ * @{
+ */
+#define IS_TMR0_UNIT(x)                                                        \
+(   ((x) == CM_TMR0_1)                              ||                         \
+    ((x) == CM_TMR0_2))
+
+#define IS_TMR0_CH(x)                                                          \
+(   ((x) == TMR0_CH_A)                              ||                         \
+    ((x) == TMR0_CH_B))
+
+#define IS_TMR0_CLK_SRC(x)                                                     \
+(   ((x) == TMR0_CLK_SRC_INTERN_CLK)                ||                         \
+    ((x) == TMR0_CLK_SRC_SPEC_EVT)                  ||                         \
+    ((x) == TMR0_CLK_SRC_LRC)                       ||                         \
+    ((x) == TMR0_CLK_SRC_XTAL32))
+
+#define IS_TMR0_CLK_DIV(x)                                                     \
+(   ((x) == TMR0_CLK_DIV1)                          ||                         \
+    ((x) == TMR0_CLK_DIV2)                          ||                         \
+    ((x) == TMR0_CLK_DIV4)                          ||                         \
+    ((x) == TMR0_CLK_DIV8)                          ||                         \
+    ((x) == TMR0_CLK_DIV16)                         ||                         \
+    ((x) == TMR0_CLK_DIV32)                         ||                         \
+    ((x) == TMR0_CLK_DIV64)                         ||                         \
+    ((x) == TMR0_CLK_DIV128)                        ||                         \
+    ((x) == TMR0_CLK_DIV256)                        ||                         \
+    ((x) == TMR0_CLK_DIV512)                        ||                         \
+    ((x) == TMR0_CLK_DIV1024))
+
+#define IS_TMR0_FUNC(x)                                                        \
+(   ((x) == TMR0_FUNC_CMP)                          ||                         \
+    ((x) == TMR0_FUNC_CAPT))
+
+#define IS_TMR0_INT(x)                                                         \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | TMR0_INT_ALL) == TMR0_INT_ALL))
+
+#define IS_TMR0_FLAG(x)                                                        \
+(   ((x) != 0U)                                     &&                         \
+    (((x) | TMR0_FLAG_ALL) == TMR0_FLAG_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup TMR0_Global_Functions TMR0 Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-Initialize TMR0 function
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t TMR0_DeInit(CM_TMR0_TypeDef *TMR0x)
+{
+    int32_t i32Ret = LL_OK;
+
+    uint32_t u32Ch;
+    __IO uint32_t *CNTR;
+    __IO uint32_t *CMPR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+
+    WRITE_REG32(TMR0x->BCONR, 0UL);
+    WRITE_REG32(TMR0x->STFLR, 0UL);
+    for (u32Ch = 0UL; u32Ch < TMR0_CH_MAX; u32Ch++) {
+        CNTR = TMR0_CNTR_ADDR(TMR0x, u32Ch);
+        WRITE_REG32(*CNTR, 0UL);
+        CMPR = TMR0_CMPR_ADDR(TMR0x, u32Ch);
+        WRITE_REG32(*CMPR, 0x0000FFFFUL);
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize TMR0 function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] pstcTmr0Init            Pointer to a @ref stc_tmr0_init_t.
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcTmr0Init is NULL
+ */
+int32_t TMR0_Init(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, const stc_tmr0_init_t *pstcTmr0Init)
+{
+    __IO uint32_t *CNTR;
+    __IO uint32_t *CMPR;
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTmr0Init) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+        DDL_ASSERT(IS_TMR0_CH(u32Ch));
+        DDL_ASSERT(IS_TMR0_CLK_SRC(pstcTmr0Init->u32ClockSrc));
+        DDL_ASSERT(IS_TMR0_CLK_DIV(pstcTmr0Init->u32ClockDiv));
+        DDL_ASSERT(IS_TMR0_FUNC(pstcTmr0Init->u32Func));
+
+        CNTR = TMR0_CNTR_ADDR(TMR0x, u32Ch);
+        WRITE_REG32(*CNTR, 0UL);
+        CMPR = TMR0_CMPR_ADDR(TMR0x, u32Ch);
+        WRITE_REG32(*CMPR, pstcTmr0Init->u16CompareValue);
+        MODIFY_REG32(TMR0x->BCONR, (TMR0_BCONR_CLR_MASK << TMR0_CH_OFFSET(u32Ch)),
+                     ((pstcTmr0Init->u32ClockSrc | pstcTmr0Init->u32ClockDiv |
+                       pstcTmr0Init->u32Func) << TMR0_CH_OFFSET(u32Ch)));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr0_init_t to default values.
+ * @param  [out] pstcTmr0Init           Pointer to a @ref stc_tmr0_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK: Initialize success
+ *           - LL_ERR_INVD_PARAM: pstcTmr0Init is NULL
+ */
+int32_t TMR0_StructInit(stc_tmr0_init_t *pstcTmr0Init)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcTmr0Init) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        pstcTmr0Init->u32ClockSrc       = TMR0_CLK_SRC_INTERN_CLK;
+        pstcTmr0Init->u32ClockDiv       = TMR0_CLK_DIV1;
+        pstcTmr0Init->u32Func           = TMR0_FUNC_CMP;
+        pstcTmr0Init->u16CompareValue   = 0xFFFFU;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Start TMR0.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @retval None
+ */
+void TMR0_Start(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    SET_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_CSTA << TMR0_CH_OFFSET(u32Ch)));
+}
+
+/**
+ * @brief  Stop TMR0.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @retval None
+ */
+void TMR0_Stop(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    CLR_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_CSTA << TMR0_CH_OFFSET(u32Ch)));
+}
+
+/**
+ * @brief  Set Tmr0 counter value.
+ * @note   Setting the count requires stop tmr0.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] u16Value                The data to write to the counter register
+ * @retval None
+ */
+void TMR0_SetCountValue(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint16_t u16Value)
+{
+    __IO uint32_t *CNTR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    CNTR = TMR0_CNTR_ADDR(TMR0x, u32Ch);
+    WRITE_REG32(*CNTR, u16Value);
+}
+
+/**
+ * @brief  Get Tmr0 counter value.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @retval uint16_t                     The counter register data
+ */
+uint16_t TMR0_GetCountValue(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch)
+{
+    __IO uint32_t *CNTR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    CNTR = TMR0_CNTR_ADDR(TMR0x, u32Ch);
+    return (uint16_t)READ_REG32(*CNTR);
+}
+
+/**
+ * @brief  Set Tmr0 compare value.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] u16Value                The data to write to the compare register
+ * @retval None
+ */
+void TMR0_SetCompareValue(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint16_t u16Value)
+{
+    __IO uint32_t *CMPR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    CMPR = TMR0_CMPR_ADDR(TMR0x, u32Ch);
+    WRITE_REG32(*CMPR, u16Value);
+}
+
+/**
+ * @brief  Get Tmr0 compare value.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @retval The compare register data
+ */
+uint16_t TMR0_GetCompareValue(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch)
+{
+    __IO uint32_t *CMPR;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+
+    CMPR = TMR0_CMPR_ADDR(TMR0x, u32Ch);
+    return (uint16_t)READ_REG32(*CMPR);
+}
+
+/**
+ * @brief  Set clock source.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] u32Src                  Specifies the clock source
+ *         This parameter can be a value of the following:
+ *           @arg @ref TMR0_Clock_Source
+ * @retval None
+ */
+void TMR0_SetClockSrc(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Src)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_TMR0_CLK_SRC(u32Src));
+
+    MODIFY_REG32(TMR0x->BCONR, (TMR0_CLK_SRC_MASK << TMR0_CH_OFFSET(u32Ch)), (u32Src << TMR0_CH_OFFSET(u32Ch)));
+}
+
+/**
+ * @brief  Set the division of clock.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] u32Div                  Specifies the clock source division
+ *         This parameter can be a value of the following:
+ *           @arg TMR0_CLK_DIV1:        Clock source / 1
+ *           @arg TMR0_CLK_DIV2:        Clock source / 2
+ *           @arg TMR0_CLK_DIV4:        Clock source / 4
+ *           @arg TMR0_CLK_DIV8:        Clock source / 8
+ *           @arg TMR0_CLK_DIV16:       Clock source / 16
+ *           @arg TMR0_CLK_DIV32:       Clock source / 32
+ *           @arg TMR0_CLK_DIV64:       Clock source / 64
+ *           @arg TMR0_CLK_DIV128:      Clock source / 128
+ *           @arg TMR0_CLK_DIV256:      Clock source / 256
+ *           @arg TMR0_CLK_DIV512:      Clock source / 512
+ *           @arg TMR0_CLK_DIV1024:     Clock source / 1024
+ * @retval None.
+ */
+void TMR0_SetClockDiv(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Div)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_TMR0_CLK_DIV(u32Div));
+
+    MODIFY_REG32(TMR0x->BCONR, (TMR0_BCONR_CKDIVA << TMR0_CH_OFFSET(u32Ch)), (u32Div << TMR0_CH_OFFSET(u32Ch)));
+}
+
+/**
+ * @brief  Set Tmr0 Function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] u32Func                 Select TMR0 function
+ *         This parameter can be a value of the following:
+ *           @arg TMR0_FUNC_CMP:        Select the Compare function
+ *           @arg TMR0_FUNC_CAPT:       Select the Capture function
+ * @retval None
+ */
+void TMR0_SetFunc(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, uint32_t u32Func)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_TMR0_FUNC(u32Func));
+
+    MODIFY_REG32(TMR0x->BCONR, ((TMR0_BCONR_CAPMDA | TMR0_BCONR_HICPA) << TMR0_CH_OFFSET(u32Ch)),
+                 (u32Func << TMR0_CH_OFFSET(u32Ch)));
+}
+
+/**
+ * @brief  Enable or disable hardware trigger capture function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR0_HWCaptureCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HICPA << TMR0_CH_OFFSET(u32Ch)));
+    } else {
+        CLR_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HICPA << TMR0_CH_OFFSET(u32Ch)));
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware trigger start function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR0_HWStartCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HSTAA << TMR0_CH_OFFSET(u32Ch)));
+    } else {
+        CLR_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HSTAA << TMR0_CH_OFFSET(u32Ch)));
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware trigger stop function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR0_HWStopCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HSTPA << TMR0_CH_OFFSET(u32Ch)));
+    } else {
+        CLR_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HSTPA << TMR0_CH_OFFSET(u32Ch)));
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware trigger clear function.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Ch                   TMR0 channel
+ *         This parameter can be one of the following values:
+ *           @arg @ref TMR0_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR0_HWClearCondCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HCLEA << TMR0_CH_OFFSET(u32Ch)));
+    } else {
+        CLR_REG32_BIT(TMR0x->BCONR, (TMR0_BCONR_HCLEA << TMR0_CH_OFFSET(u32Ch)));
+    }
+}
+
+/**
+ * @brief  Enable or disable specified Tmr0 interrupt.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32IntType              TMR0 interrupt type
+ *         This parameter can be any combination value of the following values:
+ *           @arg @ref TMR0_Interrupt.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR0_IntCmd(CM_TMR0_TypeDef *TMR0x, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR0x->BCONR, u32IntType);
+    } else {
+        CLR_REG32_BIT(TMR0x->BCONR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get Tmr0 status.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Flag                 TMR0 flag type
+ *         This parameter can be any combination value of the following values:
+ *           @arg @ref TMR0_FLAG
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t TMR0_GetStatus(const CM_TMR0_TypeDef *TMR0x, uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_FLAG(u32Flag));
+
+    if (0UL != (READ_REG32_BIT(TMR0x->STFLR, u32Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear Tmr0 status.
+ * @param  [in] TMR0x                   Pointer to TMR0 unit instance
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR0 or CM_TMR0_x: TMR0 unit instance
+ * @param  [in] u32Flag                 TMR0 flag type
+ *         This parameter can be any combination value of the following values:
+ *           @arg @ref TMR0_FLAG
+ * @retval None
+ */
+void TMR0_ClearStatus(CM_TMR0_TypeDef *TMR0x, uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR0_UNIT(TMR0x));
+    DDL_ASSERT(IS_TMR0_FLAG(u32Flag));
+
+    WRITE_REG32(TMR0x->STFLR, (~u32Flag) & TMR0_FLAG_ALL);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR0_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_tmr2.c
+++ b/hc32f4a2/src/hc32_ll_tmr2.c
@@ -1,0 +1,813 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr2.c
+ * @brief This file provides firmware functions to manage the TMR2(Timer2).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Deleted redundant comments
+   2024-06-30       CDT             Modify TMR2_DeInit()
+                                    Modify TMR2_ClearStatus for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_tmr2.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TMR2 TMR2
+ * @brief TMR2 Driver Library
+ * @{
+ */
+#if (LL_TMR2_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR2_Local_Macros TMR2 Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR2_Configuration_Bit_Mask TMR2 Configuration Bit Mask
+ * @{
+ */
+#define TMR2_BCONR_INIT_MASK                (TMR2_BCONR_CAPMDA | TMR2_BCONR_SYNSA | TMR2_BCONR_SYNCLKA | \
+                                             TMR2_BCONR_ASYNCLKA | TMR2_BCONR_CKDIVA | TMR2_BCONR_SYNCLKAT)
+#define TMR2_BCONR_CLK_CFG_MASK             (TMR2_BCONR_SYNSA | TMR2_BCONR_SYNCLKA | \
+                                             TMR2_BCONR_ASYNCLKA | TMR2_BCONR_SYNCLKAT)
+
+#define TMR2_PWM_POLARITY_MASK              (TMR2_PCONR_STACA | TMR2_PCONR_STPCA | TMR2_PCONR_CMPCA)
+#define TMR2_FILTER_CLK_DIV_MASK            (TMR2_PCONR_NOFICKA)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Channel_Cfg_Bit_Field_Offset TMR2 Channel Configuration Bit Field Offset
+ * @{
+ */
+#define TMR2_CH_OFFSET                      (16U)
+
+#define TMR2_PWM_POLARITY_OFFSET            (2U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR2_Check_Parameters_Validity TMR2 check parameters validity
+ * @{
+ */
+#define IS_TMR2_BIT_MASK(x, mask)   (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+#define IS_TMR2_UNIT(x)                                                        \
+(   ((x) == CM_TMR2_1)                       ||                                \
+    ((x) == CM_TMR2_2)                       ||                                \
+    ((x) == CM_TMR2_3)                       ||                                \
+    ((x) == CM_TMR2_4))
+
+#define IS_TMR2_CH(x)               ((x) <= TMR2_CH_B)
+
+#define IS_TMR2_FUNC(x)             (((x) == TMR2_FUNC_CMP) || ((x) == TMR2_FUNC_CAPT))
+
+#define IS_TMR2_CLK_SRC(x)                                                     \
+(   ((x) == TMR2_CLK_PCLK1)                 ||                                 \
+    ((x) == TMR2_CLK_TRIG_RISING)           ||                                 \
+    ((x) == TMR2_CLK_TRIG_FALLING)          ||                                 \
+    ((x) == TMR2_CLK_EVT)                   ||                                 \
+    ((x) == TMR2_CLK_TMR6_OVF)              ||                                 \
+    ((x) == TMR2_CLK_TMR6_UDF)              ||                                 \
+    ((x) == TMR2_CLK_TMR6_OVF_UDF)          ||                                 \
+    ((x) == TMR2_CLK_LRC)                   ||                                 \
+    ((x) == TMR2_CLK_XTAL32)                ||                                 \
+    ((x) == TMR2_CLK_PIN_CLK))
+
+#define IS_TMR2_CLK_DIV(x)                                                     \
+(   ((x) == TMR2_CLK_DIV1)                  ||                                 \
+    ((x) == TMR2_CLK_DIV2)                  ||                                 \
+    ((x) == TMR2_CLK_DIV4)                  ||                                 \
+    ((x) == TMR2_CLK_DIV8)                  ||                                 \
+    ((x) == TMR2_CLK_DIV16)                 ||                                 \
+    ((x) == TMR2_CLK_DIV32)                 ||                                 \
+    ((x) == TMR2_CLK_DIV64)                 ||                                 \
+    ((x) == TMR2_CLK_DIV128)                ||                                 \
+    ((x) == TMR2_CLK_DIV256)                ||                                 \
+    ((x) == TMR2_CLK_DIV512)                ||                                 \
+    ((x) == TMR2_CLK_DIV1024))
+
+#define IS_TMR2_INT(x)              IS_TMR2_BIT_MASK((x), TMR2_INT_ALL)
+
+#define IS_TMR2_FLAG(x)             IS_TMR2_BIT_MASK((x), TMR2_FLAG_ALL)
+
+#define IS_TMR2_PWM_START_POLARITY(x)                                          \
+(   ((x) == TMR2_PWM_LOW)                   ||                                 \
+    ((x) == TMR2_PWM_HIGH)                  ||                                 \
+    ((x) == TMR2_PWM_HOLD))
+
+#define IS_TMR2_PWM_STOP_POLARITY(x)                                           \
+(   ((x) == TMR2_PWM_LOW)                   ||                                 \
+    ((x) == TMR2_PWM_HIGH)                  ||                                 \
+    ((x) == TMR2_PWM_HOLD))
+
+#define IS_TMR2_PWM_MATCH_CMP_POLARITY(x)                                      \
+(   ((x) == TMR2_PWM_LOW)                   ||                                 \
+    ((x) == TMR2_PWM_HIGH)                  ||                                 \
+    ((x) == TMR2_PWM_HOLD)                  ||                                 \
+    ((x) == TMR2_PWM_INVT))
+
+#define IS_TMR2_PWM_POLARITY(st, pol)                                          \
+(   (((st) == TMR2_CNT_STAT_START) && IS_TMR2_PWM_START_POLARITY(pol))      || \
+    (((st) == TMR2_CNT_STAT_STOP) && IS_TMR2_PWM_STOP_POLARITY(pol))        || \
+    (((st) == TMR2_CNT_STAT_MATCH_CMP) && IS_TMR2_PWM_MATCH_CMP_POLARITY(pol)))
+
+#define IS_TMR2_START_COND(x)       IS_TMR2_BIT_MASK((x), TMR2_START_COND_ALL)
+
+#define IS_TMR2_STOP_COND(x)        IS_TMR2_BIT_MASK((x), TMR2_STOP_COND_ALL)
+
+#define IS_TMR2_CLR_COND(x)         IS_TMR2_BIT_MASK((x), TMR2_CLR_COND_ALL)
+
+#define IS_TMR2_CAPT_COND(x)        IS_TMR2_BIT_MASK((x), TMR2_CAPT_COND_ALL)
+
+#define IS_TMR2_FILTER_CLK_DIV(x)                                              \
+(   ((x) == TMR2_FILTER_CLK_DIV1)           ||                                 \
+    ((x) == TMR2_FILTER_CLK_DIV4)           ||                                 \
+    ((x) == TMR2_FILTER_CLK_DIV16)          ||                                 \
+    ((x) == TMR2_FILTER_CLK_DIV64))
+
+#define IS_TMR2_VALID_VAL(x)        ((x) <= 0xFFFFUL)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup TMR2_Global_Functions TMR2 Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes the specified TMR2 channel according to the specified parameters
+ *         in the structure stc_tmr2_init_t
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  pstcTmr2Init           Pointer to a stc_tmr2_init_t structure value that
+ *                                      contains the configuration information for the TMR2 channel.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmr2Init == NULL.
+ */
+int32_t TMR2_Init(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, const stc_tmr2_init_t *pstcTmr2Init)
+{
+    uint32_t u32Tmp;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    __IO uint32_t *reg32CMPR;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    if (pstcTmr2Init != NULL) {
+        DDL_ASSERT(IS_TMR2_CLK_SRC(pstcTmr2Init->u32ClockSrc));
+        DDL_ASSERT(IS_TMR2_CLK_DIV(pstcTmr2Init->u32ClockDiv));
+        DDL_ASSERT(IS_TMR2_FUNC(pstcTmr2Init->u32Func));
+        DDL_ASSERT(IS_TMR2_VALID_VAL(pstcTmr2Init->u32CompareValue));
+
+        u32Tmp = pstcTmr2Init->u32Func | pstcTmr2Init->u32ClockSrc |
+                 pstcTmr2Init->u32ClockDiv;
+        reg32CMPR = (__IO uint32_t *)((uint32_t)&TMR2x->CMPAR);
+        WRITE_REG32(reg32CMPR[u32Ch], pstcTmr2Init->u32CompareValue);
+        /* Channel bit filed offset. */
+        u32Ch *= TMR2_CH_OFFSET;
+        MODIFY_REG32(TMR2x->BCONR, (TMR2_BCONR_INIT_MASK << u32Ch), (u32Tmp << u32Ch));
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set a default value for TMR2 initialization structure.
+ * @param  [in]  pstcTmr2Init           Pointer to a stc_tmr2_init_t structure that
+ *                                      contains configuration information.
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmr2Init == NULL.
+ */
+int32_t TMR2_StructInit(stc_tmr2_init_t *pstcTmr2Init)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcTmr2Init != NULL) {
+        pstcTmr2Init->u32ClockSrc = TMR2_CLK_PCLK1;
+        pstcTmr2Init->u32ClockDiv = TMR2_CLK_DIV1;
+        pstcTmr2Init->u32Func     = TMR2_FUNC_CMP;
+        pstcTmr2Init->u32CompareValue = 0xFFFFUL;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initializes the specified TMR2 unit.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t TMR2_DeInit(CM_TMR2_TypeDef *TMR2x)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+
+    CLR_REG32_BIT(TMR2x->BCONR, TMR2_BCONR_CSTA | TMR2_BCONR_CSTB);
+    WRITE_REG32(TMR2x->CMPBR, 0xFFFFU);
+    CLR_REG32(TMR2x->CNTBR);
+    CLR_REG32(TMR2x->CNTAR);
+    CLR_REG32(TMR2x->BCONR);
+    CLR_REG32(TMR2x->ICONR);
+    CLR_REG32(TMR2x->PCONR);
+    CLR_REG32(TMR2x->HCONR);
+    CLR_REG32(TMR2x->STFLR);
+    WRITE_REG32(TMR2x->CMPAR, 0xFFFFU);
+
+    return LL_OK;
+}
+
+/**
+ * @brief  Specifies the function mode for the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Func                Function mode.
+ *                                      This parameter can be a value of @ref TMR2_Function
+ *   @arg  TMR2_FUNC_CMP:               The function of TMR2 channel is output compare.
+ *   @arg  TMR2_FUNC_CAPT:              The function of TMR2 channel is input capture.
+ * @retval None
+ */
+void TMR2_SetFunc(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Func)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_FUNC(u32Func));
+
+    /* Channel bit filed offset. */
+    u32Ch *= TMR2_CH_OFFSET;
+    MODIFY_REG32(TMR2x->BCONR, (TMR2_BCONR_CAPMDA << u32Ch), (u32Func << u32Ch));
+}
+
+/**
+ * @brief  Specifies the clock source for the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Src                 Clock source.
+ *                                      This parameter can be a value of @ref TMR2_Clock_Source
+ * @retval None
+ */
+void TMR2_SetClockSrc(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Src)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_CLK_SRC(u32Src));
+
+    /* Channel bit filed offset. */
+    u32Ch *= TMR2_CH_OFFSET;
+    MODIFY_REG32(TMR2x->BCONR, (TMR2_BCONR_CLK_CFG_MASK << u32Ch), (u32Src << u32Ch));
+}
+
+/**
+ * @brief  Specifies the clock divider for the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Div                 Clock divider.
+ *                                      This parameter can be a value of @ref TMR2_Clock_Divider
+ * @retval None
+ */
+void TMR2_SetClockDiv(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Div)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_CLK_DIV(u32Div));
+
+    /* Channel bit filed offset. */
+    u32Ch *= TMR2_CH_OFFSET;
+    MODIFY_REG32(TMR2x->BCONR, (TMR2_BCONR_CKDIVA << u32Ch), (u32Div << u32Ch));
+}
+
+/**
+ * @brief  Set a default value for the TMR2 output compare configuration structure.
+ * @param  [in]  pstcPwmInit            Pointer to a stc_tmr2_pwm_init_t structure value that
+ *                                      contains the configuration information for the TMR2 PWM.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmr2Init == NULL.
+ */
+int32_t TMR2_PWM_StructInit(stc_tmr2_pwm_init_t *pstcPwmInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcPwmInit != NULL) {
+        pstcPwmInit->u32StartPolarity = TMR2_PWM_HIGH;
+        pstcPwmInit->u32StopPolarity  = TMR2_PWM_LOW;
+        pstcPwmInit->u32CompareMatchPolarity = TMR2_PWM_INVT;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Configures the PWM of the specified TMR2 channel
+ *         according to the specified parameters in the structure @ref stc_tmr2_pwm_init_t
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  pstcPwmInit            Pointer to a @ref stc_tmr2_pwm_init_t structure value that
+ *                                      contains the configuration information for the TMR2 PWM.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmr2Init == NULL.
+ */
+int32_t TMR2_PWM_Init(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, const stc_tmr2_pwm_init_t *pstcPwmInit)
+{
+    uint32_t u32Tmp;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    if (pstcPwmInit != NULL) {
+        DDL_ASSERT(IS_TMR2_PWM_START_POLARITY(pstcPwmInit->u32StartPolarity));
+        DDL_ASSERT(IS_TMR2_PWM_STOP_POLARITY(pstcPwmInit->u32StopPolarity));
+        DDL_ASSERT(IS_TMR2_PWM_MATCH_CMP_POLARITY(pstcPwmInit->u32CompareMatchPolarity));
+        /* Configures PWM polarity. */
+        u32Tmp = (pstcPwmInit->u32StartPolarity << TMR2_PCONR_STACA_POS) | \
+                 (pstcPwmInit->u32StopPolarity << TMR2_PCONR_STPCA_POS)  | \
+                 (pstcPwmInit->u32CompareMatchPolarity << TMR2_PCONR_CMPCA_POS);
+        u32Ch *= TMR2_CH_OFFSET;
+        MODIFY_REG32(TMR2x->PCONR, (TMR2_PWM_POLARITY_MASK << u32Ch), (u32Tmp << u32Ch));
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable PWM output of the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_PWM_OutputCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    uint32_t u32PCONRAddr;
+    uint8_t au8EnPos[] = {TMR2_PCONR_OUTENA_POS, TMR2_PCONR_OUTENB_POS};
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32PCONRAddr = (uint32_t)&TMR2x->PCONR;
+    WRITE_REG32(PERIPH_BIT_BAND(u32PCONRAddr, au8EnPos[u32Ch]), enNewState);
+}
+
+/**
+ * @brief  Enable or disable the specified hardware capture condition.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Cond                Hardware capture condition.
+ *                                      This parameter can be a value of @ref TMR2_Capture_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_HWCaptureCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_CAPT_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Cond <<= (u32Ch * TMR2_CH_OFFSET);
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(TMR2x->HCONR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR2x->HCONR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified hardware start condition.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Cond                Hardware start condition.
+ *                                      This parameter can be a value of @ref TMR2_Start_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_HWStartCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_START_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Cond <<= (u32Ch * TMR2_CH_OFFSET);
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(TMR2x->HCONR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR2x->HCONR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified hardware stop condition.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Cond                Hardware stop condition.
+ *                                      This parameter can be a value of @ref TMR2_Stop_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_HWStopCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_STOP_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Cond <<= (u32Ch * TMR2_CH_OFFSET);
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(TMR2x->HCONR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR2x->HCONR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified hardware clear condition.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Cond                Hardware clear condition.
+ *                                      This parameter can be a value of @ref TMR2_Clear_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_HWClearCondCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_CLR_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Cond <<= (u32Ch * TMR2_CH_OFFSET);
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(TMR2x->HCONR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR2x->HCONR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Specifies the clock divider of filter.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Div                 The clock source divider of the filter.
+ *                                      This parameter can be a value of @ref TMR2_Filter_Clock_Divider
+ *   @arg  TMR2_FILTER_CLK_DIV1:        The filter clock is the clock of timer2 / 1.
+ *   @arg  TMR2_FILTER_CLK_DIV4:        The filter clock is the clock of timer2 / 4.
+ *   @arg  TMR2_FILTER_CLK_DIV16:       The filter clock is the clock of timer2 / 16.
+ *   @arg  TMR2_FILTER_CLK_DIV64:       The filter clock is the clock of timer2 / 64.
+ * @retval None
+ */
+void TMR2_SetFilterClockDiv(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Div)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_FILTER_CLK_DIV(u32Div));
+
+    u32Ch *= TMR2_CH_OFFSET;
+    MODIFY_REG32(TMR2x->PCONR, TMR2_FILTER_CLK_DIV_MASK << u32Ch, u32Div << u32Ch);
+}
+
+/**
+ * @brief  Enable or disable the filter of the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_FilterCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    uint32_t u32PCONRAddr;
+    uint8_t au8EnPos[] = {TMR2_PCONR_NOFIENA_POS, TMR2_PCONR_NOFIENB_POS};
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32PCONRAddr = (uint32_t)&TMR2x->PCONR;
+    WRITE_REG32(PERIPH_BIT_BAND(u32PCONRAddr, au8EnPos[u32Ch]), enNewState);
+}
+
+/**
+ * @brief  Enable or disable the interrupt of the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32IntType             The interrupt type.
+ *                                      This parameter can be values of @ref TMR2_Interrupt_Type
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR2_IntCmd(CM_TMR2_TypeDef *TMR2x, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG32_BIT(TMR2x->ICONR, u32IntType);
+    } else {
+        CLR_REG32_BIT(TMR2x->ICONR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Start the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @retval None
+ */
+void TMR2_Start(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    SET_REG32_BIT(TMR2x->BCONR, TMR2_BCONR_CSTA << (u32Ch * TMR2_CH_OFFSET));
+}
+
+/**
+ * @brief  Stop the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @retval None
+ */
+void TMR2_Stop(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    CLR_REG32_BIT(TMR2x->BCONR, TMR2_BCONR_CSTA << (u32Ch * TMR2_CH_OFFSET));
+}
+
+/**
+ * @brief  Get the status of the specified TMR2 flag.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Flag                TMR2 status flag.
+ *                                      This parameter can be values of @ref TMR2_Status_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t TMR2_GetStatus(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Flag)
+{
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_FLAG(u32Flag));
+
+    if (READ_REG32_BIT(TMR2x->STFLR, u32Flag) != 0U) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified TMR2 flag.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Flag                TMR2 status flag.
+ *                                      This parameter can be values of @ref TMR2_Status_Flag
+ * @retval None
+ */
+void TMR2_ClearStatus(CM_TMR2_TypeDef *TMR2x, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_FLAG(u32Flag));
+
+    WRITE_REG32(TMR2x->STFLR, (~u32Flag) & TMR2_FLAG_ALL);
+}
+
+/**
+ * @brief  Set compare value for the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  The TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Value               The compare reference value of the specified TMR2 channel.
+ *                                      This parameter can be a number between 0U and 0xFFFFU, inclusive.
+ * @retval None
+ */
+void TMR2_SetCompareValue(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Value)
+{
+    __IO uint32_t *reg32CMPR;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_VALID_VAL(u32Value));
+
+    reg32CMPR = (__IO uint32_t *)((uint32_t)&TMR2x->CMPAR);
+    WRITE_REG32(reg32CMPR[u32Ch], u32Value);
+}
+
+/**
+ * @brief  Get compare value of the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                The TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @retval The compare value of the specified TMR2 channel. A number between 0U and 0xFFFFU, inclusive.
+ */
+uint32_t TMR2_GetCompareValue(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch)
+{
+    __IO uint32_t *reg32CMPR;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    reg32CMPR = (__IO uint32_t *)((uint32_t)&TMR2x->CMPAR);
+    return reg32CMPR[u32Ch];
+}
+
+/**
+ * @brief  Set counter value for the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  The TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @param  [in]  u32Value               The counter value for the specified TMR2 channel.
+ *                                      This parameter can be a number between 0U and 0xFFFFU, inclusive.
+ * @retval None
+ */
+void TMR2_SetCountValue(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint32_t u32Value)
+{
+    __IO uint32_t *reg32CNTR;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_VALID_VAL(u32Value));
+
+    reg32CNTR = (__IO uint32_t *)((uint32_t)&TMR2x->CNTAR);
+    WRITE_REG32(reg32CNTR[u32Ch], u32Value);
+}
+
+/**
+ * @brief  Get counter value of the specified TMR2 channel.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  The TMR2 channel.
+ *                                      This parameter can be a value of @ref TMR2_Channel
+ * @retval The counter value of the specified TMR2 channel. A number between 0U and 0xFFFFU, inclusive.
+ */
+uint32_t TMR2_GetCountValue(const CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch)
+{
+    __IO uint32_t *reg32CNTR;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+
+    reg32CNTR = (__IO uint32_t *)((uint32_t)&TMR2x->CNTAR);
+    return reg32CNTR[u32Ch];
+}
+
+/**
+ * @brief  Specifies the output polarity of the PWM at the specified state of counter.
+ * @param  [in]  TMR2x                  Pointer to TMR2 instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMR2_x or CM_TMR2
+ * @param  [in]  u32Ch                  TMR2 channel.
+ *                                      This parameter can be a value @ref TMR2_Channel
+ * @param  [in]  u8CountState           TMR2 counter state.
+ *                                      This parameter can be a value @ref TMR2_Counter_State
+ * @param  [in]  u32Polarity            The polarity of PWM.
+ *                                      This parameter can be a value @ref TMR2_PWM_Polarity
+ * @retval None
+ */
+void TMR2_PWM_SetPolarity(CM_TMR2_TypeDef *TMR2x, uint32_t u32Ch, uint8_t u8CountState, uint32_t u32Polarity)
+{
+    uint32_t u32PolarityPos;
+
+    DDL_ASSERT(IS_TMR2_UNIT(TMR2x));
+    DDL_ASSERT(IS_TMR2_CH(u32Ch));
+    DDL_ASSERT(IS_TMR2_PWM_POLARITY(u8CountState, u32Polarity));
+
+    u32PolarityPos = ((uint32_t)u8CountState * TMR2_PWM_POLARITY_OFFSET) + (u32Ch * TMR2_CH_OFFSET);
+    MODIFY_REG32(TMR2x->PCONR, TMR2_PCONR_STACA << u32PolarityPos, u32Polarity << u32PolarityPos);
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR2_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_tmr4.c
+++ b/hc32f4a2/src/hc32_ll_tmr4.c
@@ -1,0 +1,2369 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr4.c
+ * @brief This file provides firmware functions to manage the TMR4(Timer4).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Modify macro-define: TMR4_OCSR_MASK
+                                    Re-name parameter u16IntType to u32IntType
+   2023-01-15       CDT             Add RCSR register data type
+   2023-06-30       CDT             Add function comments: macros group @ref TMR4_OC_Channel
+                                    Modify function return value comments: TMR4_OC_GetPolarity
+                                    Modify function parameter comments: TMR4_PWM_SetPolarity
+                                    Modify typo
+                                    Modify function: TMR4_DeInit, TMR4_OC_DeInit, TMR4_PWM_DeInit, TMR4_EVT_DeInit
+                                    Modify macro-definition: IS_TMR4_OC_BUF_OBJECT
+                                    Fix magic number of function:  TMR4_OC_StructInit
+   2023-09-30       CDT             Fix spell error about "response" that in function name
+                                    Modify function:TMR4_PWM_Init
+                                    Modify comment
+   2024-06-30       CDT             Fix bug that the status flag of CCSR/OCSR for couping risk
+                                    Refine TMR4_GetStatus()
+   2024-09-13       CDT             Fix misra warning, MODIFY_REG->MODIFY_RCSR_REG
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_tmr4.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TMR4 TMR4
+ * @brief TMR4 Driver Library
+ * @{
+ */
+
+#if (LL_TMR4_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR4_Local_Macros TMR4 Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_Check_Parameters_Validity TMR4 Check Parameters Validity
+ * @{
+ */
+#define IS_TMR4_UNIT(x)                                                        \
+(   ((x) == CM_TMR4_1)                      ||                                 \
+    ((x) == CM_TMR4_2)                      ||                                 \
+    ((x) == CM_TMR4_3))
+
+#define IS_TMR4_CLK_DIV(x)                                                     \
+(   ((x) == TMR4_CLK_DIV1)                  ||                                 \
+    ((x) == TMR4_CLK_DIV2)                  ||                                 \
+    ((x) == TMR4_CLK_DIV4)                  ||                                 \
+    ((x) == TMR4_CLK_DIV8)                  ||                                 \
+    ((x) == TMR4_CLK_DIV16)                 ||                                 \
+    ((x) == TMR4_CLK_DIV32)                 ||                                 \
+    ((x) == TMR4_CLK_DIV64)                 ||                                 \
+    ((x) == TMR4_CLK_DIV128)                ||                                 \
+    ((x) == TMR4_CLK_DIV256)                ||                                 \
+    ((x) == TMR4_CLK_DIV512)                ||                                 \
+    ((x) == TMR4_CLK_DIV1024))
+
+#define IS_TMR4_MD(x)                                                          \
+(   ((x) == TMR4_MD_SAWTOOTH)               ||                                 \
+    ((x) == TMR4_MD_TRIANGLE))
+
+#define IS_TMR4_CLK_SRC(x)                                                     \
+(   ((x) == TMR4_CLK_SRC_INTERNCLK)         ||                                 \
+    ((x) == TMR4_CLK_SRC_EXTCLK))
+
+#define IS_TMR4_INT_CNT_MASKTIME(x)         ((x) <= TMR4_INT_CNT_MASK15)
+
+#define IS_TMR4_INT_CNT(x)                                                     \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | TMR4_INT_CNT_MASK) == TMR4_INT_CNT_MASK))
+
+#define IS_TMR4_INT(x)                                                         \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | TMR4_INT_ALL) == TMR4_INT_ALL))
+
+#define IS_TMR4_FLAG(x)                                                        \
+(   ((x) != 0UL)                            &&                                 \
+    (((x) | TMR4_FLAG_ALL) == TMR4_FLAG_ALL))
+
+#define IS_TMR4_OC_HIGH_CH(x)               (((x) & 0x1UL) == 0UL)
+#define IS_TMR4_OC_LOW_CH(x)                (((x) & 0x1UL) == 1UL)
+
+#define IS_TMR4_OC_BUF_OBJECT(x)                                               \
+(   (((x) | TMR4_OC_BUF_OBJECT_MASK) == TMR4_OC_BUF_OBJECT_MASK))
+
+#define IS_TMR4_OC_BUF_COND(x)                                                 \
+(   ((x) == TMR4_OC_BUF_COND_IMMED)         ||                                 \
+    ((x) == TMR4_OC_BUF_COND_PEAK)          ||                                 \
+    ((x) == TMR4_OC_BUF_COND_VALLEY)        ||                                 \
+    ((x) == TMR4_OC_BUF_COND_PEAK_VALLEY))
+
+#define IS_TMR4_OC_INVD_POLARITY(x)                                            \
+(   ((x) == TMR4_OC_INVD_LOW)               ||                                 \
+    ((x) == TMR4_OC_INVD_HIGH))
+
+#define IS_TMR4_PWM_MD(x)                                                      \
+(   ((x) == TMR4_PWM_MD_THROUGH)            ||                                 \
+    ((x) == TMR4_PWM_MD_DEAD_TMR)           ||                                 \
+    ((x) == TMR4_PWM_MD_DEAD_TMR_FILTER))
+
+#define IS_TMR4_PWM_POLARITY(x)                                                \
+(   ((x) == TMR4_PWM_OXH_HOLD_OXL_HOLD)     ||                                 \
+    ((x) == TMR4_PWM_OXH_INVT_OXL_HOLD)     ||                                 \
+    ((x) == TMR4_PWM_OXH_HOLD_OXL_INVT)     ||                                 \
+    ((x) == TMR4_PWM_OXH_INVT_OXL_INVT))
+
+#define IS_TMR4_PWM_CLK_DIV(x)              (((x) | TMR4_PWM_CLK_DIV128) == TMR4_PWM_CLK_DIV128)
+
+#define IS_TMR4_PWM_DEADTIME_REG_IDX(x)                                        \
+(   ((x) == TMR4_PWM_PDAR_IDX)              ||                                 \
+    ((x) == TMR4_PWM_PDBR_IDX))
+
+#define IS_TMR4_PWM_OE_EFFECT(x)                                               \
+(   ((x) == TMR4_PWM_OE_EFFECT_IMMED)       ||                                 \
+    ((x) == TMR4_PWM_OE_EFFECT_COUNT_PEAK)  ||                                 \
+    ((x) == TMR4_PWM_OE_EFFECT_COUNT_VALLEY))
+
+#define IS_TMR4_PWM_PIN_MD(x)                                                  \
+(   ((x) == TMR4_PWM_PIN_OUTPUT_OS)         ||                                 \
+    ((x) == TMR4_PWM_PIN_OUTPUT_NORMAL))
+
+#define IS_TMR4_EVT_MATCH_COND(x)           (((x) | TMR4_EVT_MATCH_CNT_ALL) == TMR4_EVT_MATCH_CNT_ALL)
+
+#define IS_TMR4_EVT_MASK_TYPE(x)                                               \
+(   ((x) != 0U)                             ||                                 \
+    (((x) | TMR4_EVT_MASK_TYPE_ALL) == TMR4_EVT_MASK_TYPE_ALL))
+
+#define IS_TMR4_EVT_DELAY_OBJECT(x)                                            \
+(   ((x) == TMR4_EVT_DELAY_OCCRXH)          ||                                 \
+    ((x) == TMR4_EVT_DELAY_OCCRXL))
+
+#define IS_TMR4_EVT_MD(x)                                                      \
+(   ((x) == TMR4_EVT_MD_DELAY)              ||                                 \
+    ((x) == TMR4_EVT_MD_CMP))
+
+#define IS_TMR4_EVT_MASK(x)                 (((x) | TMR4_EVT_MASK15) == TMR4_EVT_MASK15)
+
+#define IS_TMR4_EVT_BUF_COND(x)                                                \
+(   ((x) == TMR4_EVT_BUF_COND_IMMED)        ||                                 \
+    ((x) == TMR4_EVT_BUF_COND_PEAK)         ||                                 \
+    ((x) == TMR4_EVT_BUF_COND_VALLEY)       ||                                 \
+    ((x) == TMR4_EVT_BUF_COND_PEAK_VALLEY))
+
+#define IS_TMR4_OC_CH(x)                    ((x) <= TMR4_OC_CH_WL)
+#define IS_TMR4_PWM_CH(x)                   ((x) <= TMR4_PWM_CH_W)
+#define IS_TMR4_PWM_PIN(x)                  ((x) <= TMR4_PWM_PIN_OWL)
+#define IS_TMR4_EVT_CH(x)                   ((x) <= TMR4_EVT_CH_WL)
+#define IS_TMR4_EVT_OUTPUT_EVT(x)                                              \
+(   ((x) >> TMR4_SCSR_EVTOS_POS) <= (TMR4_EVT_OUTPUT_EVT5 >> TMR4_SCSR_EVTOS_POS))
+#define IS_TMR4_EVT_OUTPUT_SIGNAL(x)        ((x) <= TMR4_EVT_OUTPUT_EVT5_SIGNAL)
+
+#define IS_TMR4_PWM_ABNORMAL_PIN_STAT(x)    ((x) <= TMR4_PWM_ABNORMAL_PIN_HIGH)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Channel_Max TMR4 Channel Max
+ * @{
+ */
+#define TMR4_OC_CH_MAX              (TMR4_OC_CH_WL)
+#define TMR4_PWM_CH_MAX             (TMR4_PWM_CH_W)
+#define TMR4_EVT_CH_MAX             (TMR4_EVT_CH_WL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Flag_Interrupt_Mask TMR4 Flag and Interrupt Mask
+ * @{
+ */
+#define TMR4_FLAG_CNT_MASK          (TMR4_FLAG_CNT_PEAK | TMR4_FLAG_CNT_VALLEY)
+#define TMR4_INT_CNT_MASK           (TMR4_INT_CNT_PEAK | TMR4_INT_CNT_VALLEY)
+
+#define TMR4_FLAG_OC_MASK           (TMR4_FLAG_OC_CMP_UH | TMR4_FLAG_OC_CMP_UL | TMR4_FLAG_OC_CMP_VH | \
+                                     TMR4_FLAG_OC_CMP_VL | TMR4_FLAG_OC_CMP_WH | TMR4_FLAG_OC_CMP_WL)
+#define TMR4_INT_OC_MASK            (TMR4_INT_OC_CMP_UH | TMR4_INT_OC_CMP_UL | TMR4_INT_OC_CMP_VH | \
+                                     TMR4_INT_OC_CMP_VL | TMR4_INT_OC_CMP_WH | TMR4_INT_OC_CMP_WL)
+
+#define TMR4_FLAG_RELOAD_TMR_MASK   (TMR4_FLAG_RELOAD_TMR_U | TMR4_FLAG_RELOAD_TMR_V | TMR4_FLAG_RELOAD_TMR_W)
+#define TMR4_INT_RELOAD_TMR_MASK    (TMR4_INT_RELOAD_TMR_U | TMR4_INT_RELOAD_TMR_V | TMR4_INT_RELOAD_TMR_W)
+
+/**
+ * @}
+ */
+
+#define RCSR_REG_TYPE               uint16_t
+
+#define MODIFY_RCSR_REG(REGS, CLRMASK, SETMASK)    (WRITE_REG((REGS), (((READ_REG(REGS)) & (RCSR_REG_TYPE)(~(CLRMASK))) | ((SETMASK) & (CLRMASK)))))
+
+/**
+ * @defgroup TMR4_Registers_Reset_Value TMR4 Registers Reset Value
+ * @{
+ */
+#define TMR4_CCSR_RST_VALUE         (0x0040U)
+#define TMR4_SCER_RST_VALUE         (0xFF00U)
+#define TMR4_SCMR_RST_VALUE         (0xFF00U)
+#define TMR4_POCR_RST_VALUE         (0xFF00U)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Buffer_Object_Mask TMR4 OC Buffer Object Mask
+ * @{
+ */
+#define TMR4_OC_BUF_OBJECT_MASK     (TMR4_OC_BUF_CMP_VALUE | TMR4_OC_BUF_CMP_MD)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_CCSR_Bit TMR4_CCSR Bit
+ * @brief Get the specified TMR4_CCSR register bis value of the specified TMR4 OC channel
+ * @{
+ */
+#define TMR4_CCSR_IRQF              (TMR4_CCSR_IRQZF | TMR4_CCSR_IRQPF)
+#define TMR4_CCSR_IRQEN             (TMR4_CCSR_IRQZEN | TMR4_CCSR_IRQPEN)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OCSR_Bit_Mask TMR4_OCSR Bit Mask
+ * @brief Get the specified TMR4_OCSR register bis value of the specified TMR4 OC channel
+ * @{
+ */
+#define TMR4_OCSR_OCEx_MASK(CH)     (((uint16_t)TMR4_OCSR_OCEH) << ((CH) % 2UL))
+#define TMR4_OCSR_OCPx_MASK(CH)     (((uint16_t)TMR4_OCSR_OCPH) << ((CH) % 2UL))
+#define TMR4_OCSR_OCIE              (TMR4_OCSR_OCIEH | TMR4_OCSR_OCIEL)
+#define TMR4_OCSR_OCF               (TMR4_OCSR_OCFH | TMR4_OCSR_OCFL)
+#define TMR4_OCSR_MASK(CH)                                                     \
+(   ((uint16_t)(TMR4_OCSR_OCEH | TMR4_OCSR_OCPH | TMR4_OCSR_OCIEH | TMR4_OCSR_OCFH)) << (((CH) % 2UL)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OCSR_Bit TMR4_OCSR Bit
+ * @brief Get the specified TMR4_OCSR register bis value of the specified TMR4 OC channel
+ * @{
+ */
+#define TMR4_OCSR_OCEx(CH, OCEx)    (((uint16_t)OCEx) << (((uint16_t)((CH) % 2UL)) + TMR4_OCSR_OCEH_POS))
+#define TMR4_OCSR_OCPx(CH, OCPx)    (((uint16_t)OCPx) << ((CH) % 2UL))
+#define TMR4_OCSR_OCIEx(CH, OCIEx)  (((uint16_t)OCIEx) << ((CH) % 2UL))
+#define TMR4_OCSR_OCFx(CH, OCFx)    (((uint16_t)OCFx) << ((CH) % 2UL))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OCER_Bit_Mask TMR4_OCER Bit Mask
+ * @brief Get the specified TMR4_OCER register bis value of the specified TMR4 OC channel
+ * @{
+ */
+#define TMR4_OCER_CxBUFEN_MASK(CH)  (((uint16_t)TMR4_OCER_CHBUFEN) << (((CH) % 2UL) << 1U))
+#define TMR4_OCER_MxBUFEN_MASK(CH)  (((uint16_t)TMR4_OCER_MHBUFEN) << (((CH) % 2UL) << 1U))
+#define TMR4_OCER_LMCx_MASK(CH)     (((uint16_t)TMR4_OCER_LMCH) << ((CH) % 2UL))
+#define TMR4_OCER_LMMx_MASK(CH)     (((uint16_t)TMR4_OCER_LMMH) << ((CH) % 2UL))
+#define TMR4_OCER_MCECx_MASK(CH)    (((uint16_t)TMR4_OCER_MCECH) << ((CH) % 2UL))
+#define TMR4_OCER_MASK(CH)                                                   \
+(   (((uint16_t)(TMR4_OCER_CHBUFEN | TMR4_OCER_MHBUFEN)) << (((CH) % 2UL) << 1U)) | \
+    (((uint16_t)(TMR4_OCER_LMCH | TMR4_OCER_LMMH | TMR4_OCER_MCECH)) << ((CH) % 2UL)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OCER_Bit TMR4_OCER Bit
+ * @brief Get the specified TMR4_OCER register bis value of the specified TMR4 OC channel
+ * @{
+ */
+#define TMR4_OCER_CxBUFEN(CH, CxBUFEN)  ((uint16_t)((uint16_t)(CxBUFEN) << ((((CH) % 2UL) << 1U) + TMR4_OCER_CHBUFEN_POS)))
+#define TMR4_OCER_MxBUFEN(CH, MxBUFEN)  ((uint16_t)((uint16_t)(MxBUFEN) << ((((CH) % 2UL) << 1U) + TMR4_OCER_MHBUFEN_POS)))
+#define TMR4_OCER_LMCx(CH, LMCx)        ((uint16_t)(LMCx) << ((((CH) % 2UL)) + TMR4_OCER_LMCH_POS))
+#define TMR4_OCER_LMMx(CH, LMMx)        ((uint16_t)(LMMx) << ((((CH) % 2UL)) + TMR4_OCER_LMMH_POS))
+#define TMR4_OCER_MCECx(CH, MCECx)      ((uint16_t)(MCECx) << ((((CH) % 2UL)) + TMR4_OCER_MCECH_POS))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_RCSR_Bit_Mask TMR4_RCSR Bit Mask
+ * @brief Get the specified TMR4_RCSR register bis value of the specified TMR4 PWM channel
+ * @{
+ */
+#define TMR4_RCSR_RTIDx_MASK(CH)    ((RCSR_REG_TYPE)(((RCSR_REG_TYPE)TMR4_RCSR_RTIDU) << (CH)))
+#define TMR4_RCSR_RTIFx_MASK(CH)    ((RCSR_REG_TYPE)(((RCSR_REG_TYPE)TMR4_RCSR_RTIFU) << ((CH) << 2U)))
+#define TMR4_RCSR_RTICx_MASK(CH)    ((RCSR_REG_TYPE)(((RCSR_REG_TYPE)TMR4_RCSR_RTICU) << ((CH) << 2U)))
+#define TMR4_RCSR_RTEx_MASK(CH)     ((RCSR_REG_TYPE)(((RCSR_REG_TYPE)TMR4_RCSR_RTEU) << ((CH) << 2U)))
+#define TMR4_RCSR_RTSx_MASK(CH)     ((RCSR_REG_TYPE)(((RCSR_REG_TYPE)TMR4_RCSR_RTSU) << ((CH) << 2U)))
+#define TMR4_RCSR_MASK(CH)          (TMR4_RCSR_RTIDx_MASK(CH) | TMR4_RCSR_RTIFx_MASK(CH) | TMR4_RCSR_RTICx_MASK(CH) | \
+                                     TMR4_RCSR_RTEx_MASK(CH) | TMR4_RCSR_RTSx_MASK(CH))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PSCR_Bit_Mask TMR4_PSCR Bit Mask
+ * @brief Get the specified TMR4_PSCR register bis value of the specified TMR4 PWM port channel
+ * @{
+ */
+#define TMR4_PSCR_OExy_MASK(PORT)   (TMR4_PSCR_OEUH << (PORT))
+#define TMR4_PSCR_OSxy_MASK(PORT)   (TMR4_PSCR_OSUH << ((PORT) << 1U))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PSCR_Bit TMR4_PSCR Bit
+ * @brief Get the specified TMR4_PSCR register bis value of the specified TMR4 PWM port channel
+ * @{
+ */
+#define TMR4_PSCR_OExy(PORT, OExy)  ((OExy) << (PORT))
+#define TMR4_PSCR_OSxy(PORT, OSxy)  ((OSxy) << (((PORT) << 1U) + TMR4_PSCR_OSUH_POS))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Register TMR4 Register
+ * @{
+ */
+#define TMR4_REG_ADDR(_REG_)        ((uint32_t)(&(_REG_)))
+#define TMR4_REG16(_ADDR_)          ((__IO uint16_t *)(_ADDR_))
+#define TMR4_REG32(_ADDR_)          ((__IO uint32_t *)(_ADDR_))
+#define TMR4_RCSR_REG(_ADDR_)       ((__IO RCSR_REG_TYPE *)(_ADDR_))
+
+/**
+ * @defgroup TMR4_OC_Register_UVW TMR4 OC Register
+ * @brief Get the specified OC register address of the specified TMR4 unit
+ * @{
+ */
+#define _TMR4_OCCR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->OCCRUH) + ((CH) << 2U))
+#define _TMR4_OCMR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->OCMRUH) + ((CH) << 2U))
+#define _TMR4_OCER(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->OCERU) + (((CH) & 0x06UL) << 1U))
+#define _TMR4_OCSR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->OCSRU) + (((CH) & 0x06UL) << 1U))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Register_UVW TMR4 PWM Register
+ * @brief Get the specified PWM register address of the specified TMR4 unit
+ * @{
+ */
+#define _TMR4_RCSR(UNIT)            TMR4_RCSR_REG(TMR4_REG_ADDR((UNIT)->RCSR))
+#define _TMR4_POCR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->POCRU) + ((CH) << 2U))
+#define _TMR4_PFSR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->PFSRU) + ((CH) << 3U))
+#define _TMR4_PDR(UNIT, CH, IDX)    TMR4_REG16(TMR4_REG_ADDR((UNIT)->PDARU) + ((CH) << 3U) + ((IDX) << 1U))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Register_UVW TMR4 Event Register
+ * @brief Get the specified event register address of the specified TMR4 unit
+ * @{
+ */
+#define _TMR4_SCCR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->SCCRUH) + ((CH) << 2U))
+#define _TMR4_SCSR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->SCSRUH) + ((CH) << 2U))
+#define _TMR4_SCMR(UNIT, CH)        TMR4_REG16(TMR4_REG_ADDR((UNIT)->SCMRUH) + ((CH) << 2U))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_OC_Register TMR4 OC Register
+ * @{
+ */
+#define TMR4_OCCR(UNIT, CH)         _TMR4_OCCR(UNIT, CH)
+#define TMR4_OCMR(UNIT, CH)         _TMR4_OCMR(UNIT, CH)
+#define TMR4_OCER(UNIT, CH)         _TMR4_OCER(UNIT, CH)
+#define TMR4_OCSR(UNIT, CH)         _TMR4_OCSR(UNIT, CH)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Register TMR4 PWM Register
+ * @{
+ */
+#define TMR4_RCSR(UNIT)             _TMR4_RCSR(UNIT)
+#define TMR4_POCR(UNIT, CH)         _TMR4_POCR(UNIT, CH)
+#define TMR4_PFSR(UNIT, CH)         _TMR4_PFSR(UNIT, CH)
+#define TMR4_PDR(UNIT, CH, IDX)     _TMR4_PDR(UNIT, CH, IDX)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Register TMR4 Event Register
+ * @{
+ */
+#define TMR4_SCCR(UNIT, CH)         _TMR4_SCCR(UNIT, CH)
+#define TMR4_SCSR(UNIT, CH)         _TMR4_SCSR(UNIT, CH)
+#define TMR4_SCMR(UNIT, CH)         _TMR4_SCMR(UNIT, CH)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup TMR4_Global_Functions TMR4 Global Functions
+ * @{
+ */
+
+/**
+ * @defgroup TMR4_Counter_Global_Functions TMR4 Counter Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_tmr4_init_t to default values
+ * @param  [out] pstcTmr4Init           Pointer to a @ref stc_tmr4_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4Init value is NULL.
+ */
+int32_t TMR4_StructInit(stc_tmr4_init_t *pstcTmr4Init)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4Init) {
+        pstcTmr4Init->u16PeriodValue = 0xFFFFU;
+        pstcTmr4Init->u16CountMode = TMR4_MD_SAWTOOTH;
+        pstcTmr4Init->u16ClockSrc = TMR4_CLK_SRC_INTERNCLK;
+        pstcTmr4Init->u16ClockDiv = TMR4_CLK_DIV1;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize TMR4 counter.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] pstcTmr4Init            Pointer to a @ref stc_tmr4_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4Init value is NULL.
+ */
+int32_t TMR4_Init(CM_TMR4_TypeDef *TMR4x, const stc_tmr4_init_t *pstcTmr4Init)
+{
+    uint16_t u16Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4Init) {
+        DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+        DDL_ASSERT(IS_TMR4_CLK_SRC(pstcTmr4Init->u16ClockSrc));
+        DDL_ASSERT(IS_TMR4_CLK_DIV(pstcTmr4Init->u16ClockDiv));
+        DDL_ASSERT(IS_TMR4_MD(pstcTmr4Init->u16CountMode));
+
+        /* Set TMR4_CCSR */
+        u16Value = (pstcTmr4Init->u16ClockDiv | pstcTmr4Init->u16ClockSrc | \
+                    pstcTmr4Init->u16CountMode | TMR4_CCSR_CLEAR | TMR4_CCSR_STOP);
+        WRITE_REG16(TMR4x->CCSR, u16Value);
+
+        /* Set TMR4_CVPR: default value */
+        WRITE_REG16(TMR4x->CVPR, 0x0000U);
+
+        /* Set TMR4 period */
+        WRITE_REG16(TMR4x->CPSR, pstcTmr4Init->u16PeriodValue);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize TMR4 counter function
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t TMR4_DeInit(CM_TMR4_TypeDef *TMR4x)
+{
+    uint32_t u32Ch;
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    /* Configures the registers to reset value. */
+    WRITE_REG16(TMR4x->CCSR, TMR4_CCSR_RST_VALUE);
+    WRITE_REG16(TMR4x->CPSR, 0xFFFFU);
+    WRITE_REG16(TMR4x->CVPR, 0x0000U);
+    WRITE_REG16(TMR4x->CNTR, 0x0000U);
+
+    /* De-initialize OC */
+    for (u32Ch = 0UL; u32Ch <= TMR4_OC_CH_MAX; u32Ch++) {
+        TMR4_OC_DeInit(TMR4x, u32Ch);
+    }
+
+    /* De-initialize PWM */
+    MODIFY_REG32(TMR4x->PSCR, (TMR4_PSCR_MOE | TMR4_PSCR_AOE), 0UL);
+    for (u32Ch = 0UL; u32Ch <= TMR4_PWM_CH_MAX; u32Ch++) {
+        TMR4_PWM_DeInit(TMR4x, u32Ch);
+    }
+
+    /* De-initialize special event */
+    WRITE_REG16(TMR4x->SCER, TMR4_SCER_RST_VALUE);
+    for (u32Ch = 0UL; u32Ch <= TMR4_OC_CH_MAX; u32Ch++) {
+        TMR4_EVT_DeInit(TMR4x, u32Ch);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief Set TMR4 counter clock source
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Src                  TMR4 counter clock source
+ *         This parameter can be one of the macros group @ref TMR4_Count_Clock_Source
+ *           @arg TMR4_CLK_SRC_INTERNCLK: Uses the internal clock as counter's count clock
+ *           @arg TMR4_CLK_SRC_EXTCLK:    Uses an external input clock as counter's count clock
+ * @retval None
+ * @note   The clock division function is valid when clock source is internal clock.
+ */
+void TMR4_SetClockSrc(CM_TMR4_TypeDef *TMR4x, uint16_t u16Src)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_CLK_SRC(u16Src));
+
+    MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_ECKEN, TMR4_CCSR_IRQF | u16Src);
+}
+
+/**
+ * @brief  Set TMR4 counter clock division
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Div                  TMR4 clock division
+ *         This parameter can be one of the macros group @ref TMR4_Count_Clock_Division
+ *           @arg TMR4_CLK_DIV1:        CLK
+ *           @arg TMR4_CLK_DIV2:        CLK/2
+ *           @arg TMR4_CLK_DIV4:        CLK/4
+ *           @arg TMR4_CLK_DIV8:        CLK/8
+ *           @arg TMR4_CLK_DIV16:       CLK/16
+ *           @arg TMR4_CLK_DIV32:       CLK/32
+ *           @arg TMR4_CLK_DIV64:       CLK/64
+ *           @arg TMR4_CLK_DIV128:      CLK/128
+ *           @arg TMR4_CLK_DIV256:      CLK/256
+ *           @arg TMR4_CLK_DIV512:      CLK/512
+ *           @arg TMR4_CLK_DIV1024:     CLK/1024
+ * @retval None
+ * @note   The clock division function is valid when clock source is the internal clock.
+ */
+void TMR4_SetClockDiv(CM_TMR4_TypeDef *TMR4x, uint16_t u16Div)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_CLK_DIV(u16Div));
+
+    MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_CKDIV, TMR4_CCSR_IRQF | u16Div);
+}
+
+/**
+ * @brief Set TMR4 counter count mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Mode                 TMR4 counter count mode
+ *         This parameter can be one of the macros group @ref TMR4_Count_Mode
+ *           @arg TMR4_MD_SAWTOOTH:     TMR4 count mode sawtooth wave
+ *           @arg TMR4_MD_TRIANGLE:     TMR4 count mode triangular
+ * @retval None
+ */
+void TMR4_SetCountMode(CM_TMR4_TypeDef *TMR4x, uint16_t u16Mode)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_MD(u16Mode));
+
+    MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_MODE, TMR4_CCSR_IRQF | u16Mode);
+}
+
+/**
+ * @brief  Get the period value of the TMR4 counter.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval The period value of the TMR4 counter
+ */
+uint16_t TMR4_GetPeriodValue(const CM_TMR4_TypeDef *TMR4x)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    return READ_REG16(TMR4x->CPSR);
+}
+
+/**
+ * @brief  Set the period value of the TMR4 counter.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Value                The period value of the TMR4 counter
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_SetPeriodValue(CM_TMR4_TypeDef *TMR4x, uint16_t u16Value)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    WRITE_REG16(TMR4x->CPSR, u16Value);
+}
+
+/**
+ * @brief  Get the count value of the TMR4 counter.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval The count value of the TMR4 counter
+ */
+uint16_t TMR4_GetCountValue(const CM_TMR4_TypeDef *TMR4x)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    return READ_REG16(TMR4x->CNTR);
+}
+
+/**
+ * @brief  Set the count value of the TMR4 counter.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Value                The count value of the TMR4 counter
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_SetCountValue(CM_TMR4_TypeDef *TMR4x, uint16_t u16Value)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    WRITE_REG16(TMR4x->CNTR, u16Value);
+}
+
+/**
+ * @brief  Clear TMR4 counter count value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval None
+ */
+void TMR4_ClearCountValue(CM_TMR4_TypeDef *TMR4x)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    SET_REG16_BIT(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_CLEAR);
+}
+
+/**
+ * @brief Start TMR4 counter
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval None
+ */
+void TMR4_Start(CM_TMR4_TypeDef *TMR4x)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_STOP, ~TMR4_CCSR_STOP);
+}
+
+/**
+ * @brief  Stop TMR4 counter
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @retval None
+ */
+void TMR4_Stop(CM_TMR4_TypeDef *TMR4x)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+
+    SET_REG16_BIT(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_STOP);
+}
+
+/**
+ * @brief  Clear TMR4 flag
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Flag                 TMR4 flag
+ *         This parameter can be any composed value of the macros group @ref TMR4_Flag
+ * @retval None
+ */
+void TMR4_ClearStatus(CM_TMR4_TypeDef *TMR4x, uint32_t u32Flag)
+{
+    uint16_t u16ClearFlag;
+    uint32_t u32ClearFlag;
+    __IO uint16_t *OCSR;
+    uint32_t u32Ch;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_FLAG(u32Flag));
+
+    /* Counter flag */
+    u16ClearFlag = (uint16_t)u32Flag & TMR4_CCSR_IRQF;
+    if (u16ClearFlag != 0U) {
+        MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF, ~u16ClearFlag);
+    }
+
+    /* Output-compare flag */
+    u16ClearFlag = (uint16_t)((u32Flag & TMR4_FLAG_OC_MASK) >> 10U);
+    if (u16ClearFlag != 0U) {
+        for (u32Ch = TMR4_OC_CH_UH; u32Ch <= TMR4_OC_CH_MAX; u32Ch += 2UL) {
+            if ((u16ClearFlag & TMR4_OCSR_OCF) != 0U) {
+                OCSR = TMR4_OCSR(TMR4x, u32Ch);
+                MODIFY_REG16(*OCSR, TMR4_OCSR_OCF, ~u16ClearFlag);
+            }
+            u16ClearFlag >>= 2UL;
+        }
+    }
+
+    /* PWM reload timer flag */
+    u32ClearFlag = ((u32Flag & TMR4_FLAG_RELOAD_TMR_MASK) << 5U);
+    if (u32ClearFlag != 0UL) {
+        SET_REG_BIT(TMR4x->RCSR, (RCSR_REG_TYPE)u32ClearFlag);
+    }
+}
+
+/**
+ * @brief  Get TMR4 flag
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Flag                 TMR4 flag
+ *         This parameter can be any composed value of the macros group @ref TMR4_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t TMR4_GetStatus(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Flag)
+{
+    uint16_t u16ReadFlag;
+    uint32_t u32ReadFlag;
+    uint8_t u8FlagSetCount = 0;
+    __IO uint16_t *OCSR;
+    uint32_t u32Ch;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_FLAG(u32Flag));
+
+    /* Counter flag status */
+    if (READ_REG16_BIT(TMR4x->CCSR, ((uint16_t)u32Flag & TMR4_CCSR_IRQF)) != 0U) {
+        u8FlagSetCount++;
+    }
+
+    /* Output-compare interrupt */
+    u16ReadFlag = (uint16_t)((u32Flag & TMR4_FLAG_OC_MASK) >> 10U);
+    if (u16ReadFlag != 0UL) {
+        for (u32Ch = TMR4_OC_CH_UH; u32Ch <= TMR4_OC_CH_MAX; u32Ch += 2UL) {
+            OCSR = TMR4_OCSR(TMR4x, u32Ch);
+            if ((*OCSR & (u16ReadFlag & TMR4_OCSR_OCF)) != 0U) {
+                u8FlagSetCount++;
+            }
+            u16ReadFlag >>= 2UL;
+        }
+    }
+
+    /* PWM reload timer flag status */
+    u32ReadFlag = ((u32Flag & (TMR4_FLAG_RELOAD_TMR_MASK)) << 4U);
+    if (READ_REG_BIT(TMR4x->RCSR, (RCSR_REG_TYPE)u32ReadFlag) > 0U) {
+        u8FlagSetCount++;
+    }
+
+    return (u8FlagSetCount == 0U) ? RESET : SET;
+}
+
+/**
+ * @brief  Enable or disable the specified TMR4 interrupt
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32IntType              TMR4 interrupt source
+ *         This parameter can be any composed value of the macros group @ref TMR4_Interrupt
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_IntCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint16_t u16Type;
+    uint32_t u32Type;
+    uint16_t u16OCIE;
+    __IO uint16_t *OCSR;
+    uint32_t u32Ch;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_INT(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Counter interrupt */
+    u16Type = (uint16_t)u32IntType & TMR4_CCSR_IRQEN;
+    if (u16Type != 0U) {
+        if (ENABLE == enNewState) {
+            SET_REG16_BIT(TMR4x->CCSR, TMR4_CCSR_IRQF | u16Type);
+        } else {
+            MODIFY_REG16(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_IRQEN, ~u16Type);
+        }
+    }
+
+    /* Output-compare interrupt */
+    u16Type = (uint16_t)((u32IntType & TMR4_INT_OC_MASK) >> 12U);
+    if (u16Type != 0U) {
+        for (u32Ch = TMR4_OC_CH_UH; u32Ch <= TMR4_OC_CH_MAX; u32Ch += 2UL) {
+            u16OCIE = u16Type & TMR4_OCSR_OCIE;
+            if (u16OCIE != 0U) {
+                OCSR = TMR4_OCSR(TMR4x, u32Ch);
+                if (ENABLE == enNewState) {
+                    SET_REG16_BIT(*OCSR, TMR4_OCSR_OCF | u16OCIE);
+                } else {
+                    MODIFY_REG16(*OCSR, TMR4_OCSR_OCF | TMR4_OCSR_OCIE, ~u16OCIE);
+                }
+            }
+            u16Type >>= 2UL;
+        }
+    }
+
+    /* PWM reload timer interrupt */
+    u32Type = (u32IntType & TMR4_INT_RELOAD_TMR_MASK);
+    if (u32Type > 0UL) {
+        (ENABLE == enNewState) ? CLR_REG_BIT(TMR4x->RCSR, (RCSR_REG_TYPE)u32Type) : SET_REG_BIT(TMR4x->RCSR, (RCSR_REG_TYPE)u32Type);
+    }
+}
+
+/**
+ * @brief  Enable or disable the TMR4 counter period buffer function.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_PeriodBufCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(TMR4x->CCSR, TMR4_CCSR_IRQF | TMR4_CCSR_BUFEN);
+    } else {
+        MODIFY_REG16(TMR4x->CCSR, (TMR4_CCSR_IRQF | TMR4_CCSR_BUFEN), ~TMR4_CCSR_BUFEN);
+    }
+}
+
+/**
+ * @brief  Get TMR4 count interrupt mask times
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32IntType              TMR4 interrupt source
+ *         This parameter can be one of the following values:
+ *           @arg TMR4_INT_CNT_PEAK:    Count peak interrupt
+ *           @arg TMR4_INT_CNT_VALLEY : Count valley interrupt
+ * @retval Returned value can be one of the macros group @ref TMR4_Count_Interrupt_Mask_Time
+ *           - TMR4_INT_CNT_MASK0:  Counter interrupt flag is always set(not masked) for counter count every time at "0x0000" or peak
+ *           - TMR4_INT_CNT_MASK1:  Counter interrupt flag is set once when counter counts 2 times at "0x0000" or peak (skipping 1 count)
+ *           - TMR4_INT_CNT_MASK2:  Counter interrupt flag is set once when counter counts 3 times at "0x0000" or peak (skipping 2 count)
+ *           - TMR4_INT_CNT_MASK3:  Counter interrupt flag is set once when counter counts 4 times at "0x0000" or peak (skipping 3 count)
+ *           - TMR4_INT_CNT_MASK4:  Counter interrupt flag is set once when counter counts 5 times at "0x0000" or peak (skipping 4 count)
+ *           - TMR4_INT_CNT_MASK5:  Counter interrupt flag is set once when counter counts 6 times at "0x0000" or peak (skipping 5 count)
+ *           - TMR4_INT_CNT_MASK6:  Counter interrupt flag is set once when counter counts 7 times at "0x0000" or peak (skipping 6 count)
+ *           - TMR4_INT_CNT_MASK7:  Counter interrupt flag is set once when counter counts 8 times at "0x0000" or peak (skipping 7 count)
+ *           - TMR4_INT_CNT_MASK8:  Counter interrupt flag is set once when counter counts 9 times at "0x0000" or peak (skipping 8 count)
+ *           - TMR4_INT_CNT_MASK9:  Counter interrupt flag is set once when counter counts 10 times at "0x0000" or peak (skipping 9 count)
+ *           - TMR4_INT_CNT_MASK10: Counter interrupt flag is set once when counter counts 11 times at "0x0000" or peak (skipping 10 count)
+ *           - TMR4_INT_CNT_MASK11: Counter interrupt flag is set once when counter counts 12 times at "0x0000" or peak (skipping 11 count)
+ *           - TMR4_INT_CNT_MASK12: Counter interrupt flag is set once when counter counts 13 times at "0x0000" or peak (skipping 12 count)
+ *           - TMR4_INT_CNT_MASK13: Counter interrupt flag is set once when counter counts 14 times at "0x0000" or peak (skipping 13 count)
+ *           - TMR4_INT_CNT_MASK14: Counter interrupt flag is set once when counter counts 15 times at "0x0000" or peak (skipping 14 count)
+ *           - TMR4_INT_CNT_MASK15: Counter interrupt flag is set once when counter counts 16 times at "0x0000" or peak (skipping 15 count)
+ */
+uint16_t TMR4_GetCountIntMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType)
+{
+    uint16_t u16MaskTimes;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_INT_CNT(u32IntType));
+
+    if (TMR4_INT_CNT_VALLEY == u32IntType) {
+        u16MaskTimes = (READ_REG16_BIT(TMR4x->CVPR, TMR4_CVPR_ZIM) >> TMR4_CVPR_ZIM_POS);
+    } else {
+        u16MaskTimes = (READ_REG16_BIT(TMR4x->CVPR, TMR4_CVPR_PIM) >> TMR4_CVPR_PIM_POS);
+    }
+
+    return u16MaskTimes;
+}
+
+/**
+ * @brief  Set TMR4 counter interrupt mask times
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32IntType              TMR4 interrupt source
+ *         This parameter can be one of the following values:
+ *           @arg TMR4_INT_CNT_PEAK:    Count peak interrupt
+ *           @arg TMR4_INT_CNT_VALLEY : Count valley interrupt
+ * @param [in] u16MaskTime              TMR4 counter interrupt mask times
+ *         This parameter can be one of the macros group @ref TMR4_Count_Interrupt_Mask_Time
+ *           @arg TMR4_INT_CNT_MASK0:  Counter interrupt flag is always set(not masked) for counter count every time at "0x0000" or peak
+ *           @arg TMR4_INT_CNT_MASK1:  Counter interrupt flag is set once when counter counts 2 times at "0x0000" or peak (skipping 1 count)
+ *           @arg TMR4_INT_CNT_MASK2:  Counter interrupt flag is set once when counter counts 3 times at "0x0000" or peak (skipping 2 count)
+ *           @arg TMR4_INT_CNT_MASK3:  Counter interrupt flag is set once when counter counts 4 times at "0x0000" or peak (skipping 3 count)
+ *           @arg TMR4_INT_CNT_MASK4:  Counter interrupt flag is set once when counter counts 5 times at "0x0000" or peak (skipping 4 count)
+ *           @arg TMR4_INT_CNT_MASK5:  Counter interrupt flag is set once when counter counts 6 times at "0x0000" or peak (skipping 5 count)
+ *           @arg TMR4_INT_CNT_MASK6:  Counter interrupt flag is set once when counter counts 7 times at "0x0000" or peak (skipping 6 count)
+ *           @arg TMR4_INT_CNT_MASK7:  Counter interrupt flag is set once when counter counts 8 times at "0x0000" or peak (skipping 7 count)
+ *           @arg TMR4_INT_CNT_MASK8:  Counter interrupt flag is set once when counter counts 9 times at "0x0000" or peak (skipping 8 count)
+ *           @arg TMR4_INT_CNT_MASK9:  Counter interrupt flag is set once when counter counts 10 times at "0x0000" or peak (skipping 9 count)
+ *           @arg TMR4_INT_CNT_MASK10: Counter interrupt flag is set once when counter counts 11 times at "0x0000" or peak (skipping 10 count)
+ *           @arg TMR4_INT_CNT_MASK11: Counter interrupt flag is set once when counter counts 12 times at "0x0000" or peak (skipping 11 count)
+ *           @arg TMR4_INT_CNT_MASK12: Counter interrupt flag is set once when counter counts 13 times at "0x0000" or peak (skipping 12 count)
+ *           @arg TMR4_INT_CNT_MASK13: Counter interrupt flag is set once when counter counts 14 times at "0x0000" or peak (skipping 13 count)
+ *           @arg TMR4_INT_CNT_MASK14: Counter interrupt flag is set once when counter counts 15 times at "0x0000" or peak (skipping 14 count)
+ *           @arg TMR4_INT_CNT_MASK15: Counter interrupt flag is set once when counter counts 16 times at "0x0000" or peak (skipping 15 count)
+ * @retval None
+ */
+void TMR4_SetCountIntMaskTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType, uint16_t u16MaskTime)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_INT_CNT(u32IntType));
+    DDL_ASSERT(IS_TMR4_INT_CNT_MASKTIME(u16MaskTime));
+
+    if (TMR4_INT_CNT_VALLEY == (u32IntType & TMR4_INT_CNT_VALLEY)) {
+        MODIFY_REG16(TMR4x->CVPR, TMR4_CVPR_ZIM, (u16MaskTime << TMR4_CVPR_ZIM_POS));
+    }
+
+    if (TMR4_INT_CNT_PEAK == (u32IntType & TMR4_INT_CNT_PEAK)) {
+        MODIFY_REG16(TMR4x->CVPR, TMR4_CVPR_PIM, (u16MaskTime << TMR4_CVPR_PIM_POS));
+    }
+}
+
+/**
+ * @brief  Get TMR4 counter current interrupt mask times
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32IntType              TMR4 interrupt source
+ *         This parameter can be one of the macros group @ref TMR4_Interrupt
+ *           @arg TMR4_INT_CNT_PEAK:    Count peak interrupt
+ *           @arg TMR4_INT_CNT_VALLEY : Count valley interrupt
+ * @retval Returned value can be one of the macros group @ref TMR4_Count_Interrupt_Mask_Time
+ *           - TMR4_INT_CNT_MASK0:   Counter interrupt flag is always set(not masked) for every counter count at "0x0000" or peak
+ *           - TMR4_INT_CNT_MASK1:   Counter interrupt flag is set once for 2 every counter counts at "0x0000" or peak (skipping 1 count)
+ *           - TMR4_INT_CNT_MASK2:   Counter interrupt flag is set once for 3 every counter counts at "0x0000" or peak (skipping 2 count)
+ *           - TMR4_INT_CNT_MASK3:   Counter interrupt flag is set once for 4 every counter counts at "0x0000" or peak (skipping 3 count)
+ *           - TMR4_INT_CNT_MASK4:   Counter interrupt flag is set once for 5 every counter counts at "0x0000" or peak (skipping 4 count)
+ *           - TMR4_INT_CNT_MASK5:   Counter interrupt flag is set once for 6 every counter counts at "0x0000" or peak (skipping 5 count)
+ *           - TMR4_INT_CNT_MASK6:   Counter interrupt flag is set once for 7 every counter counts at "0x0000" or peak (skipping 6 count)
+ *           - TMR4_INT_CNT_MASK7:   Counter interrupt flag is set once for 8 every counter counts at "0x0000" or peak (skipping 7 count)
+ *           - TMR4_INT_CNT_MASK8:   Counter interrupt flag is set once for 9 every counter counts at "0x0000" or peak (skipping 8 count)
+ *           - TMR4_INT_CNT_MASK9:   Counter interrupt flag is set once for 10 every counter counts at "0x0000" or peak (skipping 9 count)
+ *           - TMR4_INT_CNT_MASK10:  Counter interrupt flag is set once for 11 every counter counts at "0x0000" or peak (skipping 10 count)
+ *           - TMR4_INT_CNT_MASK11:  Counter interrupt flag is set once for 12 every counter counts at "0x0000" or peak (skipping 11 count)
+ *           - TMR4_INT_CNT_MASK12:  Counter interrupt flag is set once for 13 every counter counts at "0x0000" or peak (skipping 12 count)
+ *           - TMR4_INT_CNT_MASK13:  Counter interrupt flag is set once for 14 every counter counts at "0x0000" or peak (skipping 13 count)
+ *           - TMR4_INT_CNT_MASK14:  Counter interrupt flag is set once for 15 every counter counts at "0x0000" or peak (skipping 14 count)
+ *           - TMR4_INT_CNT_MASK15:  Counter interrupt flag is set once for 16 every counter counts at "0x0000" or peak (skipping 15 count)
+ */
+uint16_t TMR4_GetCurrentCountIntMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32IntType)
+{
+    uint16_t u16MaskTimes;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_INT_CNT(u32IntType));
+
+    if (TMR4_INT_CNT_VALLEY == u32IntType) {
+        u16MaskTimes = (READ_REG16_BIT(TMR4x->CVPR, TMR4_CVPR_ZIC) >> TMR4_CVPR_ZIC_POS);
+    } else {
+        u16MaskTimes = (READ_REG16_BIT(TMR4x->CVPR, TMR4_CVPR_PIC) >> TMR4_CVPR_PIC_POS);
+    }
+
+    return u16MaskTimes;
+}
+
+/**
+ * @brief  Enable or disable port output TMR4 counter direction signal
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_PortOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(TMR4x->SCER, TMR4_SCER_PCTS);
+    } else {
+        CLR_REG16_BIT(TMR4x->SCER, TMR4_SCER_PCTS);
+    }
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Output_Compare_Global_Functions TMR4 Output-Compare Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_tmr4_oc_init_t to default values
+ * @param  [out] pstcTmr4OcInit         Pointer to a @ref stc_tmr4_oc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4OcInit value is NULL.
+ */
+int32_t TMR4_OC_StructInit(stc_tmr4_oc_init_t *pstcTmr4OcInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4OcInit) {
+        pstcTmr4OcInit->u16CompareValue = 0U;
+        pstcTmr4OcInit->u16OcInvalidPolarity = TMR4_OC_INVD_LOW;
+        pstcTmr4OcInit->u16CompareModeBufCond = TMR4_OC_BUF_COND_IMMED;
+        pstcTmr4OcInit->u16CompareValueBufCond = TMR4_OC_BUF_COND_IMMED;
+        pstcTmr4OcInit->u16BufLinkTransObject = TMR4_OC_BUF_NONE;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize TMR4 OC
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] pstcTmr4OcInit          Pointer to a @ref stc_tmr4_oc_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4OcInit value is NULL.
+ */
+int32_t TMR4_OC_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_oc_init_t *pstcTmr4OcInit)
+{
+    uint16_t u16Value;
+    __IO uint16_t *OCER;
+    __IO uint16_t *OCSR;
+    __IO uint16_t *OCCR;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4OcInit) {
+        DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+        DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+        DDL_ASSERT(IS_TMR4_OC_INVD_POLARITY(pstcTmr4OcInit->u16OcInvalidPolarity));
+        DDL_ASSERT(IS_TMR4_OC_BUF_COND(pstcTmr4OcInit->u16CompareModeBufCond));
+        DDL_ASSERT(IS_TMR4_OC_BUF_COND(pstcTmr4OcInit->u16CompareValueBufCond));
+        DDL_ASSERT(IS_TMR4_OC_BUF_OBJECT(pstcTmr4OcInit->u16BufLinkTransObject));
+
+        /* Get pointer of current channel OC register address */
+        OCSR = TMR4_OCSR(TMR4x, u32Ch);
+        OCER = TMR4_OCER(TMR4x, u32Ch);
+        OCCR = TMR4_OCCR(TMR4x, u32Ch);
+
+        /* Set output polarity when OC is disabled. */
+        MODIFY_REG16(*OCSR, TMR4_OCSR_MASK(u32Ch), TMR4_OCSR_OCPx(u32Ch, pstcTmr4OcInit->u16OcInvalidPolarity));
+
+        /* Set OCMR&&OCCR buffer function */
+        u16Value = (TMR4_OCER_MxBUFEN(u32Ch, pstcTmr4OcInit->u16CompareModeBufCond) | \
+                    TMR4_OCER_CxBUFEN(u32Ch, pstcTmr4OcInit->u16CompareValueBufCond));
+        if (TMR4_OC_BUF_CMP_VALUE == (pstcTmr4OcInit->u16BufLinkTransObject & TMR4_OC_BUF_CMP_VALUE)) {
+            u16Value |= TMR4_OCER_LMCx_MASK(u32Ch);
+        }
+
+        if (TMR4_OC_BUF_CMP_MD == (pstcTmr4OcInit->u16BufLinkTransObject & TMR4_OC_BUF_CMP_MD)) {
+            u16Value |= TMR4_OCER_LMMx_MASK(u32Ch);
+        }
+
+        MODIFY_REG16(*OCER, TMR4_OCER_MASK(u32Ch), u16Value);
+
+        /* Set OC compare value */
+        WRITE_REG16(*OCCR, pstcTmr4OcInit->u16CompareValue);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize TMR4 OC
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @retval None
+ */
+void TMR4_OC_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __IO uint16_t *OCER;
+    __IO uint16_t *OCSR;
+    __IO uint16_t *OCCR;
+    __IO uint16_t *OCMRxH;
+    __IO uint32_t *OCMRxL;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCSR = TMR4_OCSR(TMR4x, u32Ch);
+    OCER = TMR4_OCER(TMR4x, u32Ch);
+    OCCR = TMR4_OCCR(TMR4x, u32Ch);
+
+    /* Clear bits: port output valid && OP level && interrupt */
+    CLR_REG16_BIT(*OCSR, TMR4_OCSR_MASK(u32Ch));
+
+    /* Clear bits: OCMR&&OCCR buffer */
+    CLR_REG16_BIT(*OCER, TMR4_OCER_MASK(u32Ch));
+
+    /* Set OC compare match value */
+    WRITE_REG16(*OCCR, 0x0000U);
+
+    /* Set OCMR value */
+    if ((u32Ch & 0x01UL) == 0UL) {
+        OCMRxH = TMR4_OCMR(TMR4x, u32Ch);
+        WRITE_REG16(*OCMRxH, 0x0000U);
+    } else {
+        OCMRxL = (__IO uint32_t *)((uint32_t)TMR4_OCMR(TMR4x, u32Ch));
+        WRITE_REG32(*OCMRxL, 0x00000000UL);
+    }
+}
+
+/**
+ * @brief  Get TMR4 OC OCCR compare value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @retval The compare value of the TMR4 OC OCCR register
+ */
+uint16_t TMR4_OC_GetCompareValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint16_t *OCCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCCR = TMR4_OCCR(TMR4x, u32Ch);
+
+    return READ_REG16(*OCCR);
+}
+
+/**
+ * @brief  Set TMR4 OC compare value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] u16Value                The compare value of the TMR4 OC OCCR register
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_OC_SetCompareValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value)
+{
+    __IO uint16_t *OCCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCCR = TMR4_OCCR(TMR4x, u32Ch);
+
+    WRITE_REG16(*OCCR, u16Value);
+}
+
+/**
+ * @brief  Enable or disable the TMR4 OC of the specified channel.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_OC_Cmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint16_t *OCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get pointer of current channel OC register address */
+    OCSR = TMR4_OCSR(TMR4x, u32Ch);
+
+    /* Set OCSR port output compare */
+    MODIFY_REG16(*OCSR, TMR4_OCSR_OCEx_MASK(u32Ch) | TMR4_OCSR_OCF, \
+                 TMR4_OCSR_OCEx(u32Ch, enNewState) | TMR4_OCSR_OCF);
+}
+
+/**
+ * @brief  Extend the matching conditions of TMR4 OC channel
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_OC_ExtendControlCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint16_t *OCER;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get pointer of current channel OC register address */
+    OCER = TMR4_OCER(TMR4x, u32Ch);
+
+    /* Set OCER register: Extend match function */
+    MODIFY_REG16(*OCER, TMR4_OCER_MCECx_MASK(u32Ch), TMR4_OCER_MCECx(u32Ch, enNewState));
+}
+
+/**
+ * @brief  Set TMR4 OC OCCR/OCMR buffer interval response function
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] u16Object               TMR4 OC register buffer: OCCR/OCMR
+ *         This parameter can be any composed value of the macros group @ref TMR4_OC_Buffer_Object
+ *           @arg TMR4_OC_BUF_CMP_VALUE: The register OCCR buffer function
+ *           @arg TMR4_OC_BUF_CMP_MD:    The register OCMR buffer function
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ *           @arg ENABLE:               Enable the OCMR/OCMR register buffer function.
+ *           @arg DISABLE:              Disable the OCMR/OCMR register buffer function.
+ * @retval None
+ */
+void TMR4_OC_BufIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch,
+                                    uint16_t u16Object, en_functional_state_t enNewState)
+{
+    __IO uint16_t *OCER;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_OC_BUF_OBJECT(u16Object));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get pointer of current channel OC register address */
+    OCER = TMR4_OCER(TMR4x, u32Ch);
+
+    if (TMR4_OC_BUF_CMP_VALUE == (u16Object & TMR4_OC_BUF_CMP_VALUE)) {
+        /* Set OCER register: OCCR link transfer function */
+        MODIFY_REG16(*OCER, TMR4_OCER_LMCx_MASK(u32Ch), TMR4_OCER_LMCx(u32Ch, enNewState));
+    }
+
+    if (TMR4_OC_BUF_CMP_MD == (u16Object & TMR4_OC_BUF_CMP_MD)) {
+        /* Set OCER register: OCMR link transfer function */
+        MODIFY_REG16(*OCER, TMR4_OCER_LMMx_MASK(u32Ch), TMR4_OCER_LMMx(u32Ch, enNewState));
+    }
+}
+
+/**
+ * @brief  Get TMR4 OC output current polarity
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @retval Returned value can be one of the macros group @ref TMR4_OC_Output_Polarity
+ *           - TMR4_OC_PORT_LOW:        TMR4 OC output low level
+ *           - TMR4_OC_PORT_HIGH:       TMR4 OC output high level
+ */
+uint16_t TMR4_OC_GetPolarity(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint16_t *OCSR;
+    uint16_t u16Polarity;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCSR = TMR4_OCSR(TMR4x, u32Ch);
+
+    /* Get OCSR register: OC output polarity */
+    u16Polarity = READ_REG16_BIT(*OCSR, TMR4_OCSR_OCPx_MASK(u32Ch));
+    return (u16Polarity >> (u32Ch % 2UL));
+}
+
+/**
+ * @brief  Set TMR4 OC invalid output polarity
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] u16Polarity             TMR4 OC invalid output polarity.
+ *         This parameter can be one of the macros group @ref TMR4_OC_Invalid_Output_Polarity
+ *           @arg TMR4_OC_INVD_LOW:     TMR4 OC output low level when OC is invalid
+ *           @arg TMR4_OC_INVD_HIGH:    TMR4 OC output high level when OC is invalid
+ * @retval None
+ */
+void TMR4_OC_SetOcInvalidPolarity(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Polarity)
+{
+    __IO uint16_t *OCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_OC_INVD_POLARITY(u16Polarity));
+
+    /* Get pointer of current channel OC register address */
+    OCSR = TMR4_OCSR(TMR4x, u32Ch);
+
+    /* Set OCSR register: OC invalid output polarity */
+    MODIFY_REG16(*OCSR, TMR4_OCSR_OCPx_MASK(u32Ch) | TMR4_OCSR_OCF, \
+                 TMR4_OCSR_OCPx(u32Ch, u16Polarity) | TMR4_OCSR_OCF);
+}
+
+/**
+ * @brief  Set TMR4 OC OCCR/OCMR buffer transfer condition
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] u16Object               TMR4 OC register buffer type: OCCR/OCMR
+ *         This parameter can be any composed value of the macros group @ref TMR4_OC_Buffer_Object
+ *           @arg TMR4_OC_BUF_CMP_VALUE: The register OCCR buffer function
+ *           @arg TMR4_OC_BUF_CMP_MD:    The register OCMR buffer function
+ * @param  [in] u16BufCond              TMR4 OC OCCR/OCMR buffer transfer condition
+ *         This parameter can be one of the macros group @ref TMR4_OC_Buffer_Transfer_Condition
+ *           @arg TMR4_OC_BUF_COND_IMMED:   Buffer transfer is made when writing to the OCCR/OCMR register.
+ *           @arg TMR4_OC_BUF_COND_VALLEY:  Buffer transfer is made when counter count valley.
+ *           @arg TMR4_OC_BUF_COND_PEAK:    Buffer transfer is made when counter count peak.
+ *           @arg TMR4_OC_BUF_COND_PEAK_VALLEY: Buffer transfer is made when counter count peak or valley.
+ * @retval None
+ */
+void TMR4_OC_SetCompareBufCond(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Object, uint16_t u16BufCond)
+{
+    __IO uint16_t *OCER;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_OC_BUF_OBJECT(u16Object));
+    DDL_ASSERT(IS_TMR4_OC_BUF_COND(u16BufCond));
+
+    /* Get pointer of current channel OC register address */
+    OCER = TMR4_OCER(TMR4x, u32Ch);
+
+    if (TMR4_OC_BUF_CMP_VALUE == (u16Object & TMR4_OC_BUF_CMP_VALUE)) {
+        /* Set OCER register: OCCR buffer mode */
+        MODIFY_REG16(*OCER, TMR4_OCER_CxBUFEN_MASK(u32Ch), TMR4_OCER_CxBUFEN(u32Ch, u16BufCond));
+    }
+
+    if (TMR4_OC_BUF_CMP_MD == (u16Object & TMR4_OC_BUF_CMP_MD)) {
+        /* Set OCER register: OCMR buffer mode */
+        MODIFY_REG16(*OCER, TMR4_OCER_MxBUFEN_MASK(u32Ch), TMR4_OCER_MxBUFEN(u32Ch, u16BufCond));
+    }
+}
+
+/**
+ * @brief  Get the TMR4 OC high channel mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel.
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @retval The TMR4 OC high channel mode
+ * @note   The function only can get high channel mode:TMR4_OC_CH_xH(x = U/V/W)
+ */
+uint16_t TMR4_OC_GetHighChCompareMode(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint16_t *OCMRxH;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_HIGH_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCMRxH = TMR4_OCMR(TMR4x, u32Ch);
+    return READ_REG16(*OCMRxH);
+}
+
+/**
+ * @brief  Set the TMR4 OC high channel mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel.
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] unTmr4Ocmrh             The TMR4 OC high channel mode @ref un_tmr4_oc_ocmrh_t
+ * @retval None
+ * @note   The function only can set high channel mode:TMR4_OC_CH_xH(x = U/V/W)
+ */
+void TMR4_OC_SetHighChCompareMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, un_tmr4_oc_ocmrh_t unTmr4Ocmrh)
+{
+    __IO uint16_t *OCMRxH;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_HIGH_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCMRxH = TMR4_OCMR(TMR4x, u32Ch);
+    WRITE_REG16(*OCMRxH, unTmr4Ocmrh.OCMRx);
+}
+
+/**
+ * @brief  Get the TMR4 OC low channel mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel.
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @retval The TMR4 OC low channel mode
+ * @note   The function only can get low channel mode:TMR4_OC_CH_xL(x = U/V/W)
+ */
+uint32_t TMR4_OC_GetLowChCompareMode(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint32_t *OCMRxL;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_LOW_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCMRxL = (__IO uint32_t *)((uint32_t)TMR4_OCMR(TMR4x, u32Ch));
+    return READ_REG32(*OCMRxL);
+}
+
+/**
+ * @brief  Set the TMR4 OC low channel mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 OC channel.
+ *         This parameter can be one of the macros group @ref TMR4_OC_Channel
+ * @param  [in] unTmr4Ocmrl             The TMR4 OC low channel mode @ref un_tmr4_oc_ocmrl_t
+ * @retval None
+ * @note   The function only can set low channel mode:TMR4_OC_CH_xL(x = U/V/W)
+ */
+void TMR4_OC_SetLowChCompareMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, un_tmr4_oc_ocmrl_t unTmr4Ocmrl)
+{
+    __IO uint32_t *OCMRxL;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_OC_LOW_CH(u32Ch));
+
+    /* Get pointer of current channel OC register address */
+    OCMRxL = (__IO uint32_t *)((uint32_t)TMR4_OCMR(TMR4x, u32Ch));
+    WRITE_REG32(*OCMRxL, unTmr4Ocmrl.OCMRx);
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_PWM_Global_Functions TMR4 PWM Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_tmr4_pwm_init_t to default values
+ * @param  [out] pstcTmr4PwmInit        Pointer to a @ref stc_tmr4_pwm_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4PwmInit value is NULL.
+ */
+int32_t TMR4_PWM_StructInit(stc_tmr4_pwm_init_t *pstcTmr4PwmInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4PwmInit) {
+        pstcTmr4PwmInit->u16Mode = TMR4_PWM_MD_THROUGH;
+        pstcTmr4PwmInit->u16ClockDiv = TMR4_PWM_CLK_DIV1;
+        pstcTmr4PwmInit->u16Polarity = TMR4_PWM_OXH_HOLD_OXL_HOLD;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize TMR4 PWM
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] pstcTmr4PwmInit         Pointer to a @ref stc_tmr4_pwm_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4PwmInit value is NULL.
+ */
+int32_t TMR4_PWM_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_pwm_init_t *pstcTmr4PwmInit)
+{
+    uint16_t POCRValue;
+    __IO uint16_t *POCR;
+    RCSR_REG_TYPE RCSRValue;
+    __IO RCSR_REG_TYPE *RCSR;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4PwmInit) {
+        DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+        DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+        DDL_ASSERT(IS_TMR4_PWM_MD(pstcTmr4PwmInit->u16Mode));
+        DDL_ASSERT(IS_TMR4_PWM_CLK_DIV(pstcTmr4PwmInit->u16ClockDiv));
+        DDL_ASSERT(IS_TMR4_PWM_POLARITY(pstcTmr4PwmInit->u16Polarity));
+
+        /* Get pointer of current channel PWM register address */
+        POCR = TMR4_POCR(TMR4x, u32Ch);
+        RCSR = TMR4_RCSR(TMR4x);
+
+        /* Set POCR register */
+        POCRValue = (pstcTmr4PwmInit->u16Mode | pstcTmr4PwmInit->u16ClockDiv | pstcTmr4PwmInit->u16Polarity);
+        WRITE_REG16(*POCR, POCRValue);
+
+        /* Set RCSR register */
+        RCSRValue = (TMR4_RCSR_RTSx_MASK(u32Ch) | TMR4_RCSR_RTIDx_MASK(u32Ch) | TMR4_RCSR_RTICx_MASK(u32Ch));
+        MODIFY_RCSR_REG(*RCSR, TMR4_RCSR_MASK(u32Ch), RCSRValue);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize TMR4 PWM
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @retval None
+ */
+void TMR4_PWM_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __IO uint16_t *POCR;
+    __IO RCSR_REG_TYPE *RCSR;
+    RCSR_REG_TYPE RCSRValue;
+    __IO uint16_t *PDAR;
+    __IO uint16_t *PDBR;
+    __IO uint16_t *PFSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+
+    /* Get pointer of current channel PWM register address */
+    POCR = TMR4_POCR(TMR4x, u32Ch);
+    RCSR = TMR4_RCSR(TMR4x);
+    PDAR = TMR4_PDR(TMR4x, u32Ch, TMR4_PWM_PDAR_IDX);
+    PDBR = TMR4_PDR(TMR4x, u32Ch, TMR4_PWM_PDBR_IDX);
+    PFSR = TMR4_PFSR(TMR4x, u32Ch);
+
+    /* Set POCR register to reset value */
+    WRITE_REG16(*POCR, TMR4_POCR_RST_VALUE);
+
+    /* Set RCSR register */
+    RCSRValue = (TMR4_RCSR_RTSx_MASK(u32Ch) | TMR4_RCSR_RTICx_MASK(u32Ch));
+    MODIFY_RCSR_REG(*RCSR, TMR4_RCSR_MASK(u32Ch), RCSRValue);
+
+    /* Set PDAR/PDBR register to reset value */
+    WRITE_REG16(*PDAR, 0U);
+    WRITE_REG16(*PDBR, 0U);
+
+    /* Set POCR register to reset value */
+    WRITE_REG16(*PFSR, 0U);
+
+    /* Set abnormal pin status to reset value */
+    TMR4_PWM_SetAbnormalPinStatus(TMR4x, ((u32Ch << 1) + 0UL), TMR4_PWM_ABNORMAL_PIN_HIZ);
+    TMR4_PWM_SetAbnormalPinStatus(TMR4x, ((u32Ch << 1) + 1UL), TMR4_PWM_ABNORMAL_PIN_HIZ);
+
+    /* Set port output mode to reset value */
+    TMR4_PWM_SetPortOutputMode(TMR4x, ((u32Ch << 1) + 0UL), TMR4_PWM_PIN_OUTPUT_OS);
+    TMR4_PWM_SetPortOutputMode(TMR4x, ((u32Ch << 1) + 1UL), TMR4_PWM_PIN_OUTPUT_OS);
+}
+
+/**
+ * @brief  Set TMR4 PWM clock division
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] u16Div                  TMR4 PWM internal clock division
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Clock_Division
+ *           @arg TMR4_PWM_CLK_DIV1:    CLK
+ *           @arg TMR4_PWM_CLK_DIV2:    CLK/2
+ *           @arg TMR4_PWM_CLK_DIV4:    CLK/4
+ *           @arg TMR4_PWM_CLK_DIV8:    CLK/8
+ *           @arg TMR4_PWM_CLK_DIV16:   CLK/16
+ *           @arg TMR4_PWM_CLK_DIV32:   CLK/32
+ *           @arg TMR4_PWM_CLK_DIV64:   CLK/64
+ *           @arg TMR4_PWM_CLK_DIV128:  CLK/128
+ * @retval None
+ */
+void TMR4_PWM_SetClockDiv(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Div)
+{
+    __IO uint16_t *POCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_PWM_CLK_DIV(u16Div));
+
+    /* Get pointer of current channel PWM register address */
+    POCR = TMR4_POCR(TMR4x, u32Ch);
+
+    MODIFY_REG16(*POCR, TMR4_POCR_DIVCK, u16Div);
+}
+
+/**
+ * @brief  Set TMR4 PWM output polarity.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] u16Polarity             TMR4 PWM output polarity
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Polarity
+ *           @arg TMR4_PWM_OXH_HOLD_OXL_HOLD: Output PWML and PWMH signals without changing the level
+ *           @arg TMR4_PWM_OXH_INVT_OXL_INVT: Output both PWML and PWMH signals reversed
+ *           @arg TMR4_PWM_OXH_INVT_OXL_HOLD: Output the PWMH signal reversed, outputs the PWML signal without changing the level
+ *           @arg TMR4_PWM_OXH_HOLD_OXL_INVT: Output the PWMH signal without changing the level, Outputs the PWML signal reversed
+ * @retval None
+ */
+void TMR4_PWM_SetPolarity(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Polarity)
+{
+    __IO uint16_t *POCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_PWM_POLARITY(u16Polarity));
+
+    /* Get pointer of current channel PWM register address */
+    POCR = TMR4_POCR(TMR4x, u32Ch);
+
+    MODIFY_REG16(*POCR, TMR4_POCR_LVLS, u16Polarity);
+}
+
+/**
+ * @brief  Start TMR4 PWM reload-timer
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @retval None
+ */
+void TMR4_PWM_StartReloadTimer(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+
+    SET_REG_BIT(TMR4x->RCSR, TMR4_RCSR_RTEx_MASK(u32Ch));
+}
+
+/**
+ * @brief  Stop TMR4 PWM reload-timer
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @retval None
+ */
+void TMR4_PWM_StopReloadTimer(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+
+    SET_REG_BIT(TMR4x->RCSR, TMR4_RCSR_RTSx_MASK(u32Ch));
+}
+
+/**
+ * @brief  Set TMR4 PWM filter count value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] u16Value                TMR4 PWM filter count value
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_PWM_SetFilterCountValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value)
+{
+    __IO uint16_t *PFSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+
+    /* Get pointer of current channel PWM register address */
+    PFSR = TMR4_PFSR(TMR4x, u32Ch);
+
+    WRITE_REG16(*PFSR, u16Value);
+}
+
+/**
+ * @brief  Set TMR4 PWM dead time count
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] u32DeadTimeIndex        TMR4 PWM dead time register index
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Dead_Time_Register_Index
+ *           @arg TMR4_PWM_PDAR_IDX:    TMR4_PDARn
+ *           @arg TMR4_PWM_PDBR_IDX:    TMR4_PDBRn
+ * @param  [in] u16Value                TMR4 PWM dead time register value
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_PWM_SetDeadTimeValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint32_t u32DeadTimeIndex, uint16_t u16Value)
+{
+    __IO uint16_t *PDR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_PWM_DEADTIME_REG_IDX(u32DeadTimeIndex));
+
+    /* Get pointer of current channel PWM register address */
+    PDR = TMR4_PDR(TMR4x, u32Ch, u32DeadTimeIndex);
+
+    WRITE_REG16(*PDR, u16Value);
+}
+
+/**
+ * @brief  Get TMR4 PWM dead time count
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 PWM channel
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Channel
+ * @param  [in] u32DeadTimeIndex        TMR4 PWM dead time register index
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Dead_Time_Register_Index
+ *           @arg TMR4_PWM_PDAR_IDX:    TMR4_PDARn
+ *           @arg TMR4_PWM_PDBR_IDX:    TMR4_PDBRn
+ * @retval TMR4 PWM dead time register value
+ */
+uint16_t TMR4_PWM_GetDeadTimeValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint32_t u32DeadTimeIndex)
+{
+    __I uint16_t *PDR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_PWM_DEADTIME_REG_IDX(u32DeadTimeIndex));
+
+    /* Get pointer of current channel PWM register address */
+    PDR = TMR4_PDR(TMR4x, u32Ch, u32DeadTimeIndex);
+
+    return READ_REG16(*PDR);
+}
+
+/**
+ * @brief Set TMR4 PWM register TMR4_PSCR.OE bit effect time
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Time                 Effect time
+ *         This parameter can be one of the macros group @ref TMR4_PWM_OE_Bit_Effect_Time
+ *           @arg TMR4_PWM_OE_EFFECT_IMMED:        TMR4 PWM register TMR4_PSCR.OE bit immediate effect
+ *           @arg TMR4_PWM_OE_EFFECT_COUNT_PEAK:   TMR4 PWM register TMR4_PSCR.OE bit effect when TMR4 counter count peak
+ *           @arg TMR4_PWM_OE_EFFECT_COUNT_VALLEY: TMR4 PWM register TMR4_PSCR.OE bit effect when TMR4 counter count valley
+ * @retval None
+ */
+void TMR4_PWM_SetOEEffectTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32Time)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_OE_EFFECT(u32Time));
+
+    MODIFY_REG32(TMR4x->PSCR, TMR4_PSCR_ODT, u32Time);
+}
+
+/**
+ * @brief Enable or disable the TMR4 PWM main output by hardware after clear EMB event.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ *           @arg ENABLE:               The TMR4_PSCR.MOE bit automatically set to 1 by hardware to restore the PWM normal output.
+ *           @arg DISABLE:              The TMR4_PSCR.MOE bit can only be set to 1 by software to restore the PWM normal output.
+ * @retval None
+ */
+void TMR4_PWM_EmbHWMainOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR4x->PSCR, TMR4_PSCR_AOE);
+    } else {
+        CLR_REG32_BIT(TMR4x->PSCR, TMR4_PSCR_AOE);
+    }
+}
+
+/**
+ * @brief Enable or disable the TMR4 PWM main output function.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_PWM_MainOutputCmd(CM_TMR4_TypeDef *TMR4x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR4x->PSCR, TMR4_PSCR_MOE);
+    } else {
+        CLR_REG32_BIT(TMR4x->PSCR, TMR4_PSCR_MOE);
+    }
+}
+
+/**
+ * @brief  Set TMR4 PWM port output mode
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32PwmPin               TMR4 PWM pin
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Pin
+ * @param  [in] u32Mode                 The PWM port output mode
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Pin_Output_Mode
+ *           @arg TMR4_PWM_PIN_OUTPUT_OS:     TIM4_<t>_Oxy(x=U/V/W,y=H/L) output polarity by specified OSxy
+ *           @arg TMR4_PWM_PIN_OUTPUT_NORMAL: TIM4_<t>_Oxy(x=U/V/W,y=H/L) output normal PWM
+ * @retval None
+ */
+void TMR4_PWM_SetPortOutputMode(CM_TMR4_TypeDef *TMR4x, uint32_t u32PwmPin, uint32_t u32Mode)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_PIN(u32PwmPin));
+    DDL_ASSERT(IS_TMR4_PWM_PIN_MD(u32Mode));
+
+    MODIFY_REG32(TMR4x->PSCR, TMR4_PSCR_OExy_MASK(u32PwmPin), TMR4_PSCR_OExy(u32PwmPin, u32Mode));
+}
+
+/**
+ * @brief Set TMR4 PWM pin status when below conditions occur:1.EMB 2.MOE=0 3.MOE=1&OExy=0
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32PwmPin               TMR4 PWM pin
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Pin
+ * @param  [in] u32PinStatus            TMR4 PWM pin status
+ *         This parameter can be one of the macros group @ref TMR4_PWM_Abnormal_Pin_Status.
+ * @retval None
+ */
+void TMR4_PWM_SetAbnormalPinStatus(CM_TMR4_TypeDef *TMR4x, uint32_t u32PwmPin, uint32_t u32PinStatus)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_PWM_ABNORMAL_PIN_STAT(u32PinStatus));
+    DDL_ASSERT(IS_TMR4_PWM_PIN(u32PwmPin));
+
+    MODIFY_REG32(TMR4x->PSCR, TMR4_PSCR_OSxy_MASK(u32PwmPin), TMR4_PSCR_OSxy(u32PwmPin, u32PinStatus));
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMR4_Event_Global_Functions TMR4 Event Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_tmr4_evt_init_t to default values
+ * @param  [in] pstcTmr4EventInit       Pointer to a @ref stc_tmr4_evt_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4EventInit value is NULL.
+ */
+int32_t TMR4_EVT_StructInit(stc_tmr4_evt_init_t *pstcTmr4EventInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4EventInit) {
+        pstcTmr4EventInit->u16Mode = TMR4_EVT_MD_CMP;
+        pstcTmr4EventInit->u16CompareValue = 0U;
+        pstcTmr4EventInit->u16OutputEvent = TMR4_EVT_OUTPUT_EVT0;
+        pstcTmr4EventInit->u16MatchCond = 0U;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize TMR4 event
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] pstcTmr4EventInit       Pointer to a @ref stc_tmr4_evt_init_t structure
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcTmr4EventInit value is NULL.
+ */
+int32_t TMR4_EVT_Init(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, const stc_tmr4_evt_init_t *pstcTmr4EventInit)
+{
+    uint16_t u16Value;
+    __IO uint16_t *SCCR;
+    __IO uint16_t *SCSR;
+    __IO uint16_t *SCMR;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcTmr4EventInit) {
+        DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+        DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+        DDL_ASSERT(IS_TMR4_EVT_MD(pstcTmr4EventInit->u16Mode));
+        DDL_ASSERT(IS_TMR4_EVT_OUTPUT_EVT(pstcTmr4EventInit->u16OutputEvent));
+        DDL_ASSERT(IS_TMR4_EVT_MATCH_COND(pstcTmr4EventInit->u16MatchCond));
+
+        /* Get actual address of register list of current channel */
+        SCCR = TMR4_SCCR(TMR4x, u32Ch);
+        SCSR = TMR4_SCSR(TMR4x, u32Ch);
+        SCMR = TMR4_SCMR(TMR4x, u32Ch);
+
+        /* Set SCSR register */
+        u16Value = (pstcTmr4EventInit->u16Mode | pstcTmr4EventInit->u16OutputEvent | pstcTmr4EventInit->u16MatchCond);
+        WRITE_REG16(*SCSR, u16Value);
+
+        /* Set SCMR register */
+        WRITE_REG16(*SCMR, 0xFF00U);
+
+        /* Set SCCR register: compare value */
+        WRITE_REG16(*SCCR, pstcTmr4EventInit->u16CompareValue);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-initialize TMR4 PWM
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @retval None
+ */
+void TMR4_EVT_DeInit(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __IO uint16_t *SCCR;
+    __IO uint16_t *SCSR;
+    __IO uint16_t *SCMR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+
+    /* Get actual address of register list of current channel */
+    SCCR = TMR4_SCCR(TMR4x, u32Ch);
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+    SCMR = TMR4_SCMR(TMR4x, u32Ch);
+
+    /* Configure default parameter */
+    WRITE_REG16(*SCCR, 0x0U);
+    WRITE_REG16(*SCSR, 0x0000U);
+    WRITE_REG16(*SCMR, TMR4_SCMR_RST_VALUE);
+}
+
+/**
+ * @brief  Set TMR4 event delay object
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16Object               TMR4 event delay object
+ *         This parameter can be one of the macros group @ref TMR4_Event_Delay_Object
+ *           @arg TMR4_EVT_DELAY_OCCRXH: TMR4 event delay object - OCCRxh
+ *           @arg TMR4_EVT_DELAY_OCCRXL: TMR4 event delay object - OCCRxl
+ * @retval None
+ */
+void TMR4_EVT_SetDelayObject(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Object)
+{
+    __IO uint16_t *SCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_DELAY_OBJECT(u16Object));
+
+    /* Get actual address of register list of current channel */
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+
+    /* Set SCSR register */
+    MODIFY_REG16(*SCSR, TMR4_SCSR_EVTDS, u16Object);
+}
+
+/**
+ * @brief  Set TMR4 event trigger event.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16MaskTime             Mask times
+ *         This parameter can be one of the macros group @ref TMR4_Event_Mask_Times
+ *           @arg TMR4_EVT_MASK0:       Mask 0 times
+ *           @arg TMR4_EVT_MASK1:       Mask 1 times
+ *           @arg TMR4_EVT_MASK2:       Mask 2 times
+ *           @arg TMR4_EVT_MASK3:       Mask 3 times
+ *           @arg TMR4_EVT_MASK4:       Mask 4 times
+ *           @arg TMR4_EVT_MASK5:       Mask 5 times
+ *           @arg TMR4_EVT_MASK6:       Mask 6 times
+ *           @arg TMR4_EVT_MASK7:       Mask 7 times
+ *           @arg TMR4_EVT_MASK8:       Mask 8 times
+ *           @arg TMR4_EVT_MASK9:       Mask 9 times
+ *           @arg TMR4_EVT_MASK10:      Mask 10 times
+ *           @arg TMR4_EVT_MASK11:      Mask 11 times
+ *           @arg TMR4_EVT_MASK12:      Mask 12 times
+ *           @arg TMR4_EVT_MASK13:      Mask 13 times
+ *           @arg TMR4_EVT_MASK14:      Mask 14 times
+ *           @arg TMR4_EVT_MASK15:      Mask 15 times
+ * @retval None
+ */
+void TMR4_EVT_SetMaskTime(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16MaskTime)
+{
+    __IO uint16_t *SCMR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_MASK(u16MaskTime));
+
+    /* Get actual address of register list of current channel */
+    SCMR = TMR4_SCMR(TMR4x, u32Ch);
+
+    /* Set SCMR register */
+    MODIFY_REG16(*SCMR, TMR4_SCMR_AMC, u16MaskTime);
+}
+
+/**
+ * @brief  Get TMR4 event SCCR register value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @retval Returned value can be one of the macros group @ref TMR4_Event_Mask_Times
+ *           - TMR4_EVT_MASK0:          Mask 0 times
+ *           - TMR4_EVT_MASK1:          Mask 1 times
+ *           - TMR4_EVT_MASK2:          Mask 2 times
+ *           - TMR4_EVT_MASK3:          Mask 3 times
+ *           - TMR4_EVT_MASK4:          Mask 4 times
+ *           - TMR4_EVT_MASK5:          Mask 5 times
+ *           - TMR4_EVT_MASK6:          Mask 6 times
+ *           - TMR4_EVT_MASK7:          Mask 7 times
+ *           - TMR4_EVT_MASK8:          Mask 8 times
+ *           - TMR4_EVT_MASK9:          Mask 9 times
+ *           - TMR4_EVT_MASK10:         Mask 10 times
+ *           - TMR4_EVT_MASK11:         Mask 11 times
+ *           - TMR4_EVT_MASK12:         Mask 12 times
+ *           - TMR4_EVT_MASK13:         Mask 13 times
+ *           - TMR4_EVT_MASK14:         Mask 14 times
+ *           - TMR4_EVT_MASK15:         Mask 15 times
+ */
+uint16_t TMR4_EVT_GetMaskTime(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint16_t *SCMR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+
+    /* Get actual address of register list of current channel */
+    SCMR = TMR4_SCMR(TMR4x, u32Ch);
+
+    return READ_REG16_BIT(*SCMR, TMR4_SCMR_AMC);
+}
+
+/**
+ * @brief  Set TMR4 event compare value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16Value                SCCR register value
+ *           @arg number of 16bit
+ * @retval None
+ */
+void TMR4_EVT_SetCompareValue(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Value)
+{
+    __IO uint16_t *SCCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+
+    /* Get actual address of register list of current channel */
+    SCCR = TMR4_SCCR(TMR4x, u32Ch);
+
+    /* Set SCCR register */
+    WRITE_REG16(*SCCR, u16Value);
+}
+
+/**
+ * @brief  Get TMR4 event compare value
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @retval SCCR register value
+ */
+uint16_t TMR4_EVT_GetCompareValue(const CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch)
+{
+    __I uint16_t *SCCR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+
+    /* Get actual address of register list of current channel */
+    SCCR = TMR4_SCCR(TMR4x, u32Ch);
+
+    return READ_REG16(*SCCR);
+}
+
+/**
+ * @brief  Set TMR4 output event
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16Event                TMR4 event output event
+ *         This parameter can be one of the macros group @ref TMR4_Event_Output_Event
+ * @retval None
+ */
+void TMR4_EVT_SetOutputEvent(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Event)
+{
+    __IO uint16_t *SCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_OUTPUT_EVT(u16Event));
+
+    /* Get actual address of register list of current channel */
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+
+    /* Set SCSR register */
+    MODIFY_REG16(*SCSR, TMR4_SCSR_EVTOS, u16Event);
+}
+
+/**
+ * @brief  Set the SCCR&SCMR buffer transfer condition
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16BufCond              The buffer transfer condition
+ *         This parameter can be one of the macros group @ref TMR4_Event_Buffer_Transfer_Condition
+ *           @arg TMR4_EVT_BUF_COND_IMMED:       Register SCCR&SCMR buffer transfer when writing to the SCCR&SCMR register
+ *           @arg TMR4_EVT_BUF_COND_VALLEY:      Register SCCR&SCMR buffer transfer when counter count valley
+ *           @arg TMR4_EVT_BUF_COND_PEAK:        Register SCCR&SCMR buffer transfer when counter count peak
+ *           @arg TMR4_EVT_BUF_COND_PEAK_VALLEY: Register SCCR&SCMR buffer transfer when counter count peak or valley
+ * @retval None
+ */
+void TMR4_EVT_SetCompareBufCond(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16BufCond)
+{
+    __IO uint16_t *SCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_BUF_COND(u16BufCond));
+
+    /* Get actual address of register list of current channel */
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+
+    MODIFY_REG16(*SCSR, TMR4_SCSR_BUFEN, u16BufCond);
+}
+
+/**
+ * @brief  Enable or disable the buffer interval response function of TMR4 event.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_EVT_BufIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    __IO uint16_t *SCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get actual address of register list of current channel */
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(*SCSR, TMR4_SCSR_LMC);
+    } else {
+        CLR_REG16_BIT(*SCSR, TMR4_SCSR_LMC);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified interval response of TMR4 event.
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16MaskType             The specified mask compare type of TMR4 event
+ *         This parameter can be any composed value of the macros group @ref TMR4_Event_Mask
+ *           @arg TMR4_EVT_MASK_VALLEY: Compare with the counter valley interrupt mask counter
+ *           @arg TMR4_EVT_MASK_PEAK:   Compare with the counter peak interrupt mask counter
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_EVT_EventIntervalResponseCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch,
+                                       uint16_t u16MaskType, en_functional_state_t enNewState)
+{
+    __IO uint16_t *SCMR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_MASK_TYPE(u16MaskType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get actual address of register list of current channel */
+    SCMR = TMR4_SCMR(TMR4x, u32Ch);
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(*SCMR, u16MaskType);
+    } else {
+        CLR_REG16_BIT(*SCMR, u16MaskType);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified count compare type of TMR4 event
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u32Ch                   TMR4 event channel
+ *         This parameter can be one of the macros group @ref TMR4_Event_Channel
+ * @param  [in] u16Cond                 The specified count compare type of TMR4 event
+ *         This parameter can be any composed value of the macros group @ref TMR4_Event_Match_Condition
+ *           @arg TMR4_EVT_MATCH_CNT_UP:     Start event operate when match with SCCR&SCMR and TMR4 counter count up
+ *           @arg TMR4_EVT_MATCH_CNT_DOWN:   Start event operate when match with SCCR&SCMR and TMR4 counter count down
+ *           @arg TMR4_EVT_MATCH_CNT_VALLEY: Start event operate when match with SCCR&SCMR and TMR4 counter count valley
+ *           @arg TMR4_EVT_MATCH_CNT_PEAK:   Start event operate when match with SCCR&SCMR and TMR4 counter count peak
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR4_EVT_MatchCondCmd(CM_TMR4_TypeDef *TMR4x, uint32_t u32Ch, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    __IO uint16_t *SCSR;
+
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR4_EVT_MATCH_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    /* Get actual address of register list of current channel */
+    SCSR = TMR4_SCSR(TMR4x, u32Ch);
+
+    if (ENABLE == enNewState) {
+        SET_REG16_BIT(*SCSR, u16Cond);
+    } else {
+        CLR_REG16_BIT(*SCSR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Set TMR4 event signal output to port
+ * @param  [in] TMR4x                   Pointer to TMR4 instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_TMR4 or CM_TMR4_x: TMR4 unit instance register base
+ * @param  [in] u16Signal               TMR4 event signal selection
+ *         This parameter can be one of the macros group @ref TMR4_Event_Output_Signal
+ * @retval None
+ */
+void TMR4_EVT_SetOutputEventSignal(CM_TMR4_TypeDef *TMR4x, uint16_t u16Signal)
+{
+    DDL_ASSERT(IS_TMR4_UNIT(TMR4x));
+    DDL_ASSERT(IS_TMR4_EVT_OUTPUT_SIGNAL(u16Signal));
+
+    MODIFY_REG16(TMR4x->SCER, TMR4_SCER_EVTRS, u16Signal);
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR4_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_tmr6.c
+++ b/hc32f4a2/src/hc32_ll_tmr6.c
@@ -1,0 +1,1909 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmr6.c
+ * @brief This file provides firmware functions to manage the TMR6(TMR6).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Define variable in the beginning of the function
+                                    Modify structure stc_tmr6_deadtime_config_t
+   2023-01-15       CDT             Modify structure stc_timer6_init_t to stc_tmr6_init_t
+                                    Modify API TMR6_SetFilterClockDiv()
+   2023-06-30       CDT             Modify typo
+                                    Delete union in stc_tmr6_init_t structure
+                                    Modify API TMR6_GetCountDir()
+   2023-12-15       CDT             Modify for headfile update: CM_TMR6CR -> CM_TMR6_COMMON
+   2024-06-30       CDT             Modify API TMR6_ClearStatus() for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_tmr6.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TMR6 TMR6
+ * @brief TMR6 Driver Library
+ * @{
+ */
+
+#if (LL_TMR6_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMR6_Local_Macros TMR6 Local Macros
+ * @{
+ */
+
+/* Timer6 registers reset value */
+#define TMR6_REG_RST_VALUE_U32              (0xFFFFFFFFUL)
+#define TMR6_REG_RST_VALUE_U16              (0xFFFFU)
+#define TMR6_REG_GCONR_RST_VALUE            (0x00000100UL)
+
+/* Define for BCONR register configuration */
+#define BCONR_FUNC_CMD_MASK                 (0x01UL)
+#define BCONR_GEN_CFG_MASK                  (0x0000000EUL)
+#define BCONR_GEN_CFG_CHB_OFS               (0x04UL)
+#define BCONR_PERIOD_CFG_MASK               (0x0000000EUL)
+#define BCONR_PERIOD_CFG_OFS                (0x08UL)
+#define BCONR_SPECIAL_CFG_MASK              (0x0000000EUL)
+#define BCONR_SPECIAL_CFG_CHA_OFS           (0x10UL)
+#define BCONR_SPECIAL_CFG_CHB_OFS           (0x14UL)
+
+/* Define mask value for PWM output configuration for PCNAR/PCNBR register */
+#define PCNA_BR_REG_OUTPUT_CFG_MASK         (0x8000FFFFUL)
+#define PCNA_BR_REG_EMB_CFG_MASK            (TMR6_PCNAR_EMBSA | TMR6_PCNAR_EMBRA | TMR6_PCNAR_EMBCA)
+#define PCONR_REG_POLARITY_MASK             (0x03UL)
+
+/* Define mask value for GCONR register */
+#define TMR6_INIT_MASK                      (TMR6_GCONR_DIR | TMR6_GCONR_MODE | TMR6_GCONR_CKDIV)
+#define TMR6_ZMASK_CFG_MASK                 (TMR6_GCONR_ZMSKVAL | TMR6_GCONR_ZMSKPOS | TMR6_GCONR_ZMSKREV)
+
+/**
+ * @defgroup TMR6_Check_Param_Validity TMR6 Check Parameters Validity
+ * @{
+ */
+
+/*! Parameter valid check for normal timer6 unit */
+#define IS_TMR6_UNIT(x)                                                        \
+(   ((x) == CM_TMR6_1)                          ||                             \
+    ((x) == CM_TMR6_2)                          ||                             \
+    ((x) == CM_TMR6_3)                          ||                             \
+    ((x) == CM_TMR6_4)                          ||                             \
+    ((x) == CM_TMR6_5)                          ||                             \
+    ((x) == CM_TMR6_6)                          ||                             \
+    ((x) == CM_TMR6_7)                          ||                             \
+    ((x) == CM_TMR6_8))
+
+/*! Parameter valid check for timer6 count source */
+#define IS_TMR6_CNT_SRC(x)                                                     \
+(   ((x) == TMR6_CNT_SRC_SW)                    ||                             \
+    ((x) == TMR6_CNT_SRC_HW))
+
+/*! Parameter valid check for interrupt source configuration */
+#define IS_TMR6_IRQ(x)                                                         \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_INT_ALL) == TMR6_INT_ALL))
+
+/*! Parameter valid check for status bit read */
+#define IS_TMR6_GET_FLAG(x)                                                    \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_FLAG_ALL) == TMR6_FLAG_ALL))
+
+/*! Parameter valid check for status bit clear */
+#define IS_TMR6_CLR_FLAG(x)                                                    \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_FLAG_CLR_ALL) == TMR6_FLAG_CLR_ALL))
+
+/*! Parameter valid check for period register */
+#define IS_TMR6_PERIOD_REG(x)                                                  \
+(   (x) <= TMR6_PERIOD_REG_C)
+
+/*! Parameter valid check for general compare register */
+#define IS_TMR6_CMP_REG(x)                                                     \
+(   (x) <= TMR6_CMP_REG_F)
+
+/*! Parameter valid check for general/special compare channel */
+#define IS_TMR6_CNT_CH(x)                                                      \
+(   ((x) == TMR6_CH_A)                          ||                             \
+    ((x) == TMR6_CH_B))
+
+/*! Parameter valid check for buffer function number */
+#define IS_TMR6_BUF_NUM(x)                                                     \
+(   ((x) == TMR6_BUF_SINGLE)                    ||                             \
+    ((x) == TMR6_BUF_DUAL))
+
+/*! Parameter valid check for buffer transfer timer configuration */
+#define IS_TMR6_BUF_TRANS_TRIG(x)                                              \
+(   ((x) == TMR6_BUF_TRANS_INVD)                ||                             \
+    ((x) == TMR6_BUF_TRANS_OVF)                 ||                             \
+    ((x) == TMR6_BUF_TRANS_UDF)                 ||                             \
+    ((x) == TMR6_BUF_TRANS_OVF_UDF))
+
+/*! Parameter valid check for count condition for valid period function */
+#define IS_TMR6_PERIOD_CNT_COND(x)                                             \
+(   ((x) == TMR6_VALID_PERIOD_INVD)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT_COND_VALLEY)  ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT_COND_PEAK)    ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT_COND_VALLEY_PEAK))
+
+/*! Parameter valid check for count condition for valid period count */
+#define IS_TMR6_PERIOD_CNT(x)                                                  \
+(   ((x) == TMR6_VALID_PERIOD_CNT_INVD)         ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT1)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT2)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT3)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT4)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT5)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT6)             ||                             \
+    ((x) == TMR6_VALID_PERIOD_CNT7))
+
+/*! Parameter valid check for count register data range */
+#define IS_TMR6_REG_RANGE_U16(x)               ((x) <= 0xFFFFUL)
+
+/*! Parameter valid check for dead time register */
+#define IS_TMR6_DEADTIME_REG(x)                                                \
+(   ((x) == TMR6_DEADTIME_REG_UP_A)             ||                             \
+    ((x) == TMR6_DEADTIME_REG_DOWN_A)           ||                             \
+    ((x) == TMR6_DEADTIME_REG_UP_B)             ||                             \
+    ((x) == TMR6_DEADTIME_REG_DOWN_B))
+
+/*! Parameter valid check for pin */
+#define IS_TMR6_PIN(x)                                                         \
+(   ((x) == TMR6_IO_PWMA)                       ||                             \
+    ((x) == TMR6_IO_PWMB)                       ||                             \
+    ((x) == TMR6_INPUT_TRIGA)                   ||                             \
+    ((x) == TMR6_INPUT_TRIGB)                   ||                             \
+    ((x) == TMR6_INPUT_TRIGC)                   ||                             \
+    ((x) == TMR6_INPUT_TRIGD))
+
+/*! Parameter valid check for input pin filter clock */
+#define IS_TMR6_FILTER_CLK(x)                                                  \
+(   ((x) == TMR6_FILTER_CLK_DIV1)               ||                             \
+    ((x) == TMR6_FILTER_CLK_DIV4)               ||                             \
+    ((x) == TMR6_FILTER_CLK_DIV16)              ||                             \
+    ((x) == TMR6_FILTER_CLK_DIV64))
+
+/*! Parameter valid check for PWM pin status */
+#define IS_TMR6_PWM_POLARITY(x)                                                \
+(   ((x) == TMR6_PWM_LOW)                       ||                             \
+    ((x) == TMR6_PWM_HIGH)                      ||                             \
+    ((x) == TMR6_PWM_HOLD)                      ||                             \
+    ((x) == TMR6_PWM_INVT))
+
+/*! Parameter valid check for force PWM output pin */
+#define IS_TMR6_PWM_FORCE_POLARITY(x)                                          \
+(   ((x) == TMR6_PWM_FORCE_INVD)                ||                             \
+    ((x) == TMR6_PWM_FORCE_LOW)                 ||                             \
+    ((x) == TMR6_PWM_FORCE_HIGH))
+
+/*! Parameter valid check for PWM pin status for count start and stop */
+#define IS_TMR6_PWM_POLARITY_START_STOP(x)                                     \
+(   ((x) == TMR6_PWM_LOW)                       ||                             \
+    ((x) == TMR6_PWM_HIGH)                      ||                             \
+    ((x) == TMR6_PWM_HOLD))
+
+#define IS_TMR6_CNT_STAT(x)                                                    \
+(   ((x) == TMR6_STAT_START)                    ||                             \
+    ((x) == TMR6_STAT_STOP)                     ||                             \
+    ((x) == TMR6_STAT_OVF)                      ||                             \
+    ((x) == TMR6_STAT_UDF)                      ||                             \
+    ((x) == TMR6_STAT_UP_CNT_MATCH_A)           ||                             \
+    ((x) == TMR6_STAT_DOWN_CNT_MATCH_A)         ||                             \
+    ((x) == TMR6_STAT_UP_CNT_MATCH_B)           ||                             \
+    ((x) == TMR6_STAT_DOWN_CNT_MATCH_B))
+
+/*! Parameter valid check for pin mode */
+#define IS_TMR6_PIN_MD(x)                                                      \
+(   ((x) == TMR6_PIN_CMP_OUTPUT)                ||                             \
+    ((x) == TMR6_PIN_CAPT_INPUT))
+
+/*! Parameter valid check for EMB event valid channel  */
+#define IS_TMR6_EMB_CH(x)                                                      \
+(   ((x) == TMR6_EMB_EVT_CH0)                   ||                             \
+    ((x) == TMR6_EMB_EVT_CH1)                   ||                             \
+    ((x) == TMR6_EMB_EVT_CH2)                   ||                             \
+    ((x) == TMR6_EMB_EVT_CH3))
+
+/*! Parameter valid check for EMB release mode when EMB event invalid   */
+#define IS_TMR6_EMB_RELEASE_MD(x)                                              \
+(   ((x) == TMR6_EMB_RELEASE_IMMED)             ||                             \
+    ((x) == TMR6_EMB_RELEASE_OVF)               ||                             \
+    ((x) == TMR6_EMB_RELEASE_UDF)               ||                             \
+    ((x) == TMR6_EMB_RELEASE_OVF_UDF))
+
+/*! Parameter valid check for pin output status when EMB event valid */
+#define IS_TMR6_EMB_VALID_PIN_POLARITY(x)                                      \
+(   ((x) == TMR6_EMB_PIN_NORMAL)                ||                             \
+    ((x) == TMR6_EMB_PIN_HIZ)                   ||                             \
+    ((x) == TMR6_EMB_PIN_LOW)                   ||                             \
+    ((x) == TMR6_EMB_PIN_HIGH))
+
+/*! Parameter valid check for dead time buffer function for DTUAR and DTUBR register */
+#define IS_TMR6_DEADTIME_BUF_FUNC_DTUAR_REG(x)                                 \
+(   ((x) == TMR6_DEADTIME_CNT_UP_BUF_OFF)       ||                             \
+    ((x) == TMR6_DEADTIME_CNT_UP_BUF_ON))
+
+/*! Parameter valid check for dead time buffer function for DTDAR and DTDBR register */
+#define IS_TMR6_DEADTIME_BUF_FUNC_DTDAR_REG(x)                                 \
+(   ((x) == TMR6_DEADTIME_CNT_DOWN_BUF_OFF)     ||                             \
+    ((x) == TMR6_DEADTIME_CNT_DOWN_BUF_ON))
+
+/*! Parameter valid check for dead time buffer transfer condition */
+#define IS_TMR6_DEADTIME_BUF_TRANS_COND_REG(x)                                 \
+(   ((x) == TMR6_DEADTIME_BUF_COND_INVD)        ||                             \
+    ((x) == TMR6_DEADTIME_BUF_COND_OVF)         ||                             \
+    ((x) == TMR6_DEADTIME_BUF_COND_UDF)         ||                             \
+    ((x) == TMR6_DEADTIME_BUF_COND_OVF_UDF))
+
+/*! Parameter valid check for dead time equal function for DTUAR and DTDAR register */
+#define IS_TMR6_DEADTIME_EQUAL_FUNC_REG(x)                                     \
+(   ((x) == TMR6_DEADTIME_EQUAL_OFF)            ||                             \
+    ((x) == TMR6_DEADTIME_EQUAL_ON))
+
+/*! Parameter valid check for start condition   */
+#define IS_TMR6_START_COND(x)                                                  \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_START_COND_ALL) == TMR6_START_COND_ALL))
+
+/*! Parameter valid check for stop condition   */
+#define IS_TMR6_STOP_COND(x)                                                   \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_STOP_COND_ALL) == TMR6_STOP_COND_ALL))
+
+/*! Parameter valid check for clear condition   */
+#define IS_TMR6_CLR_COND(x)                                                    \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_CLR_COND_ALL) == TMR6_CLR_COND_ALL))
+
+/*! Parameter valid check for update condition   */
+#define IS_TMR6_UPD_COND(x)                                                    \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_UPD_COND_ALL) == TMR6_UPD_COND_ALL))
+
+/*! Parameter valid check for capture condition   */
+#define IS_TMR6_CAPT_COND(x)                                                   \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_CAPT_COND_ALL) == TMR6_CAPT_COND_ALL))
+
+/*! Parameter valid check for hardware count up condition */
+#define IS_TMR6_CNT_UP_COND(x)                                                 \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_CNT_UP_COND_ALL) == TMR6_CNT_UP_COND_ALL))
+
+/*! Parameter valid check for hardware count down condition */
+#define IS_TMR6_CNT_DOWN_COND(x)                                               \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_CNT_DOWN_COND_ALL) == TMR6_CNT_DOWN_COND_ALL))
+
+/*! Parameter valid check for count Mode */
+#define IS_TMR6_CNT_MD(x)                                                      \
+(   ((x) == TMR6_MD_SAWTOOTH)                   ||                             \
+    ((x) == TMR6_MD_TRIANGLE))
+
+/*! Parameter valid check for count direction */
+#define IS_TMR6_CNT_DIR(x)                                                     \
+(   ((x) == TMR6_CNT_UP)                        ||                             \
+    ((x) == TMR6_CNT_DOWN))
+
+/*! Parameter valid check for count clock division  */
+#define IS_TMR6_CNT_CLK_DIV(x)                                                 \
+(   ((x) == TMR6_CLK_DIV1)                      ||                             \
+    ((x) == TMR6_CLK_DIV2)                      ||                             \
+    ((x) == TMR6_CLK_DIV4)                      ||                             \
+    ((x) == TMR6_CLK_DIV8)                      ||                             \
+    ((x) == TMR6_CLK_DIV16)                     ||                             \
+    ((x) == TMR6_CLK_DIV32)                     ||                             \
+    ((x) == TMR6_CLK_DIV64)                     ||                             \
+    ((x) == TMR6_CLK_DIV128)                    ||                             \
+    ((x) == TMR6_CLK_DIV256)                    ||                             \
+    ((x) == TMR6_CLK_DIV512)                    ||                             \
+    ((x) == TMR6_CLK_DIV1024))
+
+/*! Parameter valid check for count reload mode */
+#define IS_TMR6_CNT_RELOAD_MD(x)                                               \
+(   ((x) == TMR6_CNT_RELOAD_ON)                 ||                             \
+    ((x) == TMR6_CNT_RELOAD_OFF))
+
+/*! Parameter valid check for Z Mask input function mask cycles number  */
+#define IS_TMR6_ZMASK_CYCLES(x)                                                \
+(   ((x) == TMR6_ZMASK_FUNC_INVD)               ||                             \
+    ((x) == TMR6_ZMASK_CYCLE_4)                 ||                             \
+    ((x) == TMR6_ZMASK_CYCLE_8)                 ||                             \
+    ((x) == TMR6_ZMASK_CYCLE_16))
+
+/*! Parameter valid check for Z Mask function of timer6 position unit */
+#define IS_TMR6_POS_UNIT_ZMASK_FUNC(x)                                         \
+(   ((x) == TMR6_POS_CLR_ZMASK_FUNC_OFF)        ||                             \
+    ((x) == TMR6_POS_CLR_ZMASK_FUNC_ON))
+
+/*! Parameter valid check for Z Mask function of timer6 revolution unit */
+#define IS_TMR6_REVO_UNIT_ZMASK_FUNC(x)                                        \
+(   ((x) == TMR6_REVO_CNT_ZMASK_FUNC_OFF)       ||                             \
+    ((x) == TMR6_REVO_CNT_ZMASK_FUNC_ON))
+
+/*! Parameter valid check for software sync control unit */
+#define IS_TMR6_SW_UNIT(x)                                                     \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | TMR6_SW_SYNC_ALL) == TMR6_SW_SYNC_ALL))
+
+/*! Unit check for TMR6 which data width is 16 bit */
+#define IS_TMR6_16BIT_UNIT(x)                                                  \
+(   ((x) == CM_TMR6_5)                          ||                             \
+    ((x) == CM_TMR6_6)                          ||                             \
+    ((x) == CM_TMR6_7)                          ||                             \
+    ((x) == CM_TMR6_8))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup TMR6_Global_Functions TMR6 Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initialize the timer6 count function
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] pstcTmr6Init        Pointer of configuration structure @ref stc_tmr6_init_t
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_Init(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_init_t *pstcTmr6Init)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    if (NULL != pstcTmr6Init) {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR6_CNT_SRC(pstcTmr6Init->u8CountSrc));
+
+        if (pstcTmr6Init->u8CountSrc == TMR6_CNT_SRC_SW) {
+            /* Normal count */
+            DDL_ASSERT(IS_TMR6_CNT_MD(pstcTmr6Init->sw_count.u32CountMode));
+            DDL_ASSERT(IS_TMR6_CNT_DIR(pstcTmr6Init->sw_count.u32CountDir));
+            DDL_ASSERT(IS_TMR6_CNT_CLK_DIV(pstcTmr6Init->sw_count.u32ClockDiv));
+
+            MODIFY_REG32(TMR6x->GCONR, TMR6_INIT_MASK, (pstcTmr6Init->sw_count.u32CountMode | pstcTmr6Init->sw_count.u32CountDir | \
+                                                        pstcTmr6Init->sw_count.u32ClockDiv));
+        } else {
+            /* Hardware count */
+            DDL_ASSERT(IS_TMR6_CNT_UP_COND(pstcTmr6Init->hw_count.u32CountUpCond) ||
+                       (pstcTmr6Init->hw_count.u32CountUpCond == TMR6_CNT_UP_COND_INVD));
+            DDL_ASSERT(IS_TMR6_CNT_DOWN_COND(pstcTmr6Init->hw_count.u32CountDownCond) ||
+                       (pstcTmr6Init->hw_count.u32CountDownCond == TMR6_CNT_DOWN_COND_INVD));
+
+            WRITE_REG32(TMR6x->HCUPR, pstcTmr6Init->hw_count.u32CountUpCond);
+            WRITE_REG32(TMR6x->HCDOR, pstcTmr6Init->hw_count.u32CountDownCond);
+        }
+
+        DDL_ASSERT(IS_TMR6_CNT_RELOAD_MD(pstcTmr6Init->u32CountReload));
+        MODIFY_REG32(TMR6x->GCONR, TMR6_GCONR_OVSTP, pstcTmr6Init->u32CountReload);
+        if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+            DDL_ASSERT(IS_TMR6_REG_RANGE_U16(pstcTmr6Init->u32PeriodValue));
+        }
+        WRITE_REG32(TMR6x->PERAR, pstcTmr6Init->u32PeriodValue);
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set timer6 base count mode
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Mode             @ref TMR6_Count_Mode_Define
+ * @retval None
+ */
+void TMR6_SetCountMode(CM_TMR6_TypeDef *TMR6x, uint32_t u32Mode)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_MD(u32Mode));
+    MODIFY_REG32(TMR6x->GCONR, TMR6_GCONR_MODE, u32Mode);
+}
+
+/**
+ * @brief  Set timer6 base count direction
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Dir              @ref TMR6_Count_Dir_Define
+ * @retval None
+ */
+void TMR6_SetCountDir(CM_TMR6_TypeDef *TMR6x, uint32_t u32Dir)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_DIR(u32Dir));
+    MODIFY_REG32(TMR6x->GCONR, TMR6_GCONR_DIR, u32Dir);
+}
+
+/**
+ * @brief  Set timer6 base count direction
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval uint32_t                 Count direction @ref TMR6_Count_Dir_Status_Define
+ */
+uint32_t TMR6_GetCountDir(CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    return READ_REG32_BIT(TMR6x->STFLR, TMR6_STFLR_DIRF);
+}
+
+/**
+ * @brief  Set timer6 clock division
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Div              @ref TMR6_Count_Clock_Define
+ * @retval None
+ */
+void TMR6_SetClockDiv(CM_TMR6_TypeDef *TMR6x, uint32_t u32Div)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CLK_DIV(u32Div));
+
+    MODIFY_REG32(TMR6x->GCONR, TMR6_GCONR_CKDIV, u32Div);
+}
+
+/**
+ * @brief  Timer6 count reload function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_CountReloadCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        CLR_REG32_BIT(TMR6x->GCONR, TMR6_GCONR_OVSTP);
+    } else {
+        SET_REG32_BIT(TMR6x->GCONR, TMR6_GCONR_OVSTP);
+    }
+}
+
+/**
+ * @brief  Hardware increase condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware count, maybe one or any combination of the parameter
+ *                                  @ref TMR6_HW_Count_Up_Cond_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWCountUpCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_UP_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HCUPR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HCUPR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Hardware decrease condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware count, maybe one or any combination of the parameter
+ *                                  @ref TMR6_HW_Count_Down_Cond_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWCountDownCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_DOWN_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HCDOR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HCDOR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Initialize the timer6 hardware count function
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               @ref TMR6_Count_Ch_Define
+ * @param  [in] pstcPwmInit         Pointer of initialize structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_PWM_Init(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_pwm_init_t *pstcPwmInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    __IO uint32_t *TMR6_GCMxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+
+    TMR6_GCMxR = (__IO uint32_t *)((uint32_t)&TMR6x->GCMAR + 4UL * u32Ch);
+
+    if (NULL != pstcPwmInit) {
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY_START_STOP(pstcPwmInit->u32StartPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY_START_STOP(pstcPwmInit->u32StopPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32CountDownMatchBPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32CountUpMatchBPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32CountDownMatchAPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32CountUpMatchAPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32UdfPolarity));
+        DDL_ASSERT(IS_TMR6_PWM_POLARITY(pstcPwmInit->u32OvfPolarity));
+        if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+            DDL_ASSERT(IS_TMR6_REG_RANGE_U16(pstcPwmInit->u32CompareValue));
+        }
+        WRITE_REG32(*TMR6_GCMxR, pstcPwmInit->u32CompareValue);
+
+        if (TMR6_CH_A == u32Ch) {
+            MODIFY_REG32(TMR6x->PCNAR, PCNA_BR_REG_OUTPUT_CFG_MASK, \
+                         pstcPwmInit->u32CountDownMatchBPolarity << TMR6_PCNAR_CMBDCA_POS \
+                         | pstcPwmInit->u32CountUpMatchBPolarity << TMR6_PCNAR_CMBUCA_POS \
+                         | pstcPwmInit->u32CountDownMatchAPolarity << TMR6_PCNAR_CMADCA_POS \
+                         | pstcPwmInit->u32CountUpMatchAPolarity << TMR6_PCNAR_CMAUCA_POS \
+                         | pstcPwmInit->u32UdfPolarity << TMR6_PCNAR_UDFCA_POS \
+                         | pstcPwmInit->u32OvfPolarity << TMR6_PCNAR_OVFCA_POS \
+                         | pstcPwmInit->u32StopPolarity << TMR6_PCNAR_STPCA_POS \
+                         | pstcPwmInit->u32StartPolarity << TMR6_PCNAR_STACA_POS);
+        } else {
+            MODIFY_REG32(TMR6x->PCNBR,  PCNA_BR_REG_OUTPUT_CFG_MASK, \
+                         pstcPwmInit->u32CountDownMatchBPolarity << TMR6_PCNBR_CMBDCB_POS \
+                         | pstcPwmInit->u32CountUpMatchBPolarity << TMR6_PCNBR_CMBUCB_POS \
+                         | pstcPwmInit->u32CountDownMatchAPolarity << TMR6_PCNBR_CMADCB_POS \
+                         | pstcPwmInit->u32CountUpMatchAPolarity << TMR6_PCNBR_CMAUCB_POS \
+                         | pstcPwmInit->u32UdfPolarity << TMR6_PCNBR_UDFCB_POS \
+                         | pstcPwmInit->u32OvfPolarity << TMR6_PCNBR_OVFCB_POS \
+                         | pstcPwmInit->u32StopPolarity << TMR6_PCNBR_STPCB_POS \
+                         | pstcPwmInit->u32StartPolarity << TMR6_PCNBR_STACB_POS);
+        }
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 PWM output command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               @ref TMR6_Count_Ch_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_PWM_OutputCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    uint32_t u32Tmp;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        u32Tmp = 0xFFFFFFFFUL;
+    } else {
+        u32Tmp = 0UL;
+    }
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->PCNAR, TMR6_PCNAR_OUTENA, u32Tmp);
+    } else {
+        MODIFY_REG32(TMR6x->PCNBR, TMR6_PCNBR_OUTENB, u32Tmp);
+    }
+}
+
+/**
+ * @brief  Timer6 set pin polarity
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               @ref TMR6_Count_Ch_Define
+ * @param  [in] u32CountState       Polarity set for @ref TMR6_Count_State_Define
+ * @param  [in] u32Polarity         @ref TMR6_Pin_Polarity_Define
+ * @retval None
+ */
+void TMR6_PWM_SetPolarity(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32CountState, uint32_t u32Polarity)
+{
+    uint32_t u32PolarityMask = PCONR_REG_POLARITY_MASK;
+
+    uint8_t au8Pos[8] = {TMR6_PCNAR_STACA_POS, TMR6_PCNAR_STPCA_POS, TMR6_PCNAR_OVFCA_POS, TMR6_PCNAR_UDFCA_POS, \
+                         TMR6_PCNAR_CMAUCA_POS, TMR6_PCNAR_CMADCA_POS, TMR6_PCNAR_CMBUCA_POS, TMR6_PCNAR_CMBDCA_POS
+                        };
+    DDL_ASSERT(IS_TMR6_PWM_POLARITY(u32Polarity));
+    DDL_ASSERT(IS_TMR6_CNT_STAT(u32CountState));
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+
+    u32Polarity <<= au8Pos[u32CountState];
+    u32PolarityMask <<= au8Pos[u32CountState];
+
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->PCNAR, u32PolarityMask, u32Polarity);
+    } else {
+        MODIFY_REG32(TMR6x->PCNBR, u32PolarityMask, u32Polarity);
+    }
+}
+
+/**
+ * @brief  Timer6 set force polarity when next period
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               @ref TMR6_Count_Ch_Define
+ * @param  [in] u32Polarity         @ref TMR6_Force_Output_Polarity_Define
+ * @retval None
+ */
+void TMR6_PWM_SetForcePolarity(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Polarity)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR6_PWM_FORCE_POLARITY(u32Polarity));
+
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->PCNAR, TMR6_PCNAR_FORCA, u32Polarity << TMR6_PCNAR_FORCA_POS);
+    } else {
+        MODIFY_REG32(TMR6x->PCNBR, TMR6_PCNBR_FORCB, u32Polarity << TMR6_PCNBR_FORCB_POS);
+    }
+}
+
+/**
+ * @brief  Hardware capture condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               Input pin select @ref TMR6_Count_Ch_Define
+ * @param  [in] u32Cond             Events source for hardware capture, maybe one or any combination of the parameter
+ *                                  @ref TMR6_hardware_capture_condition_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWCaptureCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    __IO uint32_t *HCPxR;
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR6_CAPT_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    HCPxR = (__IO uint32_t *)((uint32_t)&TMR6x->HCPAR + (u32Ch * 4UL));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*HCPxR, u32Cond);
+    } else {
+        CLR_REG32_BIT(*HCPxR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Port input filter function configuration(Trig)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Pin              Pin to be configured @ref TMR6_Pin_Define
+ * @param  [in] u32Div              Filter clock @ref TMR6_Input_Filter_Clock
+ * @retval None
+ */
+void TMR6_SetFilterClockDiv(CM_TMR6_TypeDef *TMR6x, uint32_t u32Pin, uint32_t u32Div)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_PIN(u32Pin));
+    DDL_ASSERT(IS_TMR6_FILTER_CLK(u32Div));
+
+    switch (u32Pin) {
+        case TMR6_IO_PWMA:
+            MODIFY_REG32(TMR6x->FCNGR, TMR6_FCNGR_NOFICKGA, u32Div << TMR6_FCNGR_NOFICKGA_POS);
+            break;
+        case TMR6_IO_PWMB:
+            MODIFY_REG32(TMR6x->FCNGR, TMR6_FCNGR_NOFICKGB, u32Div << TMR6_FCNGR_NOFICKGB_POS);
+            break;
+        case TMR6_INPUT_TRIGA:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFICKTA, u32Div << TMR6_COMMON_FCNTR_NOFICKTA_POS);
+            break;
+        case TMR6_INPUT_TRIGB:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFICKTB, u32Div << TMR6_COMMON_FCNTR_NOFICKTB_POS);
+            break;
+        case TMR6_INPUT_TRIGC:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFICKTC, u32Div << TMR6_COMMON_FCNTR_NOFICKTC_POS);
+            break;
+        case TMR6_INPUT_TRIGD:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFICKTD, u32Div << TMR6_COMMON_FCNTR_NOFICKTD_POS);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief  Port input filter function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Pin              Input port to be configured @ref TMR6_Pin_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_FilterCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Pin, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_PIN(u32Pin));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    switch (u32Pin) {
+        case TMR6_IO_PWMA:
+            MODIFY_REG32(TMR6x->FCNGR, TMR6_FCNGR_NOFIENGA, ((uint32_t)enNewState) << TMR6_FCNGR_NOFIENGA_POS);
+            break;
+        case TMR6_IO_PWMB:
+            MODIFY_REG32(TMR6x->FCNGR, TMR6_FCNGR_NOFIENGB, ((uint32_t)enNewState) << TMR6_FCNGR_NOFIENGB_POS);
+            break;
+        case TMR6_INPUT_TRIGA:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFIENTA, ((uint32_t)enNewState) << TMR6_COMMON_FCNTR_NOFIENTA_POS);
+            break;
+        case TMR6_INPUT_TRIGB:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFIENTB, ((uint32_t)enNewState) << TMR6_COMMON_FCNTR_NOFIENTB_POS);
+            break;
+        case TMR6_INPUT_TRIGC:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFIENTC, ((uint32_t)enNewState) << TMR6_COMMON_FCNTR_NOFIENTC_POS);
+            break;
+        case TMR6_INPUT_TRIGD:
+            MODIFY_REG32(CM_TMR6_COMMON->FCNTR, TMR6_COMMON_FCNTR_NOFIENTD, ((uint32_t)enNewState) << TMR6_COMMON_FCNTR_NOFIENTD_POS);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief  Set channel function
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               Channel to be configured @ref TMR6_Count_Ch_Define
+ * @param  [in] u32Func             IO mode @ref TMR6_Pin_Mode_Define
+ * @retval None
+ */
+void TMR6_SetFunc(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, uint32_t u32Func)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_TMR6_PIN_MD(u32Func));
+
+    switch (u32Ch) {
+        case TMR6_CH_A:
+            MODIFY_REG32(TMR6x->PCNAR, TMR6_PCNAR_CAPMDA, u32Func);
+            break;
+        case TMR6_CH_B:
+            MODIFY_REG32(TMR6x->PCNBR, TMR6_PCNBR_CAPMDB, u32Func);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief  Timer6 interrupt enable or disable
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32IntType          Irq flag, Can be one or any combination of the values from
+ *                                  @ref TMR6_Int_Flag_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_IntCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_IRQ(u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->ICONR, u32IntType);
+    } else {
+        CLR_REG32_BIT(TMR6x->ICONR, u32IntType);
+    }
+}
+
+/**
+ * @brief  Get Timer6 status flag
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Flag             Status bit to be read, Can be one or any combination of the values from
+ *                                  @ref TMR6_Stat_Flag_Define
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t TMR6_GetStatus(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Flag)
+{
+    en_flag_status_t enStatus = RESET;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_GET_FLAG(u32Flag));
+
+    if (0UL != READ_REG32_BIT(TMR6x->STFLR, u32Flag)) {
+        enStatus = SET;
+    }
+    return enStatus;
+}
+
+/**
+ * @brief  Clear Timer6 status flag
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Flag             Status bit to be clear, Can be one or any combination of the values from
+ *                                  @ref TMR6_Stat_Flag_Define
+ * @retval None
+ */
+void TMR6_ClearStatus(CM_TMR6_TypeDef *TMR6x, uint32_t u32Flag)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CLR_FLAG(u32Flag));
+
+    WRITE_REG32(TMR6x->STFLR, TMR6_FLAG_CLR_ALL & ~u32Flag);
+}
+
+/**
+ * @brief  Get Timer6 period number when valid period function enable
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval uint32_t                 Data for periods number
+ */
+uint32_t TMR6_GetPeriodNum(const CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    return (READ_REG32_BIT(TMR6x->STFLR, TMR6_STFLR_VPERNUM) >> TMR6_STFLR_VPERNUM_POS);
+}
+
+/**
+ * @brief  De-initialize the timer6 unit
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval None
+ */
+void TMR6_DeInit(CM_TMR6_TypeDef *TMR6x)
+{
+    uint32_t u32RefRegResetValue;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        u32RefRegResetValue = TMR6_REG_RST_VALUE_U16;
+    } else {
+        u32RefRegResetValue = TMR6_REG_RST_VALUE_U32;
+    }
+
+    WRITE_REG32(TMR6x->GCONR, TMR6_REG_GCONR_RST_VALUE);
+    WRITE_REG32(TMR6x->CNTER, 0UL);
+    WRITE_REG32(TMR6x->UPDAR, 0UL);
+    WRITE_REG32(TMR6x->PERAR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->PERBR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->PERCR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMAR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMBR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMCR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMDR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMER, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->GCMFR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMAR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMBR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMCR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMDR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMER, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->SCMFR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->DTUAR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->DTDAR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->DTUBR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->DTDBR, u32RefRegResetValue);
+    WRITE_REG32(TMR6x->ICONR, 0UL);
+    WRITE_REG32(TMR6x->BCONR, 0UL);
+    WRITE_REG32(TMR6x->DCONR, 0UL);
+    WRITE_REG32(TMR6x->PCNAR, 0UL);
+    WRITE_REG32(TMR6x->PCNBR, 0UL);
+    WRITE_REG32(TMR6x->FCNGR, 0UL);
+    WRITE_REG32(CM_TMR6_COMMON->FCNTR, 0UL);
+    WRITE_REG32(TMR6x->VPERR, 0UL);
+    WRITE_REG32(TMR6x->STFLR, 0UL);
+    WRITE_REG32(TMR6x->HSTAR, 0UL);
+    WRITE_REG32(TMR6x->HSTPR, 0UL);
+    WRITE_REG32(TMR6x->HCLRR, 0UL);
+    WRITE_REG32(TMR6x->HUPDR, 0UL);
+    WRITE_REG32(TMR6x->HCPAR, 0UL);
+    WRITE_REG32(TMR6x->HCPBR, 0UL);
+    WRITE_REG32(TMR6x->HCUPR, 0UL);
+    WRITE_REG32(TMR6x->HCDOR, 0UL);
+
+    WRITE_REG32(CM_TMR6_COMMON->SSTAR, 0UL);
+    WRITE_REG32(CM_TMR6_COMMON->SSTPR, 0UL);
+    WRITE_REG32(CM_TMR6_COMMON->SCLRR, 0UL);
+    WRITE_REG32(CM_TMR6_COMMON->SUPDR, 0UL);
+}
+
+/**
+ * @brief  Timer6 count start
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval None
+ */
+void TMR6_Start(CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    SET_REG32_BIT(TMR6x->GCONR, TMR6_GCONR_START);
+}
+
+/**
+ * @brief  Timer6 count stop
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval None
+ */
+void TMR6_Stop(CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    CLR_REG32_BIT(TMR6x->GCONR, TMR6_GCONR_START);
+}
+
+/**
+ * @brief  Timer6 counter register set
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Value            Counter value
+ * @retval None
+ */
+void TMR6_SetCountValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Value)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(TMR6x->CNTER, u32Value);
+}
+
+/**
+ * @brief  Timer6 update register set
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Value            Counter value
+ * @retval None
+ */
+void TMR6_SetUpdateValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Value)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(TMR6x->UPDAR, u32Value);
+}
+
+/**
+ * @brief  Timer6 get counter register value
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval uint32_t                 Data for the count register value
+ */
+uint32_t TMR6_GetCountValue(const CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    return READ_REG32(TMR6x->CNTER);
+}
+
+/**
+ * @brief  Timer6 get update register value
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @retval uint32_t                 Data for register value
+ */
+uint32_t TMR6_GetUpdateValue(const CM_TMR6_TypeDef *TMR6x)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    return READ_REG32(TMR6x->UPDAR);
+}
+
+/**
+ * @brief  Timer6 set period register(A~C)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Period register to be write, @ref TMR6_Period_Reg_Index_Define
+ * @param  [in] u32Value            Period value for write
+ * @retval None
+ */
+void TMR6_SetPeriodValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value)
+{
+    __IO uint32_t *TMR6_PERxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_PERIOD_REG(u32Index));
+
+    TMR6_PERxR = (uint32_t *)((uint32_t)&TMR6x->PERAR + 4UL * u32Index);
+
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(*TMR6_PERxR, u32Value);
+}
+
+/**
+ * @brief  Timer6 set general compare register(A~F)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            General compare register to be write, @ref TMR6_Compare_Reg_Index_Define
+ * @param  [in] u32Value            Value for write
+ * @retval None
+ */
+void TMR6_SetCompareValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value)
+{
+    __IO uint32_t *TMR6_GCMxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CMP_REG(u32Index));
+    TMR6_GCMxR = (__IO uint32_t *)((uint32_t)&TMR6x->GCMAR + 4UL * u32Index);
+
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(*TMR6_GCMxR, u32Value);
+}
+
+/**
+ * @brief  Timer6 set special compare register(A~F)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Special compare register to be write, @ref TMR6_Compare_Reg_Index_Define
+ * @param  [in] u32Value            Value for write
+ * @retval None
+ */
+void TMR6_SetSpecialCompareValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value)
+{
+    __IO uint32_t *TMR6_SCMxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CMP_REG(u32Index));
+    TMR6_SCMxR = (uint32_t *)((uint32_t)&TMR6x->SCMAR + 4UL * u32Index);
+
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(*TMR6_SCMxR, u32Value);
+}
+
+/**
+ * @brief  Timer6 set dead time register
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Special compare register to be write, @ref TMR6_DeadTime_Reg_Define
+ * @param  [in] u32Value            Value for write
+ * @retval None
+ */
+void TMR6_SetDeadTimeValue(CM_TMR6_TypeDef *TMR6x, uint32_t u32Index, uint32_t u32Value)
+{
+    __IO uint32_t *TMR6_DTxyR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_DEADTIME_REG(u32Index));
+    TMR6_DTxyR = (uint32_t *)((uint32_t)&TMR6x->DTUAR + 4UL * u32Index);
+
+    if (IS_TMR6_16BIT_UNIT(TMR6x)) {
+        DDL_ASSERT(IS_TMR6_REG_RANGE_U16(u32Value));
+    }
+    WRITE_REG32(*TMR6_DTxyR, u32Value);
+}
+
+/**
+ * @brief  Timer6 get general compare registers value(A~F)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            General compare register to be read, @ref TMR6_Compare_Reg_Index_Define
+ * @retval uint32_t                 Data for value of the register
+ */
+uint32_t TMR6_GetCompareValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index)
+{
+    __IO uint32_t *TMR6_GCMxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CMP_REG(u32Index));
+    TMR6_GCMxR = (uint32_t *)((uint32_t)&TMR6x->GCMAR + 4UL * u32Index);
+
+    return READ_REG32(*TMR6_GCMxR);
+}
+
+/**
+ * @brief  Timer6 get special compare registers value(A~F)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Special compare register to be read, @ref TMR6_Compare_Reg_Index_Define
+ * @retval uint32_t                 Data for value of the register
+ */
+uint32_t TMR6_GetSpecialCompareValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index)
+{
+    __IO uint32_t *TMR6_SCMxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CMP_REG(u32Index));
+    TMR6_SCMxR = (uint32_t *)((uint32_t)&TMR6x->SCMAR + 4UL * u32Index);
+
+    return READ_REG32(*TMR6_SCMxR);
+}
+
+/**
+ * @brief  Timer6 Get period register(A~C)
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Period register to be write, @ref TMR6_Period_Reg_Index_Define
+ * @retval uint32_t                 Data for value of the register
+ */
+uint32_t TMR6_GetPeriodValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index)
+{
+    __IO uint32_t *TMR6_PERxR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_PERIOD_REG(u32Index));
+    TMR6_PERxR = (uint32_t *)((uint32_t)&TMR6x->PERAR + 4UL * u32Index);
+
+    return READ_REG32(*TMR6_PERxR);
+}
+
+/**
+ * @brief  Timer6 get dead time register
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Index            Dead time register to be write, @ref TMR6_DeadTime_Reg_Define
+ * @retval uint32_t                 Data for value of the register
+ */
+uint32_t TMR6_GetDeadTimeValue(const CM_TMR6_TypeDef *TMR6x, uint32_t u32Index)
+{
+    __IO uint32_t *TMR6_DTxyR;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_DEADTIME_REG(u32Index));
+    TMR6_DTxyR = (uint32_t *)((uint32_t)&TMR6x->DTUAR + 4UL * u32Index);
+
+    return READ_REG32(*TMR6_DTxyR);
+}
+
+/**
+ * @brief  Timer6 general compare buffer function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               General compare buffer chose, @ref TMR6_Count_Ch_Define
+ * @param  [in] pstcBufConfig       Pointer of configuration structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_GeneralBufConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_buf_config_t *pstcBufConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (NULL != pstcBufConfig) {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+        DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+        DDL_ASSERT(IS_TMR6_BUF_NUM(pstcBufConfig->u32BufNum));
+        DDL_ASSERT(IS_TMR6_BUF_TRANS_TRIG(pstcBufConfig->u32BufTransCond));
+
+        if (TMR6_CH_A == u32Ch) {
+            MODIFY_REG32(TMR6x->BCONR, BCONR_GEN_CFG_MASK, (pstcBufConfig->u32BufNum | pstcBufConfig->u32BufTransCond));
+        } else {
+            MODIFY_REG32(TMR6x->BCONR, BCONR_GEN_CFG_MASK << BCONR_GEN_CFG_CHB_OFS, \
+                         (pstcBufConfig->u32BufNum | pstcBufConfig->u32BufTransCond) << BCONR_GEN_CFG_CHB_OFS);
+        }
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 general compare buffer function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               General compare buffer chose, @ref TMR6_Count_Ch_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_GeneralBufCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->BCONR, BCONR_FUNC_CMD_MASK, enNewState);
+    } else {
+        MODIFY_REG32(TMR6x->BCONR, BCONR_FUNC_CMD_MASK << BCONR_GEN_CFG_CHB_OFS, \
+                     ((uint32_t)enNewState) << BCONR_GEN_CFG_CHB_OFS);
+    }
+}
+
+/**
+ * @brief  Timer6 special compare buffer function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               Special compare buffer chose, @ref TMR6_Count_Ch_Define
+ * @param  [in] pstcBufConfig       Pointer of configuration structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_SpecialBufConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_buf_config_t *pstcBufConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (NULL != pstcBufConfig) {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+        DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+        DDL_ASSERT(IS_TMR6_BUF_NUM(pstcBufConfig->u32BufNum));
+        DDL_ASSERT(IS_TMR6_BUF_TRANS_TRIG(pstcBufConfig->u32BufTransCond));
+
+        if (TMR6_CH_A == u32Ch) {
+            MODIFY_REG32(TMR6x->BCONR, BCONR_SPECIAL_CFG_MASK << BCONR_SPECIAL_CFG_CHA_OFS, \
+                         (pstcBufConfig->u32BufNum | pstcBufConfig->u32BufTransCond) << BCONR_SPECIAL_CFG_CHA_OFS);
+        } else {
+            MODIFY_REG32(TMR6x->BCONR, BCONR_SPECIAL_CFG_MASK << BCONR_SPECIAL_CFG_CHB_OFS, \
+                         (pstcBufConfig->u32BufNum | pstcBufConfig->u32BufTransCond) << BCONR_SPECIAL_CFG_CHB_OFS);
+        }
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 special compare buffer function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               General compare buffer chose, @ref TMR6_Count_Ch_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_SpecialBufCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->BCONR, BCONR_FUNC_CMD_MASK << BCONR_SPECIAL_CFG_CHA_OFS, \
+                     ((uint32_t)enNewState) << BCONR_SPECIAL_CFG_CHA_OFS);
+    } else {
+        MODIFY_REG32(TMR6x->BCONR, BCONR_FUNC_CMD_MASK << BCONR_SPECIAL_CFG_CHB_OFS, \
+                     ((uint32_t)enNewState) << BCONR_SPECIAL_CFG_CHB_OFS);
+    }
+}
+
+/**
+ * @brief  Timer6 period buffer function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] pstcBufConfig       Pointer of configuration structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_PeriodBufConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_buf_config_t *pstcBufConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (NULL != pstcBufConfig) {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+        DDL_ASSERT(IS_TMR6_BUF_NUM(pstcBufConfig->u32BufNum));
+        DDL_ASSERT(IS_TMR6_BUF_TRANS_TRIG(pstcBufConfig->u32BufTransCond));
+
+        MODIFY_REG32(TMR6x->BCONR, BCONR_PERIOD_CFG_MASK << BCONR_PERIOD_CFG_OFS, \
+                     (pstcBufConfig->u32BufNum | pstcBufConfig->u32BufTransCond) << BCONR_PERIOD_CFG_OFS);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 period buffer function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_PeriodBufCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(TMR6x->BCONR, BCONR_FUNC_CMD_MASK << BCONR_PERIOD_CFG_OFS,
+                 ((uint32_t)enNewState) << BCONR_PERIOD_CFG_OFS);
+}
+
+/**
+ * @brief  Timer6 valid period function configuration for special compare function
+ * @param  [in] TMR6x                   Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] pstcValidperiodConfig   Pointer of configuration structure
+ * @retval int32_t:
+ *         - LL_OK:                     Successfully done
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t TMR6_ValidPeriodConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_valid_period_config_t *pstcValidperiodConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    if (NULL != pstcValidperiodConfig) {
+        /* Check parameters */
+        DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+        DDL_ASSERT(IS_TMR6_PERIOD_CNT_COND(pstcValidperiodConfig->u32CountCond));
+        DDL_ASSERT(IS_TMR6_PERIOD_CNT(pstcValidperiodConfig->u32PeriodInterval));
+
+        MODIFY_REG32(TMR6x->VPERR, TMR6_VPERR_PCNTS | TMR6_VPERR_PCNTE, \
+                     pstcValidperiodConfig->u32CountCond | pstcValidperiodConfig->u32PeriodInterval);
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 valid period function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Ch               General compare buffer chose, @ref TMR6_Count_Ch_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_ValidPeriodCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (TMR6_CH_A == u32Ch) {
+        MODIFY_REG32(TMR6x->VPERR, TMR6_VPERR_SPPERIA, ((uint32_t)enNewState) << TMR6_VPERR_SPPERIA_POS);
+    } else {
+        MODIFY_REG32(TMR6x->VPERR, TMR6_VPERR_SPPERIB, ((uint32_t)enNewState) << TMR6_VPERR_SPPERIB_POS);
+    }
+}
+
+/**
+ * @brief  Timer6 dead time function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_DeadTimeFuncCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->DCONR, TMR6_DCONR_DTCEN);
+    } else {
+        CLR_REG32_BIT(TMR6x->DCONR, TMR6_DCONR_DTCEN);
+    }
+}
+
+/**
+ * @brief  DeadTime function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in]  pstcDeadTimeConfig Timer6 dead time config pointer
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_DeadTimeConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_deadtime_config_t *pstcDeadTimeConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    if (NULL != pstcDeadTimeConfig) {
+        DDL_ASSERT(IS_TMR6_DEADTIME_EQUAL_FUNC_REG(pstcDeadTimeConfig->u32EqualUpDown));
+        DDL_ASSERT(IS_TMR6_DEADTIME_BUF_FUNC_DTUAR_REG(pstcDeadTimeConfig->u32BufUp));
+        DDL_ASSERT(IS_TMR6_DEADTIME_BUF_FUNC_DTDAR_REG(pstcDeadTimeConfig->u32BufDown));
+        DDL_ASSERT(IS_TMR6_DEADTIME_BUF_TRANS_COND_REG(pstcDeadTimeConfig->u32BufTransCond));
+
+        WRITE_REG32(TMR6x->DCONR, pstcDeadTimeConfig->u32EqualUpDown | pstcDeadTimeConfig->u32BufUp \
+                    | pstcDeadTimeConfig->u32BufDown | pstcDeadTimeConfig->u32BufTransCond);
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Timer6 unit Z phase input mask config
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] pstcZMaskConfig     Pointer of configuration structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_ZMaskConfig(CM_TMR6_TypeDef *TMR6x, const stc_tmr6_zmask_config_t *pstcZMaskConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    /* Check parameters */
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    if (NULL != pstcZMaskConfig) {
+        DDL_ASSERT(IS_TMR6_ZMASK_CYCLES(pstcZMaskConfig->u32ZMaskCycle));
+        DDL_ASSERT(IS_TMR6_POS_UNIT_ZMASK_FUNC(pstcZMaskConfig->u32PosCountMaskFunc));
+        DDL_ASSERT(IS_TMR6_REVO_UNIT_ZMASK_FUNC(pstcZMaskConfig->u32RevoCountMaskFunc));
+
+        MODIFY_REG32(TMR6x->GCONR, TMR6_ZMASK_CFG_MASK, pstcZMaskConfig->u32ZMaskCycle | \
+                     pstcZMaskConfig->u32PosCountMaskFunc | pstcZMaskConfig->u32RevoCountMaskFunc);
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  EMB function configuration
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in]  u32Ch              Channel to be configured @ref TMR6_Count_Ch_Define
+ * @param  [in]  pstcEmbConfig      Point EMB function Config Pointer
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_EMBConfig(CM_TMR6_TypeDef *TMR6x, uint32_t u32Ch, const stc_tmr6_emb_config_t *pstcEmbConfig)
+{
+    __IO uint32_t *PCNXR;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+
+    if (NULL != pstcEmbConfig) {
+        DDL_ASSERT(IS_TMR6_CNT_CH(u32Ch));
+        DDL_ASSERT(IS_TMR6_EMB_CH(pstcEmbConfig->u32ValidCh));
+        DDL_ASSERT(IS_TMR6_EMB_RELEASE_MD(pstcEmbConfig->u32ReleaseMode));
+        DDL_ASSERT(IS_TMR6_EMB_VALID_PIN_POLARITY(pstcEmbConfig->u32PinStatus));
+
+        if (TMR6_CH_A == u32Ch) {
+            PCNXR = (__IO uint32_t *)&TMR6x->PCNAR;
+        } else {
+            PCNXR = (__IO uint32_t *)&TMR6x->PCNBR;
+        }
+
+        MODIFY_REG32(*PCNXR, PCNA_BR_REG_EMB_CFG_MASK, pstcEmbConfig->u32ValidCh | pstcEmbConfig->u32ReleaseMode
+                     | pstcEmbConfig->u32PinStatus);
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+
+}
+
+/**
+ * @brief  Software Sync Start
+ * @param  [in]  u32Unit            Software Sync units, This parameter can be one or any combination of the parameter
+ *                                  @ref TMR6_SW_Sync_Unit_define
+ * @retval None
+ */
+void TMR6_SWSyncStart(uint32_t u32Unit)
+{
+    DDL_ASSERT(IS_TMR6_SW_UNIT(u32Unit));
+    WRITE_REG32(CM_TMR6_COMMON->SSTAR, u32Unit);
+}
+
+/**
+ * @brief  Software Sync Stop
+ * @param  [in]  u32Unit            Software Sync units, This parameter can be one or any combination of the parameter
+ *                                  @ref TMR6_SW_Sync_Unit_define
+ * @retval None
+ */
+void TMR6_SWSyncStop(uint32_t u32Unit)
+{
+    DDL_ASSERT(IS_TMR6_SW_UNIT(u32Unit));
+    WRITE_REG32(CM_TMR6_COMMON->SSTPR, u32Unit);
+}
+
+/**
+ * @brief  Software Sync clear
+ * @param  [in]  u32Unit            Software Sync units, This parameter can be one or any combination of the parameter
+ *                                  @ref TMR6_SW_Sync_Unit_define
+ * @retval None
+ */
+void TMR6_SWSyncClear(uint32_t u32Unit)
+{
+    DDL_ASSERT(IS_TMR6_SW_UNIT(u32Unit));
+    WRITE_REG32(CM_TMR6_COMMON->SCLRR, u32Unit);
+}
+
+/**
+ * @brief  Software Sync update
+ * @param  [in]  u32Unit            Software Sync units, This parameter can be one or any combination of the parameter
+ *                                  @ref TMR6_SW_Sync_Unit_define
+ * @retval None
+ */
+void TMR6_SWSyncUpdate(uint32_t u32Unit)
+{
+    DDL_ASSERT(IS_TMR6_SW_UNIT(u32Unit));
+    WRITE_REG32(CM_TMR6_COMMON->SUPDR, u32Unit);
+}
+
+/**
+ * @brief  Hardware start function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWStartCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(TMR6x->HSTAR, TMR6_HSTAR_STAS, ((uint32_t)enNewState) << TMR6_HSTAR_STAS_POS);
+}
+
+/**
+ * @brief  Hardware stop function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWStopCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(TMR6x->HSTPR, TMR6_HSTPR_STPS, ((uint32_t)enNewState) << TMR6_HSTPR_STPS_POS);
+}
+
+/**
+ * @brief  Hardware clear function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWClearCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(TMR6x->HCLRR, TMR6_HCLRR_CLES, ((uint32_t)enNewState) << TMR6_HCLRR_CLES_POS);
+}
+
+/**
+ * @brief  Hardware update function command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWUpdateCmd(CM_TMR6_TypeDef *TMR6x, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    MODIFY_REG32(TMR6x->HUPDR, TMR6_HUPDR_UPDS, ((uint32_t)enNewState) << TMR6_HUPDR_UPDS_POS);
+}
+
+/**
+ * @brief  Hardware start condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware start, maybe one or any combination of the parameter
+ *                                  @ref TMR6_hardware_start_condition_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWStartCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_START_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HSTAR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HSTAR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Hardware stop condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware stop, maybe one or any combination of the parameter
+ *                                  @ref TMR6_hardware_stop_condition_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWStopCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_STOP_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HSTPR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HSTPR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Hardware clear condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware clear, maybe one or any combination of the parameter
+ *                                  @ref TMR6_hardware_clear_condition_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWClearCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_CLR_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HCLRR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HCLRR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Hardware update condition command
+ * @param  [in] TMR6x               Timer6 unit
+ *  @arg CM_TMR6_x
+ * @param  [in] u32Cond             Events source for hardware update, maybe one or any combination of the parameter
+ *                                  @ref TMR6_hardware_update_condition_Define
+ * @param  [in] enNewState          An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMR6_HWUpdateCondCmd(CM_TMR6_TypeDef *TMR6x, uint32_t u32Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMR6_UNIT(TMR6x));
+    DDL_ASSERT(IS_TMR6_UPD_COND(u32Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(TMR6x->HUPDR, u32Cond);
+    } else {
+        CLR_REG32_BIT(TMR6x->HUPDR, u32Cond);
+    }
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_init_t to default values
+ * @param  [out] pstcTmr6Init       Pointer to a @ref stc_tmr6_init_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_StructInit(stc_tmr6_init_t *pstcTmr6Init)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint32_t u32RefRegResetValue;
+
+    /* Check structure pointer */
+    if (NULL != pstcTmr6Init) {
+        pstcTmr6Init->u8CountSrc = TMR6_CNT_SRC_SW;
+        pstcTmr6Init->sw_count.u32ClockDiv  = TMR6_CLK_DIV1;
+        pstcTmr6Init->sw_count.u32CountMode = TMR6_MD_SAWTOOTH;
+        pstcTmr6Init->sw_count.u32CountDir  = TMR6_CNT_UP;
+        pstcTmr6Init->hw_count.u32CountUpCond   = TMR6_CNT_UP_COND_INVD;
+        pstcTmr6Init->hw_count.u32CountDownCond = TMR6_CNT_DOWN_COND_INVD;
+        u32RefRegResetValue = TMR6_REG_RST_VALUE_U32;
+        pstcTmr6Init->u32CountReload = TMR6_CNT_RELOAD_ON;
+        pstcTmr6Init->u32PeriodValue = u32RefRegResetValue;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_buf_config_t to default values
+ * @param  [out] pstcBufConfig      Pointer to a @ref stc_tmr6_buf_config_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_BufFuncStructInit(stc_tmr6_buf_config_t *pstcBufConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    /* Check structure pointer */
+    if (NULL != pstcBufConfig) {
+        pstcBufConfig->u32BufNum = TMR6_BUF_SINGLE;
+        pstcBufConfig->u32BufTransCond = TMR6_BUF_TRANS_INVD;
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_valid_period_config_t to default values
+ * @param  [out] pstcValidperiodConfig  Pointer to a @ref stc_tmr6_valid_period_config_t structure
+ * @retval int32_t:
+ *         - LL_OK:                     Successfully done
+ *         - LL_ERR_INVD_PARAM:         Parameter error
+ */
+int32_t TMR6_ValidPeriodStructInit(stc_tmr6_valid_period_config_t *pstcValidperiodConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    /* Check structure pointer */
+    if (NULL != pstcValidperiodConfig) {
+        pstcValidperiodConfig->u32CountCond = TMR6_VALID_PERIOD_INVD;
+        pstcValidperiodConfig->u32PeriodInterval = TMR6_VALID_PERIOD_CNT_INVD;
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_emb_config_t to default values
+ * @param  [out] pstcEmbConfig      Pointer to a @ref stc_tmr6_emb_config_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_EMBConfigStructInit(stc_tmr6_emb_config_t *pstcEmbConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    /* Check structure pointer */
+    if (NULL != pstcEmbConfig) {
+        pstcEmbConfig->u32ValidCh = TMR6_EMB_EVT_CH0;
+        pstcEmbConfig->u32ReleaseMode = TMR6_EMB_RELEASE_IMMED;
+        pstcEmbConfig->u32PinStatus = TMR6_EMB_PIN_NORMAL;
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_deadtime_config_t to default values
+ * @param  [out] pstcDeadTimeConfig Pointer to a @ref stc_tmr6_deadtime_config_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_DeadTimeStructInit(stc_tmr6_deadtime_config_t *pstcDeadTimeConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    /* Check structure pointer */
+    if (NULL != pstcDeadTimeConfig) {
+        pstcDeadTimeConfig->u32EqualUpDown = TMR6_DEADTIME_EQUAL_OFF;
+        pstcDeadTimeConfig->u32BufUp = TMR6_DEADTIME_CNT_UP_BUF_OFF;
+        pstcDeadTimeConfig->u32BufDown = TMR6_DEADTIME_CNT_DOWN_BUF_OFF;
+        pstcDeadTimeConfig->u32BufTransCond = TMR6_DEADTIME_BUF_COND_INVD;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_zmask_config_t to default values
+ * @param  [out] pstcZMaskConfig    Pointer to a @ref stc_tmr6_zmask_config_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_ZMaskConfigStructInit(stc_tmr6_zmask_config_t *pstcZMaskConfig)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    /* Check structure pointer */
+    if (NULL != pstcZMaskConfig) {
+        pstcZMaskConfig->u32ZMaskCycle = TMR6_ZMASK_FUNC_INVD;
+        pstcZMaskConfig->u32PosCountMaskFunc = TMR6_POS_CLR_ZMASK_FUNC_OFF;
+        pstcZMaskConfig->u32RevoCountMaskFunc = TMR6_REVO_CNT_ZMASK_FUNC_OFF;
+
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_tmr6_pwm_init_t to default values
+ * @param  [out] pstcPwmInit        Pointer to a @ref stc_tmr6_pwm_init_t structure
+ * @retval int32_t:
+ *         - LL_OK:                 Successfully done
+ *         - LL_ERR_INVD_PARAM:     Parameter error
+ */
+int32_t TMR6_PWM_StructInit(stc_tmr6_pwm_init_t *pstcPwmInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint32_t u32RefRegResetValue;
+
+    /* Check structure pointer */
+    if (NULL != pstcPwmInit) {
+        pstcPwmInit->u32StartPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32StopPolarity = TMR6_PWM_LOW;
+
+        u32RefRegResetValue = TMR6_REG_RST_VALUE_U32;
+        pstcPwmInit->u32CountDownMatchBPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32CountUpMatchBPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32CountDownMatchAPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32CountUpMatchAPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32UdfPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32OvfPolarity = TMR6_PWM_LOW;
+        pstcPwmInit->u32CompareValue = u32RefRegResetValue;
+        i32Ret = LL_OK;
+    }
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_TMR6_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+* @}
+*/
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_tmra.c
+++ b/hc32f4a2/src/hc32_ll_tmra.c
@@ -1,0 +1,1173 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_tmra.c
+ * @brief This file provides firmware functions to manage the TMRA(TimerA).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Comments optimization
+   2023-06-30       CDT             Modify typo
+                                    Update about split 16bit register TMRA_BCSTR into two 8bit registers TMRA_BCSTRH and TMRA_BCSTRL
+                                    Delete union in stc_tmra_init_t structure
+   2023-09-30       CDT             Modify some of member type of struct stc_tmra_init_t and relate function about these member
+                                    Rename macro definition IS_TMRA_CMPVAL_BUF_COND to IS_TMRA_BUF_TRANS_COND
+   2024-06-30       CDT             API TMRA_DeInit() refined
+                                    API TMRA_DeInit() added return value
+                                    Modify PCONR reg from RW_MEM16 to MODIFY_REG16 in TMRA_PWM_Init() function
+                                    Modify TMRA_CountReloadCmd,TMRA_ClearStatus,TMRA_IntCmd for couping risk
+   2024-08-31       CDT             Optimized access code for some registers to improve readability
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_tmra.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TMRA TMRA
+ * @brief TMRA Driver Library
+ * @{
+ */
+
+#if (LL_TMRA_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TMRA_Local_Macros TMRA Local Macros
+ * @{
+ */
+/**
+ * @defgroup TMRA_Registers_Setting_definition TMRA Registers setting definition
+ * @{
+ */
+#define TMRA_REG_TYPE                       uint16_t
+#define TMRA_REG_VALUE_MAX                  (0xFFFFUL)
+
+#define CMPAR_ADDR(ch)                      ((uint32_t)(&TMRAx->CMPAR1) + ((ch) * 4UL))
+#define BCONR_ADDR(ch)                      ((uint32_t)(&TMRAx->BCONR1) + ((ch) * 4UL))
+#define CCONR_ADDR(ch)                      ((uint32_t)(&TMRAx->CCONR1) + ((ch) * 4UL))
+#define PCONR_ADDR(ch)                      ((uint32_t)(&TMRAx->PCONR1) + ((ch) * 4UL))
+
+#define CMPAR_REG(ch)                       (*(__IO TMRA_REG_TYPE *)CMPAR_ADDR(ch))
+#define BCONR_REG(ch)                       (*(__IO uint16_t *)BCONR_ADDR(ch))
+#define CCONR_REG(ch)                       (*(__IO uint16_t *)CCONR_ADDR(ch))
+#define PCONR_REG(ch)                       (*(__IO uint16_t *)PCONR_ADDR(ch))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Configuration_Bit_Mask TMRA Configuration Bit Mask
+ * @{
+ */
+#define TMRA_BCSTRH_INT_MASK                (TMRA_BCSTRH_ITENUDF | TMRA_BCSTRH_ITENOVF)
+#define TMRA_BCSTRH_FLAG_MASK               (TMRA_BCSTRH_UDFF | TMRA_BCSTRH_OVFF)
+#define TMRA_FCONR_FILTER_CLK_MASK          (0x3UL)
+#define TMRA_CCONR_FILTER_CLK_MASK          (TMRA_CCONR_NOFICKCP)
+#define TMRA_PWM_POLARITY_MASK              (TMRA_PCONR_STAC)
+#define TMRA_STFLR_FLAG_MASK                (0xFU)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Filter_Pin_Max TMRA Pin With Filter Max
+ * @{
+ */
+#define TMRA_PIN_MAX                        (TMRA_PIN_PWM4)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Check_Parameters_Validity TMRA check parameters validity
+ * @{
+ */
+#define IS_TMRA_BIT_MASK(x, mask)   (((x) != 0U) && (((x) | (mask)) == (mask)))
+
+#define IS_TMRA_UNIT(x)                                                        \
+(   ((x) == CM_TMRA_1)                      ||                                 \
+    ((x) == CM_TMRA_2)                      ||                                 \
+    ((x) == CM_TMRA_3)                      ||                                 \
+    ((x) == CM_TMRA_4)                      ||                                 \
+    ((x) == CM_TMRA_5)                      ||                                 \
+    ((x) == CM_TMRA_6)                      ||                                 \
+    ((x) == CM_TMRA_7)                      ||                                 \
+    ((x) == CM_TMRA_8)                      ||                                 \
+    ((x) == CM_TMRA_9)                      ||                                 \
+    ((x) == CM_TMRA_10)                     ||                                 \
+    ((x) == CM_TMRA_11)                     ||                                 \
+    ((x) == CM_TMRA_12))
+
+#define IS_TMRA_SYNC_UNIT(x)                                                   \
+(   ((x) == CM_TMRA_2)                      ||                                 \
+    ((x) == CM_TMRA_4)                      ||                                 \
+    ((x) == CM_TMRA_6)                      ||                                 \
+    ((x) == CM_TMRA_8)                      ||                                 \
+    ((x) == CM_TMRA_10)                     ||                                 \
+    ((x) == CM_TMRA_12))
+
+#define IS_TMRA_CH(x)               ((x) <= TMRA_CH4)
+
+#define IS_TMRA_UNIT_CH(unit, ch)   (IS_TMRA_UNIT(unit) && IS_TMRA_CH(ch))
+
+#define IS_TMRA_CNT_SRC(x)          (((x) == TMRA_CNT_SRC_SW) || ((x) == TMRA_CNT_SRC_HW))
+
+#define IS_TMRA_FUNC(x)             (((x) == TMRA_FUNC_CMP) || ((x) == TMRA_FUNC_CAPT))
+
+#define IS_TMRA_DIR(x)              (((x) == TMRA_DIR_DOWN) || ((x) == TMRA_DIR_UP))
+
+#define IS_TMRA_MD(x)               (((x) == TMRA_MD_SAWTOOTH) || ((x) == TMRA_MD_TRIANGLE))
+
+#define IS_TMRA_CNT_RELOAD(x)       (((x) == TMRA_CNT_RELOAD_DISABLE) || ((x) == TMRA_CNT_RELOAD_ENABLE))
+
+#define IS_TMRA_CMPVAL_BUF_CH(x)    (((x) == TMRA_CH1) || ((x) == TMRA_CH3))
+
+#define IS_TMRA_CLK_DIV(x)                                                     \
+(   ((x) == TMRA_CLK_DIV1)                  ||                                 \
+    ((x) == TMRA_CLK_DIV2)                  ||                                 \
+    ((x) == TMRA_CLK_DIV4)                  ||                                 \
+    ((x) == TMRA_CLK_DIV8)                  ||                                 \
+    ((x) == TMRA_CLK_DIV16)                 ||                                 \
+    ((x) == TMRA_CLK_DIV32)                 ||                                 \
+    ((x) == TMRA_CLK_DIV64)                 ||                                 \
+    ((x) == TMRA_CLK_DIV128)                ||                                 \
+    ((x) == TMRA_CLK_DIV256)                ||                                 \
+    ((x) == TMRA_CLK_DIV512)                ||                                 \
+    ((x) == TMRA_CLK_DIV1024))
+
+#define IS_TMRA_FILTER_PIN(x)           ((x) <= TMRA_PIN_MAX)
+
+#define IS_TMRA_CNT_UP_COND(x)          IS_TMRA_BIT_MASK(x, TMRA_CNT_UP_COND_ALL)
+
+#define IS_TMRA_CNT_DOWN_COND(x)        IS_TMRA_BIT_MASK(x, TMRA_CNT_DOWN_COND_ALL)
+
+#define IS_TMRA_INT(x)                  IS_TMRA_BIT_MASK(x, TMRA_INT_ALL)
+
+#define IS_TMRA_EVT(x)                  IS_TMRA_BIT_MASK(x, TMRA_EVT_ALL)
+
+#define IS_TMRA_FLAG(x)                 IS_TMRA_BIT_MASK(x, TMRA_FLAG_ALL)
+
+#define IS_TMRA_CAPT_COND(x)            IS_TMRA_BIT_MASK(x, TMRA_CAPT_COND_ALL)
+
+#define IS_TMRA_FILTER_CLK_DIV(x)       ((x) <= TMRA_FILTER_CLK_DIV64)
+
+#define IS_TMRA_UNIT_INT(u, x)      (IS_TMRA_UNIT(u) && IS_TMRA_INT(x))
+
+#define IS_TMRA_CH_EVT(u, x)        (IS_TMRA_UNIT(u) && IS_TMRA_EVT(x))
+
+#define IS_TMRA_UNIT_FPIN(u, x)     (IS_TMRA_UNIT(u) && IS_TMRA_FILTER_PIN(x))
+
+#define IS_TMRA_UNIT_FLAG(u, x)     (IS_TMRA_UNIT(u) && IS_TMRA_FLAG(x))
+
+#define IS_TMRA_BUF_TRANS_COND(x)                                              \
+(   ((x) == TMRA_BUF_TRANS_COND_OVF_UDF_CLR)    ||                             \
+    ((x) == TMRA_BUF_TRANS_COND_PEAK)           ||                             \
+    ((x) == TMRA_BUF_TRANS_COND_VALLEY)         ||                             \
+    ((x) == TMRA_BUF_TRANS_COND_PEAK_VALLEY))
+
+#define IS_TMRA_PWM_START_POLARITY(x)                                          \
+(   ((x) == TMRA_PWM_LOW)                   ||                                 \
+    ((x) == TMRA_PWM_HIGH)                  ||                                 \
+    ((x) == TMRA_PWM_HOLD))
+
+#define IS_TMRA_PWM_STOP_POLARITY(x)                                           \
+(   ((x) == TMRA_PWM_LOW)                   ||                                 \
+    ((x) == TMRA_PWM_HIGH)                  ||                                 \
+    ((x) == TMRA_PWM_HOLD))
+
+#define IS_TMRA_PWM_CMP_POLARITY(x)                                            \
+(   ((x) == TMRA_PWM_LOW)                   ||                                 \
+    ((x) == TMRA_PWM_HIGH)                  ||                                 \
+    ((x) == TMRA_PWM_HOLD)                  ||                                 \
+    ((x) == TMRA_PWM_INVT))
+
+#define IS_TMRA_PWM_PERIOD_POLARITY(x)                                         \
+(   ((x) == TMRA_PWM_LOW)                   ||                                 \
+    ((x) == TMRA_PWM_HIGH)                  ||                                 \
+    ((x) == TMRA_PWM_HOLD)                  ||                                 \
+    ((x) == TMRA_PWM_INVT))
+
+#define IS_TMRA_PWM_FORCE_POLARITY(x)                                          \
+(   ((x) == TMRA_PWM_FORCE_INVD)            ||                                 \
+    ((x) == TMRA_PWM_FORCE_LOW)             ||                                 \
+    ((x) == TMRA_PWM_FORCE_HIGH))
+
+#define IS_TMRA_PWM_POLARITY(st, pol)                                          \
+(   (((st) == TMRA_CNT_STAT_START) && IS_TMRA_PWM_START_POLARITY(pol))      || \
+    (((st) == TMRA_CNT_STAT_STOP) && IS_TMRA_PWM_STOP_POLARITY(pol))        || \
+    (((st) == TMRA_CNT_STAT_MATCH_CMP) && IS_TMRA_PWM_CMP_POLARITY(pol))    || \
+    (((st) == TMRA_CNT_STAT_MATCH_PERIOD) && IS_TMRA_PWM_PERIOD_POLARITY(pol)))
+
+#define IS_TMRA_START_COND(x)       IS_TMRA_BIT_MASK((x), TMRA_START_COND_ALL)
+
+#define IS_TMRA_STOP_COND(x)        IS_TMRA_BIT_MASK((x), TMRA_STOP_COND_ALL)
+
+#define IS_TMRA_CLR_COND(x)         IS_TMRA_BIT_MASK((x), TMRA_CLR_COND_ALL)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup TMRA_Miscellaneous_Macros TMRA Miscellaneous Macros
+ * @{
+ */
+#define TMRA_PIN_PWM_OFFSET         (3U)
+
+#define TMRA_CH_NUM                 (4U)
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup TMRA_Global_Functions TMRA Global Functions
+ * @{
+ */
+/**
+ * @brief  Initializes the specified TMRA peripheral according to the specified parameters
+ *         in the structure stc_tmra_init_t
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  pstcTmraInit           Pointer to a stc_tmra_init_t structure value that
+ *                                      contains the configuration information for the TMRA.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmraInit == NULL.
+ */
+int32_t TMRA_Init(CM_TMRA_TypeDef *TMRAx, const stc_tmra_init_t *pstcTmraInit)
+{
+    int32_t i32Ret  = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    if (pstcTmraInit != NULL) {
+        DDL_ASSERT(IS_TMRA_CNT_SRC(pstcTmraInit->u8CountSrc));
+
+        if (pstcTmraInit->u8CountSrc == TMRA_CNT_SRC_SW) {
+            DDL_ASSERT(IS_TMRA_MD(pstcTmraInit->sw_count.u8CountMode));
+            DDL_ASSERT(IS_TMRA_DIR(pstcTmraInit->sw_count.u8CountDir));
+            DDL_ASSERT(IS_TMRA_CLK_DIV(pstcTmraInit->sw_count.u8ClockDiv));
+
+            WRITE_REG8(TMRAx->BCSTRL, pstcTmraInit->sw_count.u8CountMode | \
+                       pstcTmraInit->sw_count.u8CountDir                 | \
+                       pstcTmraInit->sw_count.u8ClockDiv);
+        } else {
+            DDL_ASSERT(IS_TMRA_CNT_UP_COND(pstcTmraInit->hw_count.u16CountUpCond) || \
+                       (pstcTmraInit->hw_count.u16CountUpCond == TMRA_CNT_UP_COND_INVD));
+            DDL_ASSERT(IS_TMRA_CNT_DOWN_COND(pstcTmraInit->hw_count.u16CountDownCond) || \
+                       (pstcTmraInit->hw_count.u16CountDownCond == TMRA_CNT_DOWN_COND_INVD));
+            WRITE_REG16(TMRAx->HCUPR, pstcTmraInit->hw_count.u16CountUpCond);
+            WRITE_REG16(TMRAx->HCDOR, pstcTmraInit->hw_count.u16CountDownCond);
+        }
+
+        /* Counter reload */
+        DDL_ASSERT(IS_TMRA_CNT_RELOAD(pstcTmraInit->u8CountReload));
+        WRITE_REG8(TMRAx->BCSTRH, pstcTmraInit->u8CountReload);
+
+        /* Specifies period value. */
+        TMRA_SetPeriodValue(TMRAx, pstcTmraInit->u32PeriodValue);
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set a default value for the TMRA initialization structure.
+ * @param  [out] pstcTmraInit           Pointer to a stc_tmra_init_t structure value that
+ *                                      contains the configuration information for the TMRA.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcTmraInit == NULL.
+ */
+int32_t TMRA_StructInit(stc_tmra_init_t *pstcTmraInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcTmraInit != NULL) {
+        pstcTmraInit->u8CountSrc                = TMRA_CNT_SRC_SW;
+        pstcTmraInit->sw_count.u8ClockDiv       = TMRA_CLK_DIV1;
+        pstcTmraInit->sw_count.u8CountMode      = TMRA_MD_SAWTOOTH;
+        pstcTmraInit->sw_count.u8CountDir       = TMRA_DIR_UP;
+        pstcTmraInit->hw_count.u16CountUpCond   = TMRA_CNT_UP_COND_INVD;
+        pstcTmraInit->hw_count.u16CountDownCond = TMRA_CNT_DOWN_COND_INVD;
+        pstcTmraInit->u32PeriodValue            = (TMRA_REG_TYPE)0xFFFFFFFFUL;
+        pstcTmraInit->u8CountReload = TMRA_CNT_RELOAD_ENABLE;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Specifies the counting mode for the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u8Mode                 Count mode.
+ *                                      This parameter can be a value of @ref TMRA_Count_Mode
+ *   @arg  TMRA_MD_SAWTOOTH:            Count mode is sawtooth wave.
+ *   @arg  TMRA_MD_TRIANGLE:            Count mode is triangle wave.
+ * @retval None
+ */
+void TMRA_SetCountMode(CM_TMRA_TypeDef *TMRAx, uint8_t u8Mode)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_MD(u8Mode));
+    MODIFY_REG8(TMRAx->BCSTRL, TMRA_BCSTRL_MODE, u8Mode);
+}
+
+/**
+ * @brief  Specifies the counting direction for the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u8Dir                  Count direction.
+ *                                      This parameter can be a value of @ref TMRA_Count_Dir
+ *   @arg  TMRA_DIR_DOWN:               TMRA count down.
+ *   @arg  TMRA_DIR_UP:                 TMRA count up.
+ * @retval None
+ */
+void TMRA_SetCountDir(CM_TMRA_TypeDef *TMRAx, uint8_t u8Dir)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_DIR(u8Dir));
+    MODIFY_REG8(TMRAx->BCSTRL, TMRA_BCSTRL_DIR, u8Dir);
+}
+
+/**
+ * @brief  Specifies the clock divider for the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u8Div                  Clock divider.
+ *                                      This parameter can be a value of @ref TMRA_Clock_Divider
+ * @retval None
+ */
+void TMRA_SetClockDiv(CM_TMRA_TypeDef *TMRAx, uint8_t u8Div)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CLK_DIV(u8Div));
+    MODIFY_REG8(TMRAx->BCSTRL, TMRA_BCSTRL_CKDIV, u8Div);
+}
+
+/**
+ * @brief  Enable or disable the specified hardware count up condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Cond                Hardware count up condition.
+ *                                      This parameter can be values of @ref TMRA_Hard_Count_Up_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWCountUpCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CNT_UP_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->HCUPR, u16Cond);
+    } else {
+        CLR_REG16_BIT(TMRAx->HCUPR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable the specified hardware count down condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Cond                Hardware count down condition.
+ *                                      This parameter can be values of @ref TMRA_Hard_Count_Down_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWCountDownCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CNT_DOWN_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->HCDOR, u16Cond);
+    } else {
+        CLR_REG16_BIT(TMRAx->HCDOR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Specifies function mode of TMRA.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Func                Function mode of TMRA.
+ *                                      This parameter can be a value of @ref TMRA_Function_Mode
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value of @ref TMRA_Channel
+ * @retval None
+ */
+void TMRA_SetFunc(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Func)
+{
+    __IO uint16_t *CCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    DDL_ASSERT(IS_TMRA_FUNC(u16Func));
+
+    CCONRx = &CCONR_REG(u32Ch);
+    MODIFY_REG16(*CCONRx, TMRA_CCONR_CAPMD, u16Func);
+}
+
+/**
+ * @brief  Initializes the PWM according to the specified parameters
+ *         in the structure stc_tmra_pwm_init_t
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  pstcPwmInit            Pointer to a stc_tmra_pwm_init_t structure value that
+ *                                      contains the configuration information for PWM.
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value of @ref TMRA_Channel
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcPwmInit == NULL.
+ */
+int32_t TMRA_PWM_Init(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, const stc_tmra_pwm_init_t *pstcPwmInit)
+{
+    __IO uint16_t *PCONRx;
+    __IO TMRA_REG_TYPE *CMPARx;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+
+    if (pstcPwmInit != NULL) {
+        DDL_ASSERT(IS_TMRA_PWM_START_POLARITY(pstcPwmInit->u16StartPolarity));
+        DDL_ASSERT(IS_TMRA_PWM_STOP_POLARITY(pstcPwmInit->u16StopPolarity));
+        DDL_ASSERT(IS_TMRA_PWM_CMP_POLARITY(pstcPwmInit->u16CompareMatchPolarity));
+        DDL_ASSERT(IS_TMRA_PWM_PERIOD_POLARITY(pstcPwmInit->u16PeriodMatchPolarity));
+
+        CMPARx = &CMPAR_REG(u32Ch);
+        WRITE_REG(*CMPARx, (TMRA_REG_TYPE)pstcPwmInit->u32CompareValue);
+
+        PCONRx = &PCONR_REG(u32Ch);
+        MODIFY_REG16(*PCONRx, (TMRA_PCONR_STAC | TMRA_PCONR_STPC | TMRA_PCONR_CMPC | TMRA_PCONR_PERC),
+                     ((pstcPwmInit->u16StartPolarity << TMRA_PCONR_STAC_POS)        | \
+                      (pstcPwmInit->u16StopPolarity << TMRA_PCONR_STPC_POS)         | \
+                      (pstcPwmInit->u16CompareMatchPolarity << TMRA_PCONR_CMPC_POS) | \
+                      (pstcPwmInit->u16PeriodMatchPolarity << TMRA_PCONR_PERC_POS)));
+
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set a default value for the PWM initialization structure.
+ * @param  [out] pstcPwmInit            Pointer to a stc_tmra_pwm_init_t structure value that
+ *                                      contains the configuration information for PWM.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pstcPwmInit == NULL.
+ */
+int32_t TMRA_PWM_StructInit(stc_tmra_pwm_init_t *pstcPwmInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (pstcPwmInit != NULL) {
+        pstcPwmInit->u32CompareValue         = TMRA_REG_VALUE_MAX;
+        pstcPwmInit->u16StartPolarity        = TMRA_PWM_HIGH;
+        pstcPwmInit->u16StopPolarity         = TMRA_PWM_LOW;
+        pstcPwmInit->u16CompareMatchPolarity = TMRA_PWM_INVT;
+        pstcPwmInit->u16PeriodMatchPolarity  = TMRA_PWM_INVT;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable or disable the PWM output of the specified channel.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value of @ref TMRA_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_PWM_OutputCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    uint32_t u32PCONRAddr;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32PCONRAddr = PCONR_ADDR(u32Ch);
+    WRITE_REG32(PERIPH_BIT_BAND(u32PCONRAddr, TMRA_PCONR_OUTEN_POS), enNewState);
+}
+
+/**
+ * @brief  Specifies the output polarity of the PWM at the specified state of counter.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value @ref TMRA_Channel
+ * @param  [in]  u8CountState           TMRA counter state.
+ *                                      This parameter can be a value @ref TMRA_Counter_State
+ * @param  [in]  u16Polarity            The polarity of PWM.
+ *                                      This parameter can be a value @ref TMRA_PWM_Polarity
+ * @retval None
+ * @note   The polarity(high or low) when counting start is only valid when the clock is not divided(BCSTRL.CKDIV == 0).
+ */
+void TMRA_PWM_SetPolarity(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint8_t u8CountState, uint16_t u16Polarity)
+{
+    __IO uint16_t *PCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    DDL_ASSERT(IS_TMRA_PWM_POLARITY(u8CountState, u16Polarity));
+
+    PCONRx = &PCONR_REG(u32Ch);
+    MODIFY_REG16(*PCONRx, (uint16_t)TMRA_PWM_POLARITY_MASK << (u8CountState * 2U),
+                 u16Polarity << (u8CountState * 2U));
+}
+
+/**
+ * @brief  Specifies the force polarity of the PWM.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value @ref TMRA_Channel
+ * @param  [in]  u16Polarity            The force polarity of PWM.
+ *                                      This parameter can be a value @ref TMRA_PWM_Force_Polarity
+ * @retval None
+ */
+void TMRA_PWM_SetForcePolarity(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Polarity)
+{
+    __IO uint16_t *PCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    DDL_ASSERT(IS_TMRA_PWM_FORCE_POLARITY(u16Polarity));
+
+    PCONRx = &PCONR_REG(u32Ch);
+    MODIFY_REG16(*PCONRx, TMRA_PCONR_FORC, u16Polarity);
+}
+
+/**
+ * @brief  Enable or disable the specified capture condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value @ref TMRA_Channel
+ * @param  [in]  u16Cond                The capture condition.
+ *                                      This parameter can be a value @ref TMRA_Capture_Cond
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWCaptureCondCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    __IO uint16_t *CCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    DDL_ASSERT(IS_TMRA_CAPT_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+#if defined __DEBUG
+    if ((u16Cond & (TMRA_CAPT_COND_TRIG_RISING | TMRA_CAPT_COND_TRIG_FALLING)) != 0U) {
+        DDL_ASSERT(u32Ch == TMRA_CH3);
+    }
+#endif
+    CCONRx = &CCONR_REG(u32Ch);
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(*CCONRx, u16Cond);
+    } else {
+        CLR_REG16_BIT(*CCONRx, u16Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware start condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Cond                Hardware start condition.
+ *                                      This parameter can be a value @ref TMRA_Hardware_Start_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWStartCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_START_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->HCONR, u16Cond);
+    } else {
+        CLR_REG16_BIT(TMRAx->HCONR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware stop condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Cond                Hardware stop condition.
+ *                                      This parameter can be a value @ref TMRA_Hardware_Stop_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWStopCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_STOP_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->HCONR, u16Cond);
+    } else {
+        CLR_REG16_BIT(TMRAx->HCONR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Enable or disable hardware clear condition.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u16Cond                Hardware clear condition.
+ *                                      This parameter can be a value @ref TMRA_Hardware_Clear_Condition
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_HWClearCondCmd(CM_TMRA_TypeDef *TMRAx, uint16_t u16Cond, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CLR_COND(u16Cond));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->HCONR, u16Cond);
+    } else {
+        CLR_REG16_BIT(TMRAx->HCONR, u16Cond);
+    }
+}
+
+/**
+ * @brief  Specifies the clock divider of filter.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Pin                 The pin with filter of TMRA.
+ *                                      This parameter can be a value of @ref TMRA_Filter_Pin
+ * @param  [in]  u16Div                 The clock source divider of the filter.
+ *                                      This parameter can be a value of @ref TMRA_Filter_Clock_Divider
+ *   @arg  TMRA_FILTER_CLK_DIV1:        The filter clock is the clock of timerA / 1.
+ *   @arg  TMRA_FILTER_CLK_DIV4:        The filter clock is the clock of timerA / 4.
+ *   @arg  TMRA_FILTER_CLK_DIV16:       The filter clock is the clock of timerA / 16.
+ *   @arg  TMRA_FILTER_CLK_DIV64:       The filter clock is the clock of timerA / 64.
+ * @retval None
+ */
+void TMRA_SetFilterClockDiv(CM_TMRA_TypeDef *TMRAx, uint32_t u32Pin, uint16_t u16Div)
+{
+    __IO uint16_t *CCONRx;
+    const uint8_t au8Offset[] = {
+        TMRA_FCONR_NOFICKTG_POS, TMRA_FCONR_NOFICKCA_POS, TMRA_FCONR_NOFICKCB_POS,
+    };
+
+    DDL_ASSERT(IS_TMRA_UNIT_FPIN(TMRAx, u32Pin));
+    DDL_ASSERT(IS_TMRA_FILTER_CLK_DIV(u16Div));
+
+    if (u32Pin < TMRA_PIN_PWM_OFFSET) {
+        MODIFY_REG16(TMRAx->FCONR,
+                     (TMRA_FCONR_FILTER_CLK_MASK << au8Offset[u32Pin]),
+                     (u16Div << au8Offset[u32Pin]));
+    } else {
+        CCONRx = &CCONR_REG(u32Pin - TMRA_PIN_PWM_OFFSET);
+        MODIFY_REG16(*CCONRx, TMRA_CCONR_FILTER_CLK_MASK, (u16Div << TMRA_CCONR_NOFICKCP_POS));
+    }
+}
+
+/**
+ * @brief  Enable or disable the filter function of the specified TMRA input pin.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Pin                 The pin with filter of TMRA.
+ *                                      This parameter can be values of @ref TMRA_Filter_Pin
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_FilterCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Pin, en_functional_state_t enNewState)
+{
+    uint8_t u8EnPos;
+    uint32_t u32Ch;
+    uint32_t u32RegAddr;
+    const uint8_t au8Offset[] = {
+        TMRA_FCONR_NOFIENTG_POS, TMRA_FCONR_NOFIENCA_POS, TMRA_FCONR_NOFIENCB_POS,
+    };
+
+    DDL_ASSERT(IS_TMRA_UNIT_FPIN(TMRAx, u32Pin));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (u32Pin < TMRA_PIN_PWM_OFFSET) {
+        u32RegAddr = (uint32_t)&TMRAx->FCONR;
+        u8EnPos    = au8Offset[u32Pin];
+    } else {
+        u32Ch      = u32Pin - TMRA_PIN_PWM_OFFSET;
+        u32RegAddr = CCONR_ADDR(u32Ch);
+        u8EnPos    = TMRA_CCONR_NOFIENCP_POS;
+    }
+    WRITE_REG32(PERIPH_BIT_BAND(u32RegAddr, u8EnPos), enNewState);
+}
+
+/**
+ * @brief  De-initializes the TMRA peripheral. Reset all registers of the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval int32_t:
+ *           - LL_OK:                   De-Initialize success.
+ */
+int32_t TMRA_DeInit(CM_TMRA_TypeDef *TMRAx)
+{
+    uint32_t i;
+    uint32_t u32ChNum = TMRA_CH_NUM;
+    __IO TMRA_REG_TYPE *CMPARx;
+    __IO uint16_t *CCONRx;
+    __IO uint16_t *PCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+
+    /* Stop TMRA */
+    WRITE_REG8(TMRAx->BCSTRL, 0x2U);
+    WRITE_REG8(TMRAx->BCSTRH, 0x0U);
+    WRITE_REG(TMRAx->CNTER, 0x0U);
+    WRITE_REG(TMRAx->PERAR, (TMRA_REG_TYPE)0xFFFFFFFFUL);
+
+    CCONRx = &TMRAx->CCONR1;
+    PCONRx = &TMRAx->PCONR1;
+    for (i = 0U; i < u32ChNum; i++) {
+        CMPARx = &CMPAR_REG(i);
+        WRITE_REG(*CMPARx, (TMRA_REG_TYPE)0xFFFFFFUL);
+
+        CCONRx[i * 2U] = 0x0U;
+        PCONRx[i * 2U] = 0x0U;
+    }
+
+    WRITE_REG16(TMRAx->ICONR, 0x0U);
+    WRITE_REG16(TMRAx->ECONR, 0x0U);
+    WRITE_REG16(TMRAx->FCONR, 0x0U);
+    WRITE_REG16(TMRAx->STFLR, 0x0U);
+    WRITE_REG16(TMRAx->HCONR, 0x0U);
+    WRITE_REG16(TMRAx->HCUPR, 0x0U);
+    WRITE_REG16(TMRAx->HCDOR, 0x0U);
+    WRITE_REG16(TMRAx->BCONR1, 0x0U);
+    WRITE_REG16(TMRAx->BCONR2, 0x0U);
+    return LL_OK;
+}
+
+/**
+ * @brief  Get the counting direction of the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval An uint8_t type value of counting direction.
+ *          -TMRA_DIR_DOWN:             TMRA count down.
+ *          -TMRA_DIR_UP:               TMRA count up.
+ */
+uint8_t TMRA_GetCountDir(const CM_TMRA_TypeDef *TMRAx)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    return READ_REG8_BIT(TMRAx->BCSTRL, TMRA_BCSTRL_DIR);
+}
+
+/**
+ * @brief  Set period value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Value               The period value to be set.
+ *                                      This parameter can be a number between:
+ *                                      0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *                                      0UL and 0xFFFFUL for 16-bit TimerA units.
+ * @retval None
+ */
+void TMRA_SetPeriodValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Value)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    WRITE_REG(TMRAx->PERAR, (TMRA_REG_TYPE)u32Value);
+}
+
+/**
+ * @brief  Get period value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval An uint32_t type type value of period value between:
+ *         - 0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *         - 0UL and 0xFFFFUL for 16-bit TimerA units.
+ */
+uint32_t TMRA_GetPeriodValue(const CM_TMRA_TypeDef *TMRAx)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    return READ_REG(TMRAx->PERAR);
+}
+
+/**
+ * @brief  Set general counter value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Value               The general counter value to be set.
+ *                                      This parameter can be a number between:
+ *                                      0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *                                      0UL and 0xFFFFUL for 16-bit TimerA units.
+ * @retval None
+ */
+void TMRA_SetCountValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Value)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    WRITE_REG(TMRAx->CNTER, (TMRA_REG_TYPE)u32Value);
+}
+
+/**
+ * @brief  Get general counter value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval An uint32_t type type value of counter value between:
+ *         - 0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *         - 0UL and 0xFFFFUL for 16-bit TimerA units.
+ */
+uint32_t TMRA_GetCountValue(const CM_TMRA_TypeDef *TMRAx)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    return READ_REG(TMRAx->CNTER);
+}
+
+/**
+ * @brief  Set comparison value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value of @ref TMRA_Channel
+ * @param  [in]  u32Value               The comparison value to be set.
+ *                                      This parameter can be a number between:
+ *                                      0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *                                      0UL and 0xFFFFUL for 16-bit TimerA units.
+ * @retval None
+ */
+void TMRA_SetCompareValue(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint32_t u32Value)
+{
+    __IO TMRA_REG_TYPE *CMPARx;
+
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+
+    CMPARx = &CMPAR_REG(u32Ch);
+    WRITE_REG(*CMPARx, (TMRA_REG_TYPE)u32Value);
+}
+
+/**
+ * @brief  Get comparison value.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be a value of @ref TMRA_Channel
+ * @retval An uint32_t type type value of comparison value value between:
+ *         - 0UL and 0xFFFFFFFFUL for 32-bit TimerA units.
+ *         - 0UL and 0xFFFFUL for 16-bit TimerA units.
+ */
+uint32_t TMRA_GetCompareValue(const CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch)
+{
+    DDL_ASSERT(IS_TMRA_UNIT_CH(TMRAx, u32Ch));
+    return READ_REG(CMPAR_REG(u32Ch));
+}
+
+/**
+ * @brief  Enable or disable synchronous-start. When an even unit enables synchronous-start function,
+ *         start the symmetric odd unit can start the even unit at the same time.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x(x is an even number)
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_SyncStartCmd(CM_TMRA_TypeDef *TMRAx, en_functional_state_t enNewState)
+{
+    uint32_t u32Addr;
+
+    DDL_ASSERT(IS_TMRA_SYNC_UNIT(TMRAx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32Addr = (uint32_t)&TMRAx->BCSTRL;
+    WRITE_REG32(PERIPH_BIT_BAND(u32Addr, TMRA_BCSTRL_SYNST_POS), enNewState);
+}
+
+/**
+ * @brief  Enable or disable reload and continue counting when overflow/underflow.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_CountReloadCmd(CM_TMRA_TypeDef *TMRAx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        MODIFY_REG8(TMRAx->BCSTRH, (TMRA_BCSTRH_OVSTP | TMRA_BCSTRH_FLAG_MASK), ~TMRA_BCSTRH_OVSTP);
+    } else {
+        SET_REG8_BIT(TMRAx->BCSTRH, TMRA_BCSTRH_OVSTP | TMRA_BCSTRH_FLAG_MASK);
+    }
+}
+
+/**
+ * @brief  Specifies the condition of compare value buffer transmission.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be one of the odd channels of @ref TMRA_Channel
+ * @param  [in]  u16Cond                Buffer condition of the specified TMRA unit.
+ *                                      This parameter can be a value of @ref TMRA_Cmp_Value_Buf_Trans_Cond
+ *   @arg  TMRA_BUF_TRANS_COND_OVF_UDF_CLR: This configuration value applies to non-triangular wave counting mode.
+ *                                      When counting overflow or underflow or counting register was cleared,
+ *                                      transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,...).
+ *   @arg  TMRA_BUF_TRANS_COND_PEAK:    In triangle wave count mode, when count reached peak,
+ *                                      transfer CMMARm(m=2,4,6,8,...) to CMMARn(n=1,3,5,7,...).
+ *   @arg  TMRA_BUF_TRANS_COND_VALLEY:  In triangle wave count mode, when count reached valley,
+ *                                      transfer CMMARm(m=2,4,6,8,...) to CMMARn(n=1,3,5,7,...).
+ *   @arg  TMRA_BUF_TRANS_COND_PEAK_VALLEY: In triangle wave count mode, when count reached peak or valley,
+ *                                      transfer CMPARm(m=2,4,6,8,...) to CMPARn(n=1,3,5,7,...).
+ * @retval None
+ * @note The specified condition is only valid when TMRA_BCONR.BEN is set.
+ */
+void TMRA_SetCompareBufCond(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, uint16_t u16Cond)
+{
+    __IO uint16_t *BCONRx;
+
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CMPVAL_BUF_CH(u32Ch));
+    DDL_ASSERT(IS_TMRA_BUF_TRANS_COND(u16Cond));
+
+    BCONRx = &BCONR_REG(u32Ch);
+    MODIFY_REG16(*BCONRx, TMRA_BUF_TRANS_COND_PEAK_VALLEY, u16Cond);
+}
+
+/**
+ * @brief  Enable or disable compare value buffer.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Ch                  TMRA channel.
+ *                                      This parameter can be one of the odd channels of @ref TMRA_Channel
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note DO NOT set both TMRA_BCONR.BSEN and TMRA_BCONR.BEN to '1'.
+ */
+void TMRA_CompareBufCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32Ch, en_functional_state_t enNewState)
+{
+    uint32_t u32BCONRAddr;
+
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    DDL_ASSERT(IS_TMRA_CMPVAL_BUF_CH(u32Ch));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32BCONRAddr = BCONR_ADDR(u32Ch);
+
+    WRITE_REG32(PERIPH_BIT_BAND(u32BCONRAddr, TMRA_BCONR_BEN_POS), enNewState);
+}
+
+/**
+ * @brief  Get the status of the specified flag.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Flag                The status flags of TMRA.
+ *                                      This parameter can be a value of @ref TMRA_Status_Flag
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t TMRA_GetStatus(const CM_TMRA_TypeDef *TMRAx, uint32_t u32Flag)
+{
+    uint8_t u8BCSTR;
+    uint16_t u16STFLR;
+    en_flag_status_t enStatus = RESET;
+
+    DDL_ASSERT(IS_TMRA_UNIT_FLAG(TMRAx, u32Flag));
+
+    u8BCSTR = (uint8_t)(u32Flag & TMRA_BCSTRH_FLAG_MASK);
+    u16STFLR = (uint16_t)(u32Flag >> 16U);
+    u8BCSTR = READ_REG8_BIT(TMRAx->BCSTRH, u8BCSTR);
+    u16STFLR = READ_REG16_BIT(TMRAx->STFLR, u16STFLR);
+
+    if ((u8BCSTR != 0U) || (u16STFLR != 0U)) {
+        enStatus = SET;
+    }
+
+    return enStatus;
+}
+
+/**
+ * @brief  Clear the status of the specified flags.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32Flag                The status flags of TMRA.
+ *                                      This parameter can be values of @ref TMRA_Status_Flag
+ * @retval None
+ */
+void TMRA_ClearStatus(CM_TMRA_TypeDef *TMRAx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_TMRA_UNIT_FLAG(TMRAx, u32Flag));
+
+    MODIFY_REG8(TMRAx->BCSTRH, TMRA_BCSTRH_FLAG_MASK, ~u32Flag);
+    WRITE_REG16(TMRAx->STFLR, (~(u32Flag >> 16U)) & TMRA_STFLR_FLAG_MASK);
+}
+
+/**
+ * @brief  Enable of disable the specified interrupts of the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32IntType             The interrupt type of TMRA.
+ *                                      This parameter can be values of @ref TMRA_Interrupt_Type
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_IntCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32IntType, en_functional_state_t enNewState)
+{
+    uint32_t u32BCSTRH;
+    uint32_t u32ICONR;
+
+    DDL_ASSERT(IS_TMRA_UNIT_INT(TMRAx, u32IntType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    u32BCSTRH = u32IntType & TMRA_BCSTRH_INT_MASK;
+    u32ICONR  = u32IntType >> 16U;
+    if (enNewState == ENABLE) {
+        SET_REG8_BIT(TMRAx->BCSTRH, u32BCSTRH | TMRA_BCSTRH_FLAG_MASK);
+        SET_REG16_BIT(TMRAx->ICONR, u32ICONR);
+    } else {
+        MODIFY_REG8(TMRAx->BCSTRH, (u32BCSTRH | TMRA_BCSTRH_FLAG_MASK), ~u32BCSTRH);
+        CLR_REG16_BIT(TMRAx->ICONR, u32ICONR);
+    }
+}
+
+/**
+ * @brief  Enable of disable the specified event of the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @param  [in]  u32EventType           The event type of TMRA.
+ *                                      This parameter can be values of @ref TMRA_Event_Type
+ * @param  [in]  enNewState             An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TMRA_EventCmd(CM_TMRA_TypeDef *TMRAx, uint32_t u32EventType, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_TMRA_CH_EVT(TMRAx, u32EventType));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (enNewState == ENABLE) {
+        SET_REG16_BIT(TMRAx->ECONR, u32EventType);
+    } else {
+        CLR_REG16_BIT(TMRAx->ECONR, u32EventType);
+    }
+}
+
+/**
+ * @brief  Start the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval None
+ */
+void TMRA_Start(CM_TMRA_TypeDef *TMRAx)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    SET_REG8_BIT(TMRAx->BCSTRL, TMRA_BCSTRL_START);
+}
+
+/**
+ * @brief  Stop the specified TMRA unit.
+ * @param  [in]  TMRAx                  Pointer to TMRA instance register base.
+ *                                      This parameter can be a value of the following:
+ *   @arg  CM_TMRA_x or CM_TMRA
+ * @retval None
+ */
+void TMRA_Stop(CM_TMRA_TypeDef *TMRAx)
+{
+    DDL_ASSERT(IS_TMRA_UNIT(TMRAx));
+    CLR_REG8_BIT(TMRAx->BCSTRL, TMRA_BCSTRL_START);
+}
+/**
+ * @}
+ */
+
+#endif /* LL_TMRA_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_trng.c
+++ b/hc32f4a2/src/hc32_ll_trng.c
@@ -1,0 +1,263 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_trng.c
+ * @brief This file provides firmware functions to manage the True Random
+ *        Number Generator(TRNG).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             API fixed: TRNG_Init()
+   2023-06-30       CDT             API fixed: rewrite TRNG_GenerateRandom() to Support get multiple random data
+                                    API optimized for better random numbers: TRNG_GenerateRandom(), TRNG_GetRandom()
+                                    Add TRNG_Cmd,TRNG_DeInit functions and optimize TRNG_Start function
+   2023-09-30       CDT             Optimize the processing of discarded data and enable TRNG in TRNG_Init()
+   2024-08-31       CDT             Use MODIFY_REG32() to prevent reserved bit from being overwritten
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_trng.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_TRNG TRNG
+ * @brief TRNG Driver Library
+ * @{
+ */
+
+#if (LL_TRNG_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup TRNG_Local_Macros TRNG Local Macros
+ * @{
+ */
+#define TRNG_TIMEOUT                        (20000UL)
+
+/**
+ * @defgroup TRNG_Check_Parameters_Validity TRNG Check Parameters Validity
+ * @{
+ */
+#define IS_TRNG_SHIFT_CNT(x)                                                   \
+(   ((x) == TRNG_SHIFT_CNT32)                   ||                             \
+    ((x) == TRNG_SHIFT_CNT64)                   ||                             \
+    ((x) == TRNG_SHIFT_CNT128)                  ||                             \
+    ((x) == TRNG_SHIFT_CNT256))
+
+#define IS_RNG_RELOAD_INIT_VAL_EN(x)                                           \
+(   ((x) == TRNG_RELOAD_INIT_VAL_ENABLE)        ||                             \
+    ((x) == TRNG_RELOAD_INIT_VAL_DISABLE))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup TRNG_Global_Functions TRNG Global Functions
+ * @{
+ */
+
+/**
+ * @brief  De-initializes TRNG.
+ * @param  None
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ */
+int32_t TRNG_DeInit(void)
+{
+    int32_t i32Ret = LL_ERR_TIMEOUT;
+    __IO uint32_t u32TimeCount = TRNG_TIMEOUT;
+
+    /* Wait generating done */
+    while (u32TimeCount-- != 0UL) {
+        if (READ_REG32(bCM_TRNG->CR_b.RUN) == 0U) {
+            i32Ret = LL_OK;
+            break;
+        }
+    }
+    if (i32Ret == LL_OK) {
+        WRITE_REG32(CM_TRNG->CR,  0UL);
+        WRITE_REG32(CM_TRNG->MR,  0x00000012UL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initializes TRNG.
+ * @param  [in] u32ShiftCount           TRNG shift control. This parameter can be a value of @ref TRNG_Shift_Ctrl
+ *   @arg  TRNG_SHIFT_CNT32:            Shift 32 times when capturing random noise.
+ *   @arg  TRNG_SHIFT_CNT64:            Shift 64 times when capturing random noise.
+ *   @arg  TRNG_SHIFT_CNT128:           Shift 128 times when capturing random noise.
+ *   @arg  TRNG_SHIFT_CNT256:           Shift 256 times when capturing random noise.
+ * @param  [in] u32ReloadInitValueEn    Enable or disable load new initial value.
+ *                                      This parameter can be a value of @ref TRNG_Reload_Init_Value
+ *   @arg  TRNG_RELOAD_INIT_VAL_ENABLE:  Enable load new initial value.
+ *   @arg  TRNG_RELOAD_INIT_VAL_DISABLE: Disable load new initial value.
+ * @retval None
+ */
+void TRNG_Init(uint32_t u32ShiftCount, uint32_t u32ReloadInitValueEn)
+{
+    uint32_t au32Random[20U];
+
+    DDL_ASSERT(IS_TRNG_SHIFT_CNT(u32ShiftCount));
+    DDL_ASSERT(IS_RNG_RELOAD_INIT_VAL_EN(u32ReloadInitValueEn));
+    MODIFY_REG32(CM_TRNG->MR, (TRNG_MR_CNT | TRNG_MR_LOAD), (u32ShiftCount | u32ReloadInitValueEn));
+    /* Enable TRNG */
+    SET_REG32_BIT(CM_TRNG->CR, TRNG_CR_EN);
+    /* Discard the first 10 generated data (64bit), 20 for 32bit variable storage */
+    (void)TRNG_GenerateRandom(au32Random, 20U);
+}
+
+/**
+ * @brief  Start TRNG and get random number.
+ * @param  [out] pu32Random             The destination buffer to store the random number.
+ * @param  [in]  u32RandomLen           The size(in word) of the destination buffer.
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_TIMEOUT:          Works timeout.
+ *           - LL_ERR_INVD_PARAM:       pu32Random == NULL or u32RandomLen == 0
+ */
+int32_t TRNG_GenerateRandom(uint32_t *pu32Random, uint32_t u32RandomLen)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    __IO uint32_t u32TimeCount = TRNG_TIMEOUT;
+    uint32_t u32Count = 0U;
+
+    if ((pu32Random != NULL) && (u32RandomLen > 0U)) {
+        while (u32RandomLen != u32Count) {
+            /* Start TRNG */
+            WRITE_REG32(bCM_TRNG->CR_b.RUN, 1U);
+            /* Wait generating done. */
+            i32Ret = LL_ERR_TIMEOUT;
+            while (u32TimeCount-- != 0UL) {
+                if (READ_REG32(bCM_TRNG->CR_b.RUN) == 0U) {
+                    i32Ret = LL_OK;
+                    break;
+                }
+            }
+
+            if (i32Ret == LL_OK) {
+                /* Get the random number. */
+                /* XOR with 0x55555555 for better random number */
+                pu32Random[u32Count++] = READ_REG32(CM_TRNG->DR0) ^ 0x55555555UL;
+                if (u32Count < u32RandomLen) {
+                    pu32Random[u32Count++] = READ_REG32(CM_TRNG->DR1) ^ 0x55555555UL;
+                }
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Start TRNG
+ * @param  None
+ * @retval None
+ */
+void TRNG_Start(void)
+{
+    WRITE_REG32(bCM_TRNG->CR_b.RUN, 1U);
+}
+
+/**
+ * @brief  TRNG function enable or disable.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void TRNG_Cmd(en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_TRNG->CR, TRNG_CR_EN);
+    } else {
+        CLR_REG32_BIT(CM_TRNG->CR, TRNG_CR_EN);
+    }
+}
+
+/**
+ * @brief  Get random number.
+ * @param  [out] pu32Random             The destination buffer to store the random number.
+ * @param  [in]  u8RandomLen            The size(in word) of the destination buffer.(MAX = 2U)
+ * @retval int32_t:
+ *           - LL_OK:                   No error occurred.
+ *           - LL_ERR_INVD_PARAM:       pu32Random == NULL or u8RandomLen == 0
+ */
+int32_t TRNG_GetRandom(uint32_t *pu32Random, uint8_t u8RandomLen)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if ((pu32Random != NULL) && (u8RandomLen > 0U)) {
+        /* Get the random number. */
+        /* XOR with 0x55555555 for better random number */
+        pu32Random[0U] = READ_REG32(CM_TRNG->DR0) ^ 0x55555555UL;
+        if (u8RandomLen > 1U) {
+            pu32Random[1U] = READ_REG32(CM_TRNG->DR1) ^ 0x55555555UL;
+        }
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_TRNG_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/src/hc32_ll_usart.c
+++ b/hc32f4a2/src/hc32_ll_usart.c
@@ -1,0 +1,2294 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_usart.c
+ * @brief This file provides firmware functions to manage the USART(Universal
+ *        Synchronous/Asynchronous Receiver Transmitter).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Optimize UART DIV_Fraction calculation time
+   2023-01-15       CDT             Fix bug: expressions may cause overflow when calculate UART DIV_Fraction
+   2023-06-30       CDT             Add function note: USART_FuncCmd
+                                    Modify typo
+                                    Round off baudrate fraction division
+                                    Split register USART_DR to USART_RDR and USART_TDR
+                                    Modify USART_SetTransType parameter: u32Type -> u16Type
+                                    Delete function: USART_GetUsartClockDiv
+                                    Fix MISRAC2012 warning: USART_GetUsartClockFreq
+                                    Code Refine
+                                    Modify return type of function USART_DeInit()
+   2023-09-30       CDT             Modify USART_SmartCard_Init() for stc_usart_smartcard_init_t has modified(u32StopBit has removed)
+                                    Fix bug: did not enable MP while USART_MultiProcessor_Init()
+                                    Re-define IS_USART_SMARTCARD_UNIT
+                                    API refined: USART_SetBaudrate()
+   2023-12-15       CDT             Add API USART_GetFuncState()
+   2024-06-30       CDT             Add interfaces for getting USART configuration status
+                                    Add assert for the register bit can only be set when TE=0&RE=0
+   2024-08-31       CDT             Optimize condition judgment
+   2024-11-08       CDT             Add assert for pvBuf pointer alignment for data width 9bit
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_usart.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_USART USART
+ * @brief USART Driver Library
+ * @{
+ */
+
+#if (LL_USART_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/**
+ * @defgroup USART_Local_Types USART Local Types
+ * @{
+ */
+
+/**
+ * @brief usart BRR division calculate structure definition
+ */
+typedef struct {
+    uint32_t u32UsartClock;             /*!< USART clock. */
+    uint32_t u32Baudrate;               /*!< USART baudrate. */
+    uint32_t u32Integer;                /*!< Pointer to BRR integer division value. */
+    uint32_t u32Fraction;               /*!< Pointer to BRR fraction division value. */
+    float32_t f32Error;                 /*!< E(%) baudrate error rate. */
+} stc_usart_brr_t;
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup USART_Local_Macros USART Local Macros
+ * @{
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity USART Check Parameters Validity
+ * @{
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_Unit USART Check Parameters Validity Unit
+ * @{
+ */
+#define IS_USART_UNIT(x)                                                       \
+(   ((x) == CM_USART1)                  ||                                     \
+    ((x) == CM_USART2)                  ||                                     \
+    ((x) == CM_USART3)                  ||                                     \
+    ((x) == CM_USART4)                  ||                                     \
+    ((x) == CM_USART5)                  ||                                     \
+    ((x) == CM_USART6)                  ||                                     \
+    ((x) == CM_USART7)                  ||                                     \
+    ((x) == CM_USART8)                  ||                                     \
+    ((x) == CM_USART9)                  ||                                     \
+    ((x) == CM_USART10))
+#define IS_USART_INTEGER_UNIT(x)                                               \
+(   ((x) == CM_USART5)                  ||                                     \
+    ((x) == CM_USART10))
+#define IS_USART_SMARTCARD_UNIT(x)                                             \
+(   ((x) == CM_USART1)                  ||                                     \
+    ((x) == CM_USART2)                  ||                                     \
+    ((x) == CM_USART3)                  ||                                     \
+    ((x) == CM_USART4)                  ||                                     \
+    ((x) == CM_USART6)                  ||                                     \
+    ((x) == CM_USART7)                  ||                                     \
+    ((x) == CM_USART8)                  ||                                     \
+    ((x) == CM_USART9))
+#define IS_USART_LIN_UNIT(x)                                                   \
+(   ((x) == CM_USART5)                  ||                                     \
+    ((x) == CM_USART10))
+#define IS_USART_STOP_MD_UNIT(x)        ((x) == CM_USART1)
+#define IS_USART_TIMEOUT_UNIT(x)                                               \
+(   ((x) == CM_USART1)                  ||                                     \
+    ((x) == CM_USART2)                  ||                                     \
+    ((x) == CM_USART6)                  ||                                     \
+    ((x) == CM_USART7))
+
+/**
+ * @}
+ */
+
+#define IS_USART_FUNC(x)                                                       \
+(   ((x) != 0UL)                        &&                                     \
+    (((x) | USART_FUNC_ALL) == USART_FUNC_ALL))
+
+#define IS_USART_FLAG(x)                                                       \
+(   ((x) != 0UL)                        &&                                     \
+    (((x) | USART_FLAG_ALL) == USART_FLAG_ALL))
+
+#define IS_USART_TRANS_TYPE(x)                                                 \
+(   ((x) == USART_TRANS_ID)             ||                                     \
+    ((x) == USART_TRANS_DATA))
+
+#define IS_USART_PARITY(x)                                                     \
+(   ((x) == USART_PARITY_ODD)           ||                                     \
+    ((x) == USART_PARITY_EVEN)          ||                                     \
+    ((x) == USART_PARITY_NONE))
+
+#define IS_USART_DATA_WIDTH(x)                                                 \
+(   ((x) == USART_DATA_WIDTH_8BIT)      ||                                     \
+    ((x) == USART_DATA_WIDTH_9BIT))
+
+#define IS_USART_STOPBIT(x)                                                    \
+(   ((x) == USART_STOPBIT_1BIT)         ||                                     \
+    ((x) == USART_STOPBIT_2BIT))
+
+#define IS_USART_FIRST_BIT(x)                                                  \
+(   ((x) == USART_FIRST_BIT_MSB)        ||                                     \
+    ((x) == USART_FIRST_BIT_LSB))
+
+#define IS_USART_OVER_SAMPLE_BIT(x)                                            \
+(   ((x) == USART_OVER_SAMPLE_8BIT)     ||                                     \
+    ((x) == USART_OVER_SAMPLE_16BIT))
+
+#define IS_USART_START_BIT_POLARITY(x)                                         \
+(   ((x) == USART_START_BIT_LOW)        ||                                     \
+    ((x) == USART_START_BIT_FALLING))
+
+#define IS_USART_CLK_SRC(x)                                                    \
+(   ((x) == USART_CLK_SRC_EXTCLK)       ||                                     \
+    ((x) == USART_CLK_SRC_INTERNCLK))
+
+#define IS_USART_CK_OUTPUT(x)                                                  \
+(   ((x) == USART_CK_OUTPUT_ENABLE)     ||                                     \
+    ((x) == USART_CK_OUTPUT_DISABLE))
+
+#define IS_USART_CLK_DIV(x)             ((x) <= USART_CLK_DIV_MAX)
+
+#define IS_USART_DATA(x)                ((x) <= 0x01FFUL)
+
+#define IS_USART_RX_TX_DISABLE(x)                                              \
+(   ((x)->CR1 & (USART_CR1_RE | USART_CR1_TE)) == 0UL)
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_Hardware_Flow_Control USART Check Parameters Validity Hardware Flow Control
+ * @{
+ */
+#define IS_USART_HW_FLOWCTRL(x)                                                \
+(   ((x) == USART_HW_FLOWCTRL_NONE)     ||                                     \
+    ((x) == USART_HW_FLOWCTRL_CTS)      ||                                     \
+    ((x) == USART_HW_FLOWCTRL_RTS)      ||                                     \
+    ((x) == USART_HW_FLOWCTRL_RTS_CTS))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_Smartcard_Clock USART Check Parameters Validity Smartcard Clock
+ * @{
+ */
+#define IS_USART_SMARTCARD_ETU_CLK(x)                                          \
+(   ((x) == USART_SC_ETU_CLK32)         ||                                     \
+    ((x) == USART_SC_ETU_CLK64)         ||                                     \
+    ((x) == USART_SC_ETU_CLK128)        ||                                     \
+    ((x) == USART_SC_ETU_CLK256)        ||                                     \
+    ((x) == USART_SC_ETU_CLK372))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_Stopmode_Filter USART Check Parameters Validity Stopmode Filter
+ * @{
+ */
+#define IS_USART_STOP_MD_FILTER(x)                                             \
+(   ((x) == USART_STOP_MD_FILTER_LVL1)  ||                                     \
+    ((x) == USART_STOP_MD_FILTER_LVL2)  ||                                     \
+    ((x) == USART_STOP_MD_FILTER_LVL3)  ||                                     \
+    ((x) == USART_STOP_MD_FILTER_LVL4))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_Timeout_Function USART Check Parameters Validity Timeout Function
+ * @{
+ */
+#define IS_USART_TIMEOUT_FUNC(x, func)                                         \
+(   IS_USART_TIMEOUT_UNIT(x)            ||                                     \
+    ((!IS_USART_TIMEOUT_UNIT(x)) && (((func) & (USART_RX_TIMEOUT | USART_INT_RX_TIMEOUT)) == 0UL)))
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Check_Parameters_Validity_LIN_Function USART Check Parameters Validity LIN Function
+ * @{
+ */
+#define IS_USART_LIN_FUNC(x, func)                                             \
+(   IS_USART_LIN_UNIT(x)                ||                                     \
+    ((!IS_USART_LIN_UNIT(x)) && (((func) & USART_LIN_FUNC_MASK) == 0UL)))
+
+#define IS_USART_LIN_BMC_CLK_DIV(x)                                            \
+(   ((x) == USART_LIN_BMC_CLK_DIV1)     ||                                     \
+    ((x) == USART_LIN_BMC_CLK_DIV2)     ||                                     \
+    ((x) == USART_LIN_BMC_CLK_DIV4)     ||                                     \
+    ((x) == USART_LIN_BMC_CLK_DIV8))
+
+#define IS_USART_LIN_SEND_BREAK_MD(x)                                          \
+(   ((x) == USART_LIN_SEND_BREAK_MD_SBK)    ||                                 \
+    ((x) == USART_LIN_SEND_BREAK_MD_TDR))
+
+#define IS_USART_LIN_DETECT_BREAK_LEN(x)                                       \
+(   ((x) == USART_LIN_DETECT_BREAK_10BIT)   ||                                 \
+    ((x) == USART_LIN_DETECT_BREAK_11BIT))
+
+#define IS_USART_LIN_SEND_BREAK_LEN(x)                                         \
+(   ((x) == USART_LIN_SEND_BREAK_10BIT) ||                                     \
+    ((x) == USART_LIN_SEND_BREAK_11BIT) ||                                     \
+    ((x) == USART_LIN_SEND_BREAK_13BIT) ||                                     \
+    ((x) == USART_LIN_SEND_BREAK_14BIT))
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Flag_Error_Mask USART Flag Error Mask
+ * @{
+ */
+#define USART_FLAG_ERR_MASK             (USART_FLAG_OVERRUN     |              \
+                                         USART_FLAG_FRAME_ERR   |              \
+                                         USART_FLAG_PARITY_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Registers_Reset_Value_definition USART Registers Reset Value
+ * @{
+ */
+#define USART_CR1_RST_VALUE             (0x80000000UL)
+
+#define USART_CR2_RST_VALUE             (0x0600UL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_LIN_Function_Mask USART LIN Function Mask
+ * @{
+ */
+#define USART_LIN_FUNC_OFFSET           (16U)
+
+#define USART_LIN_FUNC_MASK             (USART_LIN              |              \
+                                         USART_LIN_ERR          |              \
+                                         USART_LIN_WKUP         |              \
+                                         USART_LIN_INT_WKUP     |              \
+                                         USART_LIN_INT_BREAK    |              \
+                                         USART_LIN_INT_ERR)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_BRR_Division_Max USART BRR Register Division Max
+ * @{
+ */
+#define USART_BRR_DIV_INTEGER_MAX       (0xFFUL)
+#define USART_BRR_DIV_FRACTION_MAX      (0x7FUL)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Clock_Division_Max USART Clock Division Max
+ * @{
+ */
+#define USART_CLK_DIV_MAX               (USART_CLK_DIV64)
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Default_Baudrate USART Default Baudrate
+ * @{
+ */
+#define USART_DEFAULT_BAUDRATE          (9600UL)
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup USART_Local_Functions USART Local Functions
+ * @{
+ */
+/**
+ * @brief  Try to wait the expected status of specified flags
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Flag                 USART flag
+ *         This parameter can be a value of @ref USART_Flag
+ * @param  [in] enStatus                Expected status
+ *         This parameter can be one of the following values:
+ *           @arg  SET:                 Wait flag set
+ *           @arg  RESET:               Wait flag reset
+ * @param  [in] u32Timeout              Maximum count(Max value @ref USART_Max_Timeout) of trying to get status
+ * @retval int32_t:
+ *           - LL_OK:                   Complete wait the expected status of the specified flags.
+ *           - LL_ERR_TIMEOUT:          Wait timeout.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT.
+ */
+static int32_t USART_WaitStatus(const CM_USART_TypeDef *USARTx,
+                                uint32_t u32Flag,
+                                en_flag_status_t enStatus,
+                                uint32_t u32Timeout)
+{
+    int32_t i32Ret = LL_OK;
+    __IO uint32_t u32To = 0UL;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_FLAG(u32Flag));
+
+    while (USART_GetStatus(USARTx, u32Flag) != enStatus) {
+        /* Block checking flag if timeout value is USART_TIMEOUT_MAX */
+        if ((u32To > u32Timeout) && (u32Timeout < USART_MAX_TIMEOUT)) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+
+        u32To++;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate baudrate division for UART mode.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcUartBrr             Pointer to a stc_usart_brr_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Set successfully.
+ *           - LL_ERR:                  Set unsuccessfully.
+ */
+static int32_t UART_CalculateBrr(const CM_USART_TypeDef *USARTx, stc_usart_brr_t *pstcUartBrr)
+{
+    uint32_t B;
+    uint32_t C;
+    uint32_t OVER8;
+    uint64_t u64Temp;
+    uint64_t u64Temp0;
+    uint64_t u64Dividend;
+    uint32_t DIV_Integer;
+    uint32_t DIV_IntegerMod;
+    uint32_t DIV_Fraction;
+    float32_t f32CalcError;
+    uint32_t u32FractionFlag = 1UL;
+    int32_t i32Ret = LL_ERR;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    if (IS_USART_INTEGER_UNIT(USARTx)) {
+        u32FractionFlag = 0UL;
+    }
+    C = pstcUartBrr->u32UsartClock;
+    B = pstcUartBrr->u32Baudrate;
+    if ((C > 0UL) && (B > 0UL)) {
+        OVER8 = READ_REG32_BIT(USARTx->CR1, USART_CR1_OVER8) >> USART_CR1_OVER8_POS;
+
+        /* UART mode baudrate integer calculation formula:      */
+        /*      B = C / (8 * (2 - OVER8) * (DIV_Integer + 1))   */
+        /*      DIV_Integer = (C / (B * 8 * (2 - OVER8))) - 1   */
+        DIV_Integer = (C / (B * 8UL * (2UL - OVER8))) - 1U;
+        if ((1UL == u32FractionFlag) && (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX)) {
+            pstcUartBrr->u32Integer = DIV_Integer;
+            DIV_IntegerMod = C % (B * 8UL * (2UL - OVER8));
+            if (0UL == DIV_IntegerMod) {
+                /* Get accurate baudrate without fraction */
+                pstcUartBrr->f32Error = (float32_t)0.0F;
+                i32Ret = LL_OK;
+            } else {
+                /* UART mode baudrate fraction calculation formula:                                 */
+                /*      B = C * (128 + DIV_Fraction) / (8 * (2 - OVER8) * (DIV_Integer + 1) * 256)  */
+                /*      DIV_Fraction = (256 * (8 * (2 - OVER8) * (DIV_Integer + 1) * B) / C) - 128  */
+                /* u64Temp = (8 * (2 - OVER8) * (DIV_Integer + 1) * B)  */
+                u64Temp0 = (uint64_t)((uint64_t)8UL * ((uint64_t)2UL - (uint64_t)OVER8) * \
+                                      ((uint64_t)DIV_Integer + (uint64_t)1UL) * (uint64_t)B);
+
+                /* u64Temp = u64Temp0 *256 + C/2 */
+                u64Temp0 = (u64Temp0 << 8UL);
+                u64Temp = u64Temp0 + ((uint64_t)C >> 1);    /*  +(C >> 1) for rounding off */
+                if (u64Temp > (uint64_t)(UINT32_MAX)) {
+                    DIV_Fraction = (uint32_t)(u64Temp / C) - 128UL;
+                } else {
+                    DIV_Fraction = ((uint32_t)u64Temp) / C - 128UL;
+                }
+                if (DIV_Fraction <= USART_BRR_DIV_FRACTION_MAX) {
+                    pstcUartBrr->u32Fraction = DIV_Fraction;
+                    /* E(%) = C * (128 + DIV_Fraction) / (256 * (8 * (2 - OVER8) * (DIV_Integer + 1) * B)) - 1 */
+                    u64Temp = u64Temp0;
+                    u64Dividend = (uint64_t)C * ((uint64_t)128UL + (uint64_t)DIV_Fraction);
+                    f32CalcError = (float32_t)((float64_t)(u64Dividend) / (float64_t)(u64Temp)) - 1.0F;
+                    pstcUartBrr->f32Error = f32CalcError;
+                    i32Ret = LL_OK;
+                } else {
+                    u32FractionFlag = 0UL;
+                }
+            }
+        }
+        if (0UL == u32FractionFlag) {
+            /* Integer rounding off */
+            DIV_Integer = ((((C * 10UL) / (B * 8UL * (2UL - OVER8))) + 5UL) / 10UL) - 1UL; /*  +5UL for rounding off */
+            if (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX) {
+                pstcUartBrr->u32Integer = DIV_Integer;
+                /* E(%) = C / (8 * (2 - OVER8) * (DIV_Integer + 1) * B) - 1 */
+                /* u64Temp = (8 * (2 - OVER8) * (DIV_Integer + 1) * B)  */
+                u64Temp = (uint64_t)((uint64_t)8UL * ((uint64_t)2UL - (uint64_t)OVER8) * ((uint64_t)DIV_Integer + \
+                                                                                          (uint64_t)1UL) * (uint64_t)B);
+                f32CalcError = (float32_t)((float64_t)C / (float64_t)u64Temp) - 1.0F;
+                pstcUartBrr->f32Error = f32CalcError;
+                i32Ret = LL_OK;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate baudrate division for clock-sync mode.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcClockSyncBrr        Pointer to a stc_usart_brr_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Set successfully.
+ *           - LL_ERR:                  Set unsuccessfully.
+ */
+static int32_t ClockSync_CalculateBrr(const CM_USART_TypeDef *USARTx, stc_usart_brr_t *pstcClockSyncBrr)
+{
+    uint32_t B;
+    uint32_t C;
+    uint64_t u64Temp;
+    uint64_t u64Dividend;
+    uint32_t DIV_Integer;
+    uint32_t DIV_IntegerMod;
+    uint32_t DIV_Fraction;
+    float32_t f32CalcError;
+    uint32_t u32FractionFlag = 1UL;
+    int32_t i32Ret = LL_ERR;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    if (IS_USART_INTEGER_UNIT(USARTx)) {
+        u32FractionFlag = 0UL;
+    }
+
+    C = pstcClockSyncBrr->u32UsartClock;
+    B = pstcClockSyncBrr->u32Baudrate;
+    if ((C > 0UL) && (B > 0UL)) {
+        /* Clock sync mode baudrate integer calculation formula:    */
+        /*          B = C / (4 * (DIV_Integer + 1))                 */
+        /*          DIV_Integer = (C / (B * 4)) - 1                 */
+        DIV_Integer = (C / (B * 4UL)) - 1UL;
+        if ((1UL == u32FractionFlag) && (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX)) {
+            pstcClockSyncBrr->u32Integer = DIV_Integer;
+            DIV_IntegerMod = C % (B * 4UL);
+            if (0UL == DIV_IntegerMod) {
+                /* Get accurate baudrate without fraction */
+                pstcClockSyncBrr->f32Error = (float32_t)0.0F;
+                i32Ret = LL_OK;
+            } else {
+                /* Clock sync mode baudrate fraction calculation formula:               */
+                /*      B = C * (128 + DIV_Fraction) / (4 * (DIV_Integer + 1) * 256)    */
+                /*      DIV_Fraction = 256 * (4 * (DIV_Integer + 1) * B) / C - 128       */
+
+                /* u64Temp = (4 * (DIV_Integer + 1) * B)  */
+                u64Temp = (uint64_t)((uint64_t)4U * ((uint64_t)DIV_Integer + (uint64_t)1UL) * (uint64_t)B);
+                DIV_Fraction = (uint32_t)((256UL * u64Temp + ((uint64_t)C >> 1)) / C - 128UL);  /*  +(C >> 1) for rounding off */
+                if (DIV_Fraction <= USART_BRR_DIV_FRACTION_MAX) {
+                    pstcClockSyncBrr->u32Fraction = DIV_Fraction;
+                    /* E(%) = C * (128 + DIV_Fraction) / (4 * (DIV_Integer + 1) * B * 256) - 1 */
+                    u64Temp *= (uint64_t)256UL;
+                    u64Dividend = (uint64_t)C * ((uint64_t)128UL + (uint64_t)DIV_Fraction);
+                    f32CalcError = (float32_t)((float64_t)(u64Dividend) / (float64_t)(u64Temp)) - 1.0F;
+                    pstcClockSyncBrr->f32Error = f32CalcError;
+                    i32Ret = LL_OK;
+                } else {
+                    u32FractionFlag = 0UL;
+                }
+            }
+        }
+        if (0UL == u32FractionFlag) {
+            /* Integer rounding off */
+            DIV_Integer = ((((C * 10UL) / (B * 4UL)) + 5UL) / 10UL) - 1UL; /*  +5UL for rounding off */
+            if (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX) {
+                pstcClockSyncBrr->u32Integer = DIV_Integer;
+                /* E(%) = C / (4 * (DIV_Integer + 1) * B) - 1 */
+                /* u64Temp = 4 * (DIV_Integer + 1) * B */
+                u64Temp = (uint64_t)((uint64_t)4U * ((uint64_t)DIV_Integer + (uint64_t)1UL) * (uint64_t)B);
+                f32CalcError = (float32_t)((float64_t)C / (float64_t)u64Temp) - 1.0F;
+                pstcClockSyncBrr->f32Error = f32CalcError;
+                i32Ret = LL_OK;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Calculate baudrate division for smart-card mode.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcSmartCardBrr            Pointer to a stc_usart_brr_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Set successfully.
+ *           - LL_ERR:                  Set unsuccessfully.
+ */
+static int32_t SmartCard_CalculateBrr(const CM_USART_TypeDef *USARTx, stc_usart_brr_t *pstcSmartCardBrr)
+{
+    uint32_t B;
+    uint32_t C;
+    uint32_t BCN;
+    uint64_t u64Temp;
+    uint64_t u64Dividend;
+    uint32_t DIV_Integer;
+    uint32_t DIV_IntegerMod;
+    uint32_t DIV_Fraction;
+    float32_t f32CalcError;
+    const uint16_t au16EtuClkCnts[] = {32U, 64U, 93U, 128U, 186U, 256U, 372U, 512U};
+    int32_t i32Ret = LL_ERR;
+
+    DDL_ASSERT(IS_USART_SMARTCARD_UNIT(USARTx));
+
+    C = pstcSmartCardBrr->u32UsartClock;
+    B = pstcSmartCardBrr->u32Baudrate;
+    if ((C > 0UL) && (B > 0UL)) {
+        BCN = READ_REG32_BIT(USARTx->CR3, USART_CR3_BCN);
+        DDL_ASSERT(IS_USART_SMARTCARD_ETU_CLK(BCN));
+        BCN = au16EtuClkCnts[BCN >> USART_CR3_BCN_POS];
+        /* Smartcard mode baudrate integer calculation formula: */
+        /*      B = C / (2 * BCN * (DIV_Integer + 1))           */
+        /*      DIV_Integer = (C / (B * 2 * BCN)) - 1           */
+        DIV_Integer = (C / (B * BCN * 2UL)) - 1UL;
+        if (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX) {
+            pstcSmartCardBrr->u32Integer = DIV_Integer;
+            DIV_IntegerMod = C % (B * BCN * 2UL);
+            if (0UL == DIV_IntegerMod) {
+                /* Get accurate baudrate without fraction */
+                pstcSmartCardBrr->f32Error = (float32_t)0.0F;
+                i32Ret = LL_OK;
+            } else {
+                /* Smartcard mode baudrate fraction calculation formula:                        */
+                /*      B = C * (128 + DIV_Fraction) / ((2 * BCN) * (DIV_Integer + 1) * 256)    */
+                /*      DIV_Fraction = (256 * (2 * BCN * (DIV_Integer + 1) * B) / C) - 128      */
+
+                /* u64Temp = (2 * BCN * (DIV_Integer + 1) * B)  */
+                u64Temp = (uint64_t)((uint64_t)2UL * BCN * ((uint64_t)DIV_Integer + (uint64_t)1UL) * B);
+                DIV_Fraction = (uint32_t)((256UL * u64Temp + ((uint64_t)C >> 1)) / C - 128UL);  /*  +(C >> 1) for rounding off */
+                if (DIV_Fraction <= USART_BRR_DIV_FRACTION_MAX) {
+                    pstcSmartCardBrr->u32Fraction = DIV_Fraction;
+                    /* E(%) = C * (128 + DIV_Fraction) / (4 * (DIV_Integer + 1) * B * 256) - 1 */
+                    u64Temp *= (uint64_t)256UL;
+                    u64Dividend = (uint64_t)C * ((uint64_t)128UL + (uint64_t)DIV_Fraction);
+                    f32CalcError = (float32_t)((float64_t)u64Dividend / (float64_t)(u64Temp)) - 1.0F;
+                    pstcSmartCardBrr->f32Error = f32CalcError;
+                    i32Ret = LL_OK;
+                }
+            }
+        }
+        if (LL_ERR == i32Ret) {
+            /* Integer rounding off */
+            DIV_Integer = (((C * 10UL) / (B * BCN * 2UL) + 5UL) / 10UL) - 1UL; /*  +5UL for rounding off */
+            if (DIV_Integer <= USART_BRR_DIV_INTEGER_MAX) {
+                pstcSmartCardBrr->u32Integer = DIV_Integer;
+                /* E(%) = C / (2 * BCN * (DIV_Integer + 1) * B) - 1 */
+                /* u64Temp = 4 * (DIV_Integer + 1) * B */
+                u64Temp = (uint64_t)((uint64_t)2UL * BCN * ((uint64_t)DIV_Integer + (uint64_t)1UL) * B);
+                f32CalcError = (float32_t)((float64_t)C / (float64_t)u64Temp) - 1.0F;
+                pstcSmartCardBrr->f32Error = f32CalcError;
+                i32Ret = LL_OK;
+            }
+        }
+    }
+    return i32Ret;
+}
+
+/**
+ * @brief  Get bus(which USART mounts on) clock frequency value.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval USART clock frequency value
+ */
+static uint32_t USART_GetBusClockFreq(const CM_USART_TypeDef *USARTx)
+{
+    uint32_t u32BusClock;
+
+    (void)USARTx;
+
+    u32BusClock = SystemCoreClock >> (READ_REG32_BIT(CM_CMU->SCFGR, CMU_SCFGR_PCLK1S) >> CMU_SCFGR_PCLK1S_POS);
+
+    return u32BusClock;
+}
+
+/**
+ * @brief  Get USART clock frequency value.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval USART clock frequency value
+ */
+static uint32_t USART_GetUsartClockFreq(const CM_USART_TypeDef *USARTx)
+{
+    uint32_t u32BusClock;
+    uint32_t u32UsartClockDiv;
+    uint32_t u32UsartClock;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    u32BusClock = USART_GetBusClockFreq(USARTx);
+
+    u32UsartClockDiv = (1UL << (READ_REG32_BIT(USARTx->PR, USART_PR_PSC) * 2UL));
+
+    u32UsartClock = u32BusClock / u32UsartClockDiv;
+    return u32UsartClock;
+}
+
+/**
+ * @brief  Get USART BMC clock frequency value.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval USART BMC clock frequency value
+ */
+static uint32_t USART_GetLinBmcClockFreq(const CM_USART_TypeDef *USARTx)
+{
+    uint32_t u32BusClock;
+    uint32_t u32UsartBmcDiv;
+    uint32_t u32UsartBmcClock;
+
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+
+    u32BusClock = USART_GetBusClockFreq(USARTx);
+    u32UsartBmcDiv = (1UL << (READ_REG32_BIT((USARTx)->PR, USART_PR_LBMPSC) >> USART_PR_LBMPSC_POS));
+
+    u32UsartBmcClock = u32BusClock / u32UsartBmcDiv;
+    return u32UsartBmcClock;
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup USART_Global_Functions USART Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Set the fields of structure stc_usart_clocksync_init_t to default values.
+ * @param  [out] pstcClockSyncInit      Pointer to a @ref stc_usart_clocksync_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcClockSyncInit value is NULL.
+ */
+int32_t USART_ClockSync_StructInit(stc_usart_clocksync_init_t *pstcClockSyncInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcClockSyncInit) {
+        pstcClockSyncInit->u32ClockSrc = USART_CLK_SRC_INTERNCLK;
+        pstcClockSyncInit->u32ClockDiv = USART_CLK_DIV1;
+        pstcClockSyncInit->u32Baudrate = USART_DEFAULT_BAUDRATE;
+        pstcClockSyncInit->u32FirstBit = USART_FIRST_BIT_LSB;
+        pstcClockSyncInit->u32HWFlowControl = USART_HW_FLOWCTRL_RTS;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize clock synchronization function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcClockSyncInit       Pointer to a @ref stc_usart_clocksync_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcClockSyncInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_ClockSync_Init(CM_USART_TypeDef *USARTx,
+                             const stc_usart_clocksync_init_t *pstcClockSyncInit, float32_t *pf32Error)
+{
+    uint32_t u32CR1Value;
+    uint32_t u32CR2Value;
+    uint32_t u32CR3Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcClockSyncInit) {
+        DDL_ASSERT(IS_USART_UNIT(USARTx));
+        DDL_ASSERT(IS_USART_CLK_SRC(pstcClockSyncInit->u32ClockSrc));
+        DDL_ASSERT(IS_USART_FIRST_BIT(pstcClockSyncInit->u32FirstBit));
+        DDL_ASSERT(IS_USART_HW_FLOWCTRL(pstcClockSyncInit->u32HWFlowControl));
+
+        u32CR1Value = (pstcClockSyncInit->u32FirstBit | USART_CR1_MS | USART_CR1_SBS);
+        u32CR2Value = (pstcClockSyncInit->u32ClockSrc | USART_CR2_RST_VALUE);
+        if (USART_CLK_SRC_INTERNCLK == pstcClockSyncInit->u32ClockSrc) {
+            u32CR2Value |= USART_CK_OUTPUT_ENABLE;
+        }
+        u32CR3Value = pstcClockSyncInit->u32HWFlowControl;
+
+        /* Set control register: CR1/CR2/CR3 */
+        WRITE_REG32(USARTx->CR1, u32CR1Value);
+        WRITE_REG32(USARTx->CR2, u32CR2Value);
+        WRITE_REG32(USARTx->CR3, u32CR3Value);
+
+        if (USART_CLK_SRC_INTERNCLK == pstcClockSyncInit->u32ClockSrc) {
+            DDL_ASSERT(IS_USART_CLK_DIV(pstcClockSyncInit->u32ClockDiv));
+
+            /* Set prescaler register register: PR */
+            WRITE_REG32(USARTx->PR, pstcClockSyncInit->u32ClockDiv);
+
+            /* Set baudrate */
+            i32Ret = USART_SetBaudrate(USARTx, pstcClockSyncInit->u32Baudrate, pf32Error);
+        } else {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_usart_multiprocessor_init_t to default values.
+ * @param  [out] pstcMultiProcessorInit Pointer to a @ref stc_usart_multiprocessor_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcMultiProcessorInit value is NULL.
+ */
+int32_t USART_MultiProcessor_StructInit(stc_usart_multiprocessor_init_t *pstcMultiProcessorInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcMultiProcessorInit) {
+        pstcMultiProcessorInit->u32ClockSrc = USART_CLK_SRC_INTERNCLK;
+        pstcMultiProcessorInit->u32ClockDiv = USART_CLK_DIV1;
+        pstcMultiProcessorInit->u32CKOutput = USART_CK_OUTPUT_DISABLE;
+        pstcMultiProcessorInit->u32Baudrate = USART_DEFAULT_BAUDRATE;
+        pstcMultiProcessorInit->u32DataWidth = USART_DATA_WIDTH_8BIT;
+        pstcMultiProcessorInit->u32StopBit = USART_STOPBIT_1BIT;
+        pstcMultiProcessorInit->u32OverSampleBit = USART_OVER_SAMPLE_16BIT;
+        pstcMultiProcessorInit->u32FirstBit = USART_FIRST_BIT_LSB;
+        pstcMultiProcessorInit->u32StartBitPolarity = USART_START_BIT_FALLING;
+        pstcMultiProcessorInit->u32HWFlowControl = USART_HW_FLOWCTRL_RTS;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize UART multiple processor function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcMultiProcessorInit  Pointer to a @ref stc_usart_multiprocessor_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcMxProcessorInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_MultiProcessor_Init(CM_USART_TypeDef *USARTx,
+                                  const stc_usart_multiprocessor_init_t *pstcMultiProcessorInit, float32_t *pf32Error)
+{
+    uint32_t u32CR1Value;
+    uint32_t u32CR2Value;
+    uint32_t u32CR3Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcMultiProcessorInit) {
+        DDL_ASSERT(IS_USART_UNIT(USARTx));
+        DDL_ASSERT(IS_USART_CLK_SRC(pstcMultiProcessorInit->u32ClockSrc));
+        DDL_ASSERT(IS_USART_CK_OUTPUT(pstcMultiProcessorInit->u32CKOutput));
+        DDL_ASSERT(IS_USART_DATA_WIDTH(pstcMultiProcessorInit->u32DataWidth));
+        DDL_ASSERT(IS_USART_STOPBIT(pstcMultiProcessorInit->u32StopBit));
+        DDL_ASSERT(IS_USART_OVER_SAMPLE_BIT(pstcMultiProcessorInit->u32OverSampleBit));
+        DDL_ASSERT(IS_USART_FIRST_BIT(pstcMultiProcessorInit->u32FirstBit));
+        DDL_ASSERT(IS_USART_START_BIT_POLARITY(pstcMultiProcessorInit->u32StartBitPolarity));
+        DDL_ASSERT(IS_USART_HW_FLOWCTRL(pstcMultiProcessorInit->u32HWFlowControl));
+
+        u32CR1Value = (pstcMultiProcessorInit->u32DataWidth | pstcMultiProcessorInit->u32OverSampleBit | \
+                       pstcMultiProcessorInit->u32FirstBit  | pstcMultiProcessorInit->u32StartBitPolarity);
+        u32CR2Value = (USART_CR2_RST_VALUE | USART_CR2_MPE | pstcMultiProcessorInit->u32ClockSrc | \
+                       pstcMultiProcessorInit->u32CKOutput | pstcMultiProcessorInit->u32StopBit);
+        u32CR3Value = pstcMultiProcessorInit->u32HWFlowControl;
+
+        /* Set control register: CR1/CR2/CR3 */
+        WRITE_REG32(USARTx->CR1, u32CR1Value);
+        WRITE_REG32(USARTx->CR2, u32CR2Value);
+        WRITE_REG32(USARTx->CR3, u32CR3Value);
+
+        if (USART_CLK_SRC_INTERNCLK == pstcMultiProcessorInit->u32ClockSrc) {
+            DDL_ASSERT(IS_USART_CLK_DIV(pstcMultiProcessorInit->u32ClockDiv));
+
+            /* Set prescaler register register: PR */
+            WRITE_REG32(USARTx->PR, pstcMultiProcessorInit->u32ClockDiv);
+
+            /* Set baudrate */
+            i32Ret = USART_SetBaudrate(USARTx, pstcMultiProcessorInit->u32Baudrate, pf32Error);
+        } else {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_usart_uart_init_t to default values.
+ * @param  [out] pstcUartInit           Pointer to a @ref stc_usart_uart_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcUartInit value is NULL.
+ */
+int32_t USART_UART_StructInit(stc_usart_uart_init_t *pstcUartInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcUartInit) {
+        pstcUartInit->u32ClockSrc = USART_CLK_SRC_INTERNCLK;
+        pstcUartInit->u32ClockDiv = USART_CLK_DIV1;
+        pstcUartInit->u32CKOutput = USART_CK_OUTPUT_DISABLE;
+        pstcUartInit->u32Baudrate = USART_DEFAULT_BAUDRATE;
+        pstcUartInit->u32DataWidth = USART_DATA_WIDTH_8BIT;
+        pstcUartInit->u32StopBit = USART_STOPBIT_1BIT;
+        pstcUartInit->u32Parity = USART_PARITY_NONE;
+        pstcUartInit->u32OverSampleBit = USART_OVER_SAMPLE_16BIT;
+        pstcUartInit->u32FirstBit = USART_FIRST_BIT_LSB;
+        pstcUartInit->u32StartBitPolarity = USART_START_BIT_FALLING;
+        pstcUartInit->u32HWFlowControl = USART_HW_FLOWCTRL_RTS;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize UART function.
+ * @param  [in]  USARTx                 Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in]  pstcUartInit           Pointer to a @ref stc_usart_uart_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcUartInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_UART_Init(CM_USART_TypeDef *USARTx, const stc_usart_uart_init_t *pstcUartInit, float32_t *pf32Error)
+{
+    uint32_t u32CR1Value;
+    uint32_t u32CR2Value;
+    uint32_t u32CR3Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcUartInit) {
+        DDL_ASSERT(IS_USART_UNIT(USARTx));
+        DDL_ASSERT(IS_USART_CLK_SRC(pstcUartInit->u32ClockSrc));
+        DDL_ASSERT(IS_USART_CK_OUTPUT(pstcUartInit->u32CKOutput));
+        DDL_ASSERT(IS_USART_PARITY(pstcUartInit->u32Parity));
+        DDL_ASSERT(IS_USART_DATA_WIDTH(pstcUartInit->u32DataWidth));
+        DDL_ASSERT(IS_USART_STOPBIT(pstcUartInit->u32StopBit));
+        DDL_ASSERT(IS_USART_OVER_SAMPLE_BIT(pstcUartInit->u32OverSampleBit));
+        DDL_ASSERT(IS_USART_FIRST_BIT(pstcUartInit->u32FirstBit));
+        DDL_ASSERT(IS_USART_START_BIT_POLARITY(pstcUartInit->u32StartBitPolarity));
+        DDL_ASSERT(IS_USART_HW_FLOWCTRL(pstcUartInit->u32HWFlowControl));
+
+        u32CR1Value = (pstcUartInit->u32Parity | pstcUartInit->u32DataWidth | pstcUartInit->u32FirstBit | \
+                       pstcUartInit->u32OverSampleBit | pstcUartInit->u32StartBitPolarity);
+        u32CR2Value = (USART_CR2_RST_VALUE | pstcUartInit->u32ClockSrc | \
+                       pstcUartInit->u32CKOutput | pstcUartInit->u32StopBit);
+        u32CR3Value = pstcUartInit->u32HWFlowControl;
+
+        /* Set control register: CR1/CR2/CR3 */
+        WRITE_REG32(USARTx->CR1, u32CR1Value);
+        WRITE_REG32(USARTx->CR2, u32CR2Value);
+        WRITE_REG32(USARTx->CR3, u32CR3Value);
+
+        if (USART_CLK_SRC_INTERNCLK == pstcUartInit->u32ClockSrc) {
+            DDL_ASSERT(IS_USART_CLK_DIV(pstcUartInit->u32ClockDiv));
+
+            /* Set prescaler register register: PR */
+            WRITE_REG32(USARTx->PR, pstcUartInit->u32ClockDiv);
+
+            /* Set baudrate */
+            i32Ret = USART_SetBaudrate(USARTx, pstcUartInit->u32Baudrate, pf32Error);
+        } else {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize UART half duplex function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcUartInit            Pointer to a @ref stc_usart_uart_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcUartInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_HalfDuplex_Init(CM_USART_TypeDef *USARTx,
+                              const stc_usart_uart_init_t *pstcUartInit, float32_t *pf32Error)
+{
+    int32_t i32Ret;
+
+    i32Ret = USART_UART_Init(USARTx, pstcUartInit, pf32Error);
+    if (LL_OK == i32Ret) {
+        /* Set CR3: UART half duplex */
+        SET_REG32_BIT(USARTx->CR3, USART_CR3_HDSEL);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_usart_lin_init_t to default values.
+ * @param  [out] pstcLinInit            Pointer to a @ref stc_usart_lin_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcLinInit is NULL.
+ */
+int32_t USART_LIN_StructInit(stc_usart_lin_init_t *pstcLinInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcLinInit) {
+        pstcLinInit->u32ClockSrc = USART_CLK_SRC_INTERNCLK;
+        pstcLinInit->u32ClockDiv = USART_CLK_DIV1;
+        pstcLinInit->u32CKOutput = USART_CK_OUTPUT_DISABLE;
+        pstcLinInit->u32Baudrate = USART_DEFAULT_BAUDRATE;
+        pstcLinInit->u32OverSampleBit = USART_OVER_SAMPLE_16BIT;
+        pstcLinInit->u32BmcClockDiv = USART_LIN_BMC_CLK_DIV1;
+        pstcLinInit->u32DetectBreakLen = USART_LIN_DETECT_BREAK_10BIT;
+        pstcLinInit->u32SendBreakLen = USART_LIN_SEND_BREAK_10BIT;
+        pstcLinInit->u32SendBreakMode = USART_LIN_SEND_BREAK_MD_SBK;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Initialize LIN function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcLinInit             Pointer to a @ref stc_usart_lin_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcLinInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_LIN_Init(CM_USART_TypeDef *USARTx, const stc_usart_lin_init_t *pstcLinInit, float32_t *pf32Error)
+{
+    uint32_t u32CR1Value;
+    uint32_t u32CR2Value;
+    uint32_t u32PRValue;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcLinInit) {
+        DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+        DDL_ASSERT(IS_USART_CLK_SRC(pstcLinInit->u32ClockSrc));
+        DDL_ASSERT(IS_USART_CK_OUTPUT(pstcLinInit->u32CKOutput));
+        DDL_ASSERT(IS_USART_CLK_DIV(pstcLinInit->u32ClockDiv));
+        DDL_ASSERT(IS_USART_OVER_SAMPLE_BIT(pstcLinInit->u32OverSampleBit));
+
+        u32CR1Value = (pstcLinInit->u32OverSampleBit | USART_CR1_SBS);
+        u32CR2Value = (pstcLinInit->u32ClockSrc | pstcLinInit->u32CKOutput | USART_CR2_LINEN | USART_CR2_RST_VALUE);
+
+        DDL_ASSERT(IS_USART_LIN_DETECT_BREAK_LEN(pstcLinInit->u32DetectBreakLen));
+        DDL_ASSERT(IS_USART_LIN_SEND_BREAK_LEN(pstcLinInit->u32SendBreakLen));
+        DDL_ASSERT(IS_USART_LIN_SEND_BREAK_MD(pstcLinInit->u32SendBreakMode));
+        u32CR2Value |= (pstcLinInit->u32DetectBreakLen | pstcLinInit->u32SendBreakLen | pstcLinInit->u32SendBreakMode);
+
+        /* Set control register: CR1/CR2/CR3 */
+        WRITE_REG32(USARTx->CR1, u32CR1Value);
+        WRITE_REG32(USARTx->CR2, u32CR2Value);
+        WRITE_REG32(USARTx->CR3, 0UL);
+
+        if (USART_CLK_SRC_INTERNCLK == pstcLinInit->u32ClockSrc) {
+            DDL_ASSERT(IS_USART_CLK_DIV(pstcLinInit->u32ClockDiv));
+            u32PRValue = pstcLinInit->u32ClockDiv;
+
+            DDL_ASSERT(IS_USART_LIN_BMC_CLK_DIV(pstcLinInit->u32BmcClockDiv));
+            u32PRValue |= pstcLinInit->u32BmcClockDiv;
+
+            /* Set prescaler register register: PR */
+            WRITE_REG32(USARTx->PR, u32PRValue);
+
+            /* Set baudrate */
+            i32Ret = USART_SetBaudrate(USARTx, pstcLinInit->u32Baudrate, pf32Error);
+        } else {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set the fields of structure stc_usart_smartcard_init_t to default values.
+ * @param  [out] pstcSmartCardInit      Pointer to a @ref stc_usart_smartcard_init_t structure.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcSmartCardInit value is NULL.
+ */
+int32_t USART_SmartCard_StructInit(stc_usart_smartcard_init_t *pstcSmartCardInit)
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSmartCardInit) {
+        pstcSmartCardInit->u32ClockDiv = USART_CLK_DIV1;
+        pstcSmartCardInit->u32CKOutput = USART_CK_OUTPUT_DISABLE;
+        pstcSmartCardInit->u32Baudrate = USART_DEFAULT_BAUDRATE;
+        pstcSmartCardInit->u32FirstBit = USART_FIRST_BIT_LSB;
+        i32Ret = LL_OK;
+    }
+
+    return i32Ret;
+}
+/**
+ * @brief  Initialize smartcard function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] pstcSmartCardInit       Pointer to a @ref stc_usart_smartcard_init_t structure.
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR_INVD_PARAM:       The pointer pstcSmartCardInit value is NULL or baudrate set unsuccessfully.
+ */
+int32_t USART_SmartCard_Init(CM_USART_TypeDef *USARTx,
+                             const stc_usart_smartcard_init_t *pstcSmartCardInit, float32_t *pf32Error)
+{
+    uint32_t u32CR1Value;
+    uint32_t u32CR2Value;
+    uint32_t u32CR3Value;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pstcSmartCardInit) {
+        DDL_ASSERT(IS_USART_SMARTCARD_UNIT(USARTx));
+        DDL_ASSERT(IS_USART_CK_OUTPUT(pstcSmartCardInit->u32CKOutput));
+        DDL_ASSERT(IS_USART_CLK_DIV(pstcSmartCardInit->u32ClockDiv));
+        DDL_ASSERT(IS_USART_FIRST_BIT(pstcSmartCardInit->u32FirstBit));
+
+        u32CR1Value = (pstcSmartCardInit->u32FirstBit | USART_CR1_PCE | USART_CR1_SBS);
+        u32CR2Value = (pstcSmartCardInit->u32CKOutput | USART_CR2_RST_VALUE);
+        u32CR3Value = USART_CR3_SCEN | USART_SC_ETU_CLK372;
+
+        /* Set control register: CR1/CR2/CR3 */
+        WRITE_REG32(USARTx->CR1, u32CR1Value);
+        WRITE_REG32(USARTx->CR2, u32CR2Value);
+        WRITE_REG32(USARTx->CR3, u32CR3Value);
+
+        /* Set prescaler register register: PR */
+        WRITE_REG32(USARTx->PR, pstcSmartCardInit->u32ClockDiv);
+
+        /* Set baudrate */
+        i32Ret = USART_SetBaudrate(USARTx, pstcSmartCardInit->u32Baudrate, pf32Error);
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  De-Initialize USART function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval int32_t:
+ *           - LL_OK:           Reset success.
+ */
+int32_t USART_DeInit(CM_USART_TypeDef *USARTx)
+{
+    int32_t i32Ret = LL_OK;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    /* Configures the registers to reset value. */
+    WRITE_REG32(USARTx->CR1, USART_CR1_RST_VALUE);
+    WRITE_REG32(USARTx->CR2, USART_CR2_RST_VALUE);
+    WRITE_REG32(USARTx->CR3, 0UL);
+    WRITE_REG32(USARTx->PR, 0UL);
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Enable/disable USART Transmit/Receive Function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Func                 USART function type
+ *         This parameter can be any composed value of the macros group @ref USART_Function.
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ * @note   In clock synchronization mode, the bit TE or RE of register USART_CR can only be
+ *         written to 1 when TE = 0 and RE = 0 (transmit and receive disabled)
+ */
+void USART_FuncCmd(CM_USART_TypeDef *USARTx, uint32_t u32Func, en_functional_state_t enNewState)
+{
+    uint32_t u32BaseFunc;
+    uint32_t u32LinFunc;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+    DDL_ASSERT(IS_USART_FUNC(u32Func));
+    DDL_ASSERT(IS_USART_LIN_FUNC(USARTx, u32Func));
+    DDL_ASSERT(IS_USART_TIMEOUT_FUNC(USARTx, u32Func));
+
+    u32BaseFunc = (u32Func & 0xFFFFUL);
+    if (u32BaseFunc > 0UL) {
+        (ENABLE == enNewState) ? SET_REG32_BIT(USARTx->CR1, u32BaseFunc) : CLR_REG32_BIT(USARTx->CR1, u32BaseFunc);
+    }
+
+    u32LinFunc = ((u32Func & USART_LIN_FUNC_MASK) >> USART_LIN_FUNC_OFFSET);
+    if (u32LinFunc > 0UL) {
+        (ENABLE == enNewState) ? SET_REG32_BIT(USARTx->CR2, u32LinFunc) : CLR_REG32_BIT(USARTx->CR2, u32LinFunc);
+    }
+}
+
+/**
+ * @brief  Get USART Function Status.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Func                 USART function type
+ *         This parameter can be any composed value of the macros group @ref USART_Function.
+ * @retval An @ref en_functional_state_t enumeration value.
+ *           - ENABLE: Transmit/Receive/Interrupt active
+ *           - DISABLE: Transmit/Receive/Interrupt inactive
+ * @note   In clock synchronization mode, the bit TE or RE of register USART_CR can only be
+ *         written to 1 when TE = 0 and RE = 0 (transmit and receive disabled)
+ */
+en_functional_state_t USART_GetFuncState(CM_USART_TypeDef *USARTx, uint32_t u32Func)
+{
+    uint32_t u32BaseFunc;
+    en_functional_state_t enNewState = DISABLE;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_FUNC(u32Func));
+    DDL_ASSERT(IS_USART_LIN_FUNC(USARTx, u32Func));
+    DDL_ASSERT(IS_USART_TIMEOUT_FUNC(USARTx, u32Func));
+
+    u32BaseFunc = (u32Func & 0xFFFFUL);
+    if (0UL != u32BaseFunc) {
+        if (0UL != READ_REG32_BIT(USARTx->CR1, u32BaseFunc)) {
+            enNewState = ENABLE;
+        }
+    }
+    u32BaseFunc = u32Func >> USART_LIN_FUNC_OFFSET;
+    if (0UL != u32BaseFunc) {
+        if (0UL != READ_REG32_BIT(USARTx->CR2, u32BaseFunc)) {
+            enNewState = ENABLE;
+        }
+    }
+    return enNewState;
+}
+
+/**
+ * @brief  Get USART flag.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Flag                 USART flag type
+ *         This parameter can be any composed value of the macros group @ref USART_Flag.
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t USART_GetStatus(const CM_USART_TypeDef *USARTx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_FLAG(u32Flag));
+
+    return (0UL == (READ_REG32_BIT(USARTx->SR, u32Flag)) ? RESET : SET);
+}
+
+/**
+ * @brief  Clear USART flag.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Flag                 USART flag type
+ *         This parameter can be any composed value of the macros group @ref USART_Flag.
+ * @retval None
+ */
+void USART_ClearStatus(CM_USART_TypeDef *USARTx, uint32_t u32Flag)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_FLAG(u32Flag));
+
+    if ((u32Flag & USART_FLAG_ERR_MASK) > 0UL) {
+        SET_REG32_BIT(USARTx->CR1, (u32Flag & USART_FLAG_ERR_MASK) << USART_CR1_CPE_POS);
+    }
+
+    /* Timeout flag */
+    if ((u32Flag & USART_FLAG_RX_TIMEOUT) > 0UL) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_CRTOF);
+    }
+
+    /* LIN flag */
+    if ((u32Flag & USART_FLAG_LIN_ERR) > 0UL) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_CBE);
+    }
+
+    if ((u32Flag & USART_FLAG_LIN_WKUP) > 0UL) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_CWKUP);
+    }
+
+    if ((u32Flag & USART_FLAG_LIN_BREAK) > 0UL) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_CLBD);
+    }
+}
+
+/**
+ * @brief  Set USART parity.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Parity               USART parity
+ *         This parameter can be one of the macros group @ref USART_Parity_Control
+ *           @arg USART_PARITY_NONE:    Parity control disabled
+ *           @arg USART_PARITY_ODD:     Parity control enabled and Odd Parity is selected
+ *           @arg USART_PARITY_EVEN:    Parity control enabled and Even Parity is selected
+ * @retval None
+ */
+void USART_SetParity(CM_USART_TypeDef *USARTx, uint32_t u32Parity)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_PARITY(u32Parity));
+
+    MODIFY_REG32(USARTx->CR1, (USART_CR1_PS | USART_CR1_PCE), u32Parity);
+}
+
+/**
+ * @brief  Get USART parity.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval This parameter can be one of the macros group @ref USART_Parity_Control
+ *           @arg USART_PARITY_NONE:    Parity control disabled
+ *           @arg USART_PARITY_ODD:     Parity control enabled and Odd Parity is selected
+ *           @arg USART_PARITY_EVEN:    Parity control enabled and Even Parity is selected
+ *  None
+ */
+uint32_t USART_GetParity(CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if (0U == READ_REG32_BIT(USARTx->CR1, USART_CR1_PCE)) {
+        return USART_PARITY_NONE;
+    }
+
+    if (0U == READ_REG32_BIT(USARTx->CR1, USART_CR1_PS)) {
+        return USART_PARITY_EVEN;
+    } else {
+        return USART_PARITY_ODD;
+    }
+}
+
+/**
+ * @brief  Set USART bit direction.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32FirstBit             USART bit direction
+ *         This parameter can be one of the macros group @ref USART_First_Bit
+ *           @arg  USART_FIRST_BIT_MSB: MSB(Most Significant Bit)
+ *           @arg  USART_FIRST_BIT_LSB: LSB(Least Significant Bit)
+ * @retval None
+ */
+void USART_SetFirstBit(CM_USART_TypeDef *USARTx, uint32_t u32FirstBit)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_FIRST_BIT(u32FirstBit));
+
+    MODIFY_REG32(USARTx->CR1, USART_CR1_ML, u32FirstBit);
+}
+
+/**
+ * @brief  Set USART stop bit.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32StopBit              USART stop bits
+ *         This parameter can be one of the macros group @ref USART_Stop_Bit
+ *           @arg USART_STOPBIT_1BIT:   1 stop bit
+ *           @arg USART_STOPBIT_2BIT:   2 stop bit
+ * @retval None
+ */
+void USART_SetStopBit(CM_USART_TypeDef *USARTx, uint32_t u32StopBit)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_STOPBIT(u32StopBit));
+
+    MODIFY_REG32(USARTx->CR2, USART_CR2_STOP, u32StopBit);
+}
+
+/**
+ * @brief  Get USART stop bit.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval This parameter can be one of the macros group @ref USART_Stop_Bit
+ *           @arg USART_STOPBIT_1BIT:   1 stop bit
+ *           @arg USART_STOPBIT_2BIT:   2 stop bits
+ */
+uint32_t USART_GetStopBit(CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->CR2, USART_CR2_STOP);
+}
+
+/**
+ * @brief  Set USART data width.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32DataWidth            USART data width
+ *         This parameter can be one of the macros group @ref USART_Data_Width_Bit
+ *           @arg USART_DATA_WIDTH_8BIT: 8 bits word width
+ *           @arg USART_DATA_WIDTH_9BIT: 9 bits word width
+ * @retval None
+ */
+void USART_SetDataWidth(CM_USART_TypeDef *USARTx, uint32_t u32DataWidth)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_DATA_WIDTH(u32DataWidth));
+
+    MODIFY_REG32(USARTx->CR1, USART_CR1_M, u32DataWidth);
+}
+
+/**
+ * @brief  Get USART data width.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval This parameter can be one of the macros group @ref USART_Data_Width_Bit
+ *           @arg USART_DATA_WIDTH_8BIT: 8 bits word width
+ *           @arg USART_DATA_WIDTH_9BIT: 9 bits word width
+ */
+uint32_t USART_GetDataWidth(CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->CR1, USART_CR1_M);
+}
+
+/**
+ * @brief  Set USART oversampling bits.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32OverSampleBit        USART over sample bit
+ *         This parameter can be one of the macros group @ref USART_Over_Sample_Bit
+ *           @arg USART_OVER_SAMPLE_8BIT:  Oversampling by 8 bit
+ *           @arg USART_OVER_SAMPLE_16BIT: Oversampling by 16 bit
+ * @retval None
+ */
+void USART_SetOverSampleBit(CM_USART_TypeDef *USARTx, uint32_t u32OverSampleBit)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_OVER_SAMPLE_BIT(u32OverSampleBit));
+
+    MODIFY_REG32(USARTx->CR1, USART_CR1_OVER8, u32OverSampleBit);
+}
+
+/**
+ * @brief  Set USART start bit detect polarity.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Polarity             USART start bit detect polarity
+ *         This parameter can be one of the macros group @ref USART_Start_Bit_Polarity
+ *           @arg USART_START_BIT_LOW:     Detect RX pin low level
+ *           @arg USART_START_BIT_FALLING: Detect RX pin falling edge
+ * @retval None
+ */
+void USART_SetStartBitPolarity(CM_USART_TypeDef *USARTx, uint32_t u32Polarity)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_START_BIT_POLARITY(u32Polarity));
+
+    MODIFY_REG32(USARTx->CR1, USART_CR1_SBS, u32Polarity);
+}
+
+/**
+ * @brief  Set USART transmission type.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u16Type                 USART transmission content type
+ *         This parameter can be one of the macros group @ref USART_Transmission_Type
+ *           @arg USART_TRANS_ID:       USART transmission content type is processor ID
+ *           @arg USART_TRANS_DATA:     USART transmission content type is frame data
+ * @retval None
+ */
+void USART_SetTransType(CM_USART_TypeDef *USARTx, uint16_t u16Type)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_TRANS_TYPE(u16Type));
+
+    MODIFY_REG16(USARTx->TDR, USART_TDR_MPID, u16Type);
+}
+
+/**
+ * @brief  Set USART clock prescaler division.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32ClockDiv             USART clock prescaler division.
+ *         This parameter can be one of the macros group @ref USART_Clock_Division
+ * @retval None
+ * @note   The clock division function is valid only when clock source is internal clock.
+ */
+void USART_SetClockDiv(CM_USART_TypeDef *USARTx, uint32_t u32ClockDiv)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_CLK_DIV(u32ClockDiv));
+
+    MODIFY_REG32(USARTx->PR, USART_PR_PSC, u32ClockDiv);
+}
+
+/**
+ * @brief  Get USART clock prescaler division.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval Returned value can be one of the macros group @ref USART_Clock_Division
+ * @note   The clock division function is valid only when clock source is internal clock.
+ */
+uint32_t USART_GetClockDiv(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->PR, USART_PR_PSC);
+}
+
+/**
+ * @brief  Set USART clock source.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32ClockSrc             USART clock source
+ *         This parameter can be one of the macros group @ref USART_Clock_Source
+ *           @arg USART_CLK_SRC_EXTCLK:    Clock source is external clock(USART_CK).
+ *           @arg USART_CLK_SRC_INTERNCLK: Clock source is internal clock.
+ * @retval None
+ */
+void USART_SetClockSrc(CM_USART_TypeDef *USARTx, uint32_t u32ClockSrc)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_CLK_SRC(u32ClockSrc));
+
+    MODIFY_REG32(USARTx->CR2, USART_CR2_CLKC_1, u32ClockSrc);
+}
+
+/**
+ * @brief  Get USART clock source.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval Returned value can be one of the following values:
+ *           - USART_CLK_SRC_EXTCLK:    Clock source is external clock(USART_CK).
+ *           - USART_CLK_SRC_INTERNCLK: Clock source is internal clock.
+ */
+uint32_t USART_GetClockSrc(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->CR2, USART_CR2_CLKC_1);
+}
+
+/**
+ * @brief  Enable or disable USART noise filter.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void USART_FilterCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_NFE);
+    } else {
+        CLR_REG32_BIT(USARTx->CR1, USART_CR1_NFE);
+    }
+}
+
+/**
+ * @brief  Enable or disable USART silence.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void USART_SilenceCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(USARTx->CR1, USART_CR1_SLME);
+    } else {
+        CLR_REG32_BIT(USARTx->CR1, USART_CR1_SLME);
+    }
+}
+
+/**
+ * @brief  Set UART hardware flow control CTS/RTS selection.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32HWFlowControl        USART hardware flow control CTS/RTS selection
+ *         This parameter can be one of the macros group @ref USART_Hardware_Flow_Control.
+ * @retval None
+ */
+void USART_SetHWFlowControl(CM_USART_TypeDef *USARTx, uint32_t u32HWFlowControl)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_HW_FLOWCTRL(u32HWFlowControl));
+
+    MODIFY_REG32(USARTx->CR3, (USART_CR3_CTSE | USART_CR3_RTSE), u32HWFlowControl);
+}
+
+/**
+ * @brief  Get UART hardware flow control CTS/RTS selection.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval This parameter can be one of the macros group @ref USART_Hardware_Flow_Control.
+ */
+uint32_t USART_GetHWFlowControl(CM_USART_TypeDef *USARTx)
+{
+    uint32_t ret;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    switch ((READ_REG32(USARTx->CR3) & (USART_CR3_CTSE | USART_CR3_RTSE))) {
+        case USART_CR3_RTSE:
+            ret = USART_HW_FLOWCTRL_RTS;
+            break;
+        case USART_CR3_CTSE:
+            ret = USART_HW_FLOWCTRL_CTS;
+            break;
+        case (USART_CR3_RTSE | USART_CR3_CTSE):
+            ret = USART_HW_FLOWCTRL_RTS_CTS;
+            break;
+        default:
+            ret = USART_HW_FLOWCTRL_NONE;
+            break;
+    } ;
+    return ret;
+}
+
+/**
+ * @brief  USART receive data.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval Receive data
+ */
+uint16_t USART_ReadData(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return READ_REG16(USARTx->RDR);
+}
+
+/**
+ * @brief  USART send data.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u16Data                 Transmit data
+ * @retval None
+ */
+void USART_WriteData(CM_USART_TypeDef *USARTx, uint16_t u16Data)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_DATA(u16Data));
+
+    WRITE_REG16(USARTx->TDR, u16Data);
+}
+
+/**
+ * @brief  USART send processor ID.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ ** @param [in] u16ID                   Processor ID
+ * @retval None
+ */
+void USART_WriteID(CM_USART_TypeDef *USARTx, uint16_t u16ID)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_DATA(u16ID));
+
+    WRITE_REG16(USARTx->TDR, (USART_TDR_MPID | u16ID));
+}
+
+/**
+ * @brief  Set USART baudrate.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Baudrate             UART baudrate
+ * @param  [out] pf32Error              E(%) baudrate error rate
+ * @retval int32_t:
+ *           - LL_OK:                   Set successfully.
+ *           - LL_ERR_INVD_PARAM:       Set unsuccessfully.
+ * @note The function uses fraction division to ensure baudrate accuracy if USART unit supports baudrate fraction division.
+ */
+int32_t USART_SetBaudrate(CM_USART_TypeDef *USARTx, uint32_t u32Baudrate, float32_t *pf32Error)
+{
+    uint32_t u32Mode;
+    stc_usart_brr_t stcUsartBrr;
+    int32_t i32Ret;
+
+    DDL_ASSERT(u32Baudrate > 0UL);
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+
+    /* Get USART clock frequency */
+    stcUsartBrr.u32UsartClock = USART_GetUsartClockFreq(USARTx);
+    stcUsartBrr.u32Baudrate   = u32Baudrate;
+    stcUsartBrr.f32Error      = 0.0F;
+    stcUsartBrr.u32Fraction   = 0xFFUL;
+
+    /* Get usart mode */
+    u32Mode = READ_REG32_BIT(USARTx->CR1, USART_CR1_MS);
+    /* Calculate baudrate for BRR */
+    if (0UL == u32Mode) {
+        if (0UL == READ_REG32_BIT(USARTx->CR3, USART_CR3_SCEN)) {
+            /* uart mode */
+            i32Ret = UART_CalculateBrr(USARTx, &stcUsartBrr);
+        } else {
+            /* Smart_card function */
+            i32Ret = SmartCard_CalculateBrr(USARTx, &stcUsartBrr);
+        }
+    } else {
+        /* Clock sync mode */
+        i32Ret = ClockSync_CalculateBrr(USARTx, &stcUsartBrr);
+    }
+
+    if (LL_OK == i32Ret) {
+        /* Set BRR value(integer & fraction) */
+        MODIFY_REG32(USARTx->BRR, (USART_BRR_DIV_INTEGER | USART_BRR_DIV_FRACTION), \
+                     (stcUsartBrr.u32Fraction | (stcUsartBrr.u32Integer << USART_BRR_DIV_INTEGER_POS)));
+
+        if (0xFFUL != stcUsartBrr.u32Fraction) {
+            SET_REG32_BIT(USARTx->CR1, USART_CR1_FBME);
+        }
+    } else {
+        /* rsvd */
+    }
+    if (NULL != pf32Error) {
+        *pf32Error = stcUsartBrr.f32Error;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Set USART Smartcard ETU Clock.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32EtuClock             USART Smartcard ETU Clock.
+ *         This parameter can be one of the macros group @ref USART_Smartcard_ETU_Clock
+ *           @arg USART_SC_ETU_CLK32:   1 etu = 32/f
+ *           @arg USART_SC_ETU_CLK64:   1 etu = 64/f
+ *           @arg USART_SC_ETU_CLK128:  1 etu = 128/f
+ *           @arg USART_SC_ETU_CLK256:  1 etu = 256/f
+ *           @arg USART_SC_ETU_CLK372:  1 etu = 372/f
+ * @retval None
+ */
+void USART_SmartCard_SetEtuClock(CM_USART_TypeDef *USARTx, uint32_t u32EtuClock)
+{
+    DDL_ASSERT(IS_USART_SMARTCARD_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_SMARTCARD_ETU_CLK(u32EtuClock));
+
+    MODIFY_REG32(USARTx->CR3, USART_CR3_BCN, u32EtuClock);
+}
+
+/**
+ * @brief  Enable/disable stop mode noise filter.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void USART_StopModeNoiseFilterCmd(const CM_USART_TypeDef *USARTx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_USART_STOP_MD_UNIT(USARTx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(CM_PERIC->USART1_NFC, PERIC_USART1_NFC_USART1_NFE);
+    } else {
+        CLR_REG32_BIT(CM_PERIC->USART1_NFC, PERIC_USART1_NFC_USART1_NFE);
+    }
+}
+
+/**
+ * @brief  Set stop mode noise filter.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Level                The noise filter width level value
+ *         This parameter can be one of the macros group @ref USART_Stop_Mode_Noise_Filter_Width_Level
+ *           @arg USART_STOP_MD_FILTER_LVL1: Filter width level 1
+ *           @arg USART_STOP_MD_FILTER_LVL2: Filter width level 2
+ *           @arg USART_STOP_MD_FILTER_LVL3: Filter width level 3
+ *           @arg USART_STOP_MD_FILTER_LVL4: Filter width level 4
+ * @retval None
+ */
+void USART_SetStopModeNoiseFilter(const CM_USART_TypeDef *USARTx, uint32_t u32Level)
+{
+    DDL_ASSERT(IS_USART_STOP_MD_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_STOP_MD_FILTER(u32Level));
+
+    MODIFY_REG32(CM_PERIC->USART1_NFC, PERIC_USART1_NFC_USASRT1_NFS, u32Level);
+}
+
+/**
+ * @brief  Enable or disable USART loopback function.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] enNewState              An @ref en_functional_state_t enumeration value.
+ * @retval None
+ */
+void USART_LIN_LoopbackCmd(CM_USART_TypeDef *USARTx, en_functional_state_t enNewState)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(USARTx->CR3, USART_CR3_LOOP);
+    } else {
+        CLR_REG32_BIT(USARTx->CR3, USART_CR3_LOOP);
+    }
+}
+
+/**
+ * @brief  Set USART LIN counter clock prescaler division.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32ClockDiv             USART USART LIN counter clock prescaler division.
+ *         This parameter can be one of the macros group @ref USART_LIN_BMC_Clock_Division
+ *           @arg USART_LIN_BMC_CLK_DIV1: CLK
+ *           @arg USART_LIN_BMC_CLK_DIV2: CLK/2
+ *           @arg USART_LIN_BMC_CLK_DIV4: CLK/4
+ *           @arg USART_LIN_BMC_CLK_DIV8: CLK/8
+ * @retval None
+ * @note   The clock division function is valid when clock source is internal clock.
+ */
+void USART_LIN_SetBmcClockDiv(CM_USART_TypeDef *USARTx, uint32_t u32ClockDiv)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_LIN_BMC_CLK_DIV(u32ClockDiv));
+
+    MODIFY_REG32(USARTx->PR, USART_PR_LBMPSC, u32ClockDiv);
+}
+
+/**
+ * @brief  LIN Request break sending
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval None
+ */
+void USART_LIN_RequestBreakSending(CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+
+    SET_REG32_BIT(USARTx->CR2, USART_CR2_SBK);
+}
+
+/**
+ * @brief  Get request break sending status
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t USART_LIN_GetRequestBreakStatus(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    return (0UL == READ_REG32_BIT(USARTx->CR2, USART_CR2_SBK)) ? RESET : SET;
+}
+
+/**
+ * @brief  Set send break mode for USART LIN.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Mode                 USART send break mode
+ *         This parameter can be one of the macros group @ref USART_LIN_Send_Break_Mode
+ *           @arg USART_LIN_SEND_BREAK_MD_SBK: Start send break after USART_CR2 SBK bit set 1 value
+ *           @arg USART_LIN_SEND_BREAK_MD_TDR: Start send break after USART_DR TDR write 0x00 value
+ * @retval None
+ */
+void USART_LIN_SetBreakMode(CM_USART_TypeDef *USARTx, uint32_t u32Mode)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_LIN_SEND_BREAK_MD(u32Mode));
+
+    MODIFY_REG32(USARTx->CR2, USART_CR2_SBKM, u32Mode);
+}
+
+/**
+ * @brief  Get send break mode for USART LIN.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval Returned value can be one of the following values:
+ *           - USART_LIN_SEND_BREAK_MD_SBK: Start send break after USART_CR2 SBK bit set 1 value
+ *           - USART_LIN_SEND_BREAK_MD_TDR: Start send break after USART_DR TDR write 0x00 value
+ */
+uint32_t USART_LIN_GetBreakMode(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->CR2, USART_CR2_SBKM);
+}
+
+/**
+ * @brief  Get USART LIN baudrate measure count.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval LIN baudrate measure count value
+ */
+uint32_t USART_LIN_GetMeasureCount(const CM_USART_TypeDef *USARTx)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+
+    return READ_REG32_BIT(USARTx->LBMC, USART_LBMC_LBMC);
+}
+
+/**
+ * @brief  Get USART LIN baudrate measure count.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @retval LIN baudrate measure count value
+ */
+uint32_t USART_LIN_GetMeasureBaudrate(const CM_USART_TypeDef *USARTx)
+{
+    uint32_t u32BmClk;
+    uint32_t u32LBMC;
+
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+
+    u32BmClk = USART_GetLinBmcClockFreq(USARTx);
+    u32LBMC = READ_REG32_BIT(USARTx->LBMC, USART_LBMC_LBMC);
+
+    return (u32LBMC > 0UL) ? (u32BmClk / u32LBMC) : 0UL;
+}
+
+/**
+ * @brief  Set USART LIN break detection length.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Len                  USART clock prescaler division.
+ *         This parameter can be one of the macros group @ref USART_LIN_Detect_Break_Length
+ *           @arg USART_LIN_DETECT_BREAK_10BIT: 10-bit break detection
+ *           @arg USART_LIN_DETECT_BREAK_11BIT: 11-bit break detection
+ * @retval None
+ */
+void USART_LIN_SetDetectBreakLen(CM_USART_TypeDef *USARTx, uint32_t u32Len)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_LIN_DETECT_BREAK_LEN(u32Len));
+
+    MODIFY_REG32(USARTx->CR2, USART_CR2_LBDL, u32Len);
+}
+
+/**
+ * @brief  Set USART LIN break sending length.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] u32Len                  USART clock prescaler division.
+ *         This parameter can be one of the macros group @ref USART_LIN_Send_Break_Length
+ *           @arg USART_LIN_SEND_BREAK_10BIT: Send break 10-bit
+ *           @arg USART_LIN_SEND_BREAK_11BIT: Send break 11-bit
+ *           @arg USART_LIN_SEND_BREAK_13BIT: Send break 13-bit
+ *           @arg USART_LIN_SEND_BREAK_14BIT: Send break 14-bit
+ * @retval None
+ */
+void USART_LIN_SetSendBreakLen(CM_USART_TypeDef *USARTx, uint32_t u32Len)
+{
+    DDL_ASSERT(IS_USART_LIN_UNIT(USARTx));
+    DDL_ASSERT(IS_USART_RX_TX_DISABLE(USARTx));
+    DDL_ASSERT(IS_USART_LIN_SEND_BREAK_LEN(u32Len));
+
+    MODIFY_REG32(USARTx->CR2, USART_CR2_SBKL, u32Len);
+}
+
+/**
+ * @brief  UART transmit data in polling mode.
+ * @param  [in]  USARTx                 Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [out] pvBuf                  The pointer to data transmitted buffer
+ * @param  [in]  u32Len                 Amount of frame to be sent.
+ * @param  [in]  u32Timeout             Timeout duration(Max value @ref USART_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Communicate timeout.
+ *           - LL_ERR_INVD_PARAM:       u32Len value is 0 or pvBuf is NULL.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT
+ */
+int32_t USART_UART_Trans(CM_USART_TypeDef *USARTx, const void *pvBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t i;
+    uint32_t u32DataWidth;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if ((NULL != pvBuf) && (u32Len > 0UL)) {
+        u32DataWidth = READ_REG32_BIT(USARTx->CR1, USART_CR1_M);
+
+        if ((USART_DATA_WIDTH_8BIT == u32DataWidth) || (USART_DATA_WIDTH_9BIT == u32DataWidth)) {
+#ifdef __DEBUG
+            if (USART_DATA_WIDTH_9BIT == u32DataWidth) {
+                DDL_ASSERT(IS_ADDR_ALIGN_HALFWORD((const uint16_t *)pvBuf));
+            }
+#endif
+            for (i = 0UL; i < u32Len; i++) {
+                /* Wait TX buffer empty. */
+                i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_EMPTY, SET, u32Timeout);
+                if (LL_OK != i32Ret) {
+                    break;
+                }
+
+                if (u32DataWidth == USART_DATA_WIDTH_8BIT) {
+                    USART_WriteData(USARTx, ((const uint8_t *)pvBuf)[i]);
+                } else {
+                    USART_WriteData(USARTx, ((const uint16_t *)pvBuf)[i]);
+                }
+            }
+
+            if (LL_OK == i32Ret) {
+                i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_CPLT, SET, u32Timeout);
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  UART receive data in polling mode.
+ * @param  [in]  USARTx                 Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [out] pvBuf                  The pointer to data received buffer
+ * @param  [in]  u32Len                 Amount of frame to be received.
+ * @param  [in]  u32Timeout             Timeout duration(Max value @ref USART_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Communicate timeout.
+ *           - LL_ERR_INVD_PARAM:       u32Len value is 0 or the pointer pvBuf value is NULL.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT
+ */
+int32_t USART_UART_Receive(const CM_USART_TypeDef *USARTx, void *pvBuf, uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t u32Count;
+    uint32_t u32DataWidth;
+    uint16_t u16ReceiveData;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if ((NULL != pvBuf) && (u32Len > 0UL)) {
+        u32DataWidth = READ_REG32_BIT(USARTx->CR1, USART_CR1_M);
+#ifdef __DEBUG
+        if (USART_DATA_WIDTH_9BIT == u32DataWidth) {
+            DDL_ASSERT(IS_ADDR_ALIGN_HALFWORD((uint16_t *)pvBuf));
+        }
+#endif
+
+        for (u32Count = 0UL; u32Count < u32Len; u32Count++) {
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_RX_FULL, SET, u32Timeout);
+            if (LL_OK == i32Ret) {
+                u16ReceiveData = USART_ReadData(USARTx);
+                if (USART_DATA_WIDTH_8BIT == u32DataWidth) {
+                    ((uint8_t *)pvBuf)[u32Count] = (uint8_t)(u16ReceiveData & 0xFFU);
+                } else {
+                    ((uint16_t *)pvBuf)[u32Count] = (uint16_t)(u16ReceiveData & 0x1FFU);
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Clock sync transmit && receive data in polling mode.
+ * @param  [in] USARTx                  Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in] au8Buf                  The pointer to data transmitted buffer
+ * @param  [in] u32Len                  Amount of data to be transmitted.
+ * @param  [in] u32Timeout              Timeout duration(Max value @ref USART_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Communicate timeout.
+ *           - LL_ERR_INVD_PARAM:       u32Len value is 0 or the pointer au8Buf value is NULL.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT
+ */
+int32_t USART_ClockSync_Trans(CM_USART_TypeDef *USARTx, const uint8_t au8Buf[], uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t i;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if ((NULL != au8Buf) && (u32Len > 0UL)) {
+        for (i = 0UL; i < u32Len; i++) {
+            /* Wait TX buffer empty. */
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_EMPTY, SET, u32Timeout);
+            if (LL_OK == i32Ret) {
+                USART_WriteData(USARTx, au8Buf[i]);
+                if (READ_REG32_BIT(USARTx->CR1, USART_RX) != 0UL) {
+                    i32Ret = USART_WaitStatus(USARTx, USART_FLAG_RX_FULL, SET, u32Timeout);
+                    if (LL_OK == i32Ret) {
+                        (void)USART_ReadData(USARTx);
+                    }
+                }
+            }
+
+            if (LL_OK != i32Ret) {
+                break;
+            }
+        }
+
+        if (LL_OK == i32Ret) {
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_CPLT, SET, u32Timeout);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Clock sync receive data in polling mode.
+ * @param  [in]  USARTx                 Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [out] au8Buf                 The pointer to data received buffer
+ * @param  [in]  u32Len                 Amount of data to be sent and received.
+ * @param  [in]  u32Timeout             Timeout duration(Max value @ref USART_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Communicate timeout.
+ *           - LL_ERR_INVD_PARAM:       u32Len value is 0 or the pointer au8Buf value is NULL.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT.
+ */
+int32_t USART_ClockSync_Receive(CM_USART_TypeDef *USARTx, uint8_t au8Buf[], uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t i;
+    en_functional_state_t enTX;
+    en_functional_state_t enMasterMode;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if ((NULL != au8Buf) && (u32Len > 0UL)) {
+        i32Ret = LL_OK;
+        enTX = (READ_REG32_BIT(USARTx->CR1, USART_TX) == 0UL) ? DISABLE : ENABLE;
+        enMasterMode = (USART_CLK_SRC_EXTCLK == READ_REG32_BIT(USARTx->CR2, USART_CR2_CLKC)) ? DISABLE : ENABLE;
+
+        for (i = 0UL; i < u32Len; i++) {
+            if ((ENABLE == enMasterMode) || (ENABLE == enTX)) {
+                USART_WriteData(USARTx, 0xFFU);
+
+                /* Wait TX buffer empty. */
+                i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_EMPTY, SET, u32Timeout);
+            }
+
+            if (LL_OK == i32Ret) {
+                i32Ret = USART_WaitStatus(USARTx, USART_FLAG_RX_FULL, SET, u32Timeout);
+                if (LL_OK == i32Ret) {
+                    au8Buf[i] = (uint8_t)USART_ReadData(USARTx);
+                }
+            }
+
+            if (LL_OK != i32Ret) {
+                break;
+            }
+        }
+
+        if (LL_OK == i32Ret) {
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_CPLT, SET, u32Timeout);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Clock sync transmit && receive data in polling mode.
+ * @param  [in]  USARTx                 Pointer to USART instance register base
+ *         This parameter can be one of the following values:
+ *           @arg CM_USARTx:            USART unit instance register base
+ * @param  [in]  au8TxBuf               The pointer to data transmitted buffer
+ * @param  [out] au8RxBuf               The pointer to data received buffer
+ * @param  [in]  u32Len                 Amount of data to be sent and received.
+ * @param  [in]  u32Timeout             Timeout duration(Max value @ref USART_Max_Timeout)
+ * @retval int32_t:
+ *           - LL_OK:                   No errors occurred.
+ *           - LL_ERR_TIMEOUT:          Communicate timeout.
+ *           - LL_ERR_INVD_PARAM:       u32Len value is 0.
+ * @note Block checking flag if u32Timeout value is USART_MAX_TIMEOUT.
+ */
+int32_t USART_ClockSync_TransReceive(CM_USART_TypeDef *USARTx, const uint8_t au8TxBuf[], uint8_t au8RxBuf[],
+                                     uint32_t u32Len, uint32_t u32Timeout)
+{
+    uint32_t i;
+    uint8_t u8ReceiveData;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    DDL_ASSERT(IS_USART_UNIT(USARTx));
+
+    if (u32Len > 0UL) {
+        for (i = 0UL; i < u32Len; i++) {
+            if (NULL != au8TxBuf) {
+                USART_WriteData(USARTx, au8TxBuf[i]);
+            } else {
+                USART_WriteData(USARTx, 0xFFU);
+            }
+
+            /* Wait TX buffer empty. */
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_EMPTY, SET, u32Timeout);
+            if (LL_OK == i32Ret) {
+                i32Ret = USART_WaitStatus(USARTx, USART_FLAG_RX_FULL, SET, u32Timeout);
+                if (LL_OK == i32Ret) {
+                    u8ReceiveData = (uint8_t)USART_ReadData(USARTx);
+                    if (NULL != au8RxBuf) {
+                        au8RxBuf[i] = u8ReceiveData;
+                    }
+                }
+            }
+
+            if (LL_OK != i32Ret) {
+                break;
+            }
+        }
+
+        if (LL_OK == i32Ret) {
+            i32Ret = USART_WaitStatus(USARTx, USART_FLAG_TX_CPLT, SET, u32Timeout);
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_USART_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_usb.c
+++ b/hc32f4a2/src/hc32_ll_usb.c
@@ -1,0 +1,1382 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_usb.c
+ * @brief USB core driver.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Add USB core ID select function
+   2022-10-31       CDT             Add USB DMA function
+   2023-09-30       CDT             Fix bug for function usb_clearepstall()
+                                    Modify typo
+   2024-06-30       CDT             Select default internal PHY for USBFS core
+   2024-11-08       CDT             Modify API usb_wrpkt & usb_rdpkt for C-STAT
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_usb.h"
+#include "usb_bsp.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_USB USB
+ * @brief USB Driver Library
+ * @{
+ */
+
+#if (LL_USB_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup USB_Local_Macros USB Local Macros
+ * @{
+ */
+
+/*  Parameters check */
+#define IS_USB_CORE_ID(x)                                                      \
+(   ((x) == USBFS_CORE_ID)                      ||                             \
+    ((x) == USBHS_CORE_ID))
+
+#define IS_USB_PHY_TYPE(x)                                                     \
+(   ((x) == USBHS_PHY_EMBED)                    ||                             \
+    ((x) == USBHS_PHY_EXT))
+
+/**
+ * @}
+ */
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup USB_Global_Functions USB Global Functions
+ * @{
+ */
+
+/**
+ * @brief  core software reset
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+void usb_coresoftrst(LL_USB_TypeDef *USBx)
+{
+    __IO uint8_t u8Status = USB_OK;;
+    __IO uint32_t u32grstctl = 0UL;
+    __IO uint32_t u32Count = 0UL;
+
+    /* Wait for AHB master to be idle. */
+    do {
+        usb_udelay(1UL);
+        u32grstctl = READ_REG32(USBx->GREGS->GRSTCTL);
+        if (++u32Count > 100000UL) {
+            u8Status = USB_ERROR;
+        }
+    } while (0UL == (u32grstctl & USBFS_GRSTCTL_AHBIDL));
+
+    if (USB_OK == u8Status) {
+        /* Write the Core Soft Reset bit to reset the USB core */
+        u32Count = 0UL;
+        u32grstctl |= USBFS_GRSTCTL_CSRST;
+        WRITE_REG32(USBx->GREGS->GRSTCTL, u32grstctl);
+
+        /* Wait for the reset finishing */
+        do {
+            u32grstctl = READ_REG32(USBx->GREGS->GRSTCTL);
+            if (u32Count > 100000UL) {
+                break;
+            }
+            u32Count++;
+            usb_udelay(1UL);
+        } while (0UL != (u32grstctl & USBFS_GRSTCTL_CSRST));
+        /* Wait for at least 3 PHY clocks after the core resets */
+        usb_udelay(3UL);
+    }
+}
+
+/**
+ * @brief  Writes a packet whose byte number is len into the Tx FIFO associated
+ *         with the EP
+ * @param  [in] USBx        usb instance
+ * @param  [in] pu8src      source pointer used to hold the transmitted data
+ * @param  [in] ch_ep_num   end point index
+ * @param  [in] len         length in bytes
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_wrpkt(LL_USB_TypeDef *USBx, const uint8_t *pu8src, uint8_t ch_ep_num, uint16_t len, uint8_t u8DmaEn)
+{
+    __IO uint32_t *fifo;
+    uint32_t u32Count32b;
+    uint32_t u32Tmp;
+    uint32_t *pu32Src = (uint32_t *)(uint32_t)pu8src;
+    if (u8DmaEn == 0U) {
+        u32Count32b = (len + 3UL);
+        u32Count32b = u32Count32b >> 2U;
+        fifo = USBx->DFIFO[ch_ep_num];
+        u32Tmp = 0UL;
+        while (u32Tmp < u32Count32b) {
+            WRITE_REG32(*fifo, *pu32Src++);
+            u32Tmp++;
+        }
+    }
+}
+
+/**
+ * @brief  Reads a packet whose byte number is len from the Rx FIFO
+ * @param  [in] USBx        usb instance
+ * @param  [in] pu8dest     destination pointer that point to the received data
+ * @param  [in] len         number of bytes
+ * @retval None
+ */
+void usb_rdpkt(LL_USB_TypeDef *USBx, uint8_t *pu8dest, uint16_t len)
+{
+    uint32_t u32Tmp;
+    __IO uint32_t u32Count32b;
+    uint32_t *pu32Dest = (uint32_t *)(uint32_t)pu8dest;
+
+    __IO uint32_t *fifo = USBx->DFIFO[0];
+    u32Count32b = (len + 3UL);
+    u32Count32b = u32Count32b >> 2U;
+    u32Tmp = 0UL;
+    while (u32Tmp < u32Count32b) {
+        *pu32Dest++ = READ_REG32(*fifo);
+        u32Tmp++;
+    }
+}
+
+/**
+ * @brief  Initialize the addresses of the core registers.
+ * @param  [in] USBx                usb instance
+ * @param  [in] pstcPortIdentify    usb core and phy select
+ * @param  [in] basic_cfgs          usb core basic cfgs
+ * @retval None
+ */
+void usb_setregaddr(LL_USB_TypeDef *USBx, stc_usb_port_identify *pstcPortIdentify, USB_CORE_BASIC_CFGS *basic_cfgs)
+{
+    uint32_t u32Tmp = 0UL;
+    uint32_t u32baseAddr = CM_USBFS_BASE;
+    DDL_ASSERT(IS_USB_CORE_ID(pstcPortIdentify->u8CoreID));
+    if (USBHS_CORE_ID == pstcPortIdentify->u8CoreID) {
+        DDL_ASSERT(IS_USB_PHY_TYPE(pstcPortIdentify->u8PhyType));
+    }
+#if defined (USB_INTERNAL_DMA_ENABLED)
+    basic_cfgs->dmaen = 1U;
+#else
+    basic_cfgs->dmaen = 0U;
+#endif
+    /* initialize device cfg following its address */
+    basic_cfgs->host_chnum = USB_MAX_CH_NUM;
+    basic_cfgs->dev_epnum = USB_MAX_EP_NUM;
+    basic_cfgs->core_type = pstcPortIdentify->u8CoreID;
+    if (USBHS_CORE_ID == pstcPortIdentify->u8CoreID) {
+        basic_cfgs->phy_type = pstcPortIdentify->u8PhyType;
+    } else {
+        basic_cfgs->phy_type = USBHS_PHY_EMBED;
+    }
+    if (USBFS_CORE_ID == pstcPortIdentify->u8CoreID) {
+#ifdef USB_FS_MODE
+        u32baseAddr = CM_USBFS_BASE;
+#endif
+    } else {
+#ifdef USB_HS_MODE
+        u32baseAddr = CM_USBHS_BASE;
+#endif
+    }
+
+    USBx->GREGS = (USB_CORE_GREGS *)(u32baseAddr + 0UL);
+    USBx->DREGS = (USB_CORE_DREGS *)(u32baseAddr + 0x800UL);
+
+    while (u32Tmp < basic_cfgs->dev_epnum) {
+        USBx->INEP_REGS[u32Tmp]  = (USB_CORE_INEPREGS *)(u32baseAddr + 0x900UL + (u32Tmp * 0x20UL));
+        USBx->OUTEP_REGS[u32Tmp] = (USB_CORE_OUTEPREGS *)(u32baseAddr + 0xb00UL + (u32Tmp * 0x20UL));
+        u32Tmp++;
+    }
+    u32Tmp = 0UL;
+    while (u32Tmp < basic_cfgs->dev_epnum) {
+        USBx->DFIFO[u32Tmp] = (uint32_t *)(u32baseAddr + 0x1000UL + (u32Tmp * 0x1000UL));
+        u32Tmp++;
+    }
+    USBx->GCCTL = (uint32_t *)(u32baseAddr + 0xe00UL);
+#ifdef USE_HOST_MODE     /* if the application mode is host */
+    USBx->HREGS = (USB_CORE_HREGS *)(u32baseAddr + 0x400UL);
+    USBx->HPRT = (uint32_t *)(u32baseAddr + 0x440UL);
+    u32Tmp = 0UL;
+    while (u32Tmp < basic_cfgs->host_chnum) {
+        USBx->HC_REGS[u32Tmp] = (USB_CORE_HC_REGS *)(u32baseAddr + 0x500UL + (u32Tmp * 0x20UL));
+        u32Tmp++;
+    }
+#endif  /* USE_HOST_MODE */
+}
+
+/**
+ * @brief  Initializes the USB controller registers and prepares the core
+ *         device mode or host mode operation.
+ * @param  [in] USBx        usb instance
+ * @param  [in] basic_cfgs  usb core basic cfgs
+ * @retval None
+ */
+void usb_initusbcore(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs)
+{
+    /* reset the core through core soft reset */
+    usb_coresoftrst(USBx);
+
+    /* Select PHY for USB core*/
+    usb_PhySelect(USBx, basic_cfgs->phy_type);
+    if ((basic_cfgs->phy_type == USBHS_PHY_EMBED) && (basic_cfgs->core_type == USBHS_CORE_ID)) {
+        /* enable the embedded PHY in USBHS mode */
+        CM_PERIC->USB_SYCTLREG |= PERIC_USB_SYCTLREG_USBHS_FSPHYE;
+    }
+    /* reset the core through core soft reset */
+    usb_coresoftrst(USBx);
+    usb_mdelay(20UL);
+    if (basic_cfgs->dmaen == 1U) {
+        /* burst length/type(HBstLen) 64-words x32-bit,  core operates in a DMA mode*/
+        usb_BurstLenConfig(USBx, 5U);
+        usb_DmaCmd(USBx, 1U);
+    }
+}
+
+/**
+ * @brief  Flush a Tx FIFO whose index is num
+ * @param  [in] USBx        usb instance
+ * @param  [in] num         txFIFO index
+ * @retval None
+ */
+void usb_txfifoflush(LL_USB_TypeDef *USBx, uint32_t num)
+{
+    __IO uint32_t u32grstctl;
+    __IO uint32_t u32Tmp = 0UL;
+
+    u32grstctl = USBFS_GRSTCTL_TXFFLSH | ((num & 0x1FUL) << USBFS_GRSTCTL_TXFNUM_POS);
+    /* set the TxFIFO Flush bit, set TxFIFO Number */
+    WRITE_REG32(USBx->GREGS->GRSTCTL, u32grstctl);
+
+    /* wait for the finishing of txFIFO flushing */
+    do {
+        u32grstctl = READ_REG32(USBx->GREGS->GRSTCTL);
+        if (u32Tmp <= 200000UL) {
+            u32Tmp++;
+        } else {
+            break;
+        }
+        usb_udelay(1UL);
+    } while (0UL != (u32grstctl & USBFS_GRSTCTL_TXFFLSH));
+    /* Wait for at least 3 PHY clocks after the txfifo has been flushed */
+    usb_udelay(3UL);
+}
+
+/**
+ * @brief  Flush the whole rxFIFO
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+void usb_rxfifoflush(LL_USB_TypeDef *USBx)
+{
+    __IO uint32_t u32grstctl;
+    __IO uint32_t u32Tmp = 0UL;
+
+    u32grstctl = USBFS_GRSTCTL_RXFFLSH;    /* set the RxFIFO Flush bit */
+    WRITE_REG32(USBx->GREGS->GRSTCTL, u32grstctl);
+    /* wait for the finishing of rxFIFO flushing */
+    do {
+        u32grstctl = READ_REG32(USBx->GREGS->GRSTCTL);
+        if (u32Tmp <= 200000UL) {
+            u32Tmp++;
+        } else {
+            break;
+        }
+        usb_udelay(1UL);
+    } while (0UL != (u32grstctl & USBFS_GRSTCTL_RXFFLSH));
+    /* Wait for at least 3 PHY clocks after the rxfifo has been flushed */
+    usb_udelay(3UL);
+}
+
+/**
+ * @brief  set the core to be host mode or device mode through the second
+ *         input parameter.
+ * @param  [in] USBx        usb instance
+ * @param  [in] mode        mode of HOST_MODE or DEVICE_MODE that the core would be
+ * @retval None
+ */
+void usb_modeset(LL_USB_TypeDef *USBx, uint8_t mode)
+{
+    if (mode == HOST_MODE) {
+        MODIFY_REG32(USBx->GREGS->GUSBCFG, USBFS_GUSBCFG_FHMOD | USBFS_GUSBCFG_FDMOD, USBFS_GUSBCFG_FHMOD);
+    } else {
+        MODIFY_REG32(USBx->GREGS->GUSBCFG, USBFS_GUSBCFG_FHMOD | USBFS_GUSBCFG_FDMOD, USBFS_GUSBCFG_FDMOD);
+    }
+    /* Waite for the change to take effect */
+    usb_mdelay(50UL);
+}
+
+#ifdef USE_DEVICE_MODE
+
+/**
+ * @brief  initializes the initial status of all endpoints of the device to be
+ *         disable.
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8EpNum     EP number
+ * @retval None
+ */
+void usb_devepdis(LL_USB_TypeDef *USBx, uint8_t u8EpNum)
+{
+    uint8_t u8Tmp = 0U;
+
+    while (u8Tmp < u8EpNum) {
+        if (0UL != READ_REG32_BIT(USBx->INEP_REGS[u8Tmp]->DIEPCTL, USBFS_DIEPCTL_EPENA)) {
+            WRITE_REG32(USBx->INEP_REGS[u8Tmp]->DIEPCTL, USBFS_DIEPCTL_EPDIS | USBFS_DIEPCTL_SNAK);
+        } else {
+            WRITE_REG32(USBx->INEP_REGS[u8Tmp]->DIEPCTL, 0UL);
+        }
+        WRITE_REG32(USBx->INEP_REGS[u8Tmp]->DIEPTSIZ, 0UL);
+        WRITE_REG32(USBx->INEP_REGS[u8Tmp]->DIEPINT, 0xFFUL);
+        u8Tmp++;
+    }
+
+    u8Tmp = 0U;
+    while (u8Tmp < u8EpNum) {
+        if (0UL != READ_REG32_BIT(USBx->OUTEP_REGS[u8Tmp]->DOEPCTL, USBFS_DOEPCTL_EPENA)) {
+            WRITE_REG32(USBx->OUTEP_REGS[u8Tmp]->DOEPCTL, USBFS_DOEPCTL_EPDIS | USBFS_DOEPCTL_SNAK);
+        } else {
+            WRITE_REG32(USBx->OUTEP_REGS[u8Tmp]->DOEPCTL, 0UL);
+        }
+        WRITE_REG32(USBx->OUTEP_REGS[u8Tmp]->DOEPTSIZ, 0UL);
+        WRITE_REG32(USBx->OUTEP_REGS[u8Tmp]->DOEPINT, 0xFFUL);
+        u8Tmp++;
+    }
+}
+
+#ifdef USB_FS_MODE
+static void usb_DevFSFifoConfig(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32StardAddr;
+
+    WRITE_REG32(USBx->GREGS->GRXFSIZ, RX_FIFO_FS_SIZE);
+    /* set txFIFO and rxFIFO size of EP0 */
+    u32StardAddr = RX_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->HNPTXFSIZ,
+                (RX_FIFO_FS_SIZE << USBFS_HNPTXFSIZ_NPTXFSA_POS) | (TX0_FIFO_FS_SIZE << USBFS_HNPTXFSIZ_NPTXFD_POS));
+    /* set txFIFO size of EP1 */
+    u32StardAddr += TX0_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[0],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX1_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP2 */
+    u32StardAddr += TX1_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[1],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX2_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP3 */
+    u32StardAddr += TX2_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[2],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX3_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP4 */
+    u32StardAddr += TX3_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[3],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX4_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP5 */
+    u32StardAddr += TX4_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[4],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX5_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP6 */
+    u32StardAddr += TX5_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[5],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX6_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP7 */
+    u32StardAddr += TX6_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[6],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX7_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP8 */
+    u32StardAddr += TX7_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[7],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX8_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP9 */
+    u32StardAddr += TX8_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[8],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX9_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP10 */
+    u32StardAddr += TX9_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[9],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX10_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP11 */
+    u32StardAddr += TX10_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[10],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX11_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP12 */
+    u32StardAddr += TX11_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[11],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX12_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP13 */
+    u32StardAddr += TX12_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[12],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX13_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP14 */
+    u32StardAddr += TX13_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[13],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX14_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP15 */
+    u32StardAddr += TX14_FIFO_FS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[14],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX15_FIFO_FS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+}
+#endif
+
+#ifdef USB_HS_MODE
+static void usb_DevHSFifoConfig(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32StardAddr;
+
+    WRITE_REG32(USBx->GREGS->GRXFSIZ, RX_FIFO_HS_SIZE);
+    /* set txFIFO and rxFIFO size of EP0 */
+    u32StardAddr = RX_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->HNPTXFSIZ,
+                (RX_FIFO_HS_SIZE << USBFS_HNPTXFSIZ_NPTXFSA_POS) | (TX0_FIFO_HS_SIZE << USBFS_HNPTXFSIZ_NPTXFD_POS));
+    /* set txFIFO size of EP1 */
+    u32StardAddr += TX0_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[0],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX1_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP2 */
+    u32StardAddr += TX1_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[1],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX2_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP3 */
+    u32StardAddr += TX2_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[2],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX3_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP4 */
+    u32StardAddr += TX3_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[3],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX4_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP5 */
+    u32StardAddr += TX4_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[4],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX5_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP6 */
+    u32StardAddr += TX5_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[5],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX6_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP7 */
+    u32StardAddr += TX6_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[6],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX7_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP8 */
+    u32StardAddr += TX7_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[7],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX8_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP9 */
+    u32StardAddr += TX8_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[8],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX9_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP10 */
+    u32StardAddr += TX9_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[9],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX10_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP11 */
+    u32StardAddr += TX10_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[10],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX11_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP12 */
+    u32StardAddr += TX11_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[11],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX12_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP13 */
+    u32StardAddr += TX12_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[12],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX13_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP14 */
+    u32StardAddr += TX13_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[13],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX14_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+    /* set txFIFO size of EP15 */
+    u32StardAddr += TX14_FIFO_HS_SIZE;
+    WRITE_REG32(USBx->GREGS->DIEPTXF[14],
+                (u32StardAddr << USBFS_DIEPTXF_INEPTXSA_POS) | (TX15_FIFO_HS_SIZE << USBFS_DIEPTXF_INEPTXFD_POS));
+}
+#endif
+
+/**
+ * @brief  initializes the USB controller, include the size of txFIFO, rxFIFO
+ *         status of endpoints, interrupt register etc. Details are shown as
+ *         follows.
+ * @param  [in] USBx        usb instance
+ * @param  [in] basic_cfgs  usb core basic cfgs
+ * @retval None
+ */
+void usb_devmodeinit(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs)
+{
+    usb_FrameIntervalConfig(USBx, USB_FRAME_INTERVAL_80);
+    usb_DevPhySelect(USBx, basic_cfgs->phy_type);
+
+    if (basic_cfgs->core_type == 0U) {
+#ifdef USB_FS_MODE
+        usb_DevFSFifoConfig(USBx);
+#endif
+    } else {
+#ifdef USB_HS_MODE
+        usb_DevHSFifoConfig(USBx);
+#endif
+    }
+
+    usb_clrandmskepint(USBx);
+    usb_devepdis(USBx, basic_cfgs->dev_epnum);
+    usb_coreconn(USBx);
+    usb_devinten(USBx, basic_cfgs->dmaen);
+}
+
+/**
+ * @brief  Enable the interrupt setting when in device mode.
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_devinten(LL_USB_TypeDef *USBx, uint8_t u8DmaEn)
+{
+    uint32_t  u32gintmskTmp = 0UL;
+
+    WRITE_REG32(USBx->GREGS->GINTMSK, 0UL);
+    WRITE_REG32(USBx->GREGS->GINTSTS, 0xBFFFFFFFUL);
+    /* Enable the normal interrupt setting */
+    usb_normalinten(USBx);
+    if (u8DmaEn == 0U) {
+        u32gintmskTmp |= USBFS_GINTMSK_RXFNEM;
+    }
+    /* Enable interrupts bits corresponding to the Device mode */
+    u32gintmskTmp |= (USBFS_GINTMSK_USBSUSPM | USBFS_GINTMSK_USBRSTM | USBFS_GINTMSK_ENUMDNEM
+                      | USBFS_GINTMSK_IEPIM | USBFS_GINTMSK_OEPIM | USBFS_GINTMSK_SOFM
+                      | USBFS_GINTMSK_IISOIXFRM | USBFS_GINTMSK_IPXFRM_INCOMPISOOUTM);
+#ifdef VBUS_SENSING_ENABLED
+    u32gintmskTmp |= USBFS_GINTMSK_VBUSVIM;
+#endif
+    SET_REG32_BIT(USBx->GREGS->GINTMSK, u32gintmskTmp);
+}
+
+/**
+ * @brief  get the working status of endpoint.
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @retval current status of the endpoint
+ */
+uint32_t usb_epstatusget(LL_USB_TypeDef *USBx, USB_DEV_EP *ep)
+{
+    __IO uint32_t u32Status = 0UL;
+    uint32_t u32dxepctl;
+
+    if (ep->ep_dir == 1U) {
+        u32dxepctl = READ_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL);
+
+        if (0UL != (u32dxepctl & USBFS_DIEPCTL_STALL)) {
+            u32Status = USB_EP_TX_STALL;
+        } else if (0UL != (u32dxepctl & USBFS_DIEPCTL_NAKSTS)) {
+            u32Status = USB_EP_TX_NAK;
+        } else {
+            u32Status = USB_EP_TX_VALID;
+        }
+    } else {
+        u32dxepctl = READ_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL);
+        if (0UL != (u32dxepctl & USBFS_DOEPCTL_STALL)) {
+            u32Status = USB_EP_RX_STALL;
+        } else if (0UL != (u32dxepctl & USBFS_DOEPCTL_NAKSTS)) {
+            u32Status = USB_EP_RX_NAK;
+        } else {
+            u32Status = USB_EP_RX_VALID;
+        }
+    }
+
+    return u32Status;
+}
+
+/**
+ * @brief  set the working status of endpoint.
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @param  [in] Status      new Status that the endpoint would be
+ * @retval None
+ */
+void usb_epstatusset(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint32_t Status)
+{
+    uint32_t u32dxepctl;
+    uint8_t u8RetFlag = 0U;
+
+    if (ep->ep_dir == 1U) {
+        u32dxepctl = READ_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL);
+
+        switch (Status) {
+            case USB_EP_TX_STALL:
+                usb_setepstall(USBx, ep);
+                u8RetFlag = 1U;
+                break;
+            case USB_EP_TX_NAK:
+                u32dxepctl |= USBFS_DIEPCTL_SNAK;
+                break;
+            case USB_EP_TX_VALID:
+                if (0UL != (u32dxepctl & USBFS_DIEPCTL_STALL)) {
+                    ep->datax_pid = 0U;
+                    usb_clearepstall(USBx, ep);
+                    u8RetFlag = 1U;
+                }
+                u32dxepctl |= (USBFS_DIEPCTL_CNAK | USBFS_DIEPCTL_USBAEP | USBFS_DIEPCTL_EPENA);
+                break;
+            case USB_EP_TX_DIS:
+                u32dxepctl &= (~USBFS_DIEPCTL_USBAEP);
+                break;
+            default:
+                break;
+        }
+        /* Write register */
+        if (1U != u8RetFlag) {
+            WRITE_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL, u32dxepctl);
+        }
+    } else {
+        u32dxepctl = READ_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL);
+
+        switch (Status) {
+            case USB_EP_RX_STALL:
+                u32dxepctl |= USBFS_DOEPCTL_STALL;
+                break;
+            case USB_EP_RX_NAK:
+                u32dxepctl |= USBFS_DOEPCTL_SNAK;
+                break;
+            case USB_EP_RX_VALID:
+                if (0UL != (u32dxepctl & USBFS_DOEPCTL_STALL)) {
+                    ep->datax_pid = 0U;
+                    usb_clearepstall(USBx, ep);
+                    u8RetFlag = 1U;
+                }
+                u32dxepctl |= (USBFS_DOEPCTL_CNAK | USBFS_DOEPCTL_USBAEP | USBFS_DOEPCTL_EPENA);
+                break;
+            case USB_EP_RX_DIS:
+                u32dxepctl &= (~USBFS_DOEPCTL_USBAEP);
+                break;
+            default:
+                break;
+        }
+        /* Write register */
+        if (1U != u8RetFlag) {
+            WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL, u32dxepctl);
+        }
+    }
+}
+
+/**
+ * @brief  enable the EP0 to be active
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+void  usb_ep0activate(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32EnumSpeed;
+    uint32_t u32DiepctlTmp;
+
+    u32EnumSpeed = READ_REG32(USBx->DREGS->DSTS) & USBFS_DSTS_ENUMSPD;
+    u32DiepctlTmp = READ_REG32(USBx->INEP_REGS[0]->DIEPCTL);
+    /* Set the MPS of the DIEPCTL0 based on the enumeration speed */
+    if ((DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ == u32EnumSpeed)
+        || (DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ == u32EnumSpeed)
+        || (DSTS_ENUMSPD_FS_PHY_48MHZ == u32EnumSpeed)) {
+        u32DiepctlTmp &= (~USBFS_DIEPCTL_MPSIZ);
+    } else if (DSTS_ENUMSPD_LS_PHY_6MHZ == u32EnumSpeed) {
+        u32DiepctlTmp &= (~USBFS_DIEPCTL_MPSIZ);
+        u32DiepctlTmp |= (3UL << USBFS_DIEPCTL_MPSIZ_POS);
+    } else {
+        ;
+    }
+    WRITE_REG32(USBx->INEP_REGS[0]->DIEPCTL, u32DiepctlTmp);
+    SET_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_CGINAK);
+}
+
+/**
+ * @brief  enable an EP to be active
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @retval None
+ */
+void usb_epactive(LL_USB_TypeDef *USBx, USB_DEV_EP *ep)
+{
+    uint32_t u32Addr;
+    uint32_t u32dxepctl;
+    uint32_t u32Daintmsk;
+
+    if (ep->ep_dir == 1U) {
+        u32Addr = (uint32_t)(&(USBx->INEP_REGS[ep->epidx]->DIEPCTL));
+        u32Daintmsk = 1UL << ep->epidx;
+    } else {
+        u32Addr = (uint32_t)(&(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL));
+        u32Daintmsk = 1UL << (USBFS_DAINTMSK_OEPINTM_POS + ep->epidx);
+    }
+    u32dxepctl = READ_REG32(*(__IO uint32_t *)u32Addr);
+    if (0UL == (u32dxepctl & USBFS_DIEPCTL_USBAEP)) {
+        u32dxepctl = ((ep->maxpacket << USBFS_DIEPCTL_MPSIZ_POS)
+                      | (((uint32_t)ep->trans_type) << USBFS_DIEPCTL_EPTYP_POS)
+                      | (((uint32_t)ep->tx_fifo_num) << USBFS_DIEPCTL_TXFNUM_POS)
+                      | USBFS_DIEPCTL_SD0PID_SEVNFRM
+                      | USBFS_DIEPCTL_USBAEP);
+
+        WRITE_REG32(*(__IO uint32_t *)u32Addr, u32dxepctl);
+    }
+    SET_REG32_BIT(USBx->DREGS->DAINTMSK, u32Daintmsk);
+}
+
+/**
+ * @brief  enable an EP to be deactive state if it is active
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @retval None
+ */
+void usb_epdeactive(LL_USB_TypeDef *USBx, USB_DEV_EP *ep)
+{
+    uint32_t u32Daintmsk;
+
+    if (ep->ep_dir == 1U) {
+        CLR_REG32_BIT(USBx->INEP_REGS[ep->epidx]->DIEPCTL, USBFS_DIEPCTL_USBAEP);
+        u32Daintmsk  = 1UL << ep->epidx;
+    } else {
+        CLR_REG32_BIT(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL, USBFS_DOEPCTL_USBAEP);
+        u32Daintmsk = 1UL << (USBFS_DAINTMSK_OEPINTM_POS + ep->epidx);
+    }
+    CLR_REG32_BIT(USBx->DREGS->DAINTMSK, u32Daintmsk);
+}
+
+/**
+ * @brief  Setup the data into the EP and begin to transmit data.
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_epntransbegin(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint8_t u8DmaEn)
+{
+    uint32_t u32depctl;
+    uint32_t u32DeptsizTmp;
+    uint32_t u32Pktcnt;
+    uint32_t u32Xfersize;
+
+    if (ep->ep_dir == 1U) {
+        u32depctl = READ_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL);
+        /* Zero Length Packet? */
+        if (ep->xfer_len == 0UL) {
+            u32Xfersize = 0UL;
+            u32Pktcnt = 1UL;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DIEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DIEPTSIZ_PKTCNT_POS);
+        } else {
+            /* Program the transfer size and packet count
+            * as follows: xfersize = N * maxpacket +
+            * short_packet pktcnt = N + (short_packet
+            * exist ? 1 : 0)
+            */
+            u32Xfersize = ep->xfer_len;
+            u32Pktcnt = (ep->xfer_len - 1U + ep->maxpacket) / ep->maxpacket;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DIEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DIEPTSIZ_PKTCNT_POS);
+            if (ep->trans_type == EP_TYPE_ISOC) {
+                u32DeptsizTmp |= (1UL << USBFS_DIEPTSIZ_MCNT_POS);
+            }
+        }
+        MODIFY_REG32(USBx->INEP_REGS[ep->epidx]->DIEPTSIZ, USBFS_DIEPTSIZ_XFRSIZ | USBFS_DIEPTSIZ_PKTCNT, u32DeptsizTmp);
+
+        if (u8DmaEn == 1U) {
+            WRITE_REG32(USBx->INEP_REGS[ep->epidx]->DIEPDMA, ep->dma_addr);
+        } else {
+            if (ep->trans_type != EP_TYPE_ISOC) {
+                /* Enable the Tx FIFO Empty Interrupt for this EP */
+                if (ep->xfer_len > 0U) {
+                    SET_REG32_BIT(USBx->DREGS->DIEPEMPMSK, 1UL << ep->epidx);
+                }
+            }
+        }
+
+        if (ep->trans_type == EP_TYPE_ISOC) {
+            if (((READ_REG32(USBx->DREGS->DSTS) >> USBFS_DSTS_FNSOF_POS) & 0x1U) == 0U) {
+                u32depctl |= USBFS_DIEPCTL_SODDFRM;
+            } else {
+                u32depctl |= USBFS_DIEPCTL_SD0PID_SEVNFRM;
+            }
+        }
+
+        u32depctl |= (USBFS_DIEPCTL_CNAK | USBFS_DIEPCTL_EPENA);
+        WRITE_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL, u32depctl);
+
+        if (ep->trans_type == EP_TYPE_ISOC) {
+            usb_wrpkt(USBx, ep->xfer_buff, ep->epidx, (uint16_t)ep->xfer_len, u8DmaEn);
+        }
+    } else {
+        u32depctl = READ_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL);
+        /* Program the transfer size and packet count as follows:
+        * pktcnt = N
+        * xfersize = N * maxpacket
+        */
+        if (ep->xfer_len == 0U) {
+            u32Xfersize = ep->maxpacket;
+            u32Pktcnt = 1UL;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DOEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DOEPTSIZ_PKTCNT_POS);
+        } else {
+            u32Pktcnt   = (ep->xfer_len + (ep->maxpacket - 1U)) / ep->maxpacket;
+            u32Xfersize = u32Pktcnt * ep->maxpacket;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DOEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DOEPTSIZ_PKTCNT_POS);
+            ep->xfer_len = u32Xfersize;
+        }
+        MODIFY_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPTSIZ, USBFS_DOEPTSIZ_XFRSIZ | USBFS_DOEPTSIZ_PKTCNT, u32DeptsizTmp);
+
+        if (u8DmaEn == 1U) {
+            WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPDMA, ep->dma_addr);
+        }
+
+        if (ep->trans_type == EP_TYPE_ISOC) {
+            if (0U != ep->datax_pid) {
+                u32depctl |= USBFS_DOEPCTL_SD1PID;
+            } else {
+                u32depctl |= USBFS_DOEPCTL_SD0PID;
+            }
+        }
+        u32depctl |= (USBFS_DOEPCTL_CNAK | USBFS_DOEPCTL_EPENA);
+        WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL, u32depctl);
+    }
+}
+
+/**
+ * @brief  Setup the data into the EP0 and begin to transmit data.
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_ep0transbegin(LL_USB_TypeDef *USBx, USB_DEV_EP *ep, uint8_t u8DmaEn)
+{
+    uint32_t u32depctl;
+    uint32_t u32DeptsizTmp;
+    uint32_t u32Pktcnt;
+    uint32_t u32Xfersize;
+
+    if (ep->ep_dir == 1U) {
+        u32depctl = READ_REG32(USBx->INEP_REGS[0]->DIEPCTL);
+        /* Zero Length Packet? */
+        if (ep->xfer_len == 0U) {
+            u32Xfersize = 0UL;
+            u32Pktcnt = 1UL;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DIEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DIEPTSIZ_PKTCNT_POS);
+        } else {
+            if (ep->xfer_len > ep->maxpacket) {
+                ep->xfer_len = ep->maxpacket;
+                u32Xfersize = ep->maxpacket;
+            } else {
+                u32Xfersize = ep->xfer_len;
+            }
+            u32Pktcnt = 1UL;
+            u32DeptsizTmp = (u32Xfersize << USBFS_DIEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DIEPTSIZ_PKTCNT_POS);
+        }
+        MODIFY_REG32(USBx->INEP_REGS[0]->DIEPTSIZ, USBFS_DIEPTSIZ_XFRSIZ | USBFS_DIEPTSIZ_PKTCNT, u32DeptsizTmp);
+
+        if (u8DmaEn == 1U) {
+            WRITE_REG32(USBx->INEP_REGS[ep->epidx]->DIEPDMA, ep->dma_addr);
+        }
+
+        u32depctl |= (USBFS_DIEPCTL_CNAK | USBFS_DIEPCTL_EPENA);
+        WRITE_REG32(USBx->INEP_REGS[0]->DIEPCTL, u32depctl);
+
+        if (u8DmaEn == 0U) {
+            /* Enable the Tx FIFO Empty Interrupt for this EP */
+            if (ep->xfer_len > 0U) {
+                SET_REG32_BIT(USBx->DREGS->DIEPEMPMSK, 1UL << ep->epidx);
+            }
+        }
+    } else {
+        u32depctl  = READ_REG32(USBx->OUTEP_REGS[0]->DOEPCTL);
+        /* Program the transfer size and packet count as follows:
+        * xfersize = N * (maxpacket + 4 - (maxpacket % 4))
+        * pktcnt = N           */
+        if (ep->xfer_len == 0U) {
+            u32Xfersize = 0UL;
+            u32Pktcnt = 1UL;
+        } else {
+            ep->xfer_len = LL_MIN(ep->rem_data_len, ep->maxpacket);
+            u32Xfersize = ep->xfer_len;
+            u32Pktcnt   = 1UL;
+        }
+        u32DeptsizTmp = (u32Xfersize << USBFS_DOEPTSIZ_XFRSIZ_POS) | (u32Pktcnt << USBFS_DOEPTSIZ_PKTCNT_POS);
+        MODIFY_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPTSIZ, USBFS_DOEPTSIZ_XFRSIZ | USBFS_DOEPTSIZ_PKTCNT, u32DeptsizTmp);
+
+        if (u8DmaEn == 1U) {
+            WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPDMA, ep->dma_addr);
+        }
+        u32depctl |= (USBFS_DOEPCTL_CNAK | USBFS_DOEPCTL_EPENA);
+        WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL, u32depctl);
+    }
+}
+
+/**
+ * @brief  Set the EP to be stall status
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @retval None
+ */
+void usb_setepstall(LL_USB_TypeDef *USBx, USB_DEV_EP *ep)
+{
+    uint32_t u32depctl;
+
+    if (ep->ep_dir == 1U) {
+        u32depctl = READ_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL);
+        if (0UL != (u32depctl & USBFS_DIEPCTL_EPENA)) {
+            u32depctl |= USBFS_DIEPCTL_EPDIS;
+        }
+        u32depctl |= USBFS_DIEPCTL_STALL;
+        WRITE_REG32(USBx->INEP_REGS[ep->epidx]->DIEPCTL, u32depctl);
+    } else {
+        u32depctl = READ_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL);
+        u32depctl |= USBFS_DOEPCTL_STALL;
+        WRITE_REG32(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL, u32depctl);
+    }
+}
+
+/**
+ * @brief  clear the stall status of a EP
+ * @param  [in] USBx        usb instance
+ * @param  [in] ep          endpoint instance
+ * @retval None
+ */
+void usb_clearepstall(LL_USB_TypeDef *USBx, USB_DEV_EP *ep)
+{
+    uint32_t tmp_depctl_addr;
+    uint32_t u32depctl;
+    if (ep->ep_dir == 1U) {
+        tmp_depctl_addr = (uint32_t)(&(USBx->INEP_REGS[ep->epidx]->DIEPCTL));
+    } else {
+        tmp_depctl_addr = (uint32_t)(&(USBx->OUTEP_REGS[ep->epidx]->DOEPCTL));
+    }
+    u32depctl = READ_REG32(*(__IO uint32_t *)tmp_depctl_addr);
+
+    u32depctl &= (~USBFS_DIEPCTL_STALL);
+    if ((ep->trans_type == EP_TYPE_INTR) || (ep->trans_type == EP_TYPE_BULK)) {
+        u32depctl |= USBFS_DIEPCTL_SD0PID_SEVNFRM;
+    }
+
+    WRITE_REG32(*(__IO uint32_t *)tmp_depctl_addr, u32depctl);
+}
+
+/**
+ * @brief  configure the EPO to receive data packets
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_ep0revcfg(LL_USB_TypeDef *USBx, uint8_t u8DmaEn, uint8_t *u8RevBuf)
+{
+    uint32_t u32deptsize;
+    uint32_t u32doepctl;
+
+    u32deptsize = (3UL << USBFS_DOEPTSIZ0_STUPCNT_POS)
+                  | (1UL << USBFS_DOEPTSIZ0_PKTCNT_POS)
+                  | (64UL << USBFS_DOEPTSIZ0_XFRSIZ_POS);
+
+    WRITE_REG32(USBx->OUTEP_REGS[0]->DOEPTSIZ, u32deptsize);
+
+    if (u8DmaEn == 1U) {
+        WRITE_REG32(USBx->OUTEP_REGS[0]->DOEPDMA, (uint32_t)&u8RevBuf[0]);
+        u32doepctl = READ_REG32(USBx->OUTEP_REGS[0]->DOEPCTL);
+        u32doepctl |= (USBFS_DOEPCTL_EPENA | USBFS_DOEPCTL_USBAEP);
+        WRITE_REG32(USBx->OUTEP_REGS[0]->DOEPCTL, u32doepctl);
+    }
+}
+
+/**
+ * @brief  enable remote wakeup active
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+void usb_remotewakeupen(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32dsts;
+
+    u32dsts = READ_REG32(USBx->DREGS->DSTS);
+    if (0UL != (u32dsts & USBFS_DSTS_SUSPSTS)) {
+        /* un-gate USB Core clock */
+        CLR_REG32_BIT(*USBx->GCCTL, USBFS_GCCTL_GATEHCLK | USBFS_GCCTL_STPPCLK);
+    }
+
+    SET_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_RWUSIG);
+    usb_mdelay(5UL);
+    CLR_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_RWUSIG);
+}
+
+/**
+ * @brief  control the device to connect or disconnect
+ * @param  [in] USBx        usb instance
+ * @param  [in] link        0(conn) or 1(disconn)
+ * @retval None
+ */
+void usb_ctrldevconnect(LL_USB_TypeDef *USBx, uint8_t link)
+{
+    if (0U == link) {
+        CLR_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_SDIS);
+    } else {
+        SET_REG32_BIT(USBx->DREGS->DCTL, USBFS_DCTL_SDIS);
+    }
+    usb_mdelay(3UL);
+}
+#endif
+
+#ifdef USE_HOST_MODE
+/**
+ * @brief  Initializes the USB controller when it is host mode
+ * @param  [in] USBx        usb instance
+ * @param  [in] basic_cfgs  usb core basic cfgs
+ * @retval None
+ */
+void usb_hostmodeinit(LL_USB_TypeDef *USBx, USB_CORE_BASIC_CFGS *basic_cfgs)
+{
+    __IO uint8_t u8Tmp = 0U;
+    WRITE_REG32(*USBx->GCCTL, 0UL);  /* reset the register-GCCTL */
+    if (USBHS_PHY_EMBED == basic_cfgs->phy_type) {
+        usb_fslspclkselset(USBx, HCFG_6_MHZ);  /* PHY clock is running at 6MHz */
+    } else {
+        usb_fslspclkselset(USBx, HCFG_30_60_MHZ);  /* PHY clock is running at 6MHz */
+    }
+    usb_hprtrst(USBx);                     /* reset the port */
+    usb_enumspeed(USBx);                   /* FS or LS bases on the maximum speed supported by the connected device */
+    usb_sethostfifo(USBx, basic_cfgs->core_type);
+    /* Flush all the txFIFO and the whole rxFIFO */
+    usb_txfifoflush(USBx, 0x10UL);
+    usb_rxfifoflush(USBx);
+    /* Clear all HC Interrupt bits that are pending */
+    while (u8Tmp < basic_cfgs->host_chnum) {
+        WRITE_REG32(USBx->HC_REGS[u8Tmp]->HCINT, 0xFFFFFFFFUL);
+        WRITE_REG32(USBx->HC_REGS[u8Tmp]->HCINTMSK, 0UL);
+        u8Tmp++;
+    }
+    usb_hostinten(USBx, basic_cfgs->dmaen);
+}
+
+/**
+ * @brief  set the vbus if state is 1 or reset the vbus if state is 0.
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8State       the vbus state it would be.
+ * @retval None
+ */
+void usb_vbusctrl(LL_USB_TypeDef *USBx, uint8_t u8State)
+{
+    uint32_t u32hprt;
+
+    u32hprt = usb_rdhprt(USBx);
+    if ((0UL == (u32hprt & USBFS_HPRT_PWPR)) && (1U == u8State)) {
+        u32hprt |= USBFS_HPRT_PWPR;
+        WRITE_REG32(*USBx->HPRT, u32hprt);
+    }
+    if ((0UL != (u32hprt & USBFS_HPRT_PWPR)) && (0U == u8State)) {
+        u32hprt &= (~USBFS_HPRT_PWPR);
+        WRITE_REG32(*USBx->HPRT, u32hprt);
+    }
+}
+
+/**
+ * @brief  Enables the related interrupts when the core is host mode
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval None
+ */
+void usb_hostinten(LL_USB_TypeDef *USBx, uint8_t u8DmaEn)
+{
+    uint32_t u32gIntmsk = 0UL;
+    WRITE_REG32(USBx->GREGS->GINTMSK, 0UL);
+    /* Clear the pending interrupt bits */
+    WRITE_REG32(USBx->GREGS->GINTSTS, 0xFFFFFFFFUL);
+
+    /* Enable the normal interrupt bits */
+    usb_normalinten(USBx);
+
+    if (u8DmaEn == 0U) {
+        u32gIntmsk |= USBFS_GINTMSK_RXFNEM;
+    }
+    u32gIntmsk |= (USBFS_GINTMSK_HPRTIM
+                   | USBFS_GINTMSK_HCIM
+                   | USBFS_GINTMSK_DISCIM
+                   | USBFS_GINTMSK_SOFM
+                   | USBFS_GINTMSK_IPXFRM_INCOMPISOOUTM);
+    SET_REG32_BIT(USBx->GREGS->GINTMSK, u32gIntmsk);
+}
+
+/**
+ * @brief  Reset the port, the 1'b0 state must last at lease 10ms.
+ * @param  [in] USBx        usb instance
+ * @retval None
+ */
+void usb_hprtrst(LL_USB_TypeDef *USBx)
+{
+    uint32_t u32hprt;
+    u32hprt = usb_rdhprt(USBx);
+    u32hprt |= USBFS_HPRT_PRST;
+    WRITE_REG32(*USBx->HPRT, u32hprt);
+    usb_mdelay(10UL);
+    u32hprt &= ~USBFS_HPRT_PRST;
+    WRITE_REG32(*USBx->HPRT, u32hprt);
+    usb_mdelay(20UL);
+}
+
+/**
+ * @brief  Prepares transferring packets on a host channel
+ * @param  [in] USBx        usb instance
+ * @param  [in] hc_num      channel index
+ * @param  [in] pCh         channel structure
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval status in byte
+ */
+uint8_t usb_inithch(LL_USB_TypeDef *USBx, uint8_t hc_num, USB_HOST_CH *pCh, uint8_t u8DmaEn)
+{
+    uint32_t u32hcintmsk = 0UL;
+    uint32_t u32hcchar = 0UL;
+
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCINT, 0xFFFFFFFFUL);
+    if (u8DmaEn == 1U) {
+        u32hcintmsk |= USBFS_HCINTMSK_AHBERRM;
+    }
+    switch (pCh->ep_type) {
+        case EP_TYPE_CTRL:
+        case EP_TYPE_BULK:
+            u32hcintmsk |= (USBFS_HCINTMSK_XFRCM
+                            | USBFS_HCINTMSK_STALLM
+                            | USBFS_HCINTMSK_TXERRM
+                            | USBFS_HCINTMSK_DTERRM
+                            | USBFS_HCINTMSK_NAKM);
+            if (0U != pCh->is_epin) {
+                u32hcintmsk |= USBFS_HCINTMSK_BBERRM;
+            } else {
+                u32hcintmsk |= USBHS_HCINT_NYET;
+                if (0U != pCh->do_ping) {
+                    u32hcintmsk |= USBFS_HCINTMSK_ACKM;
+                }
+            }
+            break;
+        case EP_TYPE_INTR:
+            u32hcintmsk |= (USBFS_HCINTMSK_XFRCM
+                            | USBFS_HCINTMSK_NAKM
+                            | USBFS_HCINTMSK_STALLM
+                            | USBFS_HCINTMSK_TXERRM
+                            | USBFS_HCINTMSK_DTERRM
+                            | USBFS_HCINTMSK_FRMORM);
+            if (0U != pCh->is_epin) {
+                u32hcintmsk |= USBFS_HCINTMSK_BBERRM;
+            }
+            break;
+        case EP_TYPE_ISOC:
+            u32hcintmsk |= (USBFS_HCINTMSK_XFRCM
+                            | USBFS_HCINTMSK_FRMORM
+                            | USBFS_HCINTMSK_ACKM);
+
+            if (0U != pCh->is_epin) {
+                u32hcintmsk |= (USBFS_HCINTMSK_TXERRM | USBFS_HCINTMSK_BBERRM);
+            }
+            break;
+        default:
+            break;
+    }
+
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCINTMSK, u32hcintmsk);
+    SET_REG32_BIT(USBx->HREGS->HAINTMSK, 1UL << hc_num);
+
+    /* enable the host channel interrupts */
+    SET_REG32_BIT(USBx->GREGS->GINTMSK, USBFS_GINTMSK_HCIM);
+
+    /* modify HCCHAR */
+    u32hcchar |= (((uint32_t)pCh->dev_addr) << USBFS_HCCHAR_DAD_POS);
+    u32hcchar |= (((uint32_t)pCh->ep_idx) << USBFS_HCCHAR_EPNUM_POS);
+    u32hcchar |= (((uint32_t)pCh->is_epin) << USBFS_HCCHAR_EPDIR_POS);
+    u32hcchar |= (((uint32_t)pCh->ep_type) << USBFS_HCCHAR_EPTYP_POS);
+    u32hcchar |= (((uint32_t)pCh->max_packet) << USBFS_HCCHAR_MPSIZ_POS);
+    if (PRTSPD_LOW_SPEED == pCh->ch_speed) {
+        u32hcchar |= USBFS_HCCHAR_LSDEV;
+    } else {
+        u32hcchar &= ~USBFS_HCCHAR_LSDEV;
+    }
+
+    if (pCh->ep_type == EP_TYPE_INTR) {
+        u32hcchar |= USBFS_HCCHAR_ODDFRM;
+    }
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCCHAR, u32hcchar);
+    return USB_OK;
+}
+
+/**
+ * @brief  Start transfer on the channel whose index is hc_num.
+ * @param  [in] USBx        usb instance
+ * @param  [in] hc_num      channel index
+ * @param  [in] pCh         channel structure
+ * @param  [in] u8DmaEn     USB DMA status
+ * @retval status in 8 bits
+ */
+uint8_t usb_hchtransbegin(LL_USB_TypeDef *USBx, uint8_t hc_num, USB_HOST_CH *pCh, uint8_t u8DmaEn)
+{
+    uint32_t u32hcchar;
+    uint32_t u32hctsiz = 0UL;
+    uint32_t u32hnptxsts;
+    uint32_t u32hptxsts;
+    uint16_t u16LenWords;
+    uint16_t u16NumPacket;
+    uint16_t u16MaxHcPktCount = 256U;
+
+    /* Compute the expected number of packets associated to the transfer */
+    if (pCh->xfer_len > 0U) {
+        u16NumPacket = (uint16_t)((pCh->xfer_len +
+                                   (uint32_t)pCh->max_packet - 1UL) / (uint32_t)pCh->max_packet);
+
+        if (u16NumPacket > u16MaxHcPktCount) {
+            u16NumPacket = u16MaxHcPktCount;
+            pCh->xfer_len = (uint32_t)u16NumPacket * (uint32_t)pCh->max_packet;
+        }
+    } else {
+        u16NumPacket = 1U;
+    }
+    if (0U != pCh->is_epin) {
+        pCh->xfer_len = (uint32_t)u16NumPacket * (uint32_t)pCh->max_packet;
+    }
+
+    u32hctsiz |= (((uint32_t)pCh->xfer_len) << USBFS_HCTSIZ_XFRSIZ_POS);
+    u32hctsiz |= (((uint32_t)u16NumPacket) << USBFS_HCTSIZ_PKTCNT_POS);
+    u32hctsiz |= (((uint32_t)pCh->pid_type) << USBFS_HCTSIZ_DPID_POS);
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCTSIZ, u32hctsiz);
+
+    if (u8DmaEn == 1U) {
+        WRITE_REG32(USBx->HC_REGS[hc_num]->HCDMA, pCh->xfer_buff);
+    }
+
+    u32hcchar = READ_REG32(USBx->HC_REGS[hc_num]->HCCHAR);
+    u32hcchar &= ~USBFS_HCCHAR_ODDFRM;
+    u32hcchar |= (usb_ifevenframe(USBx) << USBFS_HCCHAR_ODDFRM_POS);
+
+    /* enable this host channel whose number is hc_num */
+    u32hcchar |= USBFS_HCCHAR_CHENA;
+    u32hcchar &= ~USBFS_HCCHAR_CHDIS;
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCCHAR, u32hcchar);
+
+    if (u8DmaEn == 0U) {
+        if ((pCh->is_epin == 0U) && (pCh->xfer_len > 0U)) {
+            switch (pCh->ep_type) {
+                /* Non-periodic transmit */
+                case EP_TYPE_CTRL:
+                case EP_TYPE_BULK:
+                    u32hnptxsts = READ_REG32(USBx->GREGS->HNPTXSTS);
+                    u16LenWords = (uint16_t)((pCh->xfer_len + 3UL) / 4UL);
+                    /* check if the amount of free space available in the non-periodic txFIFO is enough */
+                    if (u16LenWords > ((u32hnptxsts & USBFS_HNPTXSTS_NPTXFSAV) >> USBFS_HNPTXSTS_NPTXFSAV_POS)) {
+                        /* enable interrupt of nptxfempty of GINTMSK*/
+                        SET_REG32_BIT(USBx->GREGS->GINTMSK, USBFS_GINTMSK_NPTXFEM);
+                    }
+                    break;
+                /* Periodic trnsmit */
+                case EP_TYPE_INTR:
+                case EP_TYPE_ISOC:
+                    u32hptxsts = READ_REG32(USBx->HREGS->HPTXSTS);
+                    u16LenWords = (uint16_t)((pCh->xfer_len + 3UL) / 4UL);
+                    /* check if the space of periodic TxFIFO is enough */
+                    if (u16LenWords > ((u32hptxsts & USBFS_HPTXSTS_PTXFSAVL) >> USBFS_HPTXSTS_PTXFSAVL_POS)) {
+                        /* enable interrupt of ptxfempty of GINTMSK */
+                        SET_REG32_BIT(USBx->GREGS->GINTMSK, USBFS_GINTMSK_PTXFEM);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            usb_wrpkt(USBx, pCh->xfer_buff, hc_num, (uint16_t)pCh->xfer_len, u8DmaEn);
+        }
+    }
+    return USB_OK;
+}
+
+/**
+ * @brief  Stop the host and flush all the txFIFOs and the whole rxFIFO.
+ * @param  [in] USBx        usb instance
+ * @param  [in] u8ChNum     Host channel number
+ * @retval None
+ */
+void usb_hoststop(LL_USB_TypeDef *USBx, uint8_t u8ChNum)
+{
+    __IO uint32_t u32Tmp = 0UL;
+
+    WRITE_REG32(USBx->HREGS->HAINTMSK, 0UL);
+    WRITE_REG32(USBx->HREGS->HAINT, 0xFFFFFFFFUL);
+
+    do {
+        usb_chrst(USBx, (uint8_t)u32Tmp);
+        u32Tmp++;
+    } while (u32Tmp < u8ChNum);
+    /* flush all the txFIFOs and the whole rxFIFO */
+    usb_rxfifoflush(USBx);
+    usb_txfifoflush(USBx, 0x10UL);
+}
+
+/**
+ * @brief  make the channel to halt
+ * @param  [in] USBx        usb instance
+ * @param  [in] hc_num      channel index
+ * @retval None
+ */
+void usb_hchstop(LL_USB_TypeDef *USBx, uint8_t hc_num)
+{
+    uint32_t u32hcchar;
+
+    u32hcchar = READ_REG32(USBx->HC_REGS[hc_num]->HCCHAR);
+    u32hcchar |= USBFS_HCCHAR_CHDIS;
+    /* Check for space in the request queue to issue the halt. */
+    if ((EP_TYPE_CTRL == ((u32hcchar & USBFS_HCCHAR_EPTYP) >> USBFS_HCCHAR_EPTYP_POS))
+        || (EP_TYPE_BULK == ((u32hcchar & USBFS_HCCHAR_EPTYP) >> USBFS_HCCHAR_EPTYP_POS))) {
+        if (0UL == (READ_REG32(USBx->GREGS->HNPTXSTS) & USBFS_HNPTXSTS_NPTQXSAV)) {
+            u32hcchar &= (~USBFS_HCCHAR_CHENA);
+            WRITE_REG32(USBx->HC_REGS[hc_num]->HCCHAR, u32hcchar);
+        }
+    } else {
+        if (0UL == (READ_REG32(USBx->HREGS->HPTXSTS) & USBFS_HPTXSTS_PTXQSAV)) {
+            u32hcchar &= (~USBFS_HCCHAR_CHENA);
+            WRITE_REG32(USBx->HC_REGS[hc_num]->HCCHAR, u32hcchar);
+        }
+    }
+    u32hcchar |= USBFS_HCCHAR_CHENA;
+    WRITE_REG32(USBx->HC_REGS[hc_num]->HCCHAR, u32hcchar);
+}
+
+#endif
+
+/**
+ * @}
+*/
+
+#endif /* LL_USB_ENABLE */
+
+/**
+ * @}
+*/
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32_ll_utility.c
+++ b/hc32f4a2/src/hc32_ll_utility.c
@@ -1,0 +1,441 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_utility.c
+ * @brief This file provides utility functions for DDL.
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-06-30       CDT             Support re-target printf for IAR EW version 9 or later
+   2023-06-30       CDT             Modify register USART DR to USART TDR
+                                    Prohibit DDL_DelayMS and DDL_DelayUS functions from being optimized
+   2024-08-31       CDT             Optimized the Delay functions as cache is enabled
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_UTILITY UTILITY
+ * @brief DDL Utility Driver
+ * @{
+ */
+
+#if (LL_UTILITY_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+/**
+ * @defgroup UTILITY_Local_Variables UTILITY Local Variables
+ * @{
+ */
+
+static uint32_t m_u32TickStep = 0UL;
+static __IO uint32_t m_u32TickCount = 0UL;
+
+#if (LL_PRINT_ENABLE == DDL_ON)
+static void *m_pvPrintDevice = NULL;
+static uint32_t m_u32PrintTimeout = 0UL;
+#endif
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+
+/**
+ * @defgroup UTILITY_Local_Functions UTILITY Local Functions
+ * @{
+ */
+#if (LL_PRINT_ENABLE == DDL_ON)
+
+/**
+ * @brief  Set print device.
+ * @param  [in] pvPrintDevice           Pointer to print device
+ * @retval None
+ */
+__STATIC_INLINE void LL_SetPrintDevice(void *pvPrintDevice)
+{
+    m_pvPrintDevice = pvPrintDevice;
+}
+
+/**
+ * @brief  Get print device.
+ * @param  None
+ * @retval Pointer to print device
+ */
+__STATIC_INLINE void *LL_GetPrintDevice(void)
+{
+    return m_pvPrintDevice;
+}
+
+/**
+ * @brief  Set print timeout.
+ * @param  [in] u32Timeout              Print timeout value
+ * @retval None
+ */
+__STATIC_INLINE void LL_SetPrintTimeout(uint32_t u32Timeout)
+{
+    m_u32PrintTimeout = u32Timeout;
+}
+
+/**
+ * @brief  Get print timeout.
+ * @param  None
+ * @retval Print timeout value
+ */
+__STATIC_INLINE uint32_t LL_GetPrintTimeout(void)
+{
+    return m_u32PrintTimeout;
+}
+#endif /* LL_PRINT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup UTILITY_Global_Functions UTILITY Global Functions
+ * @{
+ */
+
+/**
+ * @brief Delay function, delay ms approximately
+ * @param [in] u32Count                   ms
+ * @retval None
+ */
+#if defined (__CC_ARM)  /*!< ARM Compiler */
+#pragma push
+#pragma O0
+#endif
+__NO_OPTIMIZE void DDL_DelayMS(uint32_t u32Count)
+{
+    __IO uint32_t i;
+    const uint32_t u32Cyc = (HCLK_VALUE + 6000UL - 1UL) / 6000UL;
+
+    while (u32Count-- > 0UL) {
+        i = u32Cyc;
+        while (i-- > 0UL) {
+        }
+    }
+}
+
+/**
+ * @brief Delay function, delay us approximately
+ * @param [in] u32Count                   us
+ * @retval None
+ */
+__NO_OPTIMIZE void DDL_DelayUS(uint32_t u32Count)
+{
+    __IO uint32_t i;
+    const uint32_t u32Cyc = (HCLK_VALUE + 6000000UL - 1UL) / 6000000UL;
+
+    while (u32Count-- > 0UL) {
+        i = u32Cyc;
+        while (i-- > 0UL) {
+        }
+    }
+}
+#if defined (__CC_ARM)  /*!< ARM Compiler */
+#pragma pop
+#endif
+
+/**
+ * @brief This function Initializes the interrupt frequency of the SysTick.
+ * @param [in] u32Freq                  SysTick interrupt frequency (1 to 1000).
+ * @retval int32_t:
+ *           - LL_OK: SysTick Initializes succeed
+ *           - LL_ERR: SysTick Initializes failed
+ */
+__WEAKDEF int32_t SysTick_Init(uint32_t u32Freq)
+{
+    int32_t i32Ret = LL_ERR;
+
+    if ((0UL != u32Freq) && (u32Freq <= 1000UL)) {
+        m_u32TickStep = 1000UL / u32Freq;
+        /* Configure the SysTick interrupt */
+        if (0UL == SysTick_Config(HCLK_VALUE / u32Freq)) {
+            i32Ret = LL_OK;
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief This function provides minimum delay (in milliseconds).
+ * @param [in] u32Delay                 Delay specifies the delay time.
+ * @retval None
+ */
+__WEAKDEF void SysTick_Delay(uint32_t u32Delay)
+{
+    const uint32_t tickStart = SysTick_GetTick();
+    uint32_t tickEnd = u32Delay;
+    uint32_t tickMax;
+
+    if (m_u32TickStep != 0UL) {
+        tickMax = 0xFFFFFFFFUL / m_u32TickStep * m_u32TickStep;
+        /* Add a freq to guarantee minimum wait */
+        if ((u32Delay >= tickMax) || ((tickMax - u32Delay) < m_u32TickStep)) {
+            tickEnd = tickMax;
+        }
+        while ((SysTick_GetTick() - tickStart) < tickEnd) {
+        }
+    }
+}
+
+/**
+ * @brief This function is called to increment a global variable "u32TickCount".
+ * @note  This variable is incremented in SysTick ISR.
+ * @param None
+ * @retval None
+ */
+__WEAKDEF void SysTick_IncTick(void)
+{
+    m_u32TickCount += m_u32TickStep;
+}
+
+/**
+ * @brief Provides a tick value in millisecond.
+ * @param None
+ * @retval Tick value
+ */
+__WEAKDEF uint32_t SysTick_GetTick(void)
+{
+    return m_u32TickCount;
+}
+
+/**
+ * @brief Suspend SysTick increment.
+ * @param None
+ * @retval None
+ */
+__WEAKDEF void SysTick_Suspend(void)
+{
+    /* Disable SysTick Interrupt */
+    SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+ * @brief Resume SysTick increment.
+ * @param None
+ * @retval None
+ */
+__WEAKDEF void SysTick_Resume(void)
+{
+    /* Enable SysTick Interrupt */
+    SysTick->CTRL  |= SysTick_CTRL_TICKINT_Msk;
+}
+
+#ifdef __DEBUG
+/**
+ * @brief DDL assert error handle function
+ * @param [in] file                     Point to the current assert the wrong file.
+ * @param [in] line                     Point line assert the wrong file in the current.
+ * @retval None
+ */
+__WEAKDEF void DDL_AssertHandler(const char *file, int line)
+{
+    /* Users can re-implement this function to print information */
+    DDL_Printf("Wrong parameters value: file %s on line %d\r\n", file, line);
+
+    for (;;) {
+    }
+}
+#endif /* __DEBUG */
+
+#if (LL_PRINT_ENABLE == DDL_ON)
+
+#if (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)) || \
+    (defined (__ICCARM__) && (__VER__ < 9000000)) || (defined (__CC_ARM))
+/**
+ * @brief  Re-target fputc function.
+ * @param  [in] ch
+ * @param  [in] f
+ * @retval int32_t
+ */
+int32_t fputc(int32_t ch, FILE *f)
+{
+    (void)f;  /* Prevent unused argument compilation warning */
+
+    return (LL_OK == DDL_ConsoleOutputChar((char)ch)) ? ch : -1;
+}
+
+#elif (defined (__ICCARM__) && (__VER__ >= 9000000))
+#include <LowLevelIOInterface.h>
+#pragma module_name = "?__write"
+size_t __dwrite(int handle, const unsigned char *buffer, size_t size)
+{
+    size_t nChars = 0;
+    size_t i;
+
+    if (buffer == NULL) {
+        /*
+         * This means that we should flush internal buffers.  Since we
+         * don't we just return.  (Remember, "handle" == -1 means that all
+         * handles should be flushed.)
+         */
+        return 0;
+    }
+
+    /* This template only writes to "standard out" and "standard err",
+     * for all other file handles it returns failure. */
+    if (handle != _LLIO_STDOUT && handle != _LLIO_STDERR) {
+        return _LLIO_ERROR;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (DDL_ConsoleOutputChar((char)buffer[i]) < 0) {
+            return _LLIO_ERROR;
+        }
+
+        ++nChars;
+    }
+
+    return nChars;
+}
+
+#elif defined (__GNUC__) && !defined (__CC_ARM)
+/**
+ * @brief  Re-target _write function.
+ * @param  [in] fd
+ * @param  [in] data
+ * @param  [in] size
+ * @retval int32_t
+ */
+int32_t _write(int fd, char data[], int32_t size)
+{
+    int32_t i = -1;
+
+    if (NULL != data) {
+        (void)fd;  /* Prevent unused argument compilation warning */
+
+        for (i = 0; i < size; i++) {
+            if (LL_OK != DDL_ConsoleOutputChar(data[i])) {
+                break;
+            }
+        }
+    }
+
+    return i ? i : -1;
+}
+#endif
+
+/**
+ * @brief  Initialize printf function
+ * @param  [in] vpDevice                Pointer to print device
+ * @param  [in] u32Param                Print device parameter
+ * @param  [in] pfnPreinit              The function pointer for initializing clock, port, print device etc.
+ * @retval int32_t:
+ *           - LL_OK:                   Initialize successfully.
+ *           - LL_ERR:                  The callback function pfnPreinit occurs error.
+ *           - LL_ERR_INVD_PARAM:       The pointer pfnPreinit is NULL.
+ */
+int32_t LL_PrintfInit(void *vpDevice, uint32_t u32Param, int32_t (*pfnPreinit)(void *vpDevice, uint32_t u32Param))
+{
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+
+    if (NULL != pfnPreinit) {
+        i32Ret = pfnPreinit(vpDevice, u32Param);   /* The callback function initialize clock, port, print device etc */
+        if (LL_OK == i32Ret) {
+            LL_SetPrintDevice(vpDevice);
+            LL_SetPrintTimeout((u32Param == 0UL) ? 0UL : (HCLK_VALUE / u32Param));
+        } else {
+            i32Ret = LL_ERR;
+            DDL_ASSERT(i32Ret == LL_OK);           /* Initialize unsuccessfully */
+        }
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  Transmit character.
+ * @param  [in] cData                   The character for transmitting
+ * @retval int32_t:
+ *           - LL_OK:                   Transmit successfully.
+ *           - LL_ERR_TIMEOUT:          Transmit timeout.
+ *           - LL_ERR_INVD_PARAM:       The print device is invalid.
+ */
+__WEAKDEF int32_t DDL_ConsoleOutputChar(char cData)
+{
+    uint32_t u32TxEmpty = 0UL;
+    __IO uint32_t u32TmpCount = 0UL;
+    int32_t i32Ret = LL_ERR_INVD_PARAM;
+    uint32_t u32Timeout = LL_GetPrintTimeout();
+    CM_USART_TypeDef *USARTx = (CM_USART_TypeDef *)LL_GetPrintDevice();
+
+    if (NULL != USARTx) {
+        /* Wait TX data register empty */
+        while ((u32TmpCount <= u32Timeout) && (0UL == u32TxEmpty)) {
+            u32TxEmpty = READ_REG32_BIT(USARTx->SR, USART_SR_TXE);
+            u32TmpCount++;
+        }
+
+        if (0UL != u32TxEmpty) {
+            WRITE_REG16(USARTx->TDR, (uint16_t)cData);
+            i32Ret = LL_OK;
+        } else {
+            i32Ret = LL_ERR_TIMEOUT;
+        }
+    }
+
+    return i32Ret;
+}
+
+#endif /* LL_PRINT_ENABLE */
+
+/**
+ * @}
+ */
+
+#endif /* LL_UTILITY_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * EOF (not truncated)
+ ******************************************************************************/

--- a/hc32f4a2/src/hc32_ll_wdt.c
+++ b/hc32f4a2/src/hc32_ll_wdt.c
@@ -1,0 +1,258 @@
+/**
+ *******************************************************************************
+ * @file  hc32_ll_wdt.c
+ * @brief This file provides firmware functions to manage the General Watch Dog
+ *        Timer(WDT).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2023-09-30       CDT             Optimize WDT_ClearStatus function timeout
+   2024-06-30       CDT             Modify API WDT_ClearStatus() for couping risk
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32_ll_wdt.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_WDT WDT
+ * @brief General Watch Dog Timer
+ * @{
+ */
+
+#if (LL_WDT_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+/**
+ * @defgroup WDT_Local_Macros WDT Local Macros
+ * @{
+ */
+
+/* WDT Refresh Key */
+#define WDT_REFRESH_KEY_START           (0x0123UL)
+#define WDT_REFRESH_KEY_END             (0x3210UL)
+
+/* WDT clear flag timeout(ms) */
+#define WDT_CLR_FLAG_TIMEOUT            (200UL)
+
+/* WDT Registers Clear Mask */
+#define WDT_CR_CLR_MASK                 (WDT_CR_PERI   | WDT_CR_CKS | WDT_CR_WDPT | \
+                                         WDT_CR_SLPOFF | WDT_CR_ITS)
+
+/**
+ * @defgroup WDT_Check_Parameters_Validity WDT Check Parameters Validity
+ * @{
+ */
+#define IS_WDT_CNT_PERIOD(x)                                                   \
+(   ((x) == WDT_CNT_PERIOD256)                  ||                             \
+    ((x) == WDT_CNT_PERIOD4096)                 ||                             \
+    ((x) == WDT_CNT_PERIOD16384)                ||                             \
+    ((x) == WDT_CNT_PERIOD65536))
+
+#define IS_WDT_CLK_DIV(x)                                                      \
+(   ((x) == WDT_CLK_DIV4)                       ||                             \
+    ((x) == WDT_CLK_DIV64)                      ||                             \
+    ((x) == WDT_CLK_DIV128)                     ||                             \
+    ((x) == WDT_CLK_DIV256)                     ||                             \
+    ((x) == WDT_CLK_DIV512)                     ||                             \
+    ((x) == WDT_CLK_DIV1024)                    ||                             \
+    ((x) == WDT_CLK_DIV2048)                    ||                             \
+    ((x) == WDT_CLK_DIV8192))
+
+#define IS_WDT_REFRESH_RANGE(x)                                                \
+(   ((x) == WDT_RANGE_0TO100PCT)                ||                             \
+    ((x) == WDT_RANGE_0TO25PCT)                 ||                             \
+    ((x) == WDT_RANGE_25TO50PCT)                ||                             \
+    ((x) == WDT_RANGE_0TO50PCT)                 ||                             \
+    ((x) == WDT_RANGE_50TO75PCT)                ||                             \
+    ((x) == WDT_RANGE_0TO25PCT_50TO75PCT)       ||                             \
+    ((x) == WDT_RANGE_25TO75PCT)                ||                             \
+    ((x) == WDT_RANGE_0TO75PCT)                 ||                             \
+    ((x) == WDT_RANGE_75TO100PCT)               ||                             \
+    ((x) == WDT_RANGE_0TO25PCT_75TO100PCT)      ||                             \
+    ((x) == WDT_RANGE_25TO50PCT_75TO100PCT)     ||                             \
+    ((x) == WDT_RANGE_0TO50PCT_75TO100PCT)      ||                             \
+    ((x) == WDT_RANGE_50TO100PCT)               ||                             \
+    ((x) == WDT_RANGE_0TO25PCT_50TO100PCT)      ||                             \
+    ((x) == WDT_RANGE_25TO100PCT))
+
+#define IS_WDT_LPM_CNT(x)                                                      \
+(   ((x) == WDT_LPM_CNT_CONT)                   ||                             \
+    ((x) == WDT_LPM_CNT_STOP))
+
+#define IS_WDT_EXP_TYPE(x)                                                     \
+(   ((x) == WDT_EXP_TYPE_INT)                   ||                             \
+    ((x) == WDT_EXP_TYPE_RST))
+
+#define IS_WDT_FLAG(x)                                                         \
+(   ((x) != 0UL)                                &&                             \
+    (((x) | WDT_FLAG_ALL) == WDT_FLAG_ALL))
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup WDT_Global_Functions WDT Global Functions
+ * @{
+ */
+
+/**
+ * @brief  Initializes WDT.
+ * @param  [in] pstcWdtInit             Pointer to a @ref stc_wdt_init_t structure
+ * @retval int32_t:
+ *           - LL_OK: Initializes success
+ *           - LL_ERR_INVD_PARAM: pstcWdtInit == NULL
+ */
+int32_t WDT_Init(const stc_wdt_init_t *pstcWdtInit)
+{
+    int32_t i32Ret = LL_OK;
+
+    if (NULL == pstcWdtInit) {
+        i32Ret = LL_ERR_INVD_PARAM;
+    } else {
+        /* Check parameters */
+        DDL_ASSERT(IS_WDT_CNT_PERIOD(pstcWdtInit->u32CountPeriod));
+        DDL_ASSERT(IS_WDT_CLK_DIV(pstcWdtInit->u32ClockDiv));
+        DDL_ASSERT(IS_WDT_REFRESH_RANGE(pstcWdtInit->u32RefreshRange));
+        DDL_ASSERT(IS_WDT_LPM_CNT(pstcWdtInit->u32LPMCount));
+        DDL_ASSERT(IS_WDT_EXP_TYPE(pstcWdtInit->u32ExceptionType));
+
+        /* WDT CR Configuration(Software Start Mode) */
+        MODIFY_REG32(CM_WDT->CR, WDT_CR_CLR_MASK,
+                     (pstcWdtInit->u32CountPeriod  | pstcWdtInit->u32ClockDiv |
+                      pstcWdtInit->u32RefreshRange | pstcWdtInit->u32LPMCount |
+                      pstcWdtInit->u32ExceptionType));
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @brief  WDT feed dog.
+ * @note   In software startup mode, Start counter when refreshing for the first time.
+ * @param  None
+ * @retval None
+ */
+void WDT_FeedDog(void)
+{
+    WRITE_REG32(CM_WDT->RR, WDT_REFRESH_KEY_START);
+    WRITE_REG32(CM_WDT->RR, WDT_REFRESH_KEY_END);
+}
+
+/**
+ * @brief  Get WDT flag status.
+ * @param  [in] u32Flag                 WDT flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg WDT_FLAG_UDF:         Count underflow flag
+ *           @arg WDT_FLAG_REFRESH:     Refresh error flag
+ *           @arg WDT_FLAG_ALL:         All of the above
+ * @retval An @ref en_flag_status_t enumeration type value.
+ */
+en_flag_status_t WDT_GetStatus(uint32_t u32Flag)
+{
+    en_flag_status_t enFlagSta = RESET;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_WDT_FLAG(u32Flag));
+
+    if (0UL != (READ_REG32_BIT(CM_WDT->SR, u32Flag))) {
+        enFlagSta = SET;
+    }
+
+    return enFlagSta;
+}
+
+/**
+ * @brief  Clear WDT flag.
+ * @param  [in] u32Flag                 WDT flag type
+ *         This parameter can be one or any combination of the following values:
+ *           @arg WDT_FLAG_UDF:         Count underflow flag
+ *           @arg WDT_FLAG_REFRESH:     Refresh error flag
+ *           @arg WDT_FLAG_ALL:         All of the above
+ * @retval int32_t:
+ *           - LL_OK: Clear flag success
+ *           - LL_ERR_TIMEOUT: Clear flag timeout
+ */
+int32_t WDT_ClearStatus(uint32_t u32Flag)
+{
+    __IO uint32_t u32Count;
+    int32_t i32Ret = LL_OK;
+
+    /* Check parameters */
+    DDL_ASSERT(IS_WDT_FLAG(u32Flag));
+
+    /* Waiting for FLAG bit clear */
+    u32Count = WDT_CLR_FLAG_TIMEOUT * (HCLK_VALUE / 25000UL);
+    while (0UL != READ_REG32_BIT(CM_WDT->SR, u32Flag)) {
+        MODIFY_REG32(CM_WDT->SR, WDT_FLAG_ALL, ~u32Flag);
+        if (0UL == u32Count) {
+            i32Ret = LL_ERR_TIMEOUT;
+            break;
+        }
+        u32Count--;
+    }
+
+    return i32Ret;
+}
+
+/**
+ * @}
+ */
+
+#endif /* LL_WDT_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/

--- a/hc32f4a2/src/hc32f4a2_ll_interrupts_share.c
+++ b/hc32f4a2/src/hc32f4a2_ll_interrupts_share.c
@@ -1,0 +1,4517 @@
+/**
+ *******************************************************************************
+ * @file  hc32f4a2_ll_interrupts_share.c
+ * @brief This file provides firmware functions to manage the Share Interrupt
+ *        Controller (SHARE_INTERRUPTS).
+ @verbatim
+   Change Logs:
+   Date             Author          Notes
+   2022-03-31       CDT             First version
+   2022-10-31       CDT             Refine TMRA CMP DCU MAU share handler
+                                    Rename I2Cx_Error_IrqHandler as I2Cx_EE_IrqHandler
+   2023-09-30       CDT             Modify typo
+                                    IRQxxx_Handler add __DSB for Arm Errata 838869
+                                    The BCSTR register of TimerA is split into BCSTRH and BCSTRL
+                                    Modify for head file update: EIRQFR -> EIFR
+   2024-06-30       CDT             Add handler for USB
+   2024-09-13       CDT             Refine for USB interrupt
+ @endverbatim
+ *******************************************************************************
+ * Copyright (C) 2022-2025, Xiaohua Semiconductor Co., Ltd. All rights reserved.
+ *
+ * This software component is licensed by XHSC under BSD 3-Clause license
+ * (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                    opensource.org/licenses/BSD-3-Clause
+ *
+ *******************************************************************************
+ */
+
+/*******************************************************************************
+ * Include files
+ ******************************************************************************/
+#include "hc32f4a2_ll_interrupts_share.h"
+#include "hc32_ll_utility.h"
+
+/**
+ * @addtogroup LL_Driver
+ * @{
+ */
+
+/**
+ * @defgroup LL_HC32F4A2_SHARE_INTERRUPTS SHARE_INTERRUPTS
+ * @brief Share Interrupts Driver Library
+ * @{
+ */
+
+#if (LL_INTERRUPTS_SHARE_ENABLE == DDL_ON)
+
+/*******************************************************************************
+ * Local type definitions ('typedef')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local pre-processor symbols/macros ('#define')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Global variable definitions (declared in header file with 'extern')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local function prototypes ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Local variable definitions ('static')
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Function implementation - global ('extern') and local ('static')
+ ******************************************************************************/
+/**
+ * @defgroup Share_Interrupts_Global_Functions Share Interrupts Global Functions
+ * @{
+ */
+/**
+ * @brief  Share IRQ configure
+ * @param  [in] enIntSrc: Peripheral interrupt source @ref en_int_src_t
+ * @param  [in] enNewState: An @ref en_functional_state_t enumeration value.
+ * @retval int32_t:
+ *           - LL_OK: Share IRQ configure successfully
+ */
+int32_t INTC_ShareIrqCmd(en_int_src_t enIntSrc, en_functional_state_t enNewState)
+{
+    __IO uint32_t *INTC_VSSELx;
+
+    DDL_ASSERT(IS_FUNCTIONAL_STATE(enNewState));
+
+    INTC_VSSELx = (__IO uint32_t *)(((uint32_t)&CM_INTC->VSSEL128) + (4U * ((uint32_t)enIntSrc / 0x20U)));
+    if (ENABLE == enNewState) {
+        SET_REG32_BIT(*INTC_VSSELx, (1UL << ((uint32_t)enIntSrc & 0x1FUL)));
+    } else {
+        CLR_REG32_BIT(*INTC_VSSELx, (1UL << ((uint32_t)enIntSrc & 0x1FUL)));
+    }
+    return LL_OK;
+}
+
+/**
+ * @brief  Interrupt No.128 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ128_Handler(void)
+{
+    const uint32_t VSSEL128 = CM_INTC->VSSEL128;
+
+    /* external interrupt 00 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR0) && (0UL != (VSSEL128 & BIT_MASK_00))) {
+        EXTINT00_IrqHandler();
+    }
+    /* external interrupt 01 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR1) && (0UL != (VSSEL128 & BIT_MASK_01))) {
+        EXTINT01_IrqHandler();
+    }
+    /* external interrupt 02 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR2) && (0UL != (VSSEL128 & BIT_MASK_02))) {
+        EXTINT02_IrqHandler();
+    }
+    /* external interrupt 03 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR3) && (0UL != (VSSEL128 & BIT_MASK_03))) {
+        EXTINT03_IrqHandler();
+    }
+    /* external interrupt 04 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR4) && (0UL != (VSSEL128 & BIT_MASK_04))) {
+        EXTINT04_IrqHandler();
+    }
+    /* external interrupt 05 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR5) && (0UL != (VSSEL128 & BIT_MASK_05))) {
+        EXTINT05_IrqHandler();
+    }
+    /* external interrupt 06 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR6) && (0UL != (VSSEL128 & BIT_MASK_06))) {
+        EXTINT06_IrqHandler();
+    }
+    /* external interrupt 07 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR7) && (0UL != (VSSEL128 & BIT_MASK_07))) {
+        EXTINT07_IrqHandler();
+    }
+    /* external interrupt 08 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR8) && (0UL != (VSSEL128 & BIT_MASK_08))) {
+        EXTINT08_IrqHandler();
+    }
+    /* external interrupt 09 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR9) && (0UL != (VSSEL128 & BIT_MASK_09))) {
+        EXTINT09_IrqHandler();
+    }
+    /* external interrupt 10 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR10) && (0UL != (VSSEL128 & BIT_MASK_10))) {
+        EXTINT10_IrqHandler();
+    }
+    /* external interrupt 11 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR11) && (0UL != (VSSEL128 & BIT_MASK_11))) {
+        EXTINT11_IrqHandler();
+    }
+    /* external interrupt 12 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR12) && (0UL != (VSSEL128 & BIT_MASK_12))) {
+        EXTINT12_IrqHandler();
+    }
+    /* external interrupt 13 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR13) && (0UL != (VSSEL128 & BIT_MASK_13))) {
+        EXTINT13_IrqHandler();
+    }
+    /* external interrupt 14 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR14) && (0UL != (VSSEL128 & BIT_MASK_14))) {
+        EXTINT14_IrqHandler();
+    }
+    /* external interrupt 15 */
+    if ((1UL == bCM_INTC->EIFR_b.EIFR15) && (0UL != (VSSEL128 & BIT_MASK_15))) {
+        EXTINT15_IrqHandler();
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.129 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ129_Handler(void)
+{
+    const uint32_t VSSEL129 = CM_INTC->VSSEL129;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* DMA1 Ch.0 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL0_b.IE) {
+        /* DMA1 Ch.0 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC0) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC0) && (0UL != (VSSEL129 & BIT_MASK_00))) {
+                DMA1_TC0_IrqHandler();
+            }
+        }
+        /* DMA1 ch.0 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC0) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC0) && (0UL != (VSSEL129 & BIT_MASK_08))) {
+                DMA1_BTC0_IrqHandler();
+            }
+        }
+        /* DMA1 ch.0 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_00 | BIT_MASK_16);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_00 | BIT_MASK_16));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error0_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.1 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL1_b.IE) {
+        /* DMA1 Ch.1 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC1) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC1) && (0UL != (VSSEL129 & BIT_MASK_01))) {
+                DMA1_TC1_IrqHandler();
+            }
+        }
+        /* DMA1 ch.1 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC1) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC1) && (0UL != (VSSEL129 & BIT_MASK_09))) {
+                DMA1_BTC1_IrqHandler();
+            }
+        }
+        /* DMA1 ch.1 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_01 | BIT_MASK_17);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_01 | BIT_MASK_17));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error1_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.2 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL2_b.IE) {
+        /* DMA1 Ch.2 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC2) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC2) && (0UL != (VSSEL129 & BIT_MASK_02))) {
+                DMA1_TC2_IrqHandler();
+            }
+        }
+        /* DMA1 ch.2 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC2) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC2) && (0UL != (VSSEL129 & BIT_MASK_10))) {
+                DMA1_BTC2_IrqHandler();
+            }
+        }
+        /* DMA1 ch.2 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_02 | BIT_MASK_18);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_02 | BIT_MASK_18));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error2_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.3 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL3_b.IE) {
+        /* DMA1 Ch.3 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC3) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC3) && (0UL != (VSSEL129 & BIT_MASK_03))) {
+                DMA1_TC3_IrqHandler();
+            }
+        }
+        /* DMA1 ch.3 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC3) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC3) && (0UL != (VSSEL129 & BIT_MASK_11))) {
+                DMA1_BTC3_IrqHandler();
+            }
+        }
+        /* DMA1 ch.3 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_03 | BIT_MASK_19);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_03 | BIT_MASK_19));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error3_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.4 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL4_b.IE) {
+        /* DMA1 Ch.4 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC4) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC4) && (0UL != (VSSEL129 & BIT_MASK_04))) {
+                DMA1_TC4_IrqHandler();
+            }
+        }
+        /* DMA1 ch.4 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC4) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC4) && (0UL != (VSSEL129 & BIT_MASK_12))) {
+                DMA1_BTC4_IrqHandler();
+            }
+        }
+        /* DMA1 ch.4 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_04 | BIT_MASK_20);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_04 | BIT_MASK_20));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error4_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.5 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL5_b.IE) {
+        /* DMA1 Ch.5 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC5) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC5) && (0UL != (VSSEL129 & BIT_MASK_05))) {
+                DMA1_TC5_IrqHandler();
+            }
+        }
+        /* DMA1 ch.5 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC5) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC5) && (0UL != (VSSEL129 & BIT_MASK_13))) {
+                DMA1_BTC5_IrqHandler();
+            }
+        }
+        /* DMA1 ch.5 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_05 | BIT_MASK_21);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_05 | BIT_MASK_21));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error5_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.6 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL6_b.IE) {
+        /* DMA1 Ch.6 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC6) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC6) && (0UL != (VSSEL129 & BIT_MASK_06))) {
+                DMA1_TC6_IrqHandler();
+            }
+        }
+        /* DMA1 ch.6 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC6) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC6) && (0UL != (VSSEL129 & BIT_MASK_14))) {
+                DMA1_BTC6_IrqHandler();
+            }
+        }
+        /* DMA1 ch.6 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_06 | BIT_MASK_22);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_06 | BIT_MASK_22));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error6_IrqHandler();
+        }
+    }
+    /* DMA1 Ch.7 interrupt enabled */
+    if (1UL == bCM_DMA1->CHCTL7_b.IE) {
+        /* DMA1 Ch.7 Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKTC7) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.TC7) && (0UL != (VSSEL129 & BIT_MASK_07))) {
+                DMA1_TC7_IrqHandler();
+            }
+        }
+        /* DMA1 ch.7 Block Tx completed */
+        if (0UL == bCM_DMA1->INTMASK1_b.MSKBTC7) {
+            if ((1UL == bCM_DMA1->INTSTAT1_b.BTC7) && (0UL != (VSSEL129 & BIT_MASK_15))) {
+                DMA1_BTC7_IrqHandler();
+            }
+        }
+        /* DMA1 ch.7 Transfer/Request Error */
+        u32Tmp1 = CM_DMA1->INTSTAT0 & (BIT_MASK_07 | BIT_MASK_22);
+        u32Tmp2 = (uint32_t)(~(CM_DMA1->INTMASK0) & (BIT_MASK_07 | BIT_MASK_22));
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL129 & BIT_MASK_16))) {
+            DMA1_Error7_IrqHandler();
+        }
+    }
+    /* EFM error */
+    if (1UL == bCM_EFM->FITE_b.PEERRITE) {
+        /* EFM program/erase/protect/otp error */
+        u32Tmp1 = CM_EFM->FSR & (EFM_FSR_PRTWERR0 | EFM_FSR_PGSZERR0 | EFM_FSR_MISMTCH0 |    \
+                                 EFM_FSR_PRTWERR1 | EFM_FSR_PGSZERR1 | EFM_FSR_MISMTCH1 |    \
+                                 EFM_FSR_OTPWERR0);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL129 & BIT_MASK_17))) {
+            EFM_ProgramEraseError_IrqHandler();
+        }
+    }
+    /* EFM read collision error*/
+    if (1UL == bCM_EFM->FITE_b.COLERRITE) {
+        /* EFM read collision */
+        u32Tmp1 = CM_EFM->FSR & (EFM_FSR_COLERR0 | EFM_FSR_COLERR1);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL129 & BIT_MASK_18))) {
+            EFM_ColError_IrqHandler();
+        }
+    }
+    /* EFM operate end */
+    if (1UL == bCM_EFM->FITE_b.OPTENDITE) {
+        /* EFM operate end */
+        u32Tmp1 = CM_EFM->FSR & (EFM_FSR_OPTEND0 | EFM_FSR_OPTEND1);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL129 & BIT_MASK_19))) {
+            EFM_OpEnd_IrqHandler();
+        }
+    }
+    /* QSPI access error */
+    u32Tmp1 = CM_QSPI->SR & QSPI_SR_RAER;
+    if ((0UL != u32Tmp1) && (0UL != (VSSEL129 & BIT_MASK_22))) {
+        QSPI_Error_IrqHandler();
+    }
+    /*DCU1 */
+    if (1UL == bCM_DCU1->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU1->INTEVTSEL;
+        u32Tmp2 = CM_DCU1->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_23))) {
+            DCU1_IrqHandler();
+        }
+    }
+    /*DCU2 */
+    if (1UL == bCM_DCU2->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU2->INTEVTSEL;
+        u32Tmp2 = CM_DCU2->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_24))) {
+            DCU2_IrqHandler();
+        }
+    }
+    /*DCU3 */
+    if (1UL == bCM_DCU3->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU3->INTEVTSEL;
+        u32Tmp2 = CM_DCU3->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_25))) {
+            DCU3_IrqHandler();
+        }
+    }
+    /*DCU4 */
+    if (1UL == bCM_DCU4->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU4->INTEVTSEL;
+        u32Tmp2 = CM_DCU4->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_26))) {
+            DCU4_IrqHandler();
+        }
+    }
+    /*DCU5 */
+    if (1UL == bCM_DCU5->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU5->INTEVTSEL;
+        u32Tmp2 = CM_DCU5->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_27))) {
+            DCU5_IrqHandler();
+        }
+    }
+    /*DCU6 */
+    if (1UL == bCM_DCU6->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU6->INTEVTSEL;
+        u32Tmp2 = CM_DCU6->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_28))) {
+            DCU6_IrqHandler();
+        }
+    }
+    /*DCU7 */
+    if (1UL == bCM_DCU7->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU7->INTEVTSEL;
+        u32Tmp2 = CM_DCU7->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_29))) {
+            DCU7_IrqHandler();
+        }
+    }
+    /*DCU8 */
+    if (1UL == bCM_DCU8->CTL_b.INTEN) {
+        u32Tmp1 = CM_DCU8->INTEVTSEL;
+        u32Tmp2 = CM_DCU8->FLAG;
+        if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0E7FUL)) && (0UL != (VSSEL129 & BIT_MASK_30))) {
+            DCU8_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.130 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ130_Handler(void)
+{
+    const uint32_t VSSEL130 = CM_INTC->VSSEL130;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* MAU square */
+    if (1UL == bCM_MAU->CSR_b.INTEN) {
+        if (0UL != (VSSEL130 & BIT_MASK_19)) {
+            MAU_Sqrt_IrqHandler();
+        }
+    } else {
+        /* DMA2 Ch.0 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL0_b.IE) {
+            /* DMA2 Ch.0 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC0) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC0) && (0UL != (VSSEL130 & BIT_MASK_00))) {
+                    DMA2_TC0_IrqHandler();
+                }
+            }
+            /* DMA2 ch.0 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC0) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC0) && (0UL != (VSSEL130 & BIT_MASK_08))) {
+                    DMA2_BTC0_IrqHandler();
+                }
+            }
+            /* DMA2 ch.0 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_00 | BIT_MASK_16);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_00 | BIT_MASK_16));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error0_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.1 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL1_b.IE) {
+            /* DMA2 Ch.1 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC1) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC1) && (0UL != (VSSEL130 & BIT_MASK_01))) {
+                    DMA2_TC1_IrqHandler();
+                }
+            }
+            /* DMA2 ch.1 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC1) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC1) && (0UL != (VSSEL130 & BIT_MASK_09))) {
+                    DMA2_BTC1_IrqHandler();
+                }
+            }
+            /* DMA2 ch.1 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_01 | BIT_MASK_17);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_01 | BIT_MASK_17));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error1_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.2 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL2_b.IE) {
+            /* DMA2 Ch.2 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC2) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC2) && (0UL != (VSSEL130 & BIT_MASK_02))) {
+                    DMA2_TC2_IrqHandler();
+                }
+            }
+            /* DMA2 ch.2 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC2) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC2) && (0UL != (VSSEL130 & BIT_MASK_10))) {
+                    DMA2_BTC2_IrqHandler();
+                }
+            }
+            /* DMA2 ch.2 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_02 | BIT_MASK_18);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_02 | BIT_MASK_18));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error2_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.3 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL3_b.IE) {
+            /* DMA2 Ch.3 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC3) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC3) && (0UL != (VSSEL130 & BIT_MASK_03))) {
+                    DMA2_TC3_IrqHandler();
+                }
+            }
+            /* DMA2 ch.3 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC3) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC3) && (0UL != (VSSEL130 & BIT_MASK_11))) {
+                    DMA2_BTC3_IrqHandler();
+                }
+            }
+            /* DMA2 ch.3 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_03 | BIT_MASK_19);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_03 | BIT_MASK_19));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error3_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.4 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL4_b.IE) {
+            /* DMA2 Ch.4 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC4) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC4) && (0UL != (VSSEL130 & BIT_MASK_04))) {
+                    DMA2_TC4_IrqHandler();
+                }
+            }
+            /* DMA2 ch.4 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC4) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC4) && (0UL != (VSSEL130 & BIT_MASK_12))) {
+                    DMA2_BTC4_IrqHandler();
+                }
+            }
+            /* DMA2 ch.4 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_04 | BIT_MASK_20);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_04 | BIT_MASK_20));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error4_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.5 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL5_b.IE) {
+            /* DMA2 Ch.5 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC5) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC5) && (0UL != (VSSEL130 & BIT_MASK_05))) {
+                    DMA2_TC5_IrqHandler();
+                }
+            }
+            /* DMA2 ch.5 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC5) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC5) && (0UL != (VSSEL130 & BIT_MASK_13))) {
+                    DMA2_BTC5_IrqHandler();
+                }
+            }
+            /* DMA2 ch.5 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_05 | BIT_MASK_21);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_05 | BIT_MASK_21));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error5_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.6 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL6_b.IE) {
+            /* DMA2 Ch.6 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC6) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC6) && (0UL != (VSSEL130 & BIT_MASK_06))) {
+                    DMA2_TC6_IrqHandler();
+                }
+            }
+            /* DMA2 ch.6 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC6) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC6) && (0UL != (VSSEL130 & BIT_MASK_14))) {
+                    DMA2_BTC6_IrqHandler();
+                }
+            }
+            /* DMA2 ch.6 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_06 | BIT_MASK_22);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_06 | BIT_MASK_22));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error6_IrqHandler();
+            }
+        }
+        /* DMA2 Ch.7 interrupt enabled */
+        if (1UL == bCM_DMA2->CHCTL7_b.IE) {
+            /* DMA2 Ch.7 Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKTC7) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.TC7) && (0UL != (VSSEL130 & BIT_MASK_07))) {
+                    DMA2_TC7_IrqHandler();
+                }
+            }
+            /* DMA2 ch.7 Block Tx completed */
+            if (0UL == bCM_DMA2->INTMASK1_b.MSKBTC7) {
+                if ((1UL == bCM_DMA2->INTSTAT1_b.BTC7) && (0UL != (VSSEL130 & BIT_MASK_15))) {
+                    DMA2_BTC7_IrqHandler();
+                }
+            }
+            /* DMA2 ch.7 Transfer/Request Error */
+            u32Tmp1 = CM_DMA2->INTSTAT0 & (BIT_MASK_07 | BIT_MASK_22);
+            u32Tmp2 = (uint32_t)(~(CM_DMA2->INTMASK0) & (BIT_MASK_07 | BIT_MASK_22));
+            if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL130 & BIT_MASK_16))) {
+                DMA2_Error7_IrqHandler();
+            }
+        }
+        /* DVP frame start */
+        if (1UL == bCM_DVP->IER_b.FSIEN) {
+            if ((1UL == bCM_DVP->STR_b.FSF) && (0UL != (VSSEL130 & BIT_MASK_20))) {
+                DVP_FrameStart_IrqHandler();
+            }
+        }
+        /* DVP line start */
+        if (1UL == bCM_DVP->IER_b.LSIEN) {
+            if ((1UL == bCM_DVP->STR_b.LSF) && (0UL != (VSSEL130 & BIT_MASK_21))) {
+                DVP_LineStart_IrqHandler();
+            }
+        }
+        /* DVP line end */
+        if (1UL == bCM_DVP->IER_b.LEIEN) {
+            if ((1UL == bCM_DVP->STR_b.LEF) && (0UL != (VSSEL130 & BIT_MASK_22))) {
+                DVP_LineEnd_IrqHandler();
+            }
+        }
+        /* DVP frame end */
+        if (1UL == bCM_DVP->IER_b.FEIEN) {
+            if ((1UL == bCM_DVP->STR_b.FEF) && (0UL != (VSSEL130 & BIT_MASK_23))) {
+                DVP_FrameEnd_IrqHandler();
+            }
+        }
+        /* DVP software sync err */
+        if (1UL == bCM_DVP->IER_b.SQUERIEN) {
+            if ((1UL == bCM_DVP->STR_b.SQUERF) && (0UL != (VSSEL130 & BIT_MASK_24))) {
+                DVP_SWSyncError_IrqHandler();
+            }
+        }
+        /* DVP fifo overflow err */
+        if (1UL == bCM_DVP->IER_b.FIFOERIEN) {
+            if ((1UL == bCM_DVP->STR_b.FIFOERF) && (0UL != (VSSEL130 & BIT_MASK_25))) {
+                DVP_FifoError_IrqHandler();
+            }
+        }
+        /* FMAC 1 */
+        if (1UL == bCM_FMAC1->IER_b.INTEN) {
+            if ((1UL == bCM_FMAC1->STR_b.READY) && (0UL != (VSSEL130 & BIT_MASK_27))) {
+                FMAC1_IrqHandler();
+            }
+        }
+        /* FMAC 2 */
+        if (1UL == bCM_FMAC2->IER_b.INTEN) {
+            if ((1UL == bCM_FMAC2->STR_b.READY) && (0UL != (VSSEL130 & BIT_MASK_28))) {
+                FMAC2_IrqHandler();
+            }
+        }
+        /* FMAC 3 */
+        if (1UL == bCM_FMAC3->IER_b.INTEN) {
+            if ((1UL == bCM_FMAC3->STR_b.READY) && (0UL != (VSSEL130 & BIT_MASK_29))) {
+                FMAC3_IrqHandler();
+            }
+        }
+        /* FMAC 4 */
+        if (1UL == bCM_FMAC4->IER_b.INTEN) {
+            if ((1UL == bCM_FMAC4->STR_b.READY) && (0UL != (VSSEL130 & BIT_MASK_30))) {
+                FMAC4_IrqHandler();
+            }
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.131 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ131_Handler(void)
+{
+    const uint32_t VSSEL131 = CM_INTC->VSSEL131;
+    uint32_t u32Tmp1;
+
+    /* Timer0 unit1, Ch.A compare match */
+    if (1UL == bCM_TMR0_1->BCONR_b.INTENA) {
+        if ((1UL == bCM_TMR0_1->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_00))) {
+            TMR0_1_CmpA_IrqHandler();
+        }
+    }
+    /* Timer0 unit1, Ch.B compare match */
+    if (1UL == bCM_TMR0_1->BCONR_b.INTENB) {
+        if ((1UL == bCM_TMR0_1->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_01))) {
+            TMR0_1_CmpB_IrqHandler();
+        }
+    }
+    /* Timer0 unit2, Ch.A compare match */
+    if (1UL == bCM_TMR0_2->BCONR_b.INTENA) {
+        if ((1UL == bCM_TMR0_2->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_02))) {
+            TMR0_2_CmpA_IrqHandler();
+        }
+    }
+    /* Timer0 unit2, Ch.B compare match */
+    if (1UL == bCM_TMR0_2->BCONR_b.INTENB) {
+        if ((1UL == bCM_TMR0_2->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_03))) {
+            TMR0_2_CmpB_IrqHandler();
+        }
+    }
+    /* Timer2 unit1, Ch.A compare match */
+    if (1UL == bCM_TMR2_1->ICONR_b.CMENA) {
+        if ((1UL == bCM_TMR2_1->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_04))) {
+            TMR2_1_CmpA_IrqHandler();
+        }
+    }
+    /* Timer2 unit1, Ch.B compare match */
+    if (1UL == bCM_TMR2_1->ICONR_b.CMENB) {
+        if ((1UL == bCM_TMR2_1->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_05))) {
+            TMR2_1_CmpB_IrqHandler();
+        }
+    }
+    /* Timer2 unit1, Ch.A overflow */
+    if (1UL == bCM_TMR2_1->ICONR_b.OVENA) {
+        if ((1UL == bCM_TMR2_1->STFLR_b.OVFA) && (0UL != (VSSEL131 & BIT_MASK_06))) {
+            TMR2_1_OvfA_IrqHandler();
+        }
+    }
+    /* Timer2 unit1, Ch.B overflow */
+    if (1UL == bCM_TMR2_1->ICONR_b.OVENB) {
+        if ((1UL == bCM_TMR2_1->STFLR_b.OVFB) && (0UL != (VSSEL131 & BIT_MASK_07))) {
+            TMR2_1_OvfB_IrqHandler();
+        }
+    }
+    /* Timer2 unit2, Ch.A compare match */
+    if (1UL == bCM_TMR2_2->ICONR_b.CMENA) {
+        if ((1UL == bCM_TMR2_2->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_08))) {
+            TMR2_2_CmpA_IrqHandler();
+        }
+    }
+    /* Timer2 unit2, Ch.B compare match */
+    if (1UL == bCM_TMR2_2->ICONR_b.CMENB) {
+        if ((1UL == bCM_TMR2_2->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_09))) {
+            TMR2_2_CmpB_IrqHandler();
+        }
+    }
+    /* Timer2 unit2, Ch.A overflow */
+    if (1UL == bCM_TMR2_2->ICONR_b.OVENA) {
+        if ((1UL == bCM_TMR2_2->STFLR_b.OVFA) && (0UL != (VSSEL131 & BIT_MASK_10))) {
+            TMR2_2_OvfA_IrqHandler();
+        }
+    }
+    /* Timer2 unit2, Ch.B overflow */
+    if (1UL == bCM_TMR2_2->ICONR_b.OVENB) {
+        if ((1UL == bCM_TMR2_2->STFLR_b.OVFB) && (0UL != (VSSEL131 & BIT_MASK_11))) {
+            TMR2_2_OvfB_IrqHandler();
+        }
+    }
+    /* Timer2 unit3, Ch.A compare match */
+    if (1UL == bCM_TMR2_3->ICONR_b.CMENA) {
+        if ((1UL == bCM_TMR2_3->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_12))) {
+            TMR2_3_CmpA_IrqHandler();
+        }
+    }
+    /* Timer2 unit3, Ch.B compare match */
+    if (1UL == bCM_TMR2_3->ICONR_b.CMENB) {
+        if ((1UL == bCM_TMR2_3->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_13))) {
+            TMR2_3_CmpB_IrqHandler();
+        }
+    }
+    /* Timer2 unit3, Ch.A overflow */
+    if (1UL == bCM_TMR2_3->ICONR_b.OVENA) {
+        if ((1UL == bCM_TMR2_3->STFLR_b.OVFA) && (0UL != (VSSEL131 & BIT_MASK_14))) {
+            TMR2_3_OvfA_IrqHandler();
+        }
+    }
+    /* Timer2 unit3, Ch.B overflow */
+    if (1UL == bCM_TMR2_3->ICONR_b.OVENB) {
+        if ((1UL == bCM_TMR2_3->STFLR_b.OVFB) && (0UL != (VSSEL131 & BIT_MASK_15))) {
+            TMR2_3_OvfB_IrqHandler();
+        }
+    }
+    /* Timer2 unit4, Ch.A compare match */
+    if (1UL == bCM_TMR2_4->ICONR_b.CMENA) {
+        if ((1UL == bCM_TMR2_4->STFLR_b.CMFA) && (0UL != (VSSEL131 & BIT_MASK_16))) {
+            TMR2_4_CmpA_IrqHandler();
+        }
+    }
+    /* Timer2 unit4, Ch.B compare match */
+    if (1UL == bCM_TMR2_4->ICONR_b.CMENB) {
+        if ((1UL == bCM_TMR2_4->STFLR_b.CMFB) && (0UL != (VSSEL131 & BIT_MASK_17))) {
+            TMR2_4_CmpB_IrqHandler();
+        }
+    }
+    /* Timer2 unit4, Ch.A overflow */
+    if (1UL == bCM_TMR2_4->ICONR_b.OVENA) {
+        if ((1UL == bCM_TMR2_4->STFLR_b.OVFA) && (0UL != (VSSEL131 & BIT_MASK_18))) {
+            TMR2_4_OvfA_IrqHandler();
+        }
+    }
+    /* Timer2 unit4, Ch.B overflow */
+    if (1UL == bCM_TMR2_4->ICONR_b.OVENB) {
+        if ((1UL == bCM_TMR2_4->STFLR_b.OVFB) && (0UL != (VSSEL131 & BIT_MASK_19))) {
+            TMR2_4_OvfB_IrqHandler();
+        }
+    }
+    /* RTC time stamp 0 */
+    if (1UL == bCM_RTC->TPCR0_b.TPIE0) {
+        if ((1UL == bCM_RTC->TPSR_b.TPF0) && (0UL != (VSSEL131 & BIT_MASK_24))) {
+            RTC_TimeStamp0_IrqHandler();
+        }
+    }
+    /* RTC time stamp 1 */
+    if (1UL == bCM_RTC->TPCR1_b.TPIE1) {
+        if ((1UL == bCM_RTC->TPSR_b.TPF1) && (0UL != (VSSEL131 & BIT_MASK_24))) {
+            RTC_TimeStamp1_IrqHandler();
+        }
+    }
+    /* RTC alarm */
+    if (1UL == bCM_RTC->CR2_b.ALMIE) {
+        if ((1UL == bCM_RTC->CR2_b.ALMF) && (0UL != (VSSEL131 & BIT_MASK_25))) {
+            RTC_Alarm_IrqHandler();
+        }
+    }
+    /* RTC period */
+    if (1UL == bCM_RTC->CR2_b.PRDIE) {
+        if ((1UL == bCM_RTC->CR2_b.PRDF) && (0UL != (VSSEL131 & BIT_MASK_26))) {
+            RTC_Period_IrqHandler();
+        }
+    }
+    /* XTAL stop */
+    if (1UL == bCM_CMU->XTALSTDCR_b.XTALSTDIE) {
+        if ((1UL == bCM_CMU->XTALSTDSR_b.XTALSTDF) && (0UL != (VSSEL131 & BIT_MASK_29))) {
+            CLK_XtalStop_IrqHandler();
+        }
+    }
+    /* Wakeup timer overflow */
+    if (1UL == bCM_PWC->WKTC2_b.WKTCE) {
+        if ((1UL == bCM_PWC->WKTC2_b.WKOVF) && (0UL != (VSSEL131 & BIT_MASK_30))) {
+            PWC_WakeupTimer_IrqHandler();
+        }
+    }
+    /* SWDT underflow or refresh error */
+    u32Tmp1 = CM_SWDT->SR & (SWDT_SR_UDF | SWDT_SR_REF);
+    if ((0UL != u32Tmp1) && (0UL != (VSSEL131 & BIT_MASK_31))) {
+        SWDT_IrqHandler();
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.132 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ132_Handler(void)
+{
+    const uint32_t VSSEL132 = CM_INTC->VSSEL132;
+
+    /* Timer6 Unit.1 general compare match A */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMAF) && (0UL != (VSSEL132 & BIT_MASK_00))) {
+            TMR6_1_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 general compare match B */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMBF) && (0UL != (VSSEL132 & BIT_MASK_01))) {
+            TMR6_1_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 general compare match C */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMCF) && (0UL != (VSSEL132 & BIT_MASK_02))) {
+            TMR6_1_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 general compare match D */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMDF) && (0UL != (VSSEL132 & BIT_MASK_03))) {
+            TMR6_1_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 general compare match E */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMEF) && (0UL != (VSSEL132 & BIT_MASK_04))) {
+            TMR6_1_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 general compare match F */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMFF) && (0UL != (VSSEL132 & BIT_MASK_05))) {
+            TMR6_1_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 overflow*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.OVFF) && (0UL != (VSSEL132 & BIT_MASK_06))) {
+            TMR6_1_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 underflow*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.UDFF) && (0UL != (VSSEL132 & BIT_MASK_07))) {
+            TMR6_1_GUdf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 U phase higher compare match */
+    if (1UL == bCM_TMR4_1->OCSRU_b.OCIEH) {
+        if ((1UL == bCM_TMR4_1->OCSRU_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_08))) {
+            TMR4_1_GCmpUH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 U phase lower compare match */
+    if (1UL == bCM_TMR4_1->OCSRU_b.OCIEL) {
+        if ((1UL == bCM_TMR4_1->OCSRU_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_09))) {
+            TMR4_1_GCmpUL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 V phase higher compare match */
+    if (1UL == bCM_TMR4_1->OCSRV_b.OCIEH) {
+        if ((1UL == bCM_TMR4_1->OCSRV_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_10))) {
+            TMR4_1_GCmpVH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 V phase lower compare match */
+    if (1UL == bCM_TMR4_1->OCSRV_b.OCIEL) {
+        if ((1UL == bCM_TMR4_1->OCSRV_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_11))) {
+            TMR4_1_GCmpVL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 W phase higher compare match */
+    if (1UL == bCM_TMR4_1->OCSRW_b.OCIEH) {
+        if ((1UL == bCM_TMR4_1->OCSRW_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_12))) {
+            TMR4_1_GCmpWH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 W phase lower compare match */
+    if (1UL == bCM_TMR4_1->OCSRW_b.OCIEL) {
+        if ((1UL == bCM_TMR4_1->OCSRW_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_13))) {
+            TMR4_1_GCmpWL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 overflow */
+    if (1UL == bCM_TMR4_1->CCSR_b.IRQPEN) {
+        if ((1UL == bCM_TMR4_1->CCSR_b.IRQPF) && (0UL != (VSSEL132 & BIT_MASK_14))) {
+            TMR4_1_Ovf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 underflow */
+    if (1UL == bCM_TMR4_1->CCSR_b.IRQZEN) {
+        if ((1UL == bCM_TMR4_1->CCSR_b.IRQZF) && (0UL != (VSSEL132 & BIT_MASK_15))) {
+            TMR4_1_Udf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match A */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMAF) && (0UL != (VSSEL132 & BIT_MASK_16))) {
+            TMR6_2_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match B */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMBF) && (0UL != (VSSEL132 & BIT_MASK_17))) {
+            TMR6_2_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match C */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMCF) && (0UL != (VSSEL132 & BIT_MASK_18))) {
+            TMR6_2_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match D */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMDF) && (0UL != (VSSEL132 & BIT_MASK_19))) {
+            TMR6_2_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match E */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMEF) && (0UL != (VSSEL132 & BIT_MASK_20))) {
+            TMR6_2_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 general compare match F */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMFF) && (0UL != (VSSEL132 & BIT_MASK_21))) {
+            TMR6_2_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 overflow*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.OVFF) && (0UL != (VSSEL132 & BIT_MASK_22))) {
+            TMR6_2_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 underflow*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.UDFF) && (0UL != (VSSEL132 & BIT_MASK_23))) {
+            TMR6_2_GUdf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 U phase higher compare match */
+    if (1UL == bCM_TMR4_2->OCSRU_b.OCIEH) {
+        if ((1UL == bCM_TMR4_2->OCSRU_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_24))) {
+            TMR4_2_GCmpUH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 U phase lower compare match */
+    if (1UL == bCM_TMR4_2->OCSRU_b.OCIEL) {
+        if ((1UL == bCM_TMR4_2->OCSRU_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_25))) {
+            TMR4_2_GCmpUL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 V phase higher compare match */
+    if (1UL == bCM_TMR4_2->OCSRV_b.OCIEH) {
+        if ((1UL == bCM_TMR4_2->OCSRV_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_26))) {
+            TMR4_2_GCmpVH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 V phase lower compare match */
+    if (1UL == bCM_TMR4_2->OCSRV_b.OCIEL) {
+        if ((1UL == bCM_TMR4_2->OCSRV_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_27))) {
+            TMR4_2_GCmpVL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 W phase higher compare match */
+    if (1UL == bCM_TMR4_2->OCSRW_b.OCIEH) {
+        if ((1UL == bCM_TMR4_2->OCSRW_b.OCFH) && (0UL != (VSSEL132 & BIT_MASK_28))) {
+            TMR4_2_GCmpWH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 W phase lower compare match */
+    if (1UL == bCM_TMR4_2->OCSRW_b.OCIEL) {
+        if ((1UL == bCM_TMR4_2->OCSRW_b.OCFL) && (0UL != (VSSEL132 & BIT_MASK_29))) {
+            TMR4_2_GCmpWL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 overflow */
+    if (1UL == bCM_TMR4_2->CCSR_b.IRQPEN) {
+        if ((1UL == bCM_TMR4_2->CCSR_b.IRQPF) && (0UL != (VSSEL132 & BIT_MASK_30))) {
+            TMR4_2_Ovf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 underflow */
+    if (1UL == bCM_TMR4_2->CCSR_b.IRQZEN) {
+        if ((1UL == bCM_TMR4_2->CCSR_b.IRQZF) && (0UL != (VSSEL132 & BIT_MASK_31))) {
+            TMR4_2_Udf_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.133 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ133_Handler(void)
+{
+    const uint32_t VSSEL133 = CM_INTC->VSSEL133;
+
+    /* Timer6 Unit.3 general compare match A */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMAF) && (0UL != (VSSEL133 & BIT_MASK_00))) {
+            TMR6_3_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 general compare match B */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMBF) && (0UL != (VSSEL133 & BIT_MASK_01))) {
+            TMR6_3_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 general compare match C */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMCF) && (0UL != (VSSEL133 & BIT_MASK_02))) {
+            TMR6_3_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 general compare match D */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMDF) && (0UL != (VSSEL133 & BIT_MASK_03))) {
+            TMR6_3_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 general compare match E */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMEF) && (0UL != (VSSEL133 & BIT_MASK_04))) {
+            TMR6_3_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 general compare match F */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMFF) && (0UL != (VSSEL133 & BIT_MASK_05))) {
+            TMR6_3_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 overflow*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.OVFF) && (0UL != (VSSEL133 & BIT_MASK_06))) {
+            TMR6_3_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 underflow*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.UDFF) && (0UL != (VSSEL133 & BIT_MASK_07))) {
+            TMR6_3_GUdf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 U phase higher compare match */
+    if (1UL == bCM_TMR4_3->OCSRU_b.OCIEH) {
+        if ((1UL == bCM_TMR4_3->OCSRU_b.OCFH) && (0UL != (VSSEL133 & BIT_MASK_08))) {
+            TMR4_3_GCmpUH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 U phase lower compare match */
+    if (1UL == bCM_TMR4_3->OCSRU_b.OCIEL) {
+        if ((1UL == bCM_TMR4_3->OCSRU_b.OCFL) && (0UL != (VSSEL133 & BIT_MASK_09))) {
+            TMR4_3_GCmpUL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 V phase higher compare match */
+    if (1UL == bCM_TMR4_3->OCSRV_b.OCIEH) {
+        if ((1UL == bCM_TMR4_3->OCSRV_b.OCFH) && (0UL != (VSSEL133 & BIT_MASK_10))) {
+            TMR4_3_GCmpVH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 V phase lower compare match */
+    if (1UL == bCM_TMR4_3->OCSRV_b.OCIEL) {
+        if ((1UL == bCM_TMR4_3->OCSRV_b.OCFL) && (0UL != (VSSEL133 & BIT_MASK_11))) {
+            TMR4_3_GCmpVL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 W phase higher compare match */
+    if (1UL == bCM_TMR4_3->OCSRW_b.OCIEH) {
+        if ((1UL == bCM_TMR4_3->OCSRW_b.OCFH) && (0UL != (VSSEL133 & BIT_MASK_12))) {
+            TMR4_3_GCmpWH_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 W phase lower compare match */
+    if (1UL == bCM_TMR4_3->OCSRW_b.OCIEL) {
+        if ((1UL == bCM_TMR4_3->OCSRW_b.OCFL) && (0UL != (VSSEL133 & BIT_MASK_13))) {
+            TMR4_3_GCmpWL_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 overflow */
+    if (1UL == bCM_TMR4_3->CCSR_b.IRQPEN) {
+        if ((1UL == bCM_TMR4_3->CCSR_b.IRQPF) && (0UL != (VSSEL133 & BIT_MASK_14))) {
+            TMR4_3_Ovf_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 underflow */
+    if (1UL == bCM_TMR4_3->CCSR_b.IRQZEN) {
+        if ((1UL == bCM_TMR4_3->CCSR_b.IRQZF) && (0UL != (VSSEL133 & BIT_MASK_15))) {
+            TMR4_3_Udf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 dead time */
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.DTEF) && (0UL != (VSSEL133 & BIT_MASK_16))) {
+            TMR6_1_GDte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 specified up compare match A*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMSAUF) && (0UL != (VSSEL133 & BIT_MASK_19))) {
+            TMR6_1_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 specified down compare match A*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMSADF) && (0UL != (VSSEL133 & BIT_MASK_19))) {
+            TMR6_1_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 specified up compare match B*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMSBUF) && (0UL != (VSSEL133 & BIT_MASK_20))) {
+            TMR6_1_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.1 specified down compare match B*/
+    if (1UL == bCM_TMR6_1->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_1->STFLR_b.CMSBDF) && (0UL != (VSSEL133 & BIT_MASK_20))) {
+            TMR6_1_SCmpDownB_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 U phase reload */
+    if (0UL == bCM_TMR4_1->RCSR_b.RTIDU) {
+        if ((1UL == bCM_TMR4_1->RCSR_b.RTIFU) && (0UL != (VSSEL133 & BIT_MASK_21))) {
+            TMR4_1_ReloadU_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 V phase reload */
+    if (0UL == bCM_TMR4_1->RCSR_b.RTIDV) {
+        if ((1UL == bCM_TMR4_1->RCSR_b.RTIFV) && (0UL != (VSSEL133 & BIT_MASK_22))) {
+            TMR4_1_ReloadV_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.1 W phase reload */
+    if (0UL == bCM_TMR4_1->RCSR_b.RTIDW) {
+        if ((1UL == bCM_TMR4_1->RCSR_b.RTIFW) && (0UL != (VSSEL133 & BIT_MASK_23))) {
+            TMR4_1_ReloadW_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 dead time */
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.DTEF) && (0UL != (VSSEL133 & BIT_MASK_24))) {
+            TMR6_2_GDte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 specified up compare match A*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMSAUF) && (0UL != (VSSEL133 & BIT_MASK_27))) {
+            TMR6_2_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 specified down compare match A*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMSADF) && (0UL != (VSSEL133 & BIT_MASK_27))) {
+            TMR6_2_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 specified up compare match B*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMSBUF) && (0UL != (VSSEL133 & BIT_MASK_28))) {
+            TMR6_2_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.2 specified down compare match B*/
+    if (1UL == bCM_TMR6_2->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_2->STFLR_b.CMSBDF) && (0UL != (VSSEL133 & BIT_MASK_28))) {
+            TMR6_2_SCmpDownB_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 U phase reload */
+    if (0UL == bCM_TMR4_2->RCSR_b.RTIDU) {
+        if ((1UL == bCM_TMR4_2->RCSR_b.RTIFU) && (0UL != (VSSEL133 & BIT_MASK_29))) {
+            TMR4_2_ReloadU_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 V phase reload */
+    if (0UL == bCM_TMR4_2->RCSR_b.RTIDV) {
+        if ((1UL == bCM_TMR4_2->RCSR_b.RTIFV) && (0UL != (VSSEL133 & BIT_MASK_30))) {
+            TMR4_2_ReloadV_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.2 W phase reload */
+    if (0UL == bCM_TMR4_2->RCSR_b.RTIDW) {
+        if ((1UL == bCM_TMR4_2->RCSR_b.RTIFW) && (0UL != (VSSEL133 & BIT_MASK_31))) {
+            TMR4_2_ReloadW_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.134 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ134_Handler(void)
+{
+    const uint32_t VSSEL134 = CM_INTC->VSSEL134;
+
+    /* Timer6 Unit.3 dead time */
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.DTEF) && (0UL != (VSSEL134 & BIT_MASK_00))) {
+            TMR6_3_GDte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 specified up compare match A*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMSAUF) && (0UL != (VSSEL134 & BIT_MASK_03))) {
+            TMR6_3_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 specified down compare match A*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMSADF) && (0UL != (VSSEL134 & BIT_MASK_03))) {
+            TMR6_3_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 specified up compare match B*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMSBUF) && (0UL != (VSSEL134 & BIT_MASK_04))) {
+            TMR6_3_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.3 specified down compare match B*/
+    if (1UL == bCM_TMR6_3->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_3->STFLR_b.CMSBDF) && (0UL != (VSSEL134 & BIT_MASK_04))) {
+            TMR6_3_SCmpDownB_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 U phase reload */
+    if (0UL == bCM_TMR4_3->RCSR_b.RTIDU) {
+        if ((1UL == bCM_TMR4_3->RCSR_b.RTIFU) && (0UL != (VSSEL134 & BIT_MASK_05))) {
+            TMR4_3_ReloadU_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 V phase reload */
+    if (0UL == bCM_TMR4_3->RCSR_b.RTIDV) {
+        if ((1UL == bCM_TMR4_3->RCSR_b.RTIFV) && (0UL != (VSSEL134 & BIT_MASK_06))) {
+            TMR4_3_ReloadV_IrqHandler();
+        }
+    }
+    /* Timer4 Unit.3 W phase reload */
+    if (0UL == bCM_TMR4_3->RCSR_b.RTIDW) {
+        if ((1UL == bCM_TMR4_3->RCSR_b.RTIFW) && (0UL != (VSSEL134 & BIT_MASK_07))) {
+            TMR4_3_ReloadW_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match A */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMAF) && (0UL != (VSSEL134 & BIT_MASK_16))) {
+            TMR6_4_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match B */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMBF) && (0UL != (VSSEL134 & BIT_MASK_17))) {
+            TMR6_4_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match C */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMCF) && (0UL != (VSSEL134 & BIT_MASK_18))) {
+            TMR6_4_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match D */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMDF) && (0UL != (VSSEL134 & BIT_MASK_19))) {
+            TMR6_4_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match E */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMEF) && (0UL != (VSSEL134 & BIT_MASK_20))) {
+            TMR6_4_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 general compare match F */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMFF) && (0UL != (VSSEL134 & BIT_MASK_21))) {
+            TMR6_4_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 overflow*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.OVFF) && (0UL != (VSSEL134 & BIT_MASK_22))) {
+            TMR6_4_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 underflow*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.UDFF) && (0UL != (VSSEL134 & BIT_MASK_23))) {
+            TMR6_4_GUdf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 dead time */
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.DTEF) && (0UL != (VSSEL134 & BIT_MASK_24))) {
+            TMR6_4_Gdte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 specified up compare match A*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMSAUF) && (0UL != (VSSEL134 & BIT_MASK_27))) {
+            TMR6_4_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 specified down compare match A*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMSADF) && (0UL != (VSSEL134 & BIT_MASK_27))) {
+            TMR6_4_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 specified up compare match B*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMSBUF) && (0UL != (VSSEL134 & BIT_MASK_28))) {
+            TMR6_4_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.4 specified down compare match B*/
+    if (1UL == bCM_TMR6_4->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_4->STFLR_b.CMSBDF) && (0UL != (VSSEL134 & BIT_MASK_28))) {
+            TMR6_4_SCmpDownB_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.135 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ135_Handler(void)
+{
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+    const uint32_t VSSEL135 = CM_INTC->VSSEL135;
+
+    /* Timer6 Unit.5 general compare match A */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMAF) && (0UL != (VSSEL135 & BIT_MASK_00))) {
+            TMR6_5_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 general compare match B */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMBF) && (0UL != (VSSEL135 & BIT_MASK_01))) {
+            TMR6_5_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 general compare match C */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMCF) && (0UL != (VSSEL135 & BIT_MASK_02))) {
+            TMR6_5_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 general compare match D */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMDF) && (0UL != (VSSEL135 & BIT_MASK_03))) {
+            TMR6_5_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 general compare match E */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMEF) && (0UL != (VSSEL135 & BIT_MASK_04))) {
+            TMR6_5_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 general compare match F */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMFF) && (0UL != (VSSEL135 & BIT_MASK_05))) {
+            TMR6_5_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 overflow*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.OVFF) && (0UL != (VSSEL135 & BIT_MASK_06))) {
+            TMR6_5_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 underflow*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.UDFF) && (0UL != (VSSEL135 & BIT_MASK_07))) {
+            TMR6_5_GUdf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 dead time */
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.DTEF) && (0UL != (VSSEL135 & BIT_MASK_08))) {
+            TMR6_5_Gdte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 specified up compare match A*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMSAUF) && (0UL != (VSSEL135 & BIT_MASK_11))) {
+            TMR6_5_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 specified down compare match A*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMSADF) && (0UL != (VSSEL135 & BIT_MASK_11))) {
+            TMR6_5_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 specified up compare match B*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMSBUF) && (0UL != (VSSEL135 & BIT_MASK_12))) {
+            TMR6_5_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.5 specified down compare match B*/
+    if (1UL == bCM_TMR6_5->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_5->STFLR_b.CMSBDF) && (0UL != (VSSEL135 & BIT_MASK_12))) {
+            TMR6_5_SCmpDownB_IrqHandler();
+        }
+    }
+    /* TimerA Unit.1 overflow */
+    if (1UL == bCM_TMRA_1->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_1->BCSTRH_b.OVFF) && (0UL != (VSSEL135 & BIT_MASK_13))) {
+            TMRA_1_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.1 underflow */
+    if (1UL == bCM_TMRA_1->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_1->BCSTRH_b.UDFF) && (0UL != (VSSEL135 & BIT_MASK_14))) {
+            TMRA_1_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_1->ICONR;
+    u32Tmp2 = CM_TMRA_1->STFLR;
+    /* TimerA Unit.1 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL135 & BIT_MASK_15))) {
+        TMRA_1_Cmp_IrqHandler();
+    }
+    /* Timer6 Unit.6 general compare match A */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMAF) && (0UL != (VSSEL135 & BIT_MASK_16))) {
+            TMR6_6_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 general compare match B */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMBF) && (0UL != (VSSEL135 & BIT_MASK_17))) {
+            TMR6_6_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 general compare match C */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMCF) && (0UL != (VSSEL135 & BIT_MASK_18))) {
+            TMR6_6_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 general compare match D */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMDF) && (0UL != (VSSEL135 & BIT_MASK_19))) {
+            TMR6_6_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 general compare match E */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMEF) && (0UL != (VSSEL135 & BIT_MASK_20))) {
+            TMR6_6_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 general compare match F */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMFF) && (0UL != (VSSEL135 & BIT_MASK_21))) {
+            TMR6_6_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 overflow*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.OVFF) && (0UL != (VSSEL135 & BIT_MASK_22))) {
+            TMR6_6_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 underflow*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.UDFF) && (0UL != (VSSEL135 & BIT_MASK_23))) {
+            TMR6_6_GUdf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 dead time */
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.DTEF) && (0UL != (VSSEL135 & BIT_MASK_24))) {
+            TMR6_6_Gdte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 specified up compare match A*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMSAUF) && (0UL != (VSSEL135 & BIT_MASK_27))) {
+            TMR6_6_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 specified down compare match A*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMSADF) && (0UL != (VSSEL135 & BIT_MASK_27))) {
+            TMR6_6_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 specified up compare match B*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMSBUF) && (0UL != (VSSEL135 & BIT_MASK_28))) {
+            TMR6_6_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.6 specified down compare match B*/
+    if (1UL == bCM_TMR6_6->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_6->STFLR_b.CMSBDF) && (0UL != (VSSEL135 & BIT_MASK_28))) {
+            TMR6_6_SCmpDownB_IrqHandler();
+        }
+    }
+    /* TimerA Unit.2 overflow */
+    if (1UL == bCM_TMRA_2->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_2->BCSTRH_b.OVFF) && (0UL != (VSSEL135 & BIT_MASK_29))) {
+            TMRA_2_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.2 underflow */
+    if (1UL == bCM_TMRA_2->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_2->BCSTRH_b.UDFF) && (0UL != (VSSEL135 & BIT_MASK_30))) {
+            TMRA_2_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_2->ICONR;
+    u32Tmp2 = CM_TMRA_2->STFLR;
+    /* TimerA Unit.2 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL135 & BIT_MASK_31))) {
+        TMRA_2_Cmp_IrqHandler();
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.136 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ136_Handler(void)
+{
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+    const uint32_t VSSEL136 = CM_INTC->VSSEL136;
+
+    /* Timer6 Unit.7 general compare match A */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMAF) && (0UL != (VSSEL136 & BIT_MASK_00))) {
+            TMR6_7_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 general compare match B */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMBF) && (0UL != (VSSEL136 & BIT_MASK_01))) {
+            TMR6_7_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 general compare match C */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMCF) && (0UL != (VSSEL136 & BIT_MASK_02))) {
+            TMR6_7_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 general compare match D */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMDF) && (0UL != (VSSEL136 & BIT_MASK_03))) {
+            TMR6_7_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 general compare match E */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMEF) && (0UL != (VSSEL136 & BIT_MASK_04))) {
+            TMR6_7_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 general compare match F */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMFF) && (0UL != (VSSEL136 & BIT_MASK_05))) {
+            TMR6_7_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 overflow*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.OVFF) && (0UL != (VSSEL136 & BIT_MASK_06))) {
+            TMR6_7_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 underflow*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.UDFF) && (0UL != (VSSEL136 & BIT_MASK_07))) {
+            TMR6_7_GUdf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 dead time */
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.DTEF) && (0UL != (VSSEL136 & BIT_MASK_08))) {
+            TMR6_7_Gdte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 specified up compare match A*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMSAUF) && (0UL != (VSSEL136 & BIT_MASK_11))) {
+            TMR6_7_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 specified down compare match A*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMSADF) && (0UL != (VSSEL136 & BIT_MASK_11))) {
+            TMR6_7_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 specified up compare match B*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMSBUF) && (0UL != (VSSEL136 & BIT_MASK_12))) {
+            TMR6_7_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.7 specified down compare match B*/
+    if (1UL == bCM_TMR6_7->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_7->STFLR_b.CMSBDF) && (0UL != (VSSEL136 & BIT_MASK_12))) {
+            TMR6_7_SCmpDownB_IrqHandler();
+        }
+    }
+    /* TimerA Unit.3 overflow */
+    if (1UL == bCM_TMRA_3->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_3->BCSTRH_b.OVFF) && (0UL != (VSSEL136 & BIT_MASK_13))) {
+            TMRA_3_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.3 underflow */
+    if (1UL == bCM_TMRA_3->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_3->BCSTRH_b.UDFF) && (0UL != (VSSEL136 & BIT_MASK_14))) {
+            TMRA_3_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_3->ICONR;
+    u32Tmp2 = CM_TMRA_3->STFLR;
+    /* TimerA Unit.3 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL136 & BIT_MASK_15))) {
+        TMRA_3_Cmp_IrqHandler();
+    }
+    /* Timer6 Unit.8 general compare match A */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENA) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMAF) && (0UL != (VSSEL136 & BIT_MASK_16))) {
+            TMR6_8_GCmpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 general compare match B */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENB) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMBF) && (0UL != (VSSEL136 & BIT_MASK_17))) {
+            TMR6_8_GCmpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 general compare match C */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENC) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMCF) && (0UL != (VSSEL136 & BIT_MASK_18))) {
+            TMR6_8_GCmpC_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 general compare match D */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTEND) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMDF) && (0UL != (VSSEL136 & BIT_MASK_19))) {
+            TMR6_8_GCmpD_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 general compare match E */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENE) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMEF) && (0UL != (VSSEL136 & BIT_MASK_20))) {
+            TMR6_8_GCmpE_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 general compare match F */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENF) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMFF) && (0UL != (VSSEL136 & BIT_MASK_21))) {
+            TMR6_8_GCmpF_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 overflow*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENOVF) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.OVFF) && (0UL != (VSSEL136 & BIT_MASK_22))) {
+            TMR6_8_GOvf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 underflow*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENUDF) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.UDFF) && (0UL != (VSSEL136 & BIT_MASK_23))) {
+            TMR6_8_GUdf_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 dead time */
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENDTE) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.DTEF) && (0UL != (VSSEL136 & BIT_MASK_24))) {
+            TMR6_8_Gdte_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 specified up compare match A*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENSAU) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMSAUF) && (0UL != (VSSEL136 & BIT_MASK_27))) {
+            TMR6_8_SCmpUpA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 specified down compare match A*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENSAD) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMSADF) && (0UL != (VSSEL136 & BIT_MASK_27))) {
+            TMR6_8_SCmpDownA_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 specified up compare match B*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENSBU) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMSBUF) && (0UL != (VSSEL136 & BIT_MASK_28))) {
+            TMR6_8_SCmpUpB_IrqHandler();
+        }
+    }
+    /* Timer6 Unit.8 specified down compare match B*/
+    if (1UL == bCM_TMR6_8->ICONR_b.INTENSBD) {
+        if ((1UL == bCM_TMR6_8->STFLR_b.CMSBDF) && (0UL != (VSSEL136 & BIT_MASK_28))) {
+            TMR6_8_SCmpDownB_IrqHandler();
+        }
+    }
+    /* TimerA Unit.4 overflow */
+    if (1UL == bCM_TMRA_4->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_4->BCSTRH_b.OVFF) && (0UL != (VSSEL136 & BIT_MASK_29))) {
+            TMRA_4_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.4 underflow */
+    if (1UL == bCM_TMRA_4->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_4->BCSTRH_b.UDFF) && (0UL != (VSSEL136 & BIT_MASK_30))) {
+            TMRA_4_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_4->ICONR;
+    u32Tmp2 = CM_TMRA_4->STFLR;
+    /* TimerA Unit.4 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL136 & BIT_MASK_31))) {
+        TMRA_4_Cmp_IrqHandler();
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.137 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ137_Handler(void)
+{
+    const uint32_t VSSEL137 = CM_INTC->VSSEL137;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* EMB0 */
+    u32Tmp1 = CM_EMB0->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB0->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_00))) {
+        EMB_GR0_IrqHandler();
+    }
+    /* EMB1 */
+    u32Tmp1 = CM_EMB1->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB1->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_01))) {
+        EMB_GR1_IrqHandler();
+    }
+    /* EMB2 */
+    u32Tmp1 = CM_EMB2->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB2->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_02))) {
+        EMB_GR2_IrqHandler();
+    }
+    /* EMB3 */
+    u32Tmp1 = CM_EMB3->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB3->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_03))) {
+        EMB_GR3_IrqHandler();
+    }
+    /* EMB4 */
+    u32Tmp1 = CM_EMB4->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB4->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_04))) {
+        EMB_GR4_IrqHandler();
+    }
+    /* EMB5 */
+    u32Tmp1 = CM_EMB5->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB5->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_05))) {
+        EMB_GR5_IrqHandler();
+    }
+    /* EMB6 */
+    u32Tmp1 = CM_EMB6->INTEN & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                                BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    u32Tmp2 = CM_EMB6->STAT & (BIT_MASK_01 | BIT_MASK_02 | BIT_MASK_03 |   \
+                               BIT_MASK_08 | BIT_MASK_09 | BIT_MASK_10 | BIT_MASK_11);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_06))) {
+        EMB_GR6_IrqHandler();
+    }
+    if (1UL == bCM_USBHS->GAHBCFG_b.GINTMSK) {
+        /* USB HS EP1 out interrupt */
+        u32Tmp1 = bCM_USBHS->DEACHINT_b.OEP1INT;
+        u32Tmp2 = bCM_USBHS->DEACHINTMSK_b.OEP1INTM;
+        if ((0UL != u32Tmp1) && (0UL != u32Tmp2) && (0UL != (VSSEL137 & BIT_MASK_07))) {
+            USBHS_EP1Out_IrqHandler();
+        }
+
+        /* USB HS EP1 in interrupt */
+        u32Tmp1 = bCM_USBHS->DEACHINT_b.IEP1INT;
+        u32Tmp2 = bCM_USBHS->DEACHINTMSK_b.IEP1INTM;
+        if ((0UL != u32Tmp1) && (0UL != u32Tmp2) && (0UL != (VSSEL137 & BIT_MASK_08))) {
+            USBHS_EP1In_IrqHandler();
+        }
+
+        /* USB HS global interrupt */
+        u32Tmp1 = CM_USBHS->GINTMSK & 0xFF7CFCFBUL;
+        u32Tmp2 = CM_USBHS->GINTSTS & 0xFF7CFCFBUL;
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL137 & BIT_MASK_09))) {
+            USBHS_Global_IrqHandler();
+        }
+
+        /* USB HS wakeup interrupt */
+        u32Tmp1 = bCM_USBHS->GINTSTS_b.WKUINT;
+        u32Tmp2 = bCM_USBHS->GINTMSK_b.WKUIM;
+        if ((0UL != u32Tmp1) && (0UL != u32Tmp2) && (0UL != (VSSEL137 & BIT_MASK_10))) {
+            USBHS_Wakeup_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART1->CR1_b.RIE) {
+        /* USART Ch.1 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART1->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL137 & BIT_MASK_12))) {
+            USART1_RxError_IrqHandler();
+        }
+        /* USART Ch.1 Rx end */
+        if ((1UL == bCM_USART1->SR_b.RXNE) && (0UL != (VSSEL137 & BIT_MASK_13))) {
+            USART1_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.1 Tx buffer empty */
+    if (1UL == bCM_USART1->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART1->SR_b.TXE) && (0UL != (VSSEL137 & BIT_MASK_14))) {
+            USART1_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.1 Tx end */
+    if (1UL == bCM_USART1->CR1_b.TCIE) {
+        if ((1UL == bCM_USART1->SR_b.TC) && (0UL != (VSSEL137 & BIT_MASK_15))) {
+            USART1_TxComplete_IrqHandler();
+        }
+    }
+    /* USART Ch.1 Rx timeout */
+    if (1UL == bCM_USART1->CR1_b.RTOIE) {
+        if ((1UL == bCM_USART1->SR_b.RTOF) && (0UL != (VSSEL137 & BIT_MASK_16))) {
+            USART1_RxTO_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART2->CR1_b.RIE) {
+        /* USART Ch.2 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART2->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL137 & BIT_MASK_17))) {
+            USART2_RxError_IrqHandler();
+        }
+        /* USART Ch.2 Rx end */
+        if ((1UL == bCM_USART2->SR_b.RXNE) && (0UL != (VSSEL137 & BIT_MASK_18))) {
+            USART2_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.2 Tx buffer empty */
+    if (1UL == bCM_USART2->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART2->SR_b.TXE) && (0UL != (VSSEL137 & BIT_MASK_19))) {
+            USART2_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.2 Tx end */
+    if (1UL == bCM_USART2->CR1_b.TCIE) {
+        if ((1UL == bCM_USART2->SR_b.TC) && (0UL != (VSSEL137 & BIT_MASK_20))) {
+            USART2_TxComplete_IrqHandler();
+        }
+    }
+    /* USART Ch.2 Tx timeout */
+    if (1UL == bCM_USART2->CR1_b.RTOIE) {
+        if ((1UL == bCM_USART2->SR_b.RTOF) && (0UL != (VSSEL137 & BIT_MASK_21))) {
+            USART2_RxTO_IrqHandler();
+        }
+    }
+    /* SPI Ch.1 Rx end */
+    if (1UL == bCM_SPI1->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI1->SR_b.RDFF) && (0UL != (VSSEL137 & BIT_MASK_22))) {
+            SPI1_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.1 Tx buffer empty */
+    if (1UL == bCM_SPI1->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI1->SR_b.TDEF) && (0UL != (VSSEL137 & BIT_MASK_23))) {
+            SPI1_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.1 Bus idle */
+    if (1UL == bCM_SPI1->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI1->SR_b.IDLNF) && (0UL != (VSSEL137 & BIT_MASK_24))) {
+            SPI1_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.1 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI1->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI1->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL137 & BIT_MASK_25))) {
+            SPI1_Error_IrqHandler();
+        }
+    }
+    /* SPI Ch.2 Rx end */
+    if (1UL == bCM_SPI2->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI2->SR_b.RDFF) && (0UL != (VSSEL137 & BIT_MASK_27))) {
+            SPI2_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.2 Tx buffer empty */
+    if (1UL == bCM_SPI2->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI2->SR_b.TDEF) && (0UL != (VSSEL137 & BIT_MASK_28))) {
+            SPI2_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.2 Bus idle */
+    if (1UL == bCM_SPI2->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI2->SR_b.IDLNF) && (0UL != (VSSEL137 & BIT_MASK_29))) {
+            SPI2_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.2 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI2->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI2->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL137 & BIT_MASK_30))) {
+            SPI2_Error_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.138 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ138_Handler(void)
+{
+    const uint32_t VSSEL138 = CM_INTC->VSSEL138;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+    uint8_t RTIF;
+    uint8_t RTIE;
+    uint8_t ERRINT;
+    uint8_t TTCFG;
+
+    /* TimerA Unit.5 overflow */
+    if (1UL == bCM_TMRA_5->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_5->BCSTRH_b.OVFF) && (0UL != (VSSEL138 & BIT_MASK_00))) {
+            TMRA_5_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.5 underflow */
+    if (1UL == bCM_TMRA_5->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_5->BCSTRH_b.UDFF) && (0UL != (VSSEL138 & BIT_MASK_01))) {
+            TMRA_5_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_5->ICONR;
+    u32Tmp2 = CM_TMRA_5->STFLR;
+    /* TimerA Unit.5 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL138 & BIT_MASK_02))) {
+        TMRA_5_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.6 overflow */
+    if (1UL == bCM_TMRA_6->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_6->BCSTRH_b.OVFF) && (0UL != (VSSEL138 & BIT_MASK_03))) {
+            TMRA_6_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.6 underflow */
+    if (1UL == bCM_TMRA_6->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_6->BCSTRH_b.UDFF) && (0UL != (VSSEL138 & BIT_MASK_04))) {
+            TMRA_6_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_6->ICONR;
+    u32Tmp2 = CM_TMRA_6->STFLR;
+    /* TimerA Unit.6 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL138 & BIT_MASK_05))) {
+        TMRA_6_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.7 overflow */
+    if (1UL == bCM_TMRA_7->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_7->BCSTRH_b.OVFF) && (0UL != (VSSEL138 & BIT_MASK_06))) {
+            TMRA_7_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.7 underflow */
+    if (1UL == bCM_TMRA_7->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_7->BCSTRH_b.UDFF) && (0UL != (VSSEL138 & BIT_MASK_07))) {
+            TMRA_7_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_7->ICONR;
+    u32Tmp2 = CM_TMRA_7->STFLR;
+    /* TimerA Unit.7 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL138 & BIT_MASK_08))) {
+        TMRA_7_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.8 overflow */
+    if (1UL == bCM_TMRA_8->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_8->BCSTRH_b.OVFF) && (0UL != (VSSEL138 & BIT_MASK_09))) {
+            TMRA_8_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.8 underflow */
+    if (1UL == bCM_TMRA_8->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_8->BCSTRH_b.UDFF) && (0UL != (VSSEL138 & BIT_MASK_10))) {
+            TMRA_8_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_8->ICONR;
+    u32Tmp2 = CM_TMRA_8->STFLR;
+    /* TimerA Unit.8 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL138 & BIT_MASK_11))) {
+        TMRA_8_Cmp_IrqHandler();
+    }
+    if (1UL == bCM_USART3->CR1_b.RIE) {
+        /* USART Ch.3 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART3->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL138 & BIT_MASK_12))) {
+            USART3_RxError_IrqHandler();
+        }
+        /* USART Ch.3 Rx end */
+        if ((1UL == bCM_USART3->SR_b.RXNE) && (0UL != (VSSEL138 & BIT_MASK_13))) {
+            USART3_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.3 Tx buffer empty */
+    if (1UL == bCM_USART3->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART3->SR_b.TXE) && (0UL != (VSSEL138 & BIT_MASK_14))) {
+            USART3_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.3 Tx end */
+    if (1UL == bCM_USART3->CR1_b.TCIE) {
+        if ((1UL == bCM_USART3->SR_b.TC) && (0UL != (VSSEL138 & BIT_MASK_15))) {
+            USART3_TxComplete_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART4->CR1_b.RIE) {
+        /* USART Ch.4 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART4->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL138 & BIT_MASK_16))) {
+            USART4_RxError_IrqHandler();
+        }
+        /* USART Ch.4 Rx end */
+        if ((1UL == bCM_USART4->SR_b.RXNE) && (0UL != (VSSEL138 & BIT_MASK_17))) {
+            USART4_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.4 Tx buffer empty */
+    if (1UL == bCM_USART4->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART4->SR_b.TXE) && (0UL != (VSSEL138 & BIT_MASK_18))) {
+            USART4_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.4 Tx end */
+    if (1UL == bCM_USART4->CR1_b.TCIE) {
+        if ((1UL == bCM_USART4->SR_b.TC) && (0UL != (VSSEL138 & BIT_MASK_19))) {
+            USART4_TxComplete_IrqHandler();
+        }
+    }
+    /* CAN Ch.1 */
+    if (0UL != (VSSEL138 & BIT_MASK_20)) {
+        RTIF = CM_CAN1->RTIF;
+        RTIE = CM_CAN1->RTIE;
+        ERRINT = CM_CAN1->ERRINT;
+        TTCFG = CM_CAN1->TTCFG;
+        if ((0U != (TTCFG & CAN_TTCFG_TEIF))            ||                          \
+            (0U != (RTIF & CAN_RTIF_AIF))               ||                          \
+            (0U != (RTIF & RTIE & 0xFEU))               ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_BEIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_BEIF)))        ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_ALIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_ALIF)))        ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_EPIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_EPIF)))        ||                          \
+            ((0U != (TTCFG & CAN_TTCFG_TTIE))           &&                          \
+             (0U != (TTCFG & CAN_TTCFG_TTIF)))          ||                          \
+            ((0U != (TTCFG & CAN_TTCFG_WTIE))           &&                          \
+             (0U != (TTCFG & CAN_TTCFG_WTIF)))) {
+            CAN1_IrqHandler();
+        }
+    }
+    /* CAN Ch.2 */
+    if (0UL != (VSSEL138 & BIT_MASK_21)) {
+        RTIF = CM_CAN2->RTIF;
+        RTIE = CM_CAN2->RTIE;
+        ERRINT = CM_CAN2->ERRINT;
+        TTCFG = CM_CAN2->TTCFG;
+        if ((0U != (TTCFG & CAN_TTCFG_TEIF))            ||                          \
+            (0U != (RTIF & CAN_RTIF_AIF))               ||                          \
+            (0U != (RTIF & RTIE & 0xFEU))               ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_BEIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_BEIF)))        ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_ALIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_ALIF)))        ||                          \
+            ((0U != (ERRINT & CAN_ERRINT_EPIE))         &&                          \
+             (0U != (ERRINT & CAN_ERRINT_EPIF)))        ||                          \
+            ((0U != (TTCFG & CAN_TTCFG_TTIE))           &&                          \
+             (0U != (TTCFG & CAN_TTCFG_TTIF)))          ||                          \
+            ((0U != (TTCFG & CAN_TTCFG_WTIE))           &&                          \
+             (0U != (TTCFG & CAN_TTCFG_WTIF)))) {
+            CAN2_IrqHandler();
+        }
+    }
+    /* SPI Ch.3 Rx end */
+    if (1UL == bCM_SPI3->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI3->SR_b.RDFF) && (0UL != (VSSEL138 & BIT_MASK_22))) {
+            SPI3_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.3 Tx buffer empty */
+    if (1UL == bCM_SPI3->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI3->SR_b.TDEF) && (0UL != (VSSEL138 & BIT_MASK_23))) {
+            SPI3_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.3 Bus idle */
+    if (1UL == bCM_SPI3->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI3->SR_b.IDLNF) && (0UL != (VSSEL138 & BIT_MASK_24))) {
+            SPI3_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.3 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI3->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI3->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL138 & BIT_MASK_25))) {
+            SPI3_Error_IrqHandler();
+        }
+    }
+    /* SPI Ch.4 Rx end */
+    if (1UL == bCM_SPI4->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI4->SR_b.RDFF) && (0UL != (VSSEL138 & BIT_MASK_27))) {
+            SPI4_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.4 Tx buffer empty */
+    if (1UL == bCM_SPI4->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI4->SR_b.TDEF) && (0UL != (VSSEL138 & BIT_MASK_28))) {
+            SPI4_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.4 Bus idle */
+    if (1UL == bCM_SPI4->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI4->SR_b.IDLNF) && (0UL != (VSSEL138 & BIT_MASK_29))) {
+            SPI4_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.4 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI4->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI4->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL138 & BIT_MASK_30))) {
+            SPI4_Error_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.139 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ139_Handler(void)
+{
+    const uint32_t VSSEL139 = CM_INTC->VSSEL139;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* TimerA Unit.9 overflow */
+    if (1UL == bCM_TMRA_9->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_9->BCSTRH_b.OVFF) && (0UL != (VSSEL139 & BIT_MASK_00))) {
+            TMRA_9_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.9 underflow */
+    if (1UL == bCM_TMRA_9->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_9->BCSTRH_b.UDFF) && (0UL != (VSSEL139 & BIT_MASK_01))) {
+            TMRA_9_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_9->ICONR;
+    u32Tmp2 = CM_TMRA_9->STFLR;
+    /* TimerA Unit.9 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL139 & BIT_MASK_02))) {
+        TMRA_9_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.10 overflow */
+    if (1UL == bCM_TMRA_10->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_10->BCSTRH_b.OVFF) && (0UL != (VSSEL139 & BIT_MASK_03))) {
+            TMRA_10_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.10 underflow */
+    if (1UL == bCM_TMRA_10->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_10->BCSTRH_b.UDFF) && (0UL != (VSSEL139 & BIT_MASK_04))) {
+            TMRA_10_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_10->ICONR;
+    u32Tmp2 = CM_TMRA_10->STFLR;
+    /* TimerA Unit.10 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL139 & BIT_MASK_05))) {
+        TMRA_10_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.11 overflow */
+    if (1UL == bCM_TMRA_11->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_11->BCSTRH_b.OVFF) && (0UL != (VSSEL139 & BIT_MASK_06))) {
+            TMRA_11_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.11 underflow */
+    if (1UL == bCM_TMRA_11->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_11->BCSTRH_b.UDFF) && (0UL != (VSSEL139 & BIT_MASK_07))) {
+            TMRA_11_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_11->ICONR;
+    u32Tmp2 = CM_TMRA_11->STFLR;
+    /* TimerA Unit.11 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL139 & BIT_MASK_08))) {
+        TMRA_11_Cmp_IrqHandler();
+    }
+    /* TimerA Unit.12 overflow */
+    if (1UL == bCM_TMRA_12->BCSTRH_b.ITENOVF) {
+        if ((1UL == bCM_TMRA_12->BCSTRH_b.OVFF) && (0UL != (VSSEL139 & BIT_MASK_09))) {
+            TMRA_12_Ovf_IrqHandler();
+        }
+    }
+    /* TimerA Unit.12 underflow */
+    if (1UL == bCM_TMRA_12->BCSTRH_b.ITENUDF) {
+        if ((1UL == bCM_TMRA_12->BCSTRH_b.UDFF) && (0UL != (VSSEL139 & BIT_MASK_10))) {
+            TMRA_12_Udf_IrqHandler();
+        }
+    }
+    u32Tmp1 = CM_TMRA_12->ICONR;
+    u32Tmp2 = CM_TMRA_12->STFLR;
+    /* TimerA Unit.12 compare match */
+    if ((0UL != (u32Tmp1 & u32Tmp2 & 0x0FUL)) && (0UL != (VSSEL139 & BIT_MASK_11))) {
+        TMRA_12_Cmp_IrqHandler();
+    }
+    /* USART Ch.5 LIN bus break */
+    if (1UL == bCM_USART5->CR2_b.LBDIE) {
+        if ((1UL == bCM_USART5->SR_b.LBD) && (0UL != (VSSEL139 & BIT_MASK_12))) {
+            USART5_LinBreakField_IrqHandler();
+        }
+    }
+    /* USART Ch.5 LIN bus wakeup */
+    if (1UL == bCM_USART5->CR2_b.WKUPE) {
+        if ((1UL == bCM_USART5->SR_b.WKUP) && (0UL != (VSSEL139 & BIT_MASK_12))) {
+            USART5_LinWakeup_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART5->CR1_b.RIE) {
+        /* USART Ch.5 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART5->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL139 & BIT_MASK_13))) {
+            USART5_RxError_IrqHandler();
+        }
+        /* USART Ch.5 Rx end */
+        if ((1UL == bCM_USART5->SR_b.RXNE) && (0UL != (VSSEL139 & BIT_MASK_14))) {
+            USART5_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.5 Tx buffer empty */
+    if (1UL == bCM_USART5->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART5->SR_b.TXE) && (0UL != (VSSEL139 & BIT_MASK_15))) {
+            USART5_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.5 Tx end */
+    if (1UL == bCM_USART5->CR1_b.TCIE) {
+        if ((1UL == bCM_USART5->SR_b.TC) && (0UL != (VSSEL139 & BIT_MASK_16))) {
+            USART5_TxComplete_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART6->CR1_b.RIE) {
+        /* USART Ch.6 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART6->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL139 & BIT_MASK_17))) {
+            USART6_RxError_IrqHandler();
+        }
+        /* USART Ch.6 Rx end */
+        if ((1UL == bCM_USART6->SR_b.RXNE) && (0UL != (VSSEL139 & BIT_MASK_18))) {
+            USART6_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.6 Tx buffer empty */
+    if (1UL == bCM_USART6->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART6->SR_b.TXE) && (0UL != (VSSEL139 & BIT_MASK_19))) {
+            USART6_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.6 Tx end */
+    if (1UL == bCM_USART6->CR1_b.TCIE) {
+        if ((1UL == bCM_USART6->SR_b.TC) && (0UL != (VSSEL139 & BIT_MASK_20))) {
+            USART6_TxComplete_IrqHandler();
+        }
+    }
+    /* USART Ch.6 Tx timeout */
+    if (1UL == bCM_USART6->CR1_b.RTOIE) {
+        if ((1UL == bCM_USART6->SR_b.RTOF) && (0UL != (VSSEL139 & BIT_MASK_21))) {
+            USART6_RxTO_IrqHandler();
+        }
+    }
+    /* SPI Ch.5 Rx end */
+    if (1UL == bCM_SPI5->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI5->SR_b.RDFF) && (0UL != (VSSEL139 & BIT_MASK_22))) {
+            SPI5_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.5 Tx buffer empty */
+    if (1UL == bCM_SPI5->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI5->SR_b.TDEF) && (0UL != (VSSEL139 & BIT_MASK_23))) {
+            SPI5_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.5 Bus idle */
+    if (1UL == bCM_SPI5->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI5->SR_b.IDLNF) && (0UL != (VSSEL139 & BIT_MASK_24))) {
+            SPI5_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.5 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI5->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI5->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL139 & BIT_MASK_25))) {
+            SPI5_Error_IrqHandler();
+        }
+    }
+    /* SPI Ch.6 Rx end */
+    if (1UL == bCM_SPI6->CR1_b.RXIE) {
+        if ((1UL == bCM_SPI6->SR_b.RDFF) && (0UL != (VSSEL139 & BIT_MASK_27))) {
+            SPI6_RxFull_IrqHandler();
+        }
+    }
+    /* SPI Ch.6 Tx buffer empty */
+    if (1UL == bCM_SPI6->CR1_b.TXIE) {
+        if ((1UL == bCM_SPI6->SR_b.TDEF) && (0UL != (VSSEL139 & BIT_MASK_28))) {
+            SPI6_TxEmpty_IrqHandler();
+        }
+    }
+    /* SPI Ch.6 Bus idle */
+    if (1UL == bCM_SPI6->CR1_b.IDIE) {
+        if ((0UL == bCM_SPI6->SR_b.IDLNF) && (0UL != (VSSEL139 & BIT_MASK_29))) {
+            SPI6_Idle_IrqHandler();
+        }
+    }
+    /* SPI Ch.6 parity/overflow/underflow/mode error */
+    if (1UL == bCM_SPI6->CR1_b.EIE) {
+        u32Tmp1 = CM_SPI6->SR & (SPI_SR_OVRERF | SPI_SR_MODFERF | SPI_SR_PERF | SPI_SR_UDRERF);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL139 & BIT_MASK_30))) {
+            SPI6_Error_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.140 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ140_Handler(void)
+{
+    const uint32_t VSSEL140 = CM_INTC->VSSEL140;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+    uint16_t NORINTST;
+    uint16_t NORINTSGEN;
+    uint16_t ERRINTSGEN;
+    uint32_t MMC_REVSTSR;
+    uint32_t MMC_TRSSTSR;
+    uint32_t MMC_RITCTLR;
+    uint32_t MMC_TITCTLR;
+    uint32_t DMA_DMASTSR;
+    uint32_t DMA_INTENAR;
+    uint32_t PTP_INTE;
+    uint32_t PMT_INTMASK;
+    uint32_t PMT_INTSTSR;
+    uint32_t PTP_INTMASK;
+    uint32_t PTP_INTSTSR;
+
+    /* I2S Ch.1 Tx */
+    if (1UL == bCM_I2S1->CTRL_b.TXIE) {
+        if ((1UL == bCM_I2S1->SR_b.TXBA) && (0UL != (VSSEL140 & BIT_MASK_00))) {
+            I2S1_Tx_IrqHandler();
+        }
+    }
+    /* I2S Ch.1 Rx */
+    if (1UL == bCM_I2S1->CTRL_b.RXIE) {
+        if ((1UL == bCM_I2S1->SR_b.RXBA) && (0UL != (VSSEL140 & BIT_MASK_01))) {
+            I2S1_Rx_IrqHandler();
+        }
+    }
+    /* I2S Ch.1 Error */
+    if (1UL == bCM_I2S1->CTRL_b.EIE) {
+        u32Tmp1 = CM_I2S1->ER & (I2S_ER_TXERR | I2S_ER_RXERR);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL140 & BIT_MASK_02))) {
+            I2S1_Error_IrqHandler();
+        }
+    }
+    /* I2S Ch.2 Tx */
+    if (1UL == bCM_I2S2->CTRL_b.TXIE) {
+        if ((1UL == bCM_I2S2->SR_b.TXBA) && (0UL != (VSSEL140 & BIT_MASK_03))) {
+            I2S2_Tx_IrqHandler();
+        }
+    }
+    /* I2S Ch.2 Rx */
+    if (1UL == bCM_I2S2->CTRL_b.RXIE) {
+        if ((1UL == bCM_I2S2->SR_b.RXBA) && (0UL != (VSSEL140 & BIT_MASK_04))) {
+            I2S2_Rx_IrqHandler();
+        }
+    }
+    /* I2S Ch.2 Error */
+    if (1UL == bCM_I2S2->CTRL_b.EIE) {
+        u32Tmp1 = CM_I2S2->ER & (I2S_ER_TXERR | I2S_ER_RXERR);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL140 & BIT_MASK_05))) {
+            I2S2_Error_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART7->CR1_b.RIE) {
+        /* USART Ch.7 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART7->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL140 & BIT_MASK_06))) {
+            USART7_RxError_IrqHandler();
+        }
+        /* USART Ch.7 Rx end */
+        if ((1UL == bCM_USART7->SR_b.RXNE) && (0UL != (VSSEL140 & BIT_MASK_07))) {
+            USART7_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.7 Tx buffer empty */
+    if (1UL == bCM_USART7->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART7->SR_b.TXE) && (0UL != (VSSEL140 & BIT_MASK_08))) {
+            USART7_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.7 Tx end */
+    if (1UL == bCM_USART7->CR1_b.TCIE) {
+        if ((1UL == bCM_USART7->SR_b.TC) && (0UL != (VSSEL140 & BIT_MASK_09))) {
+            USART7_TxComplete_IrqHandler();
+        }
+    }
+    /* USART Ch.7 Rx timeout */
+    if (1UL == bCM_USART7->CR1_b.RTOIE) {
+        if ((1UL == bCM_USART7->SR_b.RTOF) && (0UL != (VSSEL140 & BIT_MASK_10))) {
+            USART7_RxTO_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART8->CR1_b.RIE) {
+        /* USART Ch.8 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART8->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL140 & BIT_MASK_11))) {
+            USART8_RxError_IrqHandler();
+        }
+        /* USART Ch.8 Rx end */
+        if ((1UL == bCM_USART8->SR_b.RXNE) && (0UL != (VSSEL140 & BIT_MASK_12))) {
+            USART8_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.8 Tx buffer empty */
+    if (1UL == bCM_USART8->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART8->SR_b.TXE) && (0UL != (VSSEL140 & BIT_MASK_13))) {
+            USART8_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.8 Tx end */
+    if (1UL == bCM_USART8->CR1_b.TCIE) {
+        if ((1UL == bCM_USART8->SR_b.TC) && (0UL != (VSSEL140 & BIT_MASK_14))) {
+            USART8_TxComplete_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USBFS->GAHBCFG_b.GINTMSK) {
+        /* USB FS global interrupt */
+        u32Tmp1 = CM_USBFS->GINTMSK & 0xFF7CFCFBUL;
+        u32Tmp2 = CM_USBFS->GINTSTS & 0xFF7CFCFBUL;
+        if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL140 & BIT_MASK_15))) {
+            USBFS_Global_IrqHandler();
+        }
+        /* USB FS wakeup interrupt */
+        u32Tmp1 = bCM_USBFS->GINTSTS_b.WKUINT;
+        u32Tmp2 = bCM_USBFS->GINTMSK_b.WKUIM;
+        if ((0UL != u32Tmp1) && (0UL != u32Tmp2) && (0UL != (VSSEL140 & BIT_MASK_16))) {
+            USBFS_Wakeup_IrqHandler();
+        }
+    }
+    /* SDIO unit 1 */
+    if (0UL != (VSSEL140 & BIT_MASK_20)) {
+        NORINTST = CM_SDIOC1->NORINTST & (SDIOC_NORINTST_CINT | SDIOC_NORINTST_CRM | SDIOC_NORINTST_CIST |  \
+                                          SDIOC_NORINTST_BRR  | SDIOC_NORINTST_BWR | SDIOC_NORINTST_BGE  |  \
+                                          SDIOC_NORINTST_TC   | SDIOC_NORINTST_CC);
+        NORINTSGEN = CM_SDIOC1->NORINTSGEN & (SDIOC_NORINTSTEN_CINTEN | SDIOC_NORINTSTEN_CRMEN |    \
+                                              SDIOC_NORINTSTEN_CISTEN | SDIOC_NORINTSTEN_BRREN |    \
+                                              SDIOC_NORINTSTEN_BWREN  | SDIOC_NORINTSTEN_BGEEN |    \
+                                              SDIOC_NORINTSTEN_TCEN   | SDIOC_NORINTSTEN_CCEN);
+        ERRINTSGEN = CM_SDIOC1->ERRINTSGEN & (SDIOC_ERRINTSTEN_ACEEN | SDIOC_ERRINTSTEN_DEBEEN |    \
+                                              SDIOC_ERRINTSTEN_DCEEN | SDIOC_ERRINTSTEN_DTOEEN |    \
+                                              SDIOC_ERRINTSTEN_CIEEN | SDIOC_ERRINTSTEN_CEBEEN |    \
+                                              SDIOC_ERRINTSTEN_CCEEN | SDIOC_ERRINTSTEN_CTOEEN);
+        if (0U != (NORINTST & NORINTSGEN)) {
+            SDIOC1_Normal_IrqHandler();
+        }
+        if ((1UL == bCM_SDIOC1->NORINTST_b.EI) && (0U != ERRINTSGEN)) {
+            SDIOC1_Error_IrqHandler();
+        }
+    }
+    /* SDIO unit 2 */
+    if (0UL != (VSSEL140 & BIT_MASK_23)) {
+        NORINTST = CM_SDIOC2->NORINTST & (SDIOC_NORINTST_CINT | SDIOC_NORINTST_CRM | SDIOC_NORINTST_CIST |  \
+                                          SDIOC_NORINTST_BRR  | SDIOC_NORINTST_BWR | SDIOC_NORINTST_BGE  |  \
+                                          SDIOC_NORINTST_TC   | SDIOC_NORINTST_CC);
+        NORINTSGEN = CM_SDIOC2->NORINTSGEN & (SDIOC_NORINTSTEN_CINTEN | SDIOC_NORINTSTEN_CRMEN |    \
+                                              SDIOC_NORINTSTEN_CISTEN | SDIOC_NORINTSTEN_BRREN |    \
+                                              SDIOC_NORINTSTEN_BWREN  | SDIOC_NORINTSTEN_BGEEN |    \
+                                              SDIOC_NORINTSTEN_TCEN   | SDIOC_NORINTSTEN_CCEN);
+        ERRINTSGEN = CM_SDIOC2->ERRINTSGEN & (SDIOC_ERRINTSTEN_ACEEN | SDIOC_ERRINTSTEN_DEBEEN |    \
+                                              SDIOC_ERRINTSTEN_DCEEN | SDIOC_ERRINTSTEN_DTOEEN |    \
+                                              SDIOC_ERRINTSTEN_CIEEN | SDIOC_ERRINTSTEN_CEBEEN |    \
+                                              SDIOC_ERRINTSTEN_CCEEN | SDIOC_ERRINTSTEN_CTOEEN);
+        if (0U != (NORINTST & NORINTSGEN)) {
+            SDIOC2_Normal_IrqHandler();
+        }
+        if ((1UL == bCM_SDIOC2->NORINTST_b.EI) && (0U != ERRINTSGEN)) {
+            SDIOC2_Error_IrqHandler();
+        }
+    }
+    /* Ethernet global */
+    MMC_REVSTSR = CM_ETH->MMC_REVSTSR & (ETH_MMC_REVSTSR_RXOEIS | ETH_MMC_REVSTSR_RXLEIS |  \
+                                         ETH_MMC_REVSTSR_RXUGIS | ETH_MMC_REVSTSR_RXREIS |  \
+                                         ETH_MMC_REVSTSR_RXAEIS | ETH_MMC_REVSTSR_RXCEIS |  \
+                                         ETH_MMC_REVSTSR_RXMGIS | ETH_MMC_REVSTSR_RXBGIS);
+    MMC_TRSSTSR = CM_ETH->MMC_TRSSTSR & (ETH_MMC_TRSSTSR_TXEDEIS | ETH_MMC_TRSSTSR_TXUGIS |  \
+                                         ETH_MMC_TRSSTSR_TXCAEIS | ETH_MMC_TRSSTSR_TXECEIS |  \
+                                         ETH_MMC_TRSSTSR_TXLCEIS | ETH_MMC_TRSSTSR_TXDEEIS |  \
+                                         ETH_MMC_TRSSTSR_TXMGIS | ETH_MMC_TRSSTSR_TXBGIS);
+    MMC_RITCTLR = CM_ETH->MMC_RITCTLR & (ETH_MMC_RITCTLR_RXBGIM | ETH_MMC_RITCTLR_RXMGIM |  \
+                                         ETH_MMC_RITCTLR_RXCEIM | ETH_MMC_RITCTLR_RXAEIM |  \
+                                         ETH_MMC_RITCTLR_RXREIM | ETH_MMC_RITCTLR_RXUGIM |  \
+                                         ETH_MMC_RITCTLR_RXLEIM | ETH_MMC_RITCTLR_RXOEIM);
+    MMC_TITCTLR = CM_ETH->MMC_TITCTLR & (ETH_MMC_TITCTLR_TXBGIM | ETH_MMC_TITCTLR_TXMGIM |  \
+                                         ETH_MMC_TITCTLR_TXDEEIM | ETH_MMC_TITCTLR_TXLCEIM |  \
+                                         ETH_MMC_TITCTLR_TXECEIM | ETH_MMC_TITCTLR_TXCAEIM |  \
+                                         ETH_MMC_TITCTLR_TXUGIM | ETH_MMC_TITCTLR_TXEDEIM);
+    PMT_INTMASK = bCM_ETH->MAC_INTMSKR_b.PMTIM;
+    PMT_INTSTSR  = bCM_ETH->MAC_INTSTSR_b.PMTIS;
+    PTP_INTMASK = bCM_ETH->MAC_INTMSKR_b.TSPIM;
+    PTP_INTSTSR  = bCM_ETH->MAC_INTSTSR_b.TSPIS;
+    PTP_INTE    = bCM_ETH->PTP_TSPCTLR_b.TSPINT;
+
+    DMA_DMASTSR = CM_ETH->DMA_DMASTSR & (ETH_DMA_DMASTSR_AIS | ETH_DMA_DMASTSR_NIS);
+    DMA_INTENAR = CM_ETH->DMA_INTENAR & (ETH_DMA_INTENAR_AIE | ETH_DMA_INTENAR_NIE);
+    if (0UL != (VSSEL140 & BIT_MASK_28)) {
+        if ((0UL != (MMC_REVSTSR & (~MMC_RITCTLR))) ||                          \
+            (0UL != (MMC_TRSSTSR & (~MMC_TITCTLR))) ||                          \
+            (0UL != (PMT_INTSTSR & (~PMT_INTMASK))) ||                          \
+            (0UL != (PTP_INTSTSR & (~PTP_INTMASK) & PTP_INTE)) ||               \
+            (0UL != (DMA_DMASTSR & DMA_INTENAR))) {
+            ETH_Global_IrqHandler();
+        }
+    }
+
+    /* Ethernet wakeup */
+    if (0UL == bCM_ETH->MAC_INTMSKR_b.PMTIM) {
+        if ((1UL == bCM_ETH->MAC_INTSTSR_b.PMTIS) && (0UL != (VSSEL140 & BIT_MASK_29))) {
+            ETH_Wakeup_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.141 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ141_Handler(void)
+{
+    const uint32_t VSSEL141 = CM_INTC->VSSEL141;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* I2S Ch.3 Tx */
+    if (1UL == bCM_I2S3->CTRL_b.TXIE) {
+        if ((1UL == bCM_I2S3->SR_b.TXBA) && (0UL != (VSSEL141 & BIT_MASK_00))) {
+            I2S3_Tx_IrqHandler();
+        }
+    }
+    /* I2S Ch.3 Rx */
+    if (1UL == bCM_I2S3->CTRL_b.RXIE) {
+        if ((1UL == bCM_I2S3->SR_b.RXBA) && (0UL != (VSSEL141 & BIT_MASK_01))) {
+            I2S3_Rx_IrqHandler();
+        }
+    }
+    /* I2S Ch.3 Error */
+    if (1UL == bCM_I2S3->CTRL_b.EIE) {
+        u32Tmp1 = CM_I2S3->ER & (I2S_ER_TXERR | I2S_ER_RXERR);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL141 & BIT_MASK_02))) {
+            I2S3_Error_IrqHandler();
+        }
+    }
+    /* I2S Ch.4 Tx */
+    if (1UL == bCM_I2S4->CTRL_b.TXIE) {
+        if ((1UL == bCM_I2S4->SR_b.TXBA) && (0UL != (VSSEL141 & BIT_MASK_03))) {
+            I2S4_Tx_IrqHandler();
+        }
+    }
+    /* I2S Ch.4 Rx */
+    if (1UL == bCM_I2S4->CTRL_b.RXIE) {
+        if ((1UL == bCM_I2S4->SR_b.RXBA) && (0UL != (VSSEL141 & BIT_MASK_04))) {
+            I2S4_Rx_IrqHandler();
+        }
+    }
+    /* I2S Ch.4 Error */
+    if (1UL == bCM_I2S4->CTRL_b.EIE) {
+        u32Tmp1 = CM_I2S4->ER & (I2S_ER_TXERR | I2S_ER_RXERR);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL141 & BIT_MASK_05))) {
+            I2S4_Error_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART9->CR1_b.RIE) {
+        /* USART Ch.9 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART9->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL141 & BIT_MASK_06))) {
+            USART9_RxError_IrqHandler();
+        }
+        /* USART Ch.9 Rx end */
+        if ((1UL == bCM_USART9->SR_b.RXNE) && (0UL != (VSSEL141 & BIT_MASK_07))) {
+            USART9_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.9 Tx buffer empty */
+    if (1UL == bCM_USART9->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART9->SR_b.TXE) && (0UL != (VSSEL141 & BIT_MASK_08))) {
+            USART9_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.9 Tx end */
+    if (1UL == bCM_USART9->CR1_b.TCIE) {
+        if ((1UL == bCM_USART9->SR_b.TC) && (0UL != (VSSEL141 & BIT_MASK_09))) {
+            USART9_TxComplete_IrqHandler();
+        }
+    }
+    /* USART Ch.10 LIN bus break */
+    if (1UL == bCM_USART10->CR2_b.LBDIE) {
+        if ((1UL == bCM_USART10->SR_b.LBD) && (0UL != (VSSEL141 & BIT_MASK_10))) {
+            USART10_LinBreakField_IrqHandler();
+        }
+    }
+    /* USART Ch.10 LIN bus wakeup */
+    if (1UL == bCM_USART10->CR2_b.WKUPE) {
+        if ((1UL == bCM_USART10->SR_b.WKUP) && (0UL != (VSSEL141 & BIT_MASK_10))) {
+            USART10_LinWakeup_IrqHandler();
+        }
+    }
+    if (1UL == bCM_USART10->CR1_b.RIE) {
+        /* USART Ch.10 Rx ORE/FE/PE error */
+        u32Tmp1 = CM_USART10->SR & (USART_SR_PE | USART_SR_FE | USART_SR_ORE);
+        if ((0UL != u32Tmp1) && (0UL != (VSSEL141 & BIT_MASK_11))) {
+            USART10_RxError_IrqHandler();
+        }
+        /* USART Ch.10 Rx end */
+        if ((1UL == bCM_USART10->SR_b.RXNE) && (0UL != (VSSEL141 & BIT_MASK_12))) {
+            USART10_RxFull_IrqHandler();
+        }
+    }
+    /* USART Ch.10 Tx buffer empty */
+    if (1UL == bCM_USART10->CR1_b.TXEIE) {
+        if ((1UL == bCM_USART10->SR_b.TXE) && (0UL != (VSSEL141 & BIT_MASK_13))) {
+            USART10_TxEmpty_IrqHandler();
+        }
+    }
+    /* USART Ch.10 Tx end */
+    if (1UL == bCM_USART10->CR1_b.TCIE) {
+        if ((1UL == bCM_USART10->SR_b.TC) && (0UL != (VSSEL141 & BIT_MASK_14))) {
+            USART10_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.1 Rx end */
+    if (1UL == bCM_I2C1->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C1->SR_b.RFULLF) && (0UL != (VSSEL141 & BIT_MASK_16))) {
+            I2C1_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.1 Tx buffer empty */
+    if (1UL == bCM_I2C1->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C1->SR_b.TEMPTYF) && (0UL != (VSSEL141 & BIT_MASK_17))) {
+            I2C1_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.1 Tx end */
+    if (1UL == bCM_I2C1->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C1->SR_b.TENDF) && (0UL != (VSSEL141 & BIT_MASK_18))) {
+            I2C1_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.1 Error */
+    u32Tmp1 = CM_I2C1->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C1->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL141 & BIT_MASK_19))) {
+        I2C1_EE_IrqHandler();
+    }
+    /* I2C Ch.2 Rx end */
+    if (1UL == bCM_I2C2->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C2->SR_b.RFULLF) && (0UL != (VSSEL141 & BIT_MASK_20))) {
+            I2C2_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.2 Tx buffer empty */
+    if (1UL == bCM_I2C2->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C2->SR_b.TEMPTYF) && (0UL != (VSSEL141 & BIT_MASK_21))) {
+            I2C2_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.2 Tx end */
+    if (1UL == bCM_I2C2->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C2->SR_b.TENDF) && (0UL != (VSSEL141 & BIT_MASK_22))) {
+            I2C2_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.2 Error */
+    u32Tmp1 = CM_I2C2->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C2->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL141 & BIT_MASK_23))) {
+        I2C2_EE_IrqHandler();
+    }
+    /* I2C Ch.3 Rx end */
+    if (1UL == bCM_I2C3->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C3->SR_b.RFULLF) && (0UL != (VSSEL141 & BIT_MASK_24))) {
+            I2C3_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.3 Tx buffer empty */
+    if (1UL == bCM_I2C3->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C3->SR_b.TEMPTYF) && (0UL != (VSSEL141 & BIT_MASK_25))) {
+            I2C3_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.3 Tx end */
+    if (1UL == bCM_I2C3->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C3->SR_b.TENDF) && (0UL != (VSSEL141 & BIT_MASK_26))) {
+            I2C3_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.3 Error */
+    u32Tmp1 = CM_I2C3->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C3->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL141 & BIT_MASK_27))) {
+        I2C3_EE_IrqHandler();
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.142 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ142_Handler(void)
+{
+    const uint32_t VSSEL142 = CM_INTC->VSSEL142;
+    uint32_t u32Tmp1;
+    uint32_t u32Tmp2;
+
+    /* I2C Ch.4 Rx end */
+    if (1UL == bCM_I2C4->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C4->SR_b.RFULLF) && (0UL != (VSSEL142 & BIT_MASK_00))) {
+            I2C4_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.4 Tx buffer empty */
+    if (1UL == bCM_I2C4->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C4->SR_b.TEMPTYF) && (0UL != (VSSEL142 & BIT_MASK_01))) {
+            I2C4_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.4 Tx end */
+    if (1UL == bCM_I2C4->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C4->SR_b.TENDF) && (0UL != (VSSEL142 & BIT_MASK_02))) {
+            I2C4_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.4 Error */
+    u32Tmp1 = CM_I2C4->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C4->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL142 & BIT_MASK_03))) {
+        I2C4_EE_IrqHandler();
+    }
+    /* I2C Ch.5 Rx end */
+    if (1UL == bCM_I2C5->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C5->SR_b.RFULLF) && (0UL != (VSSEL142 & BIT_MASK_04))) {
+            I2C5_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.5 Tx buffer empty */
+    if (1UL == bCM_I2C5->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C5->SR_b.TEMPTYF) && (0UL != (VSSEL142 & BIT_MASK_05))) {
+            I2C5_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.5 Tx end */
+    if (1UL == bCM_I2C5->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C5->SR_b.TENDF) && (0UL != (VSSEL142 & BIT_MASK_06))) {
+            I2C5_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.5 Error */
+    u32Tmp1 = CM_I2C5->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C5->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL142 & BIT_MASK_07))) {
+        I2C5_EE_IrqHandler();
+    }
+    /* I2C Ch.6 Rx end */
+    if (1UL == bCM_I2C6->CR2_b.RFULLIE) {
+        if ((1UL == bCM_I2C6->SR_b.RFULLF) && (0UL != (VSSEL142 & BIT_MASK_08))) {
+            I2C6_RxFull_IrqHandler();
+        }
+    }
+    /* I2C Ch.6 Tx buffer empty */
+    if (1UL == bCM_I2C6->CR2_b.TEMPTYIE) {
+        if ((1UL == bCM_I2C6->SR_b.TEMPTYF) && (0UL != (VSSEL142 & BIT_MASK_09))) {
+            I2C6_TxEmpty_IrqHandler();
+        }
+    }
+    /* I2C Ch.6 Tx end */
+    if (1UL == bCM_I2C6->CR2_b.TENDIE) {
+        if ((1UL == bCM_I2C6->SR_b.TENDF) && (0UL != (VSSEL142 & BIT_MASK_10))) {
+            I2C6_TxComplete_IrqHandler();
+        }
+    }
+    /* I2C Ch.6 Error */
+    u32Tmp1 = CM_I2C6->CR2 & (I2C_CR2_SMBALRTIE | I2C_CR2_SMBHOSTIE | I2C_CR2_SMBDEFAULTIE | \
+                              I2C_CR2_GENCALLIE | I2C_CR2_TMOUTIE  | I2C_CR2_NACKIE       | \
+                              I2C_CR2_ARLOIE    | I2C_CR2_STOPIE   | I2C_CR2_SLADDR1IE    | \
+                              I2C_CR2_SLADDR0IE | I2C_CR2_STARTIE);
+    u32Tmp2 = CM_I2C6->SR & (I2C_SR_SMBALRTF | I2C_SR_SMBHOSTF | I2C_SR_SMBDEFAULTF |   \
+                             I2C_SR_GENCALLF | I2C_SR_TMOUTF   | I2C_SR_NACKF       |   \
+                             I2C_SR_ARLOF    | I2C_SR_STOPF    | I2C_SR_SLADDR1F    |   \
+                             I2C_SR_SLADDR0F | I2C_SR_STARTF);
+    if ((0UL != (u32Tmp1 & u32Tmp2)) && (0UL != (VSSEL142 & BIT_MASK_11))) {
+        I2C6_EE_IrqHandler();
+    }
+    /* LVD Ch.1 */
+    if (1UL == bCM_PWC->PVDCR1_b.PVD1IRE) {
+        if ((1UL == bCM_PWC->PVDDSR_b.PVD1DETFLG) && (0UL != (VSSEL142 & BIT_MASK_13))) {
+            PWC_LVD1_IrqHandler();
+        }
+    }
+    /* LVD Ch.2 */
+    if (1UL == bCM_PWC->PVDCR1_b.PVD2IRE) {
+        if ((1UL == bCM_PWC->PVDDSR_b.PVD2DETFLG) && (0UL != (VSSEL142 & BIT_MASK_14))) {
+            PWC_LVD2_IrqHandler();
+        }
+    }
+    /* FCM error */
+    if (1UL == bCM_FCM->RIER_b.ERRIE) {
+        if ((1UL == bCM_FCM->SR_b.ERRF) && (0UL != (VSSEL142 & BIT_MASK_16))) {
+            FCM_Error_IrqHandler();
+        }
+    }
+    /* FCM end */
+    if (1UL == bCM_FCM->RIER_b.MENDIE) {
+        if ((1UL == bCM_FCM->SR_b.MENDF) && (0UL != (VSSEL142 & BIT_MASK_17))) {
+            FCM_End_IrqHandler();
+        }
+    }
+    /* FCM overflow */
+    if (1UL == bCM_FCM->RIER_b.OVFIE) {
+        if ((1UL == bCM_FCM->SR_b.OVF) && (0UL != (VSSEL142 & BIT_MASK_18))) {
+            FCM_Ovf_IrqHandler();
+        }
+    }
+    /* WDT underflow or refresh error */
+    u32Tmp1 = CM_WDT->SR & (WDT_SR_UDF | WDT_SR_REF);
+    if ((0UL != u32Tmp1) && (0UL != (VSSEL142 & BIT_MASK_19))) {
+        WDT_IrqHandler();
+    }
+    /* CTC overflow or underflow error */
+    if (1UL == bCM_CTC->CR1_b.ERRIE) {
+        /* underflow */
+        if ((1UL == bCM_CTC->STR_b.TRMUDF) && (0UL != (VSSEL142 & BIT_MASK_20))) {
+            CTC_Udf_IrqHandler();
+        }
+        /* overflow */
+        if ((1UL == bCM_CTC->STR_b.TRMOVF) && (0UL != (VSSEL142 & BIT_MASK_20))) {
+            CTC_Ovf_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+
+/**
+ * @brief  Interrupt No.143 share IRQ handler
+ * @param  None
+ * @retval None
+ */
+void IRQ143_Handler(void)
+{
+    const uint32_t VSSEL143 = CM_INTC->VSSEL143;
+    uint32_t u32Tmp1;
+
+    /* ADC unit1 sequence A */
+    if (1UL == bCM_ADC1->ICR_b.EOCAIEN) {
+        if ((1UL == bCM_ADC1->ISR_b.EOCAF) && (0UL != (VSSEL143 & BIT_MASK_00))) {
+            ADC1_SeqA_IrqHandler();
+        }
+    }
+    /* ADC unit1 sequence B */
+    if (1UL == bCM_ADC1->ICR_b.EOCBIEN) {
+        if ((1UL == bCM_ADC1->ISR_b.EOCBF) && (0UL != (VSSEL143 & BIT_MASK_01))) {
+            ADC1_SeqB_IrqHandler();
+        }
+    }
+    /* ADC unit1 window 0 compare */
+    if (1UL == bCM_ADC1->AWDCR_b.AWD0IEN) {
+        if ((1UL == bCM_ADC1->AWDSR_b.AWD0F) && (0UL != (VSSEL143 & BIT_MASK_02))) {
+            ADC1_Cmp0_IrqHandler();
+        }
+    }
+    /* ADC unit1 window 1 compare */
+    if (1UL == bCM_ADC1->AWDCR_b.AWD1IEN) {
+        /* independence use */
+        u32Tmp1 = (uint16_t)(CM_ADC1->AWDCR & ADC_AWDCR_AWDCM);
+        if ((1UL == bCM_ADC1->AWDSR_b.AWD1F) && (0UL == u32Tmp1) && (0UL != (VSSEL143 & BIT_MASK_03))) {
+            ADC1_Cmp1_IrqHandler();
+        }
+        /* combination use */
+        if ((1UL == bCM_ADC1->AWDSR_b.AWDCMF) && (0UL != u32Tmp1) && (0UL != (VSSEL143 & BIT_MASK_03))) {
+            ADC1_CmpComb_IrqHandler();
+        }
+    }
+    /* ADC unit2 sequence A */
+    if (1UL == bCM_ADC2->ICR_b.EOCAIEN) {
+        if ((1UL == bCM_ADC2->ISR_b.EOCAF) && (0UL != (VSSEL143 & BIT_MASK_04))) {
+            ADC2_SeqA_IrqHandler();
+        }
+    }
+    /* ADC unit2 sequence B */
+    if (1UL == bCM_ADC2->ICR_b.EOCBIEN) {
+        if ((1UL == bCM_ADC2->ISR_b.EOCBF) && (0UL != (VSSEL143 & BIT_MASK_05))) {
+            ADC2_SeqB_IrqHandler();
+        }
+    }
+    /* ADC unit2 window 0 compare */
+    if (1UL == bCM_ADC2->AWDCR_b.AWD0IEN) {
+        if ((1UL == bCM_ADC2->AWDSR_b.AWD0F) && (0UL != (VSSEL143 & BIT_MASK_06))) {
+            ADC2_Cmp0_IrqHandler();
+        }
+    }
+    /* ADC unit2 window 1 compare */
+    if (1UL == bCM_ADC2->AWDCR_b.AWD1IEN) {
+        /* independence use */
+        u32Tmp1 = ((uint16_t)(CM_ADC2->AWDCR & ADC_AWDCR_AWDCM));
+        if ((1UL == bCM_ADC2->AWDSR_b.AWD1F) && (0UL == u32Tmp1) && (0UL != (0UL != (VSSEL143 & BIT_MASK_07)))) {
+            ADC2_Cmp1_IrqHandler();
+        }
+        /* combination use */
+        if ((1UL == bCM_ADC2->AWDSR_b.AWDCMF) && (0UL != u32Tmp1) && (0UL != (0UL != (VSSEL143 & BIT_MASK_07)))) {
+            ADC2_CmpComb_IrqHandler();
+        }
+    }
+    /* ADC unit3 sequence A */
+    if (1UL == bCM_ADC3->ICR_b.EOCAIEN) {
+        if ((1UL == bCM_ADC3->ISR_b.EOCAF) && (0UL != (VSSEL143 & BIT_MASK_08))) {
+            ADC3_SeqA_IrqHandler();
+        }
+    }
+    /* ADC unit3 sequence B */
+    if (1UL == bCM_ADC3->ICR_b.EOCBIEN) {
+        if ((1UL == bCM_ADC3->ISR_b.EOCBF) && (0UL != (VSSEL143 & BIT_MASK_09))) {
+            ADC3_SeqB_IrqHandler();
+        }
+    }
+    /* ADC unit3 window 0 compare */
+    if (1UL == bCM_ADC3->AWDCR_b.AWD0IEN) {
+        if ((1UL == bCM_ADC3->AWDSR_b.AWD0F) && (0UL != (VSSEL143 & BIT_MASK_10))) {
+            ADC3_Cmp0_IrqHandler();
+        }
+    }
+    /* ADC unit3 window 1 compare */
+    if (1UL == bCM_ADC3->AWDCR_b.AWD1IEN) {
+        /* independence use */
+        u32Tmp1 = (uint16_t)(CM_ADC3->AWDCR & ADC_AWDCR_AWDCM);
+        if ((1UL == bCM_ADC3->AWDSR_b.AWD1F) && (0UL == u32Tmp1) && (0UL != (VSSEL143 & BIT_MASK_11))) {
+            ADC3_Cmp1_IrqHandler();
+        }
+        /* combination use */
+        if ((1UL == bCM_ADC3->AWDSR_b.AWDCMF) && (0UL != u32Tmp1) && (0UL != (VSSEL143 & BIT_MASK_11))) {
+            ADC3_CmpComb_IrqHandler();
+        }
+    }
+    if (0UL != (VSSEL143 & BIT_MASK_16)) {
+        if (0UL != (CM_NFC->IRSR & (NFC_IRSR_RBRS | NFC_IRSR_ECCERS |           \
+                                    NFC_IRSR_ECCCRS | NFC_IRSR_ECCECRS | NFC_IRSR_ECCEURS))) {
+            NFC_IrqHandler();
+        }
+    }
+
+    /* Arm Errata 838869: Cortex-M4, Cortex-M4F */
+    __DSB();
+}
+/**
+ * @}
+ */
+
+/**
+ * @defgroup Share_Interrupts_Weakdef_Prototypes Share Interrupts weak function prototypes
+ * @{
+ */
+__WEAKDEF void EXTINT00_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT01_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT02_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT03_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT04_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT05_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT06_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT07_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT08_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT09_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT10_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT11_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT12_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT13_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT14_IrqHandler(void)
+{
+}
+__WEAKDEF void EXTINT15_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_TC7_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_BTC7_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA1_Error7_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_TC7_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_BTC7_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error0_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error1_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error2_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error3_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error4_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error5_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error6_IrqHandler(void)
+{
+}
+__WEAKDEF void DMA2_Error7_IrqHandler(void)
+{
+}
+__WEAKDEF void EFM_ProgramEraseError_IrqHandler(void)
+{
+}
+__WEAKDEF void EFM_ColError_IrqHandler(void)
+{
+}
+__WEAKDEF void EFM_OpEnd_IrqHandler(void)
+{
+}
+__WEAKDEF void QSPI_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void MAU_Sqrt_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_FrameStart_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_FrameEnd_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_LineStart_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_LineEnd_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_SWSyncError_IrqHandler(void)
+{
+}
+__WEAKDEF void DVP_FifoError_IrqHandler(void)
+{
+}
+__WEAKDEF void FMAC1_IrqHandler(void)
+{
+}
+__WEAKDEF void FMAC2_IrqHandler(void)
+{
+}
+__WEAKDEF void FMAC3_IrqHandler(void)
+{
+}
+__WEAKDEF void FMAC4_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU1_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU2_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU3_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU4_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU5_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU6_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU7_IrqHandler(void)
+{
+}
+__WEAKDEF void DCU8_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR0_1_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR0_1_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR0_2_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR0_2_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_1_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_1_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_1_OvfA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_1_OvfB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_2_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_2_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_2_OvfA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_2_OvfB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_3_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_3_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_3_OvfA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_3_OvfB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_4_CmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_4_CmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_4_OvfA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR2_4_OvfB_IrqHandler(void)
+{
+}
+__WEAKDEF void RTC_TimeStamp0_IrqHandler(void)
+{
+}
+__WEAKDEF void RTC_TimeStamp1_IrqHandler(void)
+{
+}
+__WEAKDEF void RTC_Alarm_IrqHandler(void)
+{
+}
+__WEAKDEF void RTC_Period_IrqHandler(void)
+{
+}
+__WEAKDEF void CLK_XtalStop_IrqHandler(void)
+{
+}
+__WEAKDEF void SWDT_IrqHandler(void)
+{
+}
+__WEAKDEF void WDT_IrqHandler(void)
+{
+}
+__WEAKDEF void PWC_WakeupTimer_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_GDte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_1_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_GDte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_2_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_GDte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_3_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_Gdte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_4_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_Gdte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_5_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_Gdte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_6_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_Gdte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_7_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpC_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpD_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpE_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GCmpF_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GOvf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_GUdf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_Gdte_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_SCmpUpA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_SCmpDownA_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_SCmpUpB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR6_8_SCmpDownB_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpUH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpUL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpVH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpVL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpWH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_GCmpWL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_ReloadU_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_ReloadV_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_1_ReloadW_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpUH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpUL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpVH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpVL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpWH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_GCmpWL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_ReloadU_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_ReloadV_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_2_ReloadW_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpUH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpUL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpVH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpVL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpWH_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_GCmpWL_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_ReloadU_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_ReloadV_IrqHandler(void)
+{
+}
+__WEAKDEF void TMR4_3_ReloadW_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_1_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_1_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_1_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_2_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_2_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_2_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_3_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_3_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_3_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_4_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_4_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_4_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_5_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_5_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_5_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_6_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_6_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_6_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_7_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_7_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_7_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_8_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_8_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_8_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_9_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_9_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_9_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_10_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_10_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_10_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_11_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_11_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_11_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_12_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_12_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void TMRA_12_Cmp_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR0_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR1_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR2_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR3_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR4_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR5_IrqHandler(void)
+{
+}
+__WEAKDEF void EMB_GR6_IrqHandler(void)
+{
+}
+__WEAKDEF void USBHS_EP1Out_IrqHandler(void)
+{
+}
+__WEAKDEF void USBHS_EP1In_IrqHandler(void)
+{
+}
+__WEAKDEF void USBHS_Global_IrqHandler(void)
+{
+}
+__WEAKDEF void USBHS_Wakeup_IrqHandler(void)
+{
+}
+__WEAKDEF void USART1_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART1_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART1_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART1_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART1_RxTO_IrqHandler(void)
+{
+}
+__WEAKDEF void USART2_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART2_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART2_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART2_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART2_RxTO_IrqHandler(void)
+{
+}
+__WEAKDEF void USART3_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART3_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART3_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART3_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART4_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART4_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART4_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART4_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_LinBreakField_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_LinWakeup_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART5_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART6_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART6_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART6_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART6_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART6_RxTO_IrqHandler(void)
+{
+}
+__WEAKDEF void USART7_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART7_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART7_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART7_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART7_RxTO_IrqHandler(void)
+{
+}
+__WEAKDEF void USART8_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART8_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART8_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART8_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART9_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART9_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART9_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART9_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_LinBreakField_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_LinWakeup_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_RxError_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void USART10_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI1_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI1_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI1_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI1_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI2_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI2_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI2_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI2_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI3_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI3_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI3_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI3_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI4_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI4_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI4_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI4_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI5_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI5_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI5_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI5_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI6_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI6_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI6_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SPI6_Idle_IrqHandler(void)
+{
+}
+__WEAKDEF void CAN1_IrqHandler(void)
+{
+}
+__WEAKDEF void CAN2_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S1_Tx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S1_Rx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S1_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S2_Tx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S2_Rx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S2_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S3_Tx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S3_Rx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S3_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S4_Tx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S4_Rx_IrqHandler(void)
+{
+}
+__WEAKDEF void I2S4_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void USBFS_Global_IrqHandler(void)
+{
+}
+__WEAKDEF void USBFS_Wakeup_IrqHandler(void)
+{
+}
+__WEAKDEF void SDIOC1_Normal_IrqHandler(void)
+{
+}
+__WEAKDEF void SDIOC1_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void SDIOC2_Normal_IrqHandler(void)
+{
+}
+__WEAKDEF void SDIOC2_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void ETH_Global_IrqHandler(void)
+{
+}
+__WEAKDEF void ETH_Wakeup_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C1_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C1_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C1_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C1_EE_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C2_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C2_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C2_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C2_EE_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C3_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C3_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C3_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C3_EE_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C4_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C4_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C4_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C4_EE_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C5_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C5_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C5_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C5_EE_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C6_RxFull_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C6_TxComplete_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C6_TxEmpty_IrqHandler(void)
+{
+}
+__WEAKDEF void I2C6_EE_IrqHandler(void)
+{
+}
+
+__WEAKDEF void PWC_LVD1_IrqHandler(void)
+{
+}
+__WEAKDEF void PWC_LVD2_IrqHandler(void)
+{
+}
+__WEAKDEF void FCM_Error_IrqHandler(void)
+{
+}
+__WEAKDEF void FCM_End_IrqHandler(void)
+{
+}
+__WEAKDEF void FCM_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void CTC_Udf_IrqHandler(void)
+{
+}
+__WEAKDEF void CTC_Ovf_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC1_SeqA_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC1_SeqB_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC1_Cmp0_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC1_Cmp1_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC1_CmpComb_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC2_SeqA_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC2_SeqB_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC2_Cmp0_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC2_Cmp1_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC2_CmpComb_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC3_SeqA_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC3_SeqB_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC3_Cmp0_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC3_Cmp1_IrqHandler(void)
+{
+}
+__WEAKDEF void ADC3_CmpComb_IrqHandler(void)
+{
+}
+__WEAKDEF void NFC_IrqHandler(void)
+{
+}
+/**
+ * @}
+ */
+
+#endif /* LL_INTERRUPTS_SHARE_ENABLE */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/******************************************************************************
+ * EOF (not truncated)
+ *****************************************************************************/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad low-layer driver support added for many HC32F4A2 peripherals (ADC, CAN/CAN‑FD/TTCAN, AES/HASH/CRC, DMA, GPIO, I2C/SPI/I2S/QSPI, SDIO/SDMMC, RTC, timers/PWM/HRPWM, DAC, EXMC (DMC/SMC/NFC), DVP, FMAC/MAU, MPU, PWC, RMU, EFM, SRAM, SWDT, OTS, EMB, EP, FCG, FCM, etc.).
  * SCons build integration for HC32F4A2.

* **Documentation**
  * Added complete changelog (V2.0.0→V2.3.0) and BSD 3‑Clause License.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->